### PR TITLE
Prototype: split the desktop chat into up to four buffer panes

### DIFF
--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -16,7 +16,7 @@
         class="net-head"
         :class="{ active: isSystemActive }"
         title="Open Lurker system buffer"
-        @click="selectSystem"
+        @click="selectSystem($event)"
       >
         <span
           class="indicator"
@@ -112,7 +112,7 @@
               <li
                 :class="rowClasses(row.buf, row.networkId)"
                 :title="sectionRowTitle(row)"
-                @click="select(row.networkId, row.buf.target)"
+                @click="select(row.networkId, row.buf.target, $event)"
                 @contextmenu.prevent="onBufferContextMenu($event, row.buf)"
               >
                 <span class="label"
@@ -159,7 +159,7 @@
             class="net-head"
             :class="netHeadClasses(net.id)"
             :title="`Open ${net.name} server buffer`"
-            @click="select(net.id, serverTarget(net.id))"
+            @click="select(net.id, serverTarget(net.id), $event)"
             @contextmenu.prevent="
               networkActions.onNetworkContextMenu(net, $event.clientX, $event.clientY)
             "
@@ -228,7 +228,7 @@
               <li
                 :class="rowClasses(buf, net.id)"
                 :title="dmTitle(buf)"
-                @click="select(net.id, buf.target)"
+                @click="select(net.id, buf.target, $event)"
                 @contextmenu.prevent="onBufferContextMenu($event, buf)"
               >
                 <span class="label">{{ labelFor(buf) }}</span>
@@ -275,7 +275,7 @@
               :key="buf.target"
               :class="rowClasses(buf, net.id)"
               :title="dmTitle(buf)"
-              @click="select(net.id, buf.target)"
+              @click="select(net.id, buf.target, $event)"
               @contextmenu.prevent="onBufferContextMenu($event, buf)"
             >
               <span class="label">{{ labelFor(buf) }}</span>
@@ -349,7 +349,8 @@ import {
 import { useRouter } from 'vue-router';
 import draggable from 'vuedraggable';
 import { useNetworksStore, type Network, type PeerPresenceEntry } from '../stores/networks.js';
-import { useBuffersStore, type Buffer } from '../stores/buffers.js';
+import { useBuffersStore, bufferKey, type Buffer } from '../stores/buffers.js';
+import { useSplitsStore } from '../stores/splits.js';
 import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
 import { connected as lurkerConnected } from '../composables/useSocket.js';
 import { useDraftStore } from '../stores/drafts.js';
@@ -372,6 +373,7 @@ import { bufferSortKey } from '../utils/bufferOrder.js';
 
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
+const splits = useSplitsStore();
 const drafts = useDraftStore();
 const pins = usePinsStore();
 const favorites = useFavoritesStore();
@@ -419,7 +421,12 @@ const systemUnread = computed(() =>
   countFor(systemBuf.value?.unread || 0, systemBuf.value?.highlighted || 0),
 );
 const systemHighlights = computed(() => systemBuf.value?.highlighted || 0);
-function selectSystem(): void {
+function selectSystem(e?: MouseEvent): void {
+  if (e && openAlongside(e)) {
+    splits.addPane(SYSTEM_KEY);
+    buffers.activate(null, SYSTEM_KEY, { retainPrevious: true });
+    return;
+  }
   buffers.activate(null, SYSTEM_KEY);
 }
 // The LURKER header's corner control collapses the channel list. (Settings
@@ -741,7 +748,27 @@ function rowClasses(buf: Buffer, networkId: number): Record<string, boolean> {
   };
 }
 
-function select(networkId: number, target: string): void {
+// Cmd (macOS) / Ctrl (elsewhere) + click opens the buffer in a pane of its own
+// beside the ones already up, rather than replacing the focused pane. Same
+// modifier test the keyboard shortcuts use.
+//
+// No macOS special-case for Ctrl: there, Ctrl+click dispatches `contextmenu`
+// and no `click` at all, so this handler never sees it and the row's context
+// menu opens as it always has. On Windows/Linux Ctrl+click is a plain click
+// with ctrlKey set, and there's no contextmenu to compete with.
+function openAlongside(e: MouseEvent): boolean {
+  return e.metaKey || e.ctrlKey;
+}
+
+function select(networkId: number, target: string, e?: MouseEvent): void {
+  if (e && openAlongside(e)) {
+    splits.addPane(bufferKey(networkId, target));
+    // retainPrevious: the pane we were in is still on screen, so it keeps its
+    // unread divider and any detached slice. The splits store owns the teardown
+    // of whatever actually leaves.
+    buffers.activate(networkId, target, { retainPrevious: true });
+    return;
+  }
   buffers.activate(networkId, target);
 }
 

--- a/vue_client/src/components/BufferPane.test.ts
+++ b/vue_client/src/components/BufferPane.test.ts
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, nextTick } from 'vue';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import BufferPane from './BufferPane.vue';
+import { useBufferKey } from '../composables/useActiveBuffer.js';
+import { useNetworksStore } from '../stores/networks.js';
+import { useBuffersStore } from '../stores/buffers.js';
+
+vi.mock('../composables/useSocket.js', () => ({
+  socketSend: vi.fn<() => void>(),
+  useSocket: vi.fn<() => void>(),
+}));
+
+// Stands in for the real message list and reports which buffer its subtree
+// resolves to. The provide/inject seam is the whole mechanism the split rests
+// on — every child of a pane has to see the PANE's buffer, not the app's active
+// one — so the probe asks the same question those children ask.
+const KeyProbe = defineComponent({
+  name: 'KeyProbe',
+  setup() {
+    const key = useBufferKey();
+    return () => h('div', { class: 'probe' }, key.value ?? 'none');
+  },
+});
+
+function mountPane(props: { paneKey: string | null; split?: boolean; focused?: boolean }) {
+  return mount(BufferPane, {
+    props,
+    global: {
+      stubs: {
+        MessageList: KeyProbe,
+        MemberList: true,
+        StatusBar: true,
+        MessageInput: true,
+        LinkedText: true,
+      },
+    },
+  });
+}
+
+// Two channels on one network, enough for the topic bar to resolve a label.
+function seedBuffers() {
+  const networks = useNetworksStore();
+  const buffers = useBuffersStore();
+  networks.networks = [{ id: 1, name: 'libera' } as never];
+  buffers.buffers = {
+    '1::#ops': { networkId: 1, target: '#ops', kind: 'channel', members: [] } as never,
+    '1::#dev': { networkId: 1, target: '#dev', kind: 'channel', members: [] } as never,
+  };
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  seedBuffers();
+});
+
+describe('BufferPane mounting', () => {
+  // The shell renders one empty pane before anything is active, so a null key
+  // has to be a legal state rather than a crash on first paint.
+  it('mounts with no buffer', () => {
+    const w = mountPane({ paneKey: null });
+    expect(w.find('.buffer-pane').exists()).toBe(true);
+    expect(w.find('.probe').text()).toBe('none');
+  });
+
+  it('renders the buffer label for its own key', () => {
+    const w = mountPane({ paneKey: '1::#ops' });
+    expect(w.find('.topic .buffer').text()).toBe('#ops');
+  });
+});
+
+describe('BufferPane buffer key provision', () => {
+  // The bug this guards: a pane that resolved its subtree through
+  // networks.activeKey would render the SAME buffer in every pane, which is
+  // the singleton behavior the split exists to break.
+  it('gives each pane its own buffer, independent of the active one', () => {
+    const networks = useNetworksStore();
+    networks.activeKey = '1::#ops';
+
+    const a = mountPane({ paneKey: '1::#ops' });
+    const b = mountPane({ paneKey: '1::#dev' });
+
+    expect(a.find('.probe').text()).toBe('1::#ops');
+    // The active buffer is #ops, but this pane is showing #dev and its subtree
+    // has to agree.
+    expect(b.find('.probe').text()).toBe('1::#dev');
+  });
+
+  // A plain click swaps the focused pane's buffer in place rather than
+  // remounting it, so the provided key is a ref the subtree keeps watching.
+  it('repoints its subtree when the pane changes buffer', async () => {
+    const w = mountPane({ paneKey: '1::#ops' });
+    expect(w.find('.probe').text()).toBe('1::#ops');
+
+    await w.setProps({ paneKey: '1::#dev' });
+    await nextTick();
+    expect(w.find('.probe').text()).toBe('1::#dev');
+    expect(w.find('.topic .buffer').text()).toBe('#dev');
+  });
+});
+
+describe('BufferPane chrome', () => {
+  // With one pane there is nothing to maximize away from and closing it would
+  // leave an empty frame, so the controls only exist once the frame is split.
+  it('hides the pane controls when the frame is not split', () => {
+    const w = mountPane({ paneKey: '1::#ops', split: false });
+    expect(w.find('.pane-btn').exists()).toBe(false);
+    // ...and the nav cluster is present, exactly as in the pre-split shell.
+    expect(w.find('.topic-nav').exists()).toBe(true);
+  });
+
+  it('shows the pane controls and drops the nav cluster when split', () => {
+    const w = mountPane({ paneKey: '1::#ops', split: true });
+    expect(w.findAll('.pane-btn')).toHaveLength(2);
+    expect(w.find('.topic-nav').exists()).toBe(false);
+  });
+
+  it('emits close and maximize from the pane controls', async () => {
+    const w = mountPane({ paneKey: '1::#ops', split: true });
+    const [maximize, close] = w.findAll('.pane-btn');
+    await maximize.trigger('click');
+    await close.trigger('click');
+    expect(w.emitted('maximize')).toHaveLength(1);
+    expect(w.emitted('close')).toHaveLength(1);
+  });
+
+  // Focus has to land before the click reaches a button, or a topic-bar action
+  // in an unfocused pane would resolve against the previously focused buffer.
+  it('emits focus on pointerdown, not on click', async () => {
+    const w = mountPane({ paneKey: '1::#ops', split: true });
+    await w.find('.buffer-pane').trigger('pointerdown');
+    expect(w.emitted('focus')).toHaveLength(1);
+  });
+
+  it('marks only the focused pane', () => {
+    const focused = mountPane({ paneKey: '1::#ops', split: true, focused: true });
+    const other = mountPane({ paneKey: '1::#dev', split: true, focused: false });
+    expect(focused.find('.buffer-pane').classes()).toContain('focused');
+    expect(other.find('.buffer-pane').classes()).not.toContain('focused');
+  });
+});

--- a/vue_client/src/components/BufferPane.vue
+++ b/vue_client/src/components/BufferPane.vue
@@ -377,8 +377,6 @@ function toggleServerConnection() {
     serverConnectionState.value === 'connected' ? networks.disconnect(id) : networks.reconnect(id);
   p.catch((err) => console.error('[BufferPane] toggle server connection failed', err));
 }
-
-defineExpose<PaneApi>(api);
 </script>
 
 <style scoped>

--- a/vue_client/src/components/BufferPane.vue
+++ b/vue_client/src/components/BufferPane.vue
@@ -1,0 +1,604 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<template>
+  <!-- pointerdown, not click: focus has to land BEFORE the click reaches
+       whatever was pressed, because the topic-bar buttons emit up to the shell
+       and the shell resolves them against the ACTIVE buffer. Focusing first is
+       what makes "search this buffer" in an unfocused pane search that pane's
+       buffer rather than the previously focused one. -->
+  <div
+    class="buffer-pane"
+    :class="{
+      focused: focused && split,
+      split,
+      'members-collapsed': !showMembers,
+      'system-pane': isSystemBuffer,
+    }"
+    @pointerdown="emit('focus')"
+  >
+    <header class="topic">
+      <!-- Back/forward are global history controls, so N panes would mean N
+           copies of one control. They stay in the single-pane shell, where
+           they're the only way to reach the history; in a split the keyboard
+           (Cmd/Ctrl+[ and ]) covers it and the bar keeps the room for the
+           buffer's own actions. -->
+      <div v-if="!split" class="topic-nav">
+        <button
+          type="button"
+          class="link nav-btn"
+          title="Back"
+          aria-label="Back"
+          :disabled="!navHistory.canBack"
+          @click="navHistory.back()"
+        >
+          <i class="fa-solid fa-angle-left"></i>
+        </button>
+        <button
+          type="button"
+          class="link nav-btn"
+          title="Forward"
+          aria-label="Forward"
+          :disabled="!navHistory.canForward"
+          @click="navHistory.forward()"
+        >
+          <i class="fa-solid fa-angle-right"></i>
+        </button>
+      </div>
+      <div class="topic-meta">
+        <span v-if="isVirtual || active" class="buffer">{{ bufferLabel }}</span>
+        <template v-if="active && topic">
+          <!-- A channel topic is user prose: auto-link it and open the full
+               view on click. A DM's pseudo-topic is the peer's ident@host —
+               an identity string, not prose; auto-linking turns the host into
+               a bogus email/URL link, so it renders as plain static text. -->
+          <button
+            v-if="isChannel"
+            type="button"
+            class="topic-text"
+            title="View full topic"
+            @click="emit('show-topic')"
+          >
+            <LinkedText :text="topic" />
+          </button>
+          <span v-else class="topic-text">{{ topic }}</span>
+        </template>
+      </div>
+      <div class="topic-actions">
+        <template v-if="active && !isVirtual">
+          <!-- Search & highlights scoped to this buffer (channels/DMs only) —
+               parity with the mobile topic bar. The server buffer has no
+               per-buffer scope, so it's excluded. -->
+          <template v-if="!isServerBuffer">
+            <button
+              type="button"
+              class="link"
+              title="Search this buffer"
+              aria-label="Search this buffer"
+              @click="emit('open-search', true)"
+            >
+              <i class="fa-solid fa-magnifying-glass"></i>
+            </button>
+            <button
+              type="button"
+              class="link"
+              title="Highlights in this buffer"
+              aria-label="Highlights in this buffer"
+              @click="emit('open-highlights', true)"
+            >
+              <i class="fa-regular fa-bell"></i>
+            </button>
+          </template>
+          <template v-if="isServerBuffer">
+            <button
+              type="button"
+              class="link"
+              title="Join channel"
+              aria-label="Join channel"
+              :disabled="serverConnectionState !== 'connected'"
+              @click="active && joinChannelModal.open(active.networkId)"
+            >
+              <i class="fa-solid fa-plus"></i>
+            </button>
+            <button
+              type="button"
+              class="link"
+              title="Channel list"
+              aria-label="Channel list"
+              @click="active && channelListModal.open(active.networkId)"
+            >
+              <i class="fa-solid fa-hashtag"></i>
+            </button>
+            <button
+              type="button"
+              class="link"
+              :title="serverConnectActionLabel"
+              :aria-label="serverConnectActionLabel"
+              @click="toggleServerConnection"
+            >
+              <i :class="serverConnectActionIcon"></i>
+            </button>
+            <button class="link" title="Edit network" @click="editPaneNetwork">
+              <i class="fa-solid fa-gear"></i>
+            </button>
+          </template>
+          <template v-else-if="isDmHeader">
+            <button
+              type="button"
+              class="link"
+              title="View profile"
+              aria-label="View profile"
+              @click="openDmProfile"
+            >
+              <i class="fa-solid fa-id-card"></i>
+            </button>
+            <button
+              type="button"
+              class="link"
+              :title="dmNoteLabel"
+              :aria-label="dmNoteLabel"
+              @click="openDmNote"
+            >
+              <i class="fa-solid fa-note-sticky"></i>
+            </button>
+          </template>
+          <template v-else-if="isChannel">
+            <button
+              class="link"
+              :title="showMembers ? 'Hide members' : 'Show members'"
+              :aria-label="showMembers ? 'Hide members' : 'Show members'"
+              @click="toggleMembers"
+            >
+              <i class="fa-solid fa-users"></i>
+            </button>
+            <span
+              v-if="memberCount != null"
+              class="member-count"
+              :title="`${memberCount} ${memberCount === 1 ? 'user' : 'users'} in channel`"
+              >{{ memberCount }}</span
+            >
+          </template>
+        </template>
+        <!-- Pane controls, split-only: with one pane there is nothing to
+             maximize away from and closing it would leave an empty frame. -->
+        <template v-if="split">
+          <span class="pane-sep" aria-hidden="true"></span>
+          <button
+            type="button"
+            class="link pane-btn"
+            title="Maximize this pane"
+            aria-label="Maximize this pane"
+            @click="emit('maximize')"
+          >
+            <i class="fa-solid fa-expand"></i>
+          </button>
+          <button
+            type="button"
+            class="link pane-btn"
+            title="Close this pane"
+            aria-label="Close this pane"
+            @click="emit('close')"
+          >
+            <i class="fa-solid fa-xmark"></i>
+          </button>
+        </template>
+      </div>
+    </header>
+    <div class="topic-divider"></div>
+
+    <MessageList ref="messageListRef" :pending-scroll-id="pendingScrollId" />
+    <MemberList v-if="showMembers && hasNicklist" />
+    <StatusBar />
+    <MessageInput v-if="hasInput" ref="messageInputRef" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, reactive, ref, toRef, watch } from 'vue';
+import type { Network } from '../stores/networks.js';
+import { useNetworksStore } from '../stores/networks.js';
+import type { Buffer } from '../stores/buffers.js';
+import { provideBufferKey, useActiveBuffer } from '../composables/useActiveBuffer.js';
+import { registerPane, unregisterPane, type PaneApi } from '../composables/usePaneRegistry.js';
+import { useSettingsStore } from '../stores/settings.js';
+import { useNicklistCollapseStore } from '../stores/nicklistCollapse.js';
+import { useNickNotesStore } from '../stores/nickNotes.js';
+import { useWhoisStore } from '../stores/whois.js';
+import { useNavHistoryStore } from '../stores/navHistory.js';
+import { useChannelListModal } from '../composables/useChannelListModal.js';
+import { useJoinChannelModal } from '../composables/useJoinChannelModal.js';
+import { useNetworkEditor } from '../composables/useNetworkEditor.js';
+import MessageList from './MessageList.vue';
+import MessageInput from './MessageInput.vue';
+import MemberList from './MemberList.vue';
+import StatusBar from './StatusBar.vue';
+import LinkedText from './LinkedText.vue';
+
+const props = withDefaults(
+  defineProps<{
+    // The buffer this pane renders. Null renders the empty header + "no
+    // messages" body, which is what the shell shows before anything is active.
+    paneKey: string | null;
+    // Whether the frame is divided. Off means this is the whole chat view and
+    // must look exactly like the pre-split shell — no focus ring, no pane
+    // controls, and the nav cluster back in the topic bar.
+    split?: boolean;
+    // Whether this is the pane the user is working in. Only meaningful while
+    // `split` — with one pane it's trivially true and the ring would be noise.
+    focused?: boolean;
+    // Jump-to-message target, forwarded to this pane's message list. The shell
+    // only hands it to the pane that owns the jump's buffer.
+    pendingScrollId?: number | null;
+  }>(),
+  { split: false, focused: false, pendingScrollId: null },
+);
+
+const emit = defineEmits<{
+  (e: 'focus'): void;
+  (e: 'close'): void;
+  (e: 'maximize'): void;
+  (e: 'open-search', scoped: boolean): void;
+  (e: 'open-highlights', scoped: boolean): void;
+  (e: 'show-topic'): void;
+}>();
+
+const paneKey = toRef(props, 'paneKey');
+// Everything below this component resolves "my buffer" from here rather than
+// from networks.activeKey.
+provideBufferKey(paneKey);
+
+const networks = useNetworksStore();
+const settings = useSettingsStore();
+const nicklistCollapse = useNicklistCollapseStore();
+const nickNotes = useNickNotesStore();
+const whois = useWhoisStore();
+const navHistory = useNavHistoryStore();
+const channelListModal = reactive(useChannelListModal());
+const joinChannelModal = reactive(useJoinChannelModal());
+const networkEditor = reactive(useNetworkEditor());
+
+// Explicit key, not the injected one: inject() resolves against the *parent's*
+// provides, so asking for our own would hand back the global activeKey.
+const {
+  active,
+  activeBuf,
+  topic,
+  isServerBuffer,
+  isChannel,
+  bufferLabel,
+  isSystemBuffer,
+  isVirtual,
+  hasInput,
+  hasNicklist,
+} = useActiveBuffer(paneKey);
+
+const messageInputRef = ref<{ focus: () => void } | null>(null);
+const messageListRef = ref<{ scrollByPage: (dir: number) => void } | null>(null);
+
+const api: PaneApi = {
+  focusInput: () => messageInputRef.value?.focus(),
+  scrollByPage: (dir: number) => messageListRef.value?.scrollByPage(dir),
+};
+onMounted(() => registerPane(paneKey.value, api));
+onBeforeUnmount(() => unregisterPane(paneKey.value, api));
+// A pane repoints at another buffer without remounting (a plain click swaps the
+// focused pane's contents), so the registration has to follow the key or the
+// shortcuts would keep reaching the buffer this pane used to show.
+watch(paneKey, (key, prev) => {
+  unregisterPane(prev, api);
+  registerPane(key, api);
+});
+
+// True when this buffer is a DM (not a channel, not the network's server
+// buffer). Drives the clickable DM header that opens the user profile modal —
+// channel headers stay non-interactive.
+const isDmHeader = computed(() => {
+  if (!active.value) return false;
+  if (isChannel.value || isServerBuffer.value) return false;
+  return true;
+});
+function openDmProfile() {
+  if (!active.value) return;
+  whois.openViewer(active.value.networkId, active.value.target);
+}
+// DM note button — mirrors the old context-menu entry, surfaced inline so the
+// per-peer note is one click from the conversation. Label flips once a note
+// exists so the button doubles as a "has a note" tell.
+const dmNoteLabel = computed(() =>
+  active.value && nickNotes.hasNote(active.value.networkId, active.value.target)
+    ? 'Edit note'
+    : 'Add note',
+);
+function openDmNote() {
+  if (!active.value) return;
+  nickNotes.openEditor(active.value.networkId, active.value.target);
+}
+
+// User count for a channel buffer. Sits in the topic bar (next to the
+// members-toggle button) rather than the status bar — the count is a property
+// of the channel, so the channel header is the natural home.
+const memberCount = computed(() => {
+  if (!isChannel.value) return null;
+  return (activeBuf.value as Buffer | null)?.members?.length ?? null;
+});
+
+// Per-channel nicklist visibility. A channel the user has explicitly toggled
+// carries an override (true = collapsed); otherwise the global
+// look.layout.show_member_list default applies. DMs and server buffers have no
+// member list at all, so the toggle and panel are hidden for them entirely.
+const showMembers = computed(() => {
+  if (!isChannel.value || !active.value) return false;
+  const { networkId, target } = active.value;
+  const override = nicklistCollapse.override(networkId, target);
+  if (override !== undefined) return !override;
+  return settings.effective('look.layout.show_member_list');
+});
+
+function toggleMembers() {
+  if (!isChannel.value || !active.value) return;
+  const { networkId, target } = active.value;
+  // Pass the current visibility through as the new collapsed flag — it flips.
+  nicklistCollapse.setCollapsed(networkId, target, !!showMembers.value);
+}
+
+function editPaneNetwork() {
+  const net = active.value?.network as Network | undefined;
+  if (net) networkEditor.open(net);
+}
+
+// State-aware connect/disconnect for the server buffer header. We label the
+// button "Disconnect" only while we're confidently connected; every other
+// state (idle, connecting, reconnecting, disconnected, unknown) reads as
+// "Reconnect" because the action — fire a fresh connect — is the same in
+// each case, and "Reconnect" is what the user reaches for when something
+// looks stuck.
+const serverConnectionState = computed(() => {
+  if (!active.value || !isServerBuffer.value) return null;
+  return networks.states[active.value.networkId]?.state ?? null;
+});
+const serverConnectActionLabel = computed(() =>
+  serverConnectionState.value === 'connected' ? 'Disconnect' : 'Reconnect',
+);
+const serverConnectActionIcon = computed(() =>
+  serverConnectionState.value === 'connected'
+    ? 'fa-solid fa-plug-circle-xmark'
+    : 'fa-solid fa-plug',
+);
+function toggleServerConnection() {
+  if (!active.value) return;
+  const id = active.value.networkId;
+  // Fire-and-forget — the button's label is driven by networks.states so
+  // success reflects itself. A failed call stays observable via the state
+  // (label doesn't flip), so we just log and let the user retry rather
+  // than wiring a toast through the topic bar for this case.
+  const p =
+    serverConnectionState.value === 'connected' ? networks.disconnect(id) : networks.reconnect(id);
+  p.catch((err) => console.error('[BufferPane] toggle server connection failed', err));
+}
+
+defineExpose<PaneApi>(api);
+</script>
+
+<style scoped>
+/* The pane's own frame: topic and status/input bars span the full width; the
+   message list and nicklist sit between them. This is the grid DesktopChat used
+   to own for the whole shell, minus the sidebar column — which is why a single
+   pane is pixel-identical to the pre-split view.
+
+   The member-list column is sized via a custom property so the
+   .members-collapsed modifier can zero it without touching the rest of the
+   grid. */
+.buffer-pane {
+  --members-w: 180px;
+  display: grid;
+  grid-template-columns: 1fr var(--members-w);
+  /* The 1px row owns the topic/messages divider as its own grid track,
+     outside the scroll container. Putting the line inside .message-list
+     (border-top, inset box-shadow) lets row backgrounds and hover states
+     paint over it as content scrolls past — the line appears to be eaten
+     by the scrolling rows. A dedicated row sits between the two children
+     and nothing can paint on top of it. */
+  grid-template-rows: auto auto 1fr auto auto;
+  grid-template-areas:
+    'topic    topic'
+    'divider  divider'
+    'messages members'
+    'status   status'
+    'input    input';
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  /* Opaque so the 1px grid gap of the split container (which paints --border)
+     shows only in the gap and not through the panes. */
+  background: var(--bg);
+}
+/* Members column fully collapses — no rail. The reopen toggle lives in the
+   topic bar on the right, so there's nothing to leave behind. */
+.buffer-pane.members-collapsed {
+  --members-w: 0px;
+}
+/* System console has no member list — collapse the rail so the log pane
+   spans the full content width instead of leaving an empty column. */
+.buffer-pane.system-pane {
+  --members-w: 0px;
+}
+/* The status bar carries the separator border above the input, but it's hidden
+   in the system buffer (no network state to show). Give the input its own top
+   border there so it stays visually divided from the message list. */
+.buffer-pane.system-pane .input {
+  border-top: 1px solid var(--border);
+}
+/* A split pane gets a narrower nicklist: 180px out of a half-width pane is a
+   much bigger bite than out of the full frame, and it squeezes the message
+   column past the point where lines stop being readable. */
+.buffer-pane.split {
+  --members-w: 140px;
+}
+/* min-height/min-width 0 lets flex/scrolling children stay inside their row. */
+.buffer-pane > * {
+  min-width: 0;
+  min-height: 0;
+}
+
+/* Which pane the keyboard is talking to. An inset ring rather than a border:
+   a border would take a pixel out of the grid track and shift the pane's
+   contents by one pixel as focus moves between panes. Accent-colored on the
+   topic bar edge only — a full outline around a pane that already has 1px
+   separators on every side reads as a box-in-a-box. */
+.buffer-pane.focused .topic-divider {
+  background: var(--accent);
+}
+/* The unfocused panes recede rather than the focused one shouting: dimming the
+   header text of what you're NOT working in is a quieter signal than painting
+   the one you are, and it survives any theme because it's an opacity, not a
+   color. */
+.buffer-pane.split:not(.focused) .topic {
+  opacity: 0.65;
+}
+
+.link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  padding: 0 var(--space-2);
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+}
+.link:hover {
+  color: var(--fg);
+}
+/* Disabled topic-bar link (e.g. Join channel while the network is disconnected):
+   dimmed and non-interactive, and it must not brighten on hover. */
+.link:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.link:disabled:hover {
+  color: var(--accent);
+}
+
+.topic {
+  grid-area: topic;
+  padding: var(--space-4) var(--space-6);
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-4);
+  white-space: nowrap;
+  overflow: hidden;
+}
+/* Back/forward history controls (#411), anchored at the far left of the bar,
+   left of the buffer title. Same accent icon buttons as the rest of the bar;
+   disabled (dimmed, non-interactive) when there's nowhere to go that way. */
+.topic-nav {
+  display: flex;
+  align-items: baseline;
+  /* Match .topic-actions' gap so the back/forward pair is spaced like every
+     other button pair in the bar, not tighter. */
+  gap: var(--space-4);
+  flex-shrink: 0;
+}
+.nav-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.nav-btn:disabled:hover {
+  color: var(--accent);
+}
+.topic-divider {
+  grid-area: divider;
+  background: var(--border);
+  height: 1px;
+}
+.topic .buffer {
+  color: var(--accent);
+}
+.topic .topic-text {
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  overflow: hidden;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  text-align: left;
+  white-space: nowrap;
+  min-width: 0;
+}
+/* Hover/click affordances belong to the clickable channel-topic BUTTON only;
+   the DM identity renders as a static span sharing the layout styles above. */
+button.topic-text {
+  cursor: pointer;
+}
+button.topic-text:hover {
+  color: var(--fg);
+}
+button.topic-text:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* These selectors target the root elements of the imported components.
+   Vue 3 scoped CSS attaches the parent's data-v attribute to a child
+   component's root element, so .message-list / .members / .input here
+   match the rendered roots of MessageList / MemberList / MessageInput. */
+.message-list {
+  grid-area: messages;
+}
+.members {
+  grid-area: members;
+  border-left: 1px solid var(--border);
+}
+.status-bar {
+  grid-area: status;
+}
+.input {
+  grid-area: input;
+}
+
+/* Two-group layout for the topic bar: .topic-meta (name + topic text, spaced
+   by the 2ch gap — wider than the 1ch bar convention to give the name and
+   topic breathing room now that the │ divider is gone) sits left,
+   .topic-actions (buffer/network/channel buttons) sits right.
+   .topic uses justify-content:space-between to split them. .topic-meta
+   shrinks first via min-width:0 + topic-text ellipsis, so the action
+   cluster stays anchored to the right edge. */
+.topic-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 2ch;
+  /* flex:1 so the meta absorbs the free space and keeps the action cluster
+     anchored to the right edge; min-width:0 lets the topic text ellipsis. */
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+.topic-actions {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-4);
+  flex-shrink: 0;
+}
+.topic .member-count {
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+/* Hairline between the buffer's own actions and the pane controls: close and
+   maximize act on the FRAME, not on the conversation, and without a divider
+   they read as two more buffer actions. */
+.pane-sep {
+  width: 1px;
+  align-self: stretch;
+  background: var(--border);
+  margin-inline: var(--space-2);
+}
+/* Pane controls sit quieter than the buffer's own actions until hovered —
+   they're frame furniture, present in every pane, and at four panes eight
+   accent-colored glyphs compete with the conversation for the eye. */
+.pane-btn {
+  color: var(--fg-muted);
+}
+</style>

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -78,8 +78,11 @@ const selfModes = computed<string[]>(() => {
   return me && Array.isArray(me.modes) ? me.modes : [];
 });
 
+// This pane's buffer, not the app's active one: a member list renders per pane,
+// so keying the reset on activeKey scrolled EVERY nicklist back to the top
+// whenever focus moved between panes.
 watch(
-  () => networks.activeKey,
+  paneKey,
   () => {
     if (listEl.value) listEl.value.scrollTop = 0;
   },

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -51,6 +51,7 @@ import {
   prefixClass as modePrefixClass,
 } from '../utils/memberPrefix.js';
 import IgnoreModal from './IgnoreModal.vue';
+import { useBufferKey } from '../composables/useActiveBuffer.js';
 
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
@@ -60,7 +61,8 @@ const ignores = useIgnoresStore();
 const modalMember = ref<BufferMember | null>(null);
 const listEl = ref<HTMLElement | null>(null);
 
-const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
+const paneKey = useBufferKey();
+const buffer = computed(() => (paneKey.value ? buffers.byKey(paneKey.value) : null));
 const members = computed((): BufferMember[] => buffer.value?.members || []);
 const selfNick = computed(() => {
   const b = buffer.value;

--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -14,12 +14,15 @@
 
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { mount, type VueWrapper } from '@vue/test-utils';
+import { ref } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useRecentBuffersStore } from '../stores/recentBuffers.js';
 import { useDraftStore } from '../stores/drafts.js';
 import { useComposerOverlay, selectNick } from '../composables/useComposerOverlay.js';
+import { BUFFER_KEY } from '../composables/useActiveBuffer.js';
+import { useUploadsStore } from '../stores/uploads.js';
 import { useViewport } from '../composables/useViewport.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useScrollState } from '../composables/useScrollState.js';
@@ -1181,5 +1184,87 @@ describe('scroll position on send (#628)', () => {
     // Positive control, as above: proves the send got as far as the detached
     // branch rather than falling out of submit() somewhere earlier.
     expect(reattach).toHaveBeenCalled();
+  });
+});
+
+// A split frame mounts one composer per pane, but three pieces of composer
+// state are module-level singletons: the overlay handler slots, the composing
+// chip, and the uploads insert-URL bus. Each now gates on "am I the FOCUSED
+// composer" (pane key === activeKey). These pin both directions, because a
+// wrong gate fails silently either way: stuck closed, the ordinary single-pane
+// composer quietly stops taking emoji picks and upload URLs; stuck open, a
+// background pane eats them.
+describe('MessageInput singleton gating across panes', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    // The nick strip these picks come from is mobile-by-default, so the pick
+    // path only runs with the viewport flipped (same as the strip tests above).
+    // Restored in afterEach — it's a module singleton.
+    isMobile.value = true;
+  });
+  afterEach(() => {
+    isMobile.value = false;
+    for (const w of mounted) w.unmount();
+    mounted = [];
+  });
+
+  // Mount a composer bound to `paneTarget` while `activeTarget` is the focused
+  // buffer — i.e. an UNFOCUSED pane. Providing the key is exactly what
+  // BufferPane does.
+  async function mountPaneComposer(paneTarget: string) {
+    const wrapper = mount(MessageInput, {
+      attachTo: document.body,
+      global: { provide: { [BUFFER_KEY as symbol]: ref(`1::${paneTarget}`) } },
+    });
+    mounted.push(wrapper);
+    await flush();
+    return { wrapper, el: wrapper.find('textarea').element as HTMLTextAreaElement };
+  }
+
+  it('routes an overlay pick to the focused composer, not the last mounted one', async () => {
+    seedStores('#zebra');
+    const focused = await mountComposer();
+    // Mounted AFTER the focused one: under the old last-mount-wins registration
+    // this composer owned the overlay handlers.
+    const background = await mountPaneComposer('#apple');
+
+    // BOTH get a token to splice into, so the assertion distinguishes "the pick
+    // went to the right composer" from "the pick went nowhere" — with only the
+    // focused one primed, a broken gate would look identical to a correct one.
+    await type(focused.el, 'hey bo');
+    await type(background.el, 'hey bo');
+
+    selectNick('bob');
+    await flush();
+
+    expect(focused.el.value).toBe('hey bob ');
+    expect(background.el.value).toBe('hey bo');
+  });
+
+  it('inserts an upload URL only into the focused composer', async () => {
+    seedStores('#zebra');
+    const focused = await mountComposer();
+    const background = await mountPaneComposer('#apple');
+
+    // What the uploads store does when a transfer completes: broadcast to every
+    // subscriber, and every mounted composer subscribes.
+    useUploadsStore().requestInsert('https://ex.ample/cat.png');
+    await flush();
+
+    expect(focused.el.value).toContain('https://ex.ample/cat.png');
+    expect(background.el.value).toBe('');
+  });
+
+  // The un-provided case IS the single-pane desktop shell and all of mobile, so
+  // the gate must be open there or the composer silently loses these features.
+  it('leaves the gate open for a composer with no pane key', async () => {
+    seedStores('#zebra');
+    const solo = await mountComposer();
+    await type(solo.el, 'hey bo');
+
+    selectNick('bob');
+    await flush();
+
+    expect(solo.el.value).toBe('hey bob ');
   });
 });

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -333,6 +333,18 @@ const { requestScrollToBottom } = useScrollState();
 // gets a local-only input ref rather than a server-synced per-buffer draft (no
 // network to key a draft row to, and command typing needn't sync cross-device).
 const isSystemBuffer = computed(() => paneKey.value === SYSTEM_KEY);
+
+// Is this the composer the user is actually typing in? A split frame mounts one
+// MessageInput per pane, but three pieces of composer state are module-level
+// singletons: the overlay popovers (useComposerOverlay), the composing chip
+// (useComposing), and the uploads insert-URL bus. That shape is still right —
+// there is only ever one FOCUSED composer — but "the only one mounted" is no
+// longer the same statement, so each of them gates on this instead.
+//
+// activeKey follows pane focus, so this is true for exactly one pane; with a
+// single pane (and on mobile, where nothing provides a key) it is always true,
+// which is why none of those three change behavior outside a split.
+const isFocusedComposer = computed(() => paneKey.value === networks.activeKey);
 const systemText = ref('');
 
 // Input contents are server-side per-buffer drafts — switching channels swaps
@@ -600,7 +612,13 @@ function multilineCountFor(raw: string): number {
 // for the live keystroke path and the bare buffer-switch so both stay in sync.
 // On a multiline network `chunks` carries the batch (message) count and
 // `multiline` is set; otherwise it's the legacy wire-PRIVMSG estimate.
+//
+// Focused composer only: the composing state is a module-level singleton, so an
+// unfocused pane publishing would paint its SPLIT/FLOOD chip across every status
+// bar — and a pane repointing to an empty draft would zero the indicator of the
+// pane actually being typed in.
 function publishComposing(raw: string): void {
+  if (!isFocusedComposer.value) return;
   const batches = multilineCountFor(raw);
   if (batches > 0) {
     setComposingState({ chunks: batches, isAction: false, multiline: true });
@@ -1879,6 +1897,11 @@ onBeforeUnmount(() => {
 });
 
 function insertUrlAtCaret(url: string): void {
+  // onInsertUrl is a broadcast to every subscriber, and every mounted composer
+  // subscribes. Without this, finishing one upload pasted the URL into all four
+  // panes' drafts at once — so the link sat in channels the user never meant to
+  // put it in, waiting to be sent — and every composer called focus().
+  if (!isFocusedComposer.value) return;
   const el = inputEl.value;
   const current = text.value;
   if (!el) {
@@ -1908,9 +1931,16 @@ let unsubInsert: (() => boolean) | null = null;
 onMounted(() => {
   unsubInsert = onInsertUrl(insertUrlAtCaret);
   if (typeof window !== 'undefined') window.addEventListener('pagehide', onPagehide);
-  // Route picks from StatusBar's overlay-rendered popovers back to the
-  // textarea-mutation logic that owns the draft. Re-registered on every
-  // mount so closures bind to the live `text`/`inputEl`.
+  if (isFocusedComposer.value) claimComposerOverlay();
+});
+
+// Route picks from StatusBar's overlay-rendered popovers back to the
+// textarea-mutation logic that owns the draft. The handler slots are a
+// singleton, so with several panes mounted the LAST mount used to win
+// regardless of where the user was typing: an emoji picked in the focused pane
+// spliced itself into a different pane's textarea. Claimed on focus instead, so
+// the composer that owns the overlay is the one being typed in.
+function claimComposerOverlay(): void {
   setComposerOverlayHandlers({
     onNickSelect: onStripSelect,
     onEmojiSelect,
@@ -1920,6 +1950,17 @@ onMounted(() => {
     onPickFile,
     onAddress: addressInComposer,
   });
+}
+
+watch(isFocusedComposer, (focused) => {
+  if (!focused) return;
+  claimComposerOverlay();
+  // Taking the overlay over must not inherit the previous pane's open strip —
+  // its items belong to that pane's buffer and its picks would now splice here.
+  closeStrip();
+  closeEmojiStrip();
+  closeEmojiPicker();
+  closeColorPicker();
 });
 
 function blobFromClipboardItem(item: DataTransferItem): File | null {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -180,7 +180,8 @@ import { useWhoisStore } from '../stores/whois.js';
 import { useChanlistStore } from '../stores/chanlist.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
 import { socketSend, socketSendWithAck } from '../composables/useSocket.js';
-import { requestScrollToBottom } from '../composables/useScrollState.js';
+import { useScrollState } from '../composables/useScrollState.js';
+import { useBufferKey } from '../composables/useActiveBuffer.js';
 import { setComposingState } from '../composables/useComposing.js';
 import {
   chunkCountForSay,
@@ -322,13 +323,16 @@ const emojiPickerOpen = ref(false);
 const emojiPickerQuery = ref('');
 const emojiPickerEl = ref<InstanceType<typeof EmojiPicker> | null>(null);
 
-const active = computed(() => networks.activeBuffer);
+const paneKey = useBufferKey();
+const active = computed(() => networks.bufferFor(paneKey.value));
+// Sending a line snaps this pane's message list back to the live tail.
+const { requestScrollToBottom } = useScrollState();
 
 // The app-scoped system buffer (issue #355) has no network, so networks
-// .activeBuffer reports null for it. It accepts slash commands, not chat, so it
+// .bufferFor reports null for it. It accepts slash commands, not chat, so it
 // gets a local-only input ref rather than a server-synced per-buffer draft (no
 // network to key a draft row to, and command typing needn't sync cross-device).
-const isSystemBuffer = computed(() => networks.activeKey === SYSTEM_KEY);
+const isSystemBuffer = computed(() => paneKey.value === SYSTEM_KEY);
 const systemText = ref('');
 
 // Input contents are server-side per-buffer drafts — switching channels swaps

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -333,7 +333,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue';
-import type { CSSProperties, ComponentPublicInstance } from 'vue';
+import type { CSSProperties, ComponentPublicInstance, Ref } from 'vue';
 import { useNetworksStore, type AwayState } from '../stores/networks.js';
 import { useBuffersStore, type BufferMember } from '../stores/buffers.js';
 import { useSettingsStore } from '../stores/settings.js';
@@ -1987,10 +1987,31 @@ watch(compactMode, async () => {
   if (stickToBottom.value) scrollToBottom();
 });
 
+// The scroll-request tokens are PER-BUFFER counters, so they only mean "the
+// user asked" while the buffer stays put: changing buffer re-resolves the
+// computed to another buffer's count, which can move it in either direction and
+// is not a request. (A bare `token > previous` test isn't enough — switching to
+// a buffer whose count happens to be higher reads as an increase.) So a change
+// counts only when the key it belongs to is the same one we last saw it under.
+//
+// Not split-only: this fires in the plain single-pane shell too, where clicking
+// "jump to unread" in one buffer and then switching to another used to run the
+// new buffer's jump unrequested — overriding its fresh scroll-to-bottom, or
+// tripping an unasked-for loadAround.
+function onScrollRequest(token: Readonly<Ref<number>>, run: () => void): void {
+  let seen = { key: paneKey.value, token: token.value };
+  watch([paneKey, token], () => {
+    const now = { key: paneKey.value, token: token.value };
+    const requested = now.key === seen.key && now.token > seen.token;
+    seen = now;
+    if (requested) run();
+  });
+}
+
 // StatusBar's "Return to present ↓" click increments scrollToBottomToken.
 // Watching the token (rather than wiring a callback) keeps the composable
 // stateless and avoids leaking refs to MessageList's DOM out of the component.
-watch(scrollToBottomToken, async () => {
+onScrollRequest(scrollToBottomToken, async () => {
   await nextTick();
   stickToBottom.value = true;
   setStuckToBottom(true);
@@ -2017,7 +2038,7 @@ function scrollDividerIntoView() {
 // the history pager, and stalls before reaching the seam (issue #216). In that
 // case fetch a slice centered on the boundary first — the same loadAround path
 // jump-to-message uses — then center the real divider once it lands.
-watch(scrollToUnreadToken, async () => {
+onScrollRequest(scrollToUnreadToken, async () => {
   await nextTick();
   if (!scroller.value) return;
   const buf = buffer.value;

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -343,13 +343,8 @@ import { useRelayBotsStore } from '../stores/relayBots.js';
 import { socketSend } from '../composables/useSocket.js';
 import { useNickColors } from '../composables/useNickColors.js';
 import { useViewport } from '../composables/useViewport.js';
-import {
-  setStuckToBottom,
-  bumpNewBelow,
-  resetScrollState,
-  setUnreadAnchor,
-  useScrollState,
-} from '../composables/useScrollState.js';
+import { useScrollState } from '../composables/useScrollState.js';
+import { useBufferKey } from '../composables/useActiveBuffer.js';
 import type { RenderSegment } from '../utils/nickColor.js';
 import {
   formatTimestamp,
@@ -382,7 +377,7 @@ import type { MemberContext, MemberLike } from '../composables/useMemberActions.
 import { useContextMenu, type ContextMenuItem } from '../composables/useContextMenu.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { addressNick } from '../composables/useComposerOverlay.js';
-import { setViewedBuffer } from '../composables/useViewedBuffer.js';
+import { retainViewedBuffer, releaseViewedBuffer } from '../composables/useViewedBuffer.js';
 import { isChannelTarget } from '../../../shared/channels.js';
 
 // Extended BufferMessage fields accessed in the template and script
@@ -508,7 +503,18 @@ const tsFormat = computed(() =>
 
 const scroller = ref<HTMLElement | null>(null);
 const stickToBottom = ref(true);
-const { scrollToBottomToken, scrollToUnreadToken } = useScrollState();
+// Which buffer this list renders: the pane's, or the global active buffer when
+// this list isn't inside a pane. Everything below keys off `paneKey`, never
+// networks.activeKey directly, so N lists can be alive at once.
+const paneKey = useBufferKey();
+const {
+  scrollToBottomToken,
+  scrollToUnreadToken,
+  setStuckToBottom,
+  bumpNewBelow,
+  reset: resetScrollState,
+  setUnreadAnchor,
+} = useScrollState();
 
 // Unread-divider visibility tracking. The divider is pinned for the whole
 // visit (dividerAfterId snapshot). The "Jump to unread" button exists to catch
@@ -600,7 +606,7 @@ function setUnreadDividerEl(el: Element | ComponentPublicInstance | null): void 
   else if (!next) setUnreadAnchor(null);
 }
 
-const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
+const buffer = computed(() => (paneKey.value ? buffers.byKey(paneKey.value) : null));
 const messages = computed(() => buffer.value?.messages || []);
 
 // "Loading messages…" vs "No messages yet.": an empty list whose buffer is
@@ -1950,12 +1956,14 @@ watch(
 );
 
 // immediate: true handles the mobile case where MessageList is v-if'd out
-// until the user taps a buffer — by the time we mount, activeKey is already
-// set, so a plain (lazy) watcher would never see it change. The first
+// until the user taps a buffer — by the time we mount, the buffer key is
+// already set, so a plain (lazy) watcher would never see it change. The first
 // nextTick after setup resolves after the initial render, so scroller.value
-// is populated by the time scrollToBottom runs.
+// is populated by the time scrollToBottom runs. Inside a windowed pane the key
+// never changes, so this fires once at mount and the resets are the pane's
+// entry scroll.
 watch(
-  () => networks.activeKey,
+  paneKey,
   async () => {
     stickToBottom.value = true;
     unreadSeen = false;
@@ -2023,7 +2031,7 @@ watch(scrollToUnreadToken, async () => {
   if (dividerPinnedToTop && buf.networkId != null && buf.hasMoreOlder && !buf.loadingHistory) {
     stickToBottom.value = false;
     setStuckToBottom(false);
-    const wantKey = networks.activeKey;
+    const wantKey = paneKey.value;
     buffers.loadAround(buf.networkId, buf.target, dividerAfterId);
     // loadAround rolls loadingHistory back to false synchronously if the send
     // failed (offline) — nothing will land to drive the scroll, and there's no
@@ -2044,7 +2052,7 @@ watch(scrollToUnreadToken, async () => {
         stop();
         // Bail if the user switched buffers while the slice was in flight —
         // the scroller now belongs to a different buffer.
-        if (networks.activeKey !== wantKey) return;
+        if (paneKey.value !== wantKey) return;
         await nextTick();
         scrollDividerIntoView();
       },
@@ -2076,11 +2084,18 @@ function onScrollerResize() {
 // "looking at this buffer" apart from networks.activeKey's looser "last-opened
 // buffer" (see useHighlightNotifier.shouldNotifyInApp). This component mounts
 // only while a buffer's messages are actually rendered, so its lifecycle is
-// the signal: follow activeKey while mounted, clear on unmount (Settings
-// route, mobile list/members screen, system console).
+// the signal: retain our buffer while mounted, release on unmount (Settings
+// route, mobile list/members screen, system console, closed window).
+//
+// Refcounted rather than a single "the viewed buffer" slot, because with
+// windowed panes several message lists are mounted at once and each is looking
+// at a buffer of its own.
 watch(
-  () => networks.activeKey,
-  (key) => setViewedBuffer(key),
+  paneKey,
+  (key, prev) => {
+    if (prev) releaseViewedBuffer(prev);
+    retainViewedBuffer(key);
+  },
   { immediate: true },
 );
 
@@ -2113,7 +2128,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-  setViewedBuffer(null);
+  releaseViewedBuffer(paneKey.value);
   if (scrollerObserver) {
     scrollerObserver.disconnect();
     scrollerObserver = null;

--- a/vue_client/src/components/NickRef.vue
+++ b/vue_client/src/components/NickRef.vue
@@ -15,6 +15,7 @@ import { computed } from 'vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useNickColors } from '../composables/useNickColors.js';
+import { useBufferKey } from '../composables/useActiveBuffer.js';
 import { prefixOf } from '../utils/memberPrefix.js';
 
 const props = defineProps<{
@@ -34,12 +35,18 @@ const props = defineProps<{
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
 const nicks = useNickColors();
+const paneKey = useBufferKey();
 
 const glyph = computed(() => (props.showPrefix ? prefixOf(props.modes) : ''));
 const glyphClass = computed(() => `mode-${glyph.value}`);
 
+// "Am I this nick" is a question about the buffer this row is IN, not about the
+// app's active buffer — a NickRef renders once per message, in whichever pane
+// owns it. Reading activeKey left a pane on another network resolving self
+// against the focused pane's nick: own lines uncoloured, and an unrelated user
+// who happens to share that nick coloured as self.
 const selfLower = computed(() => {
-  const key = networks.activeKey;
+  const key = paneKey.value;
   if (!key) return null;
   const buf = buffers.byKey(key);
   const sn = buf && buf.networkId != null ? networks.states[buf.networkId]?.nick : null;

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -141,11 +141,8 @@ import { useUploadsStore } from '../stores/uploads.js';
 import { useIgnoresStore } from '../stores/ignores.js';
 import { useAuthStore } from '../stores/auth.js';
 import { useNickColors } from '../composables/useNickColors.js';
-import {
-  useScrollState,
-  requestScrollToBottom,
-  requestScrollToUnread,
-} from '../composables/useScrollState.js';
+import { useScrollState } from '../composables/useScrollState.js';
+import { useBufferKey } from '../composables/useActiveBuffer.js';
 import { useComposing } from '../composables/useComposing.js';
 import { formatTimestamp } from '../utils/timestamp.js';
 import { isPeerOffline, isPeerAway } from '../utils/peerPresence.js';
@@ -239,10 +236,12 @@ const uploadLabel = computed(() => {
   }
   return '';
 });
-const { newBelow, stuckToBottom, unreadAnchor } = useScrollState();
+const { newBelow, stuckToBottom, unreadAnchor, requestScrollToBottom, requestScrollToUnread } =
+  useScrollState();
 
-const active = computed(() => networks.activeBuffer);
-const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
+const paneKey = useBufferKey();
+const active = computed(() => networks.bufferFor(paneKey.value));
+const buffer = computed(() => (paneKey.value ? buffers.byKey(paneKey.value) : null));
 const isServerBuffer = computed(() => !!active.value?.target?.startsWith(':server:'));
 const sendable = computed(() => !!active.value && !isServerBuffer.value && !auth.isPaused);
 const showFormatButton = computed(() => settings.effective('input.show_format_button') === true);

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -98,7 +98,7 @@
          (which owns the textarea) and StatusBar (which renders the popover)
          stay decoupled. -->
     <SuggestionStrip
-      v-show="overlay.nickOpen"
+      v-show="isFocusedPane && overlay.nickOpen"
       :items="overlay.nickItems"
       :key-for="nickKeyFor"
       :active-index="overlay.nickActiveIndex"
@@ -110,7 +110,7 @@
       </template>
     </SuggestionStrip>
     <SuggestionStrip
-      v-show="overlay.emojiOpen"
+      v-show="isFocusedPane && overlay.emojiOpen"
       :items="overlay.emojiItems"
       :key-for="emojiKeyFor"
       :active-index="overlay.emojiActiveIndex"
@@ -123,7 +123,7 @@
       </template>
     </SuggestionStrip>
     <MircColorPicker
-      v-if="overlay.colorPickerOpen"
+      v-if="isFocusedPane && overlay.colorPickerOpen"
       :open="overlay.colorPickerOpen"
       @apply="applyColor"
       @reset="resetColor"
@@ -187,6 +187,14 @@ const auth = useAuthStore();
 const nickColors = useNickColors();
 const composing = useComposing();
 
+// Is this the pane the user is typing in? The composing chip and the composer
+// overlays are module-level singletons describing ONE draft, and a split frame
+// renders a status bar per pane — so without this the pane being typed in
+// painted its SPLIT/FLOOD chip and its suggestion strip across all four bars.
+// activeKey follows pane focus, so exactly one bar answers true; with one pane
+// (and on mobile) it is always true.
+const isFocusedPane = computed(() => paneKey.value === networks.activeKey);
+
 // SPLIT at 2 chunks, FLOOD (n) at 3+. Lives just before the typing indicator so
 // heavy composers can see it without taking their eyes off the input. Empty /
 // single-chunk drafts render nothing. On a multiline network `composing.chunks`
@@ -194,6 +202,7 @@ const composing = useComposing();
 // 2+ → MULTILINE ×N. (#381) The label always states what will happen; see
 // splitClass below for when that's coloured as a warning.
 const splitLabel = computed(() => {
+  if (!isFocusedPane.value) return '';
   if (composing.multiline) {
     return composing.chunks <= 1 ? 'MULTILINE' : `MULTILINE ×${composing.chunks}`;
   }
@@ -206,6 +215,7 @@ const splitLabel = computed(() => {
 // neutral count rather than crying wolf in warn/bad on every long message
 // (#578). An overlong /me is still bad: actions never split, they're refused.
 const splitClass = computed(() => {
+  if (!isFocusedPane.value) return '';
   if (composing.multiline) {
     if (composing.chunks <= 1) return '';
     if (settings.effective('chat.allow_split_messages')) return '';

--- a/vue_client/src/composables/useActiveBuffer.ts
+++ b/vue_client/src/composables/useActiveBuffer.ts
@@ -1,15 +1,42 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import type { ComputedRef, Ref } from 'vue';
-import { computed } from 'vue';
+import type { ComputedRef, InjectionKey, Ref } from 'vue';
+import { computed, inject, provide } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { SYSTEM_KEY, virtualConfig } from '../lib/virtualBuffers.js';
 import { isChannelTarget } from '../../../shared/channels.js';
 
+// Which buffer the surrounding subtree is rendering.
+//
+// The app has always had exactly one buffer on screen, so MessageList,
+// MemberList, StatusBar and MessageInput each reached up and read
+// `networks.activeKey` directly. That coupling is what makes them singletons.
+// A BufferPane provides its own key here instead, and those components resolve
+// "my buffer" through `useBufferKey()` — which falls back to the global
+// activeKey when nothing is provided. So an un-provided subtree behaves exactly
+// as it did before, and a windowed one renders whatever its pane says.
+export const BUFFER_KEY: InjectionKey<Ref<string | null>> = Symbol('lurker:buffer-key');
+
+// Call from a component that owns a buffer's subtree (BufferPane). Pass a ref
+// so the pane can repoint at another buffer without remounting the subtree.
+export function provideBufferKey(key: Ref<string | null>): void {
+  provide(BUFFER_KEY, key);
+}
+
+// The buffer key for this subtree: the provided one, or the global active
+// buffer when this component isn't inside a pane. Must be called from setup().
+export function useBufferKey(): Ref<string | null> {
+  const provided = inject(BUFFER_KEY, null);
+  if (provided) return provided;
+  return storeToRefs(useNetworksStore()).activeKey;
+}
+
 export interface ActiveBufferState {
+  // Named `activeKey` for historical reasons — inside a BufferPane this is the
+  // pane's buffer, which is only *the* active buffer when the pane is focused.
   activeKey: Ref<string | null>;
   active: ComputedRef<{ networkId: number; target: string; network: unknown } | null>;
   activeBuf: ComputedRef<unknown>;
@@ -29,9 +56,9 @@ export interface ActiveBufferState {
 export function useActiveBuffer(): ActiveBufferState {
   const networks = useNetworksStore();
   const buffers = useBuffersStore();
-  const { activeKey } = storeToRefs(networks);
+  const activeKey = useBufferKey();
 
-  const active = computed(() => networks.activeBuffer);
+  const active = computed(() => networks.bufferFor(activeKey.value));
   const virtualCfg = computed(() => virtualConfig(activeKey.value));
   const isVirtual = computed(() => virtualCfg.value != null);
   const isSystemBuffer = computed(() => activeKey.value === SYSTEM_KEY);

--- a/vue_client/src/composables/useActiveBuffer.ts
+++ b/vue_client/src/composables/useActiveBuffer.ts
@@ -17,7 +17,7 @@ import { isChannelTarget } from '../../../shared/channels.js';
 // A BufferPane provides its own key here instead, and those components resolve
 // "my buffer" through `useBufferKey()` — which falls back to the global
 // activeKey when nothing is provided. So an un-provided subtree behaves exactly
-// as it did before, and a windowed one renders whatever its pane says.
+// as it did before, and a split pane renders whatever its pane says.
 export const BUFFER_KEY: InjectionKey<Ref<string | null>> = Symbol('lurker:buffer-key');
 
 // Call from a component that owns a buffer's subtree (BufferPane). Pass a ref
@@ -53,10 +53,15 @@ export interface ActiveBufferState {
   hasNicklist: ComputedRef<boolean>;
 }
 
-export function useActiveBuffer(): ActiveBufferState {
+// `key` names the buffer to describe. A BufferPane MUST pass its own key
+// explicitly: inject() resolves against the PARENT's provides, so a pane asking
+// for the injected key would get the global activeKey rather than the one it
+// just provided to its own subtree. Everything below the pane omits it and gets
+// the provided key, and everything outside a pane omits it and gets activeKey.
+export function useActiveBuffer(key?: Ref<string | null>): ActiveBufferState {
   const networks = useNetworksStore();
   const buffers = useBuffersStore();
-  const activeKey = useBufferKey();
+  const activeKey = key ?? useBufferKey();
 
   const active = computed(() => networks.bufferFor(activeKey.value));
   const virtualCfg = computed(() => virtualConfig(activeKey.value));

--- a/vue_client/src/composables/useHighlightNotifier.test.ts
+++ b/vue_client/src/composables/useHighlightNotifier.test.ts
@@ -15,11 +15,12 @@ import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vite
 let push: Mock<(t: unknown) => void>;
 let effective: Mock<(key: string) => unknown>;
 
-// Load a fresh notifyForEvent with the stores it reads mocked. `viewed` is the
-// buffer key currently on screen (default '' so the event's buffer is never the
-// viewed one); `hidden` models a background tab; `enabled` toggles the per-kind
-// master switch. Sound is forced off so no Audio is constructed.
-async function load(opts: { viewed?: string; hidden?: boolean; enabled?: boolean } = {}) {
+// Load a fresh notifyForEvent with the stores it reads mocked. `viewed` lists
+// the buffer keys on screen — a list, not one key, because a split layout puts
+// several message lists up at once (default empty, so the event's buffer is
+// never a viewed one); `hidden` models a background tab; `enabled` toggles the
+// per-kind master switch. Sound is forced off so no Audio is constructed.
+async function load(opts: { viewed?: string[]; hidden?: boolean; enabled?: boolean } = {}) {
   vi.resetModules();
   push = vi.fn<(t: unknown) => void>();
   effective = vi.fn<(key: string) => unknown>((key: string) => {
@@ -32,7 +33,9 @@ async function load(opts: { viewed?: string; hidden?: boolean; enabled?: boolean
   vi.doMock('../stores/networks.js', () => ({
     useNetworksStore: () => ({ networkById: () => ({ name: 'libera' }) }),
   }));
-  vi.doMock('./useViewedBuffer.js', () => ({ viewedBuffer: () => opts.viewed ?? '' }));
+  vi.doMock('./useViewedBuffer.js', () => ({
+    isBufferViewed: (key: string) => (opts.viewed ?? []).includes(key),
+  }));
   vi.stubGlobal('document', { hidden: opts.hidden ?? false });
   return import('./useHighlightNotifier.js');
 }
@@ -96,9 +99,25 @@ describe('notifyForEvent notify gate', () => {
   });
 
   it('does not toast when viewing the event’s own buffer', async () => {
-    const { notifyForEvent } = await load({ viewed: '1::bob' });
+    const { notifyForEvent } = await load({ viewed: ['1::bob'] });
     notifyForEvent(dm());
     expect(push).not.toHaveBeenCalled();
+  });
+
+  // Split view: the event's buffer is one of several on screen, not the only
+  // one. Suppression asks "can the user see it right now", so a second pane
+  // showing something else must not turn the toast back on.
+  it('does not toast when the event’s buffer is one of several on screen', async () => {
+    const { notifyForEvent } = await load({ viewed: ['1::#ops', '1::bob'] });
+    notifyForEvent(dm());
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  // The converse: panes are open, but none of them is the event's buffer.
+  it('toasts when the open panes do not include the event’s buffer', async () => {
+    const { notifyForEvent } = await load({ viewed: ['1::#ops', '1::#dev'] });
+    notifyForEvent(dm());
+    expect(push).toHaveBeenCalled();
   });
 
   it('respects the per-kind enabled toggle even when notify is true', async () => {

--- a/vue_client/src/composables/useHighlightNotifier.ts
+++ b/vue_client/src/composables/useHighlightNotifier.ts
@@ -18,7 +18,7 @@
 import { useToastsStore, type ToastKind } from '../stores/toasts.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useNetworksStore } from '../stores/networks.js';
-import { viewedBuffer } from './useViewedBuffer.js';
+import { isBufferViewed } from './useViewedBuffer.js';
 import { META_SEPARATOR } from '../utils/metaLine.js';
 import { stripFormatting } from '../../../shared/textMatch.js';
 
@@ -103,14 +103,16 @@ function throttled(event: NotifyEvent, kind: ToastKind): boolean {
 //     and a toast would be redundant (issue #50) — Discord and Slack mute the
 //     focused channel the same way.
 //
-// "Viewed buffer" is viewedBuffer(), owned by MessageList — NOT networks
-// .activeKey. activeKey only tracks the last-opened buffer and lingers across
-// route / mobile-screen changes, so keying off it would wrongly suppress a
-// toast while the user sits on the Settings route or the mobile buffer list,
-// where no message list is mounted.
+// "Viewed buffer" is the isBufferViewed() set, owned by MessageList — NOT
+// networks.activeKey. activeKey only tracks the last-opened buffer and lingers
+// across route / mobile-screen changes, so keying off it would wrongly suppress
+// a toast while the user sits on the Settings route or the mobile buffer list,
+// where no message list is mounted. With windowed panes the set holds every
+// buffer on screen, so a highlight in any visible window is suppressed — not
+// just the focused one.
 function shouldNotifyInApp(event: NotifyEvent): boolean {
   if (typeof document === 'undefined' || document.hidden) return false;
-  return viewedBuffer() !== `${event.networkId}::${event.target}`;
+  return !isBufferViewed(`${event.networkId}::${event.target}`);
 }
 
 export function notifyForEvent(event: NotifyEvent | null | undefined): void {

--- a/vue_client/src/composables/usePaneRegistry.test.ts
+++ b/vue_client/src/composables/usePaneRegistry.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  paneFor,
+  registerPane,
+  resetPanes,
+  unregisterPane,
+  type PaneApi,
+} from './usePaneRegistry.js';
+
+function api(): PaneApi {
+  return { focusInput: vi.fn<() => void>(), scrollByPage: vi.fn<() => void>() };
+}
+
+beforeEach(resetPanes);
+
+describe('pane registry', () => {
+  it('hands back the pane registered for a buffer', () => {
+    const a = api();
+    registerPane('1::#a', a);
+    expect(paneFor('1::#a')).toBe(a);
+    expect(paneFor('1::#b')).toBeNull();
+  });
+
+  // The shortcuts ask for the FOCUSED buffer's pane, and that key is null
+  // before anything is active.
+  it('reports null for no buffer', () => {
+    expect(paneFor(null)).toBeNull();
+  });
+
+  it('drops a pane on unregister', () => {
+    const a = api();
+    registerPane('1::#a', a);
+    unregisterPane('1::#a', a);
+    expect(paneFor('1::#a')).toBeNull();
+  });
+
+  // A pane repoints at another buffer without remounting, so it registers under
+  // the new key and then releases the old one. Releasing by key alone would let
+  // that teardown delete a registration it no longer owns — and if the two keys
+  // ever coincide, blind deletion drops the LIVE pane and the shortcuts stop
+  // reaching it.
+  it('ignores an unregister from a handle that no longer owns the key', () => {
+    const live = api();
+    const stale = api();
+    registerPane('1::#a', live);
+
+    unregisterPane('1::#a', stale);
+    expect(paneFor('1::#a')).toBe(live);
+  });
+
+  it('lets a repointed pane keep only its new key', () => {
+    const pane = api();
+    registerPane('1::#a', pane);
+
+    // BufferPane's watcher releases the old key then claims the new one. The
+    // identity guard above is what makes that order a free choice rather than a
+    // constraint, so assert the outcome, not the sequence.
+    unregisterPane('1::#a', pane);
+    registerPane('1::#b', pane);
+
+    expect(paneFor('1::#a')).toBeNull();
+    expect(paneFor('1::#b')).toBe(pane);
+  });
+
+  it('clears every pane on reset', () => {
+    registerPane('1::#a', api());
+    registerPane('1::#b', api());
+    resetPanes();
+    expect(paneFor('1::#a')).toBeNull();
+    expect(paneFor('1::#b')).toBeNull();
+  });
+});

--- a/vue_client/src/composables/usePaneRegistry.ts
+++ b/vue_client/src/composables/usePaneRegistry.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Imperative handles onto the mounted BufferPanes, keyed by buffer.
+//
+// The keyboard shortcuts (type-ahead focus, PageUp/PageDown) and the
+// click-anywhere-to-focus-the-input behavior have to reach *a* pane's input and
+// message list. With one pane that was a template ref in DesktopChat. With
+// several, "which pane" is a question with an answer — the focused one — so the
+// shell looks the pane up by the active buffer key instead of holding a ref.
+//
+// A pane registers on mount and unregisters on unmount. Two panes can't show
+// the same buffer (the splits store focuses the existing pane rather than
+// opening a second), so the key is unique across mounted panes.
+export interface PaneApi {
+  focusInput: () => void;
+  scrollByPage: (dir: number) => void;
+}
+
+const panes = new Map<string, PaneApi>();
+
+export function registerPane(key: string | null, api: PaneApi): void {
+  if (key) panes.set(key, api);
+}
+
+export function unregisterPane(key: string | null, api: PaneApi): void {
+  // Identity-checked so a pane that repointed at another buffer (registering
+  // under the new key) doesn't have that registration deleted by the teardown
+  // of the key it used to hold.
+  if (key && panes.get(key) === api) panes.delete(key);
+}
+
+export function paneFor(key: string | null): PaneApi | null {
+  return key ? (panes.get(key) ?? null) : null;
+}
+
+export function resetPanes(): void {
+  panes.clear();
+}

--- a/vue_client/src/composables/useScrollState.ts
+++ b/vue_client/src/composables/useScrollState.ts
@@ -1,8 +1,9 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import type { Ref } from 'vue';
-import { ref } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import { computed, ref } from 'vue';
+import { useBufferKey } from './useActiveBuffer.js';
 
 // Direction from the viewport to the pinned unread divider when it's off
 // screen and not yet seen this visit: 'up' = above the viewport, 'down' =
@@ -10,15 +11,13 @@ import { ref } from 'vue';
 // screen, or the user already scrolled it into view this visit.
 export type UnreadAnchor = 'up' | 'down' | null;
 
-// Bridges MessageList's scroll position into the StatusBar without a prop drill.
-// MessageList writes via the setters; StatusBar reads the refs.
-const stuckToBottom = ref(true);
-const newBelow = ref(0);
-const scrollToBottomToken = ref(0);
-const unreadAnchor = ref<UnreadAnchor>(null);
-const scrollToUnreadToken = ref(0);
-
-export interface ScrollState {
+// Bridges a MessageList's scroll position into the StatusBar sitting beneath
+// it, without a prop drill: MessageList writes via the setters, StatusBar reads
+// the refs. Both live inside the same BufferPane, so the bridge is keyed by
+// buffer — with several panes on screen each one's "N new ↓" and stick-to-bottom
+// belong to its own buffer, and a scrolled-up window must not tell a pinned
+// window's status bar that it's scrolled up.
+interface Entry {
   stuckToBottom: Ref<boolean>;
   newBelow: Ref<number>;
   scrollToBottomToken: Ref<number>;
@@ -26,33 +25,85 @@ export interface ScrollState {
   scrollToUnreadToken: Ref<number>;
 }
 
+// Keyed by buffer key. The empty string stands in for "no buffer" so callers
+// never have to null-check an entry. Entries are a handful of refs each and are
+// bounded by the number of buffers ever opened this session; the whole map is
+// dropped on session reset (logout).
+const entries = new Map<string, Entry>();
+const NO_BUFFER = '';
+
+function entryFor(key: string | null): Entry {
+  const k = key ?? NO_BUFFER;
+  let entry = entries.get(k);
+  if (!entry) {
+    entry = {
+      stuckToBottom: ref(true),
+      newBelow: ref(0),
+      scrollToBottomToken: ref(0),
+      unreadAnchor: ref<UnreadAnchor>(null),
+      scrollToUnreadToken: ref(0),
+    };
+    entries.set(k, entry);
+  }
+  return entry;
+}
+
+export interface ScrollState {
+  stuckToBottom: ComputedRef<boolean>;
+  newBelow: ComputedRef<number>;
+  scrollToBottomToken: ComputedRef<number>;
+  unreadAnchor: ComputedRef<UnreadAnchor>;
+  scrollToUnreadToken: ComputedRef<number>;
+  setStuckToBottom: (v: boolean) => void;
+  bumpNewBelow: () => void;
+  reset: () => void;
+  requestScrollToBottom: () => void;
+  setUnreadAnchor: (dir: UnreadAnchor) => void;
+  requestScrollToUnread: () => void;
+}
+
+// Scroll state for this subtree's buffer. Must be called from setup(): it reads
+// the injected buffer key, falling back to the global active buffer.
 export function useScrollState(): ScrollState {
-  return { stuckToBottom, newBelow, scrollToBottomToken, unreadAnchor, scrollToUnreadToken };
+  const bufferKey = useBufferKey();
+  const entry = () => entryFor(bufferKey.value);
+
+  return {
+    stuckToBottom: computed(() => entry().stuckToBottom.value),
+    newBelow: computed(() => entry().newBelow.value),
+    scrollToBottomToken: computed(() => entry().scrollToBottomToken.value),
+    unreadAnchor: computed(() => entry().unreadAnchor.value),
+    scrollToUnreadToken: computed(() => entry().scrollToUnreadToken.value),
+
+    setStuckToBottom(v: boolean) {
+      const e = entry();
+      e.stuckToBottom.value = !!v;
+      if (v) e.newBelow.value = 0;
+    },
+    bumpNewBelow() {
+      const e = entry();
+      if (!e.stuckToBottom.value) e.newBelow.value += 1;
+    },
+    reset() {
+      const e = entry();
+      e.stuckToBottom.value = true;
+      e.newBelow.value = 0;
+      e.unreadAnchor.value = null;
+    },
+    requestScrollToBottom() {
+      entry().scrollToBottomToken.value += 1;
+    },
+    setUnreadAnchor(dir: UnreadAnchor) {
+      entry().unreadAnchor.value = dir;
+    },
+    requestScrollToUnread() {
+      entry().scrollToUnreadToken.value += 1;
+    },
+  };
 }
 
-export function setStuckToBottom(v: boolean): void {
-  stuckToBottom.value = !!v;
-  if (v) newBelow.value = 0;
-}
-
-export function bumpNewBelow(): void {
-  if (!stuckToBottom.value) newBelow.value += 1;
-}
-
-export function resetScrollState(): void {
-  stuckToBottom.value = true;
-  newBelow.value = 0;
-  unreadAnchor.value = null;
-}
-
-export function requestScrollToBottom(): void {
-  scrollToBottomToken.value += 1;
-}
-
-export function setUnreadAnchor(dir: UnreadAnchor): void {
-  unreadAnchor.value = dir;
-}
-
-export function requestScrollToUnread(): void {
-  scrollToUnreadToken.value += 1;
+// Drop every buffer's scroll state. Called on session reset (logout), where the
+// buffers themselves are also going away.
+export function resetAllScrollState(): void {
+  entries.clear();
 }

--- a/vue_client/src/composables/useSelfLabel.ts
+++ b/vue_client/src/composables/useSelfLabel.ts
@@ -5,6 +5,7 @@ import type { ComputedRef } from 'vue';
 import { computed } from 'vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
+import { useBufferKey } from './useActiveBuffer.js';
 import { prefixOf } from '../utils/memberPrefix.js';
 import { isChannelTarget } from '../../../shared/channels.js';
 
@@ -22,14 +23,20 @@ export interface SelfLabelState {
 // mode suffix (issue #415). Plus a separate away label like "(brb)" when /away
 // is set.
 //
-// The channel-prefix is the user's own op/voice marker derived from the
-// active channel's member list. For DMs / server buffers it's empty.
+// The channel-prefix is the user's own op/voice marker derived from THIS
+// buffer's member list. For DMs / server buffers it's empty.
+//
+// Resolved through useBufferKey(), not networks.activeKey: the prompt renders
+// once per composer, and a composer belongs to a pane. Two panes on different
+// networks would otherwise both show the focused pane's nick — and its channel
+// op marker, so a DM's prompt could wear an `@` borrowed from another channel.
 export function useSelfLabel(): SelfLabelState {
   const networks = useNetworksStore();
   const buffers = useBuffersStore();
+  const paneKey = useBufferKey();
 
-  const active = computed(() => networks.activeBuffer);
-  const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
+  const active = computed(() => networks.bufferFor(paneKey.value));
+  const buffer = computed(() => (paneKey.value ? buffers.byKey(paneKey.value) : null));
 
   const channelPrefix = computed(() => {
     const buf = buffer.value;

--- a/vue_client/src/composables/useSessionReset.ts
+++ b/vue_client/src/composables/useSessionReset.ts
@@ -17,7 +17,8 @@ import { useFavoritesStore } from '../stores/favorites.js';
 import { useNetworkPresetsStore } from '../stores/networkPresets.js';
 import { resetSocket } from './useSocket.js';
 import { resetPresence } from './usePresence.js';
-import { resetScrollState } from './useScrollState.js';
+import { resetAllScrollState } from './useScrollState.js';
+import { resetViewedBuffers } from './useViewedBuffer.js';
 import { resetOnboarding } from './useOnboarding.js';
 import { clearAppBadgeNow } from './useAppBadge.js';
 
@@ -54,7 +55,8 @@ export function resetSession(): void {
   // response fetched under someone else's session.
   useNetworkPresetsStore().$reset();
   resetPresence();
-  resetScrollState();
+  resetAllScrollState();
+  resetViewedBuffers();
   // Closing the first-run flow unmounts it, which is what drops the half-filled
   // form (nick, SASL password) with it — the next user re-evaluates from scratch.
   resetOnboarding();

--- a/vue_client/src/composables/useSessionReset.ts
+++ b/vue_client/src/composables/useSessionReset.ts
@@ -20,6 +20,7 @@ import { resetSocket } from './useSocket.js';
 import { resetPresence } from './usePresence.js';
 import { resetAllScrollState } from './useScrollState.js';
 import { resetViewedBuffers } from './useViewedBuffer.js';
+import { resetPanes } from './usePaneRegistry.js';
 import { resetOnboarding } from './useOnboarding.js';
 import { clearAppBadgeNow } from './useAppBadge.js';
 
@@ -63,6 +64,11 @@ export function resetSession(): void {
   resetPresence();
   resetAllScrollState();
   resetViewedBuffers();
+  // Module-level Map of pane handles, like the two above — not Pinia state, so
+  // $reset() doesn't reach it. Panes unmount on logout and deregister
+  // themselves, but clear it explicitly so a handle can't outlive the session
+  // if teardown order ever changes.
+  resetPanes();
   // Closing the first-run flow unmounts it, which is what drops the half-filled
   // form (nick, SASL password) with it — the next user re-evaluates from scratch.
   resetOnboarding();

--- a/vue_client/src/composables/useSessionReset.ts
+++ b/vue_client/src/composables/useSessionReset.ts
@@ -15,6 +15,7 @@ import { usePushSubscriptionsStore } from '../stores/pushSubscriptions.js';
 import { usePinsStore } from '../stores/pins.js';
 import { useFavoritesStore } from '../stores/favorites.js';
 import { useNetworkPresetsStore } from '../stores/networkPresets.js';
+import { useSplitsStore } from '../stores/splits.js';
 import { resetSocket } from './useSocket.js';
 import { resetPresence } from './usePresence.js';
 import { resetAllScrollState } from './useScrollState.js';
@@ -54,6 +55,11 @@ export function resetSession(): void {
   // isn't — leaving it loaded would hand the next user a picker built from a
   // response fetched under someone else's session.
   useNetworkPresetsStore().$reset();
+  // Pane layout is per-session view state — $reset() rather than the store's own
+  // reset() for the same reason every other store here uses it: the buffers this
+  // layout points at were wiped above, so there is no per-pane teardown left to
+  // run, only state to drop.
+  useSplitsStore().$reset();
   resetPresence();
   resetAllScrollState();
   resetViewedBuffers();

--- a/vue_client/src/composables/useViewedBuffer.ts
+++ b/vue_client/src/composables/useViewedBuffer.ts
@@ -1,27 +1,47 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// The buffer key (`networkId::target`) whose message list is actually
-// rendered on screen right now, or null when none is. MessageList owns it:
-// it reports its buffer while mounted and clears it on unmount — so this is
-// null whenever MessageList isn't mounted, which covers the Settings route,
-// the mobile buffer-list / members screens, and the system console.
+// The set of buffer keys (`networkId::target`) whose message lists are actually
+// rendered on screen right now. Empty when none are — which covers the Settings
+// route, the mobile buffer-list / members screens, and the system console.
+//
+// MessageList owns the registration: it retains its buffer while mounted and
+// releases on unmount. With one message list on screen this is a set of at most
+// one; with several windowed panes open it holds every buffer the user can
+// currently see, which is exactly the question toast suppression is asking.
 //
 // Deliberately NOT networks.activeKey. activeKey only tracks the last-opened
-// buffer and lingers across route and mobile-screen changes, so it still
-// reads as "in view" while the user sits on Settings or the buffer list.
-// Toast suppression keys off this instead (useHighlightNotifier
-// .shouldNotifyInApp) so a highlight in the last-opened buffer still toasts
-// while that buffer's messages aren't actually on screen.
+// buffer and lingers across route and mobile-screen changes, so it still reads
+// as "in view" while the user sits on Settings or the buffer list. Toast
+// suppression keys off this instead (useHighlightNotifier.shouldNotifyInApp) so
+// a highlight in the last-opened buffer still toasts while that buffer's
+// messages aren't actually on screen.
 //
-// A plain module variable (not a ref): the only reader, shouldNotifyInApp,
-// polls it imperatively when an event arrives — there's nothing to react to.
-let viewedBufferKey: string | null = null;
+// Refcounted rather than a plain Set: two panes may show the same buffer (or a
+// pane may remount across a key change while the old one is still tearing
+// down), and the first release must not blind the survivor. Plain module state,
+// not a ref — the only reader, shouldNotifyInApp, polls it imperatively when an
+// event arrives, so there's nothing to react to.
+const viewers = new Map<string, number>();
 
-export function setViewedBuffer(key: string | null): void {
-  viewedBufferKey = key;
+export function retainViewedBuffer(key: string | null): void {
+  if (!key) return;
+  viewers.set(key, (viewers.get(key) ?? 0) + 1);
 }
 
-export function viewedBuffer(): string | null {
-  return viewedBufferKey;
+export function releaseViewedBuffer(key: string | null): void {
+  if (!key) return;
+  const next = (viewers.get(key) ?? 0) - 1;
+  if (next > 0) viewers.set(key, next);
+  else viewers.delete(key);
+}
+
+export function isBufferViewed(key: string): boolean {
+  return viewers.has(key);
+}
+
+// Session reset (logout) tears every message list down anyway; drop the map so
+// a stale key can't suppress a toast for the next user.
+export function resetViewedBuffers(): void {
+  viewers.clear();
 }

--- a/vue_client/src/lib/bufferLifecycle.ts
+++ b/vue_client/src/lib/bufferLifecycle.ts
@@ -28,6 +28,7 @@ import { usePinsStore } from '../stores/pins.js';
 import { useFavoritesStore } from '../stores/favorites.js';
 import { useNicklistCollapseStore } from '../stores/nicklistCollapse.js';
 import { useChannelNotifyStore } from '../stores/channelNotify.js';
+import { useSplitsStore } from '../stores/splits.js';
 
 export interface BufferLifecycleParticipant {
   /** Remove every trace of (networkId, target) from this store. */
@@ -52,6 +53,8 @@ const participants: Array<() => BufferLifecycleParticipant> = [
   () => useFavoritesStore(),
   () => useNicklistCollapseStore(),
   () => useChannelNotifyStore(),
+  // Which buffers the desktop frame has open in panes.
+  () => useSplitsStore(),
 ];
 
 // Most participants key exact `${networkId}::${target}` strings, but the

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -33,6 +33,7 @@ vi.mock('../composables/useSocket.js', () => ({
 import { useBuffersStore, bufferNeedsHydration, windowAroundAnchor } from './buffers.js';
 import { useSettingsStore } from './settings.js';
 import { socketSend } from '../composables/useSocket.js';
+import { retainViewedBuffer, resetViewedBuffers } from '../composables/useViewedBuffer.js';
 
 // The store always seeds the app-scoped system buffer (#355). These tests assert
 // on network-buffer counts (fork/removal semantics), so filter it out.
@@ -42,6 +43,9 @@ const netBuffers = (store: ReturnType<typeof useBuffersStore>) =>
 beforeEach(() => {
   setActivePinia(createPinia());
   h.activeKey = null;
+  // Module state like h.activeKey above: the set of buffers with a message list
+  // on screen, which live read-sync now consults.
+  resetViewedBuffers();
   vi.mocked(socketSend).mockClear();
 });
 
@@ -1286,5 +1290,61 @@ describe('applyAroundSlice — the anchor survives the ring', () => {
     expect(ids.indexOf(250528)).toBeGreaterThan(100);
     expect(buf.hasMoreOlder).toBe(true);
     expect(buf.hasMoreNewer).toBe(true);
+  });
+});
+
+// A split frame puts several buffers on screen at once, so "the user is sitting
+// in this buffer" stopped meaning "this is THE active buffer". Live read-sync
+// asks the viewed set — the same question toast suppression asks — so a pane
+// the user is watching can't accrue unread while its toasts are suppressed.
+describe('live read-sync follows what is on screen', () => {
+  const line = (target: string, id: number) => ({
+    networkId: 1,
+    target,
+    id,
+    type: 'message',
+    nick: 'bob',
+    body: 'x',
+  });
+
+  it('marks read in a visible pane that does not hold focus', () => {
+    const store = useBuffersStore();
+    store.pushMessage(line('#side', 1));
+    // Another pane has focus; this buffer is on screen in a second pane.
+    h.activeKey = '1::#focused';
+    retainViewedBuffer('1::#side');
+
+    store.pushMessage(line('#side', 2));
+
+    expect(store.byKey('1::#side')!.lastReadId).toBe(2);
+    expect(socketSend).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'mark-read', target: '#side', messageId: 2 }),
+    );
+  });
+
+  it('leaves a buffer that is on no screen alone', () => {
+    const store = useBuffersStore();
+    store.pushMessage(line('#off', 1));
+    h.activeKey = '1::#focused';
+
+    store.pushMessage(line('#off', 2));
+
+    expect(store.byKey('1::#off')!.lastReadId).toBe(0);
+    expect(socketSend).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'mark-read', target: '#off' }),
+    );
+  });
+
+  // The states with no message list mounted at all — the Settings route, the
+  // mobile buffer-list/members screens — have always marked read off activeKey,
+  // and still do.
+  it('still marks read for the active buffer with no message list mounted', () => {
+    const store = useBuffersStore();
+    store.pushMessage(line('#here', 1));
+    h.activeKey = '1::#here';
+
+    store.pushMessage(line('#here', 2));
+
+    expect(store.byKey('1::#here')!.lastReadId).toBe(2);
   });
 });

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -598,7 +598,21 @@ export const useBuffersStore = defineStore('buffers', {
         // `bob` while the user sits in the `Bob` buffer reads as inactive and
         // the divider/read-sync below silently skips (#327). Mirrors the same
         // resolve-then-compare applyReadState does.
-        const isActive = networks.activeKey === bufferKey(buf.networkId, buf.target);
+        // "The user is sitting in this buffer" is what this gates, and in a
+        // split frame that stopped being the same as "this is THE active
+        // buffer": a side pane is on screen and being read while another pane
+        // holds focus. Left as an activeKey test, such a pane accrued an unread
+        // badge and a growing divider and never advanced the server's read
+        // pointer — while its toasts WERE suppressed, because suppression asks
+        // the viewed set. Ask the same question here so the two halves of "can
+        // the user see this" cannot disagree.
+        //
+        // activeKey stays beside it for the states where no message list is
+        // mounted at all yet the buffer is still the active one — the Settings
+        // route and the mobile list/members screens, where this has always
+        // marked read.
+        const key = bufferKey(buf.networkId, buf.target);
+        const isActive = isBufferViewed(key) || networks.activeKey === key;
         if (isActive) {
           // While the user is sitting in this buffer, keep the divider
           // tracking the bottom UNLESS there's already an unread boundary

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -5,6 +5,7 @@ import { defineStore } from 'pinia';
 import { useNetworksStore } from './networks.js';
 import { useToastsStore } from './toasts.js';
 import { socketSend } from '../composables/useSocket.js';
+import { isBufferViewed } from '../composables/useViewedBuffer.js';
 import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
 import { historyCountBy } from '../lib/historyPaging.js';
 import { isChannelTarget } from '../../../shared/channels.js';
@@ -1436,13 +1437,46 @@ export const useBuffersStore = defineStore('buffers', {
     unclearBuffer(networkId: number | string, target: string) {
       socketSend({ type: 'unclear-buffer', networkId, target, bufferId: idFor(networkId, target) });
     },
+    // "The user stopped looking at this buffer." Drops the visit-scoped local
+    // state: the pinned unread divider, the unread/highlight counters, and any
+    // detached history slice.
+    //
+    // Split out of activate() because focus and visibility are the same thing in
+    // a single-pane shell and different things in a split one. With one pane,
+    // switching away IS stopping looking, so activate() calls this for the
+    // previous buffer. With a split, a pane you focused away from is still on
+    // screen and still being read — what means "stopped looking" there is
+    // closing that pane, so the splits store calls this itself.
+    leaveBuffer(bufKey: string) {
+      const prev = this.buffers[bufKey];
+      if (!prev) return;
+      prev.dividerAfterId = null;
+      prev.unread = 0;
+      prev.highlighted = 0;
+      prev.highlightsCapped = false;
+      // Carrying a detached slice across buffer switches gets weird fast
+      // (the user can't see the detach status on a buffer they aren't
+      // viewing, the live counter ticks invisibly, the next entry has
+      // to remember whether to render the slice or live). Drop it and
+      // wipe the slice on switch-away — re-entry then reseeds from
+      // snapshot or the next history fetch as if it were fresh.
+      if (prev.detached) this.clearDetached(prev.networkId, prev.target, { wipeMessages: true });
+    },
     // Switch to a buffer. We mark the entered buffer read on focus-IN (not
     // on focus-OUT of the previous one) so that a tab close / reload / lost
     // socket before switch-away still leaves the buffer marked read — no
     // phantom divider on the next session. The previous buffer's pointer
     // is already current because pushMessage keeps it synced live while
     // focused (see pushMessage), so leaving it just drops local state.
-    activate(networkId: number | string | null, target: string) {
+    //
+    // `retainPrevious` suppresses the leave-teardown of the outgoing buffer, for
+    // callers where focusing elsewhere doesn't mean the old buffer left the
+    // screen — i.e. a split layout, which owns that lifecycle itself.
+    activate(
+      networkId: number | string | null,
+      target: string,
+      opts: { retainPrevious?: boolean } = {},
+    ) {
       const networks = useNetworksStore();
       // Resolve to the canonical open buffer first (case-insensitive): a DM
       // activated from a member-list nick, /query, the profile modal, or a
@@ -1458,23 +1492,17 @@ export const useBuffersStore = defineStore('buffers', {
       // (networkId null) and the usual `${networkId}::${target}` otherwise.
       const newKey = bufferKey(networkId, canonTarget);
       const prevKey = networks.activeKey;
-      if (prevKey && prevKey !== newKey) {
-        const prev = this.buffers[prevKey];
-        if (prev) {
-          prev.dividerAfterId = null;
-          prev.unread = 0;
-          prev.highlighted = 0;
-          prev.highlightsCapped = false;
-          // Carrying a detached slice across buffer switches gets weird fast
-          // (the user can't see the detach status on a buffer they aren't
-          // viewing, the live counter ticks invisibly, the next entry has
-          // to remember whether to render the slice or live). Drop it and
-          // wipe the slice on switch-away — re-entry then reseeds from
-          // snapshot or the next history fetch as if it were fresh.
-          if (prev.detached)
-            this.clearDetached(prev.networkId, prev.target, { wipeMessages: true });
-        }
-      }
+      // Activating a buffer that is ALREADY rendered on screen is a focus
+      // change, not a switch — so the outgoing buffer hasn't gone anywhere and
+      // must keep its divider and counters. That case only exists in a split
+      // layout (focus pane B while pane A stays up), and it arrives through the
+      // paths the splits store doesn't own: the quick switcher, /query, a
+      // jump-to-message, a deep link. With one pane the only on-screen buffer
+      // IS the active one, so this never fires — prevKey === newKey is already
+      // excluded on the next line.
+      const focusingVisiblePane = isBufferViewed(newKey);
+      if (!opts.retainPrevious && !focusingVisiblePane && prevKey && prevKey !== newKey)
+        this.leaveBuffer(prevKey);
       networks.setActive(networkId, canonTarget);
       const buf = ensureBuffer(this, networkId, canonTarget);
       // Snapshot the divider from the CURRENT lastReadId before we advance

--- a/vue_client/src/stores/networks.ts
+++ b/vue_client/src/stores/networks.ts
@@ -83,17 +83,27 @@ export const useNetworksStore = defineStore('networks', {
           return { nick, state: 'offline', stateAt: null, awayMessage: null };
         return netState?.peerPresence?.[nick.toLowerCase()] ?? null;
       },
-    activeBuffer(state): ActiveBuffer | null {
-      if (!state.activeKey) return null;
-      // Virtual buffers (:system:) use a flat sentinel key (no `::`).
-      // They have no IRC send target, so report "no IRC buffer active" — the
-      // views drive their own header/rendering; the system buffer still renders
-      // messages via buffers.byKey(activeKey) directly, not through this getter.
-      if (isVirtualKey(state.activeKey)) return null;
-      if (!state.activeKey.includes('::')) return null;
-      const [networkId, name] = state.activeKey.split('::');
-      const id = Number(networkId);
-      return { networkId: id, target: name, network: state.networks.find((n) => n.id === id) };
+    // Parse any buffer key into its (network, target) pair. Split out from
+    // activeBuffer so a view rendering a buffer OTHER than the active one (a
+    // split BufferPane) can resolve its own key through the same rules rather
+    // than re-implementing the `${networkId}::${target}` split.
+    bufferFor(state) {
+      return (key: string | null): ActiveBuffer | null => {
+        if (!key) return null;
+        // Virtual buffers (:system:) use a flat sentinel key (no `::`).
+        // They have no IRC send target, so report "no IRC buffer active" — the
+        // views drive their own header/rendering; the system buffer still
+        // renders messages via buffers.byKey(key) directly, not through this
+        // getter.
+        if (isVirtualKey(key)) return null;
+        if (!key.includes('::')) return null;
+        const [networkId, name] = key.split('::');
+        const id = Number(networkId);
+        return { networkId: id, target: name, network: state.networks.find((n) => n.id === id) };
+      };
+    },
+    activeBuffer(): ActiveBuffer | null {
+      return this.bufferFor(this.activeKey);
     },
   },
   actions: {

--- a/vue_client/src/stores/splits.test.ts
+++ b/vue_client/src/stores/splits.test.ts
@@ -5,7 +5,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { useSplitsStore, MAX_PANES } from './splits.js';
 import { useBuffersStore } from './buffers.js';
-import { useNetworksStore } from './networks.js';
 
 vi.mock('../composables/useSocket.js', () => ({ socketSend: vi.fn<() => void>() }));
 
@@ -15,14 +14,6 @@ vi.mock('../composables/useSocket.js', () => ({ socketSend: vi.fn<() => void>() 
 function spyOnLeave() {
   const buffers = useBuffersStore();
   return vi.spyOn(buffers, 'leaveBuffer').mockImplementation(() => {});
-}
-
-// Declare which buffer keys the buffers store currently holds. pruneClosed
-// reads them through the real byKey getter, so seed the state rather than
-// stubbing the getter — the rows only need to exist, not to be well-formed.
-function openBuffers(...keys: string[]) {
-  const buffers = useBuffersStore();
-  buffers.buffers = Object.fromEntries(keys.map((k) => [k, { key: k } as never]));
 }
 
 beforeEach(() => {
@@ -170,41 +161,66 @@ describe('splits closing', () => {
   });
 });
 
-describe('splits pruning', () => {
-  // A pane pointing at a buffer the store has forgotten renders an empty shell
-  // no click can fix.
-  it('drops panes whose buffer is gone', () => {
+// The splits store keys state by buffer, so it joins the lifecycle sweep in
+// lib/bufferLifecycle.ts like every other store that does.
+describe('splits buffer lifecycle', () => {
+  it('closes the pane of a buffer that went away', () => {
     const splits = useSplitsStore();
     for (const k of ['1::#a', '1::#b', '1::#c']) splits.addPane(k);
-    openBuffers('1::#a', '1::#c');
 
-    splits.pruneClosed();
+    splits.dropBuffer(1, '#b');
     expect(splits.panes).toEqual(['1::#a', '1::#c']);
   });
 
-  // An empty frame has no focused pane for the next activation to land in, so
-  // the last pane survives even when its buffer is gone.
-  it('never prunes the frame down to nothing', () => {
+  it('ignores a drop for a buffer no pane is showing', () => {
     const splits = useSplitsStore();
-    const networks = useNetworksStore();
-    networks.activeKey = '1::#a';
     for (const k of ['1::#a', '1::#b']) splits.addPane(k);
-    openBuffers();
 
-    splits.pruneClosed();
-    expect(splits.panes).toEqual(['1::#a']);
-    expect(splits.focusedKey).toBe('1::#a');
+    splits.dropBuffer(1, '#zzz');
+    expect(splits.panes).toEqual(['1::#a', '1::#b']);
   });
 
-  it('keeps focus on the focused buffer when an earlier pane is pruned', () => {
+  // The system buffer is permanent — the buffers store refuses to drop it too.
+  it('never drops the system pane', () => {
     const splits = useSplitsStore();
-    for (const k of ['1::#a', '1::#b', '1::#c']) splits.addPane(k);
-    splits.focusPane(2);
-    openBuffers('1::#b', '1::#c');
+    for (const k of [':system:', '1::#a']) splits.addPane(k);
 
-    splits.pruneClosed();
-    expect(splits.panes).toEqual(['1::#b', '1::#c']);
-    expect(splits.focusedKey).toBe('1::#c');
+    splits.dropBuffer(null, ':system:');
+    expect(splits.panes).toEqual([':system:', '1::#a']);
+  });
+
+  // A rename swaps one key for another, so a pane holding the old name would
+  // silently stop tracking the conversation it is showing. It keeps its slot
+  // and its focus — nothing moved on screen.
+  it('follows a rename in place', () => {
+    const splits = useSplitsStore();
+    const leave = spyOnLeave();
+    for (const k of ['1::#a', '1::#b', '1::#c']) splits.addPane(k);
+    splits.focusPane(1);
+
+    splits.rekeyBuffer(1, '#b', '#b-renamed');
+    expect(splits.panes).toEqual(['1::#a', '1::#b-renamed', '1::#c']);
+    expect(splits.focused).toBe(1);
+    // Same buffer under a new name: nothing left the screen.
+    expect(leave).not.toHaveBeenCalled();
+  });
+
+  // A merge renames one open buffer onto another that is also open, which would
+  // otherwise leave two panes on one conversation.
+  it('closes the source pane when a rename merges onto an open buffer', () => {
+    const splits = useSplitsStore();
+    for (const k of ['1::#a', '1::#b']) splits.addPane(k);
+
+    splits.rekeyBuffer(1, '#a', '#b');
+    expect(splits.panes).toEqual(['1::#b']);
+  });
+
+  it('ignores a rename for a buffer no pane is showing', () => {
+    const splits = useSplitsStore();
+    splits.addPane('1::#a');
+
+    splits.rekeyBuffer(1, '#other', '#renamed');
+    expect(splits.panes).toEqual(['1::#a']);
   });
 });
 

--- a/vue_client/src/stores/splits.test.ts
+++ b/vue_client/src/stores/splits.test.ts
@@ -7,7 +7,7 @@ import { useSplitsStore, MAX_PANES } from './splits.js';
 import { useBuffersStore } from './buffers.js';
 import { useNetworksStore } from './networks.js';
 
-vi.mock('../composables/useSocket.js', () => ({ socketSend: vi.fn() }));
+vi.mock('../composables/useSocket.js', () => ({ socketSend: vi.fn<() => void>() }));
 
 // leaveBuffer is the teardown the pane lifecycle owns — spy on it rather than
 // asserting on divider/unread fields, since what matters here is WHICH buffers
@@ -166,7 +166,7 @@ describe('splits closing', () => {
     splits.collapseTo(1);
     expect(splits.panes).toEqual(['1::#b']);
     expect(splits.focused).toBe(0);
-    expect(leave.mock.calls.flat().sort()).toEqual(['1::#a', '1::#c']);
+    expect(leave.mock.calls.flat().toSorted()).toEqual(['1::#a', '1::#c']);
   });
 });
 

--- a/vue_client/src/stores/splits.test.ts
+++ b/vue_client/src/stores/splits.test.ts
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { useSplitsStore, MAX_PANES } from './splits.js';
+import { useBuffersStore } from './buffers.js';
+import { useNetworksStore } from './networks.js';
+
+vi.mock('../composables/useSocket.js', () => ({ socketSend: vi.fn() }));
+
+// leaveBuffer is the teardown the pane lifecycle owns — spy on it rather than
+// asserting on divider/unread fields, since what matters here is WHICH buffers
+// the store decides have left the screen, not what leaving does to them.
+function spyOnLeave() {
+  const buffers = useBuffersStore();
+  return vi.spyOn(buffers, 'leaveBuffer').mockImplementation(() => {});
+}
+
+// Declare which buffer keys the buffers store currently holds. pruneClosed
+// reads them through the real byKey getter, so seed the state rather than
+// stubbing the getter — the rows only need to exist, not to be well-formed.
+function openBuffers(...keys: string[]) {
+  const buffers = useBuffersStore();
+  buffers.buffers = Object.fromEntries(keys.map((k) => [k, { key: k } as never]));
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe('splits layout', () => {
+  it('starts empty and takes the first buffer as a single pane', () => {
+    const splits = useSplitsStore();
+    expect(splits.panes).toEqual([]);
+    expect(splits.isSplit).toBe(false);
+
+    splits.show('1::#ops');
+    expect(splits.panes).toEqual(['1::#ops']);
+    expect(splits.focused).toBe(0);
+    expect(splits.isSplit).toBe(false);
+  });
+
+  it('adds panes up to the ceiling, focusing each new one', () => {
+    const splits = useSplitsStore();
+    splits.show('1::#a');
+    splits.addPane('1::#b');
+    expect(splits.panes).toEqual(['1::#a', '1::#b']);
+    expect(splits.focused).toBe(1);
+    expect(splits.isSplit).toBe(true);
+
+    splits.addPane('1::#c');
+    splits.addPane('1::#d');
+    expect(splits.panes).toEqual(['1::#a', '1::#b', '1::#c', '1::#d']);
+    expect(splits.focused).toBe(3);
+    expect(splits.canAdd).toBe(false);
+  });
+
+  // The ceiling is a real constraint, not a soft one: a fifth buffer has to
+  // displace something, and it takes the focused pane so the pane the user is
+  // looking at is the one that visibly changes.
+  it('replaces the focused pane once the ceiling is reached', () => {
+    const splits = useSplitsStore();
+    const leave = spyOnLeave();
+    for (const k of ['1::#a', '1::#b', '1::#c', '1::#d']) splits.addPane(k);
+    splits.focusPane(1);
+
+    splits.addPane('1::#e');
+    expect(splits.panes).toEqual(['1::#a', '1::#e', '1::#c', '1::#d']);
+    expect(splits.panes).toHaveLength(MAX_PANES);
+    expect(splits.focused).toBe(1);
+    // The displaced buffer is the only one that left the screen.
+    expect(leave).toHaveBeenCalledExactlyOnceWith('1::#b');
+  });
+
+  it('focuses the existing pane instead of opening a buffer twice', () => {
+    const splits = useSplitsStore();
+    splits.show('1::#a');
+    splits.addPane('1::#b');
+    splits.focusPane(1);
+
+    splits.addPane('1::#a');
+    expect(splits.panes).toEqual(['1::#a', '1::#b']);
+    expect(splits.focused).toBe(0);
+  });
+
+  // A plain click swaps the pane you're looking at. It must NOT collapse the
+  // split — that's what the maximize control is for.
+  it('swaps the focused pane on a plain show, leaving the rest alone', () => {
+    const splits = useSplitsStore();
+    const leave = spyOnLeave();
+    splits.show('1::#a');
+    splits.addPane('1::#b');
+    splits.focusPane(0);
+
+    splits.show('1::#c');
+    expect(splits.panes).toEqual(['1::#c', '1::#b']);
+    expect(splits.focused).toBe(0);
+    expect(leave).toHaveBeenCalledExactlyOnceWith('1::#a');
+  });
+
+  // The bug the whole leave-lifecycle split exists to prevent: focusing a pane
+  // that is already on screen must not tear down the pane you focused away
+  // from, because it's still sitting there being read.
+  it('tears nothing down when showing a buffer that is already on screen', () => {
+    const splits = useSplitsStore();
+    const leave = spyOnLeave();
+    splits.show('1::#a');
+    splits.addPane('1::#b');
+    splits.focusPane(0);
+    leave.mockClear();
+
+    splits.show('1::#b');
+    expect(splits.panes).toEqual(['1::#a', '1::#b']);
+    expect(splits.focused).toBe(1);
+    expect(leave).not.toHaveBeenCalled();
+  });
+});
+
+describe('splits closing', () => {
+  it('collapses the layout in order and tears down the closed buffer', () => {
+    const splits = useSplitsStore();
+    const leave = spyOnLeave();
+    for (const k of ['1::#a', '1::#b', '1::#c']) splits.addPane(k);
+
+    splits.closePane(0);
+    expect(splits.panes).toEqual(['1::#b', '1::#c']);
+    expect(leave).toHaveBeenCalledExactlyOnceWith('1::#a');
+  });
+
+  it('keeps focus on the pane that slides into the closed slot', () => {
+    const splits = useSplitsStore();
+    for (const k of ['1::#a', '1::#b', '1::#c']) splits.addPane(k);
+    splits.focusPane(2);
+
+    splits.closePane(1);
+    expect(splits.panes).toEqual(['1::#a', '1::#c']);
+    // #c was at 2 and is now at 1 — focus follows the buffer, not the index.
+    expect(splits.focusedKey).toBe('1::#c');
+  });
+
+  it('clamps focus when the focused pane was the last one', () => {
+    const splits = useSplitsStore();
+    for (const k of ['1::#a', '1::#b']) splits.addPane(k);
+    splits.focusPane(1);
+
+    splits.closePane(1);
+    expect(splits.panes).toEqual(['1::#a']);
+    expect(splits.focused).toBe(0);
+    expect(splits.focusedKey).toBe('1::#a');
+  });
+
+  it('ignores an out-of-range close', () => {
+    const splits = useSplitsStore();
+    splits.show('1::#a');
+    splits.closePane(4);
+    splits.closePane(-1);
+    expect(splits.panes).toEqual(['1::#a']);
+  });
+
+  it('maximizes one pane and leaves the others', () => {
+    const splits = useSplitsStore();
+    const leave = spyOnLeave();
+    for (const k of ['1::#a', '1::#b', '1::#c']) splits.addPane(k);
+
+    splits.collapseTo(1);
+    expect(splits.panes).toEqual(['1::#b']);
+    expect(splits.focused).toBe(0);
+    expect(leave.mock.calls.flat().sort()).toEqual(['1::#a', '1::#c']);
+  });
+});
+
+describe('splits pruning', () => {
+  // A pane pointing at a buffer the store has forgotten renders an empty shell
+  // no click can fix.
+  it('drops panes whose buffer is gone', () => {
+    const splits = useSplitsStore();
+    for (const k of ['1::#a', '1::#b', '1::#c']) splits.addPane(k);
+    openBuffers('1::#a', '1::#c');
+
+    splits.pruneClosed();
+    expect(splits.panes).toEqual(['1::#a', '1::#c']);
+  });
+
+  // An empty frame has no focused pane for the next activation to land in, so
+  // the last pane survives even when its buffer is gone.
+  it('never prunes the frame down to nothing', () => {
+    const splits = useSplitsStore();
+    const networks = useNetworksStore();
+    networks.activeKey = '1::#a';
+    for (const k of ['1::#a', '1::#b']) splits.addPane(k);
+    openBuffers();
+
+    splits.pruneClosed();
+    expect(splits.panes).toEqual(['1::#a']);
+    expect(splits.focusedKey).toBe('1::#a');
+  });
+
+  it('keeps focus on the focused buffer when an earlier pane is pruned', () => {
+    const splits = useSplitsStore();
+    for (const k of ['1::#a', '1::#b', '1::#c']) splits.addPane(k);
+    splits.focusPane(2);
+    openBuffers('1::#b', '1::#c');
+
+    splits.pruneClosed();
+    expect(splits.panes).toEqual(['1::#b', '1::#c']);
+    expect(splits.focusedKey).toBe('1::#c');
+  });
+});
+
+describe('splits session reset', () => {
+  it('drops the layout without running per-buffer teardown', () => {
+    const splits = useSplitsStore();
+    const leave = spyOnLeave();
+    for (const k of ['1::#a', '1::#b']) splits.addPane(k);
+
+    splits.$reset();
+    expect(splits.panes).toEqual([]);
+    expect(splits.focused).toBe(0);
+    // The buffers store is being wiped wholesale by the same reset — reaching
+    // into it per-pane would touch state that is already gone.
+    expect(leave).not.toHaveBeenCalled();
+  });
+});

--- a/vue_client/src/stores/splits.test.ts
+++ b/vue_client/src/stores/splits.test.ts
@@ -130,6 +130,22 @@ describe('splits closing', () => {
     expect(splits.focusedKey).toBe('1::#c');
   });
 
+  // Closing the focused pane hands focus to a different buffer, and the shell
+  // has to re-activate it — otherwise activeKey is stranded on a buffer no pane
+  // shows, which strands the sidebar highlight AND keeps advancing that
+  // buffer's read pointer while the user looks at another one. The store's half
+  // of that contract is reporting the new focusedKey; DesktopChat's
+  // activateFocusedPane() reads it.
+  it('reports a new focused buffer after the focused pane closes', () => {
+    const splits = useSplitsStore();
+    for (const k of ['1::#a', '1::#b']) splits.addPane(k);
+    splits.focusPane(1);
+    expect(splits.focusedKey).toBe('1::#b');
+
+    splits.closePane(1);
+    expect(splits.focusedKey).toBe('1::#a');
+  });
+
   it('clamps focus when the focused pane was the last one', () => {
     const splits = useSplitsStore();
     for (const k of ['1::#a', '1::#b']) splits.addPane(k);

--- a/vue_client/src/stores/splits.ts
+++ b/vue_client/src/stores/splits.ts
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { defineStore } from 'pinia';
+import { useBuffersStore } from './buffers.js';
+import { useNetworksStore } from './networks.js';
+
+// How many buffers can share the desktop chat frame at once. Four is the point
+// where a pane stops being able to show a useful number of message rows beside
+// its own nicklist, so it's the ceiling rather than an arbitrary round number.
+export const MAX_PANES = 4;
+
+// The frame is a 2x2 grid and every layout is a way of filling it, so a pane's
+// position is one of these area names and the layout is just which template the
+// pane count selects (see PANE_AREAS / the grid templates in DesktopChat):
+//
+//   1 pane    2 panes   3 panes   4 panes
+//   ┌─────┐   ┌─────┐   ┌─────┐   ┌──┬──┐
+//   │  a  │   │  a  │   │  a  │   │a │b │
+//   │     │   ├─────┤   ├──┬──┤   ├──┼──┤
+//   │     │   │  b  │   │b │c │   │c │d │
+//   └─────┘   └─────┘   └──┴──┘   └──┴──┘
+//
+// Splitting the BOTTOM half first (rather than the right) is what makes the
+// third pane an addition instead of a re-layout: panes a and b keep their
+// full width, and only b's height changes.
+export const PANE_AREAS = ['a', 'b', 'c', 'd'] as const;
+
+interface SplitsState {
+  // Buffer keys, in layout order — index 0 is area 'a', 1 is 'b', and so on.
+  // Empty before the first buffer is opened.
+  panes: string[];
+  // Index into `panes` of the pane that has the user's attention. Everything
+  // outside the frame (the sidebar highlight, scoped search, the keyboard
+  // shortcuts) still asks "what is the active buffer" and gets this pane's, so
+  // focus is what keeps a split layout coherent with the rest of the app.
+  focused: number;
+}
+
+export const useSplitsStore = defineStore('splits', {
+  state: (): SplitsState => ({
+    panes: [],
+    focused: 0,
+  }),
+  getters: {
+    count: (state): number => state.panes.length,
+    // True once the frame is actually divided. The single-pane case must stay
+    // pixel-identical to the pre-split shell, so this gates the split-only
+    // chrome (focus ring, per-pane close button) rather than the panes.
+    isSplit: (state): boolean => state.panes.length > 1,
+    focusedKey: (state): string | null => state.panes[state.focused] ?? null,
+    canAdd: (state): boolean => state.panes.length < MAX_PANES,
+    isOpen:
+      (state) =>
+      (key: string): boolean =>
+        state.panes.includes(key),
+  },
+  actions: {
+    // Replace the pane set wholesale, tearing down whatever left the screen.
+    //
+    // Every mutation below funnels through here so the leave-lifecycle is
+    // decided in exactly one place: a buffer that is in `panes` before and not
+    // after has genuinely stopped being read, which is what buffers.leaveBuffer
+    // means. Doing it per-action instead invites the case where one action
+    // forgets and a closed pane's buffer keeps a stale unread divider forever.
+    setPanes(next: string[], nextFocused: number) {
+      const departed = this.panes.filter((k) => !next.includes(k));
+      this.panes = next;
+      // Clamp rather than trust the caller: a removal can leave `focused`
+      // pointing past the end, and a focus index outside the array would make
+      // focusedKey null and blank the sidebar highlight.
+      this.focused = next.length === 0 ? 0 : Math.min(Math.max(nextFocused, 0), next.length - 1);
+      const buffers = useBuffersStore();
+      for (const key of departed) buffers.leaveBuffer(key);
+    },
+    // A plain (un-modified) buffer-list click, and the destination of every
+    // other "go to this buffer" path in the app: show `key` in the focused
+    // pane. The rest of the layout is left alone — a plain click swaps the pane
+    // you're looking at, it doesn't tear the split down.
+    show(key: string) {
+      const at = this.panes.indexOf(key);
+      // Already on screen: this is a focus move, not a swap. Nothing departs,
+      // so no pane loses its divider.
+      if (at !== -1) {
+        this.focused = at;
+        return;
+      }
+      if (this.panes.length === 0) {
+        this.setPanes([key], 0);
+        return;
+      }
+      const next = [...this.panes];
+      next[this.focused] = key;
+      this.setPanes(next, this.focused);
+    },
+    // Cmd/Ctrl-click: give `key` a pane of its own beside the others, and focus
+    // it. At the ceiling there's nowhere to put it, so it takes over the
+    // focused pane instead — the pane wearing the focus ring, so the one the
+    // user is looking at is the one that visibly changes.
+    addPane(key: string) {
+      const at = this.panes.indexOf(key);
+      if (at !== -1) {
+        this.focused = at;
+        return;
+      }
+      if (this.panes.length >= MAX_PANES) {
+        this.show(key);
+        return;
+      }
+      this.setPanes([...this.panes, key], this.panes.length);
+    },
+    // Close one pane. The survivors keep their order, so the layout collapses
+    // predictably (closing 'a' of three promotes 'b' to the full-width top
+    // slot). Focus lands on the pane that takes the closed one's index, or the
+    // new last pane when it was the tail.
+    closePane(index: number) {
+      if (index < 0 || index >= this.panes.length) return;
+      const next = this.panes.filter((_, i) => i !== index);
+      // Focus follows the closed slot rather than resetting to 0: after closing
+      // the pane you were in, the neighbour that slides into its place is the
+      // one your attention is already on.
+      const nextFocused = this.focused > index ? this.focused - 1 : this.focused;
+      this.setPanes(next, nextFocused);
+    },
+    // Drop every pane but one — the "maximize this pane" affordance, and what a
+    // plain click has to do when the user wants out of a split.
+    collapseTo(index: number) {
+      const key = this.panes[index];
+      if (key === undefined) return;
+      this.setPanes([key], 0);
+    },
+    focusPane(index: number) {
+      if (index < 0 || index >= this.panes.length) return;
+      this.focused = index;
+    },
+    // Reconcile with an activation that didn't come through this store —
+    // /query, the quick switcher, a jump-to-message, a push deep link, the
+    // land-on-system-buffer rule. They all set networks.activeKey and expect
+    // the frame to follow, which for a split frame means "in the focused pane".
+    syncActive(key: string | null) {
+      if (!key) return;
+      this.show(key);
+    },
+    // Drop panes whose buffer is no longer open (parted, closed, or wiped by a
+    // session reset). A pane pointing at a buffer the store has forgotten
+    // renders an empty shell that no click can fix, so it shouldn't survive.
+    // The last pane is kept regardless: an empty frame has no focused pane for
+    // the next activation to land in.
+    pruneClosed() {
+      if (this.panes.length <= 1) return;
+      const buffers = useBuffersStore();
+      const networks = useNetworksStore();
+      const next = this.panes.filter((k) => buffers.byKey(k) != null);
+      if (next.length === this.panes.length) return;
+      if (next.length === 0) {
+        // Everything went at once. Keep the active buffer's pane if there is
+        // one so the frame still has somewhere to render.
+        this.setPanes(networks.activeKey ? [networks.activeKey] : [], 0);
+        return;
+      }
+      const focusedKey = this.panes[this.focused];
+      const stillThere = focusedKey ? next.indexOf(focusedKey) : -1;
+      this.setPanes(next, stillThere === -1 ? 0 : stillThere);
+    },
+  },
+});

--- a/vue_client/src/stores/splits.ts
+++ b/vue_client/src/stores/splits.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { defineStore } from 'pinia';
-import { useBuffersStore } from './buffers.js';
-import { useNetworksStore } from './networks.js';
+import { useBuffersStore, bufferKey } from './buffers.js';
 
 // How many buffers can share the desktop chat frame at once. Four is the point
 // where a pane stops being able to show a useful number of message rows beside
@@ -141,26 +140,42 @@ export const useSplitsStore = defineStore('splits', {
       if (!key) return;
       this.show(key);
     },
-    // Drop panes whose buffer is no longer open (parted, closed, or wiped by a
-    // session reset). A pane pointing at a buffer the store has forgotten
-    // renders an empty shell that no click can fix, so it shouldn't survive.
-    // The last pane is kept regardless: an empty frame has no focused pane for
-    // the next activation to land in.
-    pruneClosed() {
-      if (this.panes.length <= 1) return;
-      const buffers = useBuffersStore();
-      const networks = useNetworksStore();
-      const next = this.panes.filter((k) => buffers.byKey(k) != null);
-      if (next.length === this.panes.length) return;
-      if (next.length === 0) {
-        // Everything went at once. Keep the active buffer's pane if there is
-        // one so the frame still has somewhere to render.
-        this.setPanes(networks.activeKey ? [networks.activeKey] : [], 0);
+    // --- buffer lifecycle (lib/bufferLifecycle.ts) ---
+    //
+    // Panes are keyed by buffer, so this store keys per-buffer state and has to
+    // join the lifecycle sweep like every other store that does. Without it a
+    // pane holding a closed buffer renders a shell no click can fix, and a pane
+    // holding a RENAMED one silently stops tracking the conversation it's
+    // showing — and a rename swaps one key for another, so nothing watching the
+    // buffer count would even notice.
+
+    /** The buffer is gone: close whichever pane was showing it. */
+    dropBuffer(networkId: number | string | null, target: string) {
+      if (networkId == null) return; // the system buffer is permanent
+      const at = this.panes.indexOf(bufferKey(networkId, target));
+      if (at !== -1) this.closePane(at);
+    },
+
+    /** The buffer changed names: the pane follows it, keeping its slot. */
+    rekeyBuffer(networkId: number | string | null, from: string, to: string) {
+      if (networkId == null) return;
+      const fromKey = bufferKey(networkId, from);
+      const toKey = bufferKey(networkId, to);
+      if (fromKey === toKey) return;
+      const at = this.panes.indexOf(fromKey);
+      if (at === -1) return;
+      // A merge can rename one open buffer onto another that's also open, which
+      // would leave two panes on one conversation. The destination pane wins —
+      // matching the destination-wins merge in the other rekey hooks — and the
+      // source pane closes.
+      if (this.panes.includes(toKey)) {
+        this.closePane(at);
         return;
       }
-      const focusedKey = this.panes[this.focused];
-      const stillThere = focusedKey ? next.indexOf(focusedKey) : -1;
-      this.setPanes(next, stillThere === -1 ? 0 : stillThere);
+      // Assigned in place rather than through setPanes: this is the same buffer
+      // under a new name, so nothing left the screen and nothing should be torn
+      // down.
+      this.panes[at] = toKey;
     },
   },
 });

--- a/vue_client/src/stores/splits.ts
+++ b/vue_client/src/stores/splits.ts
@@ -121,8 +121,9 @@ export const useSplitsStore = defineStore('splits', {
       const nextFocused = this.focused > index ? this.focused - 1 : this.focused;
       this.setPanes(next, nextFocused);
     },
-    // Drop every pane but one — the "maximize this pane" affordance, and what a
-    // plain click has to do when the user wants out of a split.
+    // Drop every pane but one — the "maximize this pane" affordance, and the
+    // only way back to a single pane. A plain click deliberately does NOT do
+    // this: it swaps the focused pane's buffer and leaves the split standing.
     collapseTo(index: number) {
       const key = this.panes[index];
       if (key === undefined) return;

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -323,7 +323,25 @@ function focusedPane() {
 // immediate, so a remount (a viewport flip back to desktop, coming back from
 // Settings) reconciles the frame with whatever is active instead of painting an
 // empty pane until the next click.
-watch(() => networks.activeKey, splits.syncActive, { immediate: true });
+watch(
+  () => networks.activeKey,
+  (key) => {
+    if (key) {
+      splits.syncActive(key);
+      return;
+    }
+    // Closing a buffer nulls activeKey (networks.dropBuffer) — right when it
+    // was the only view of it, wrong when other panes are still up. The sweep
+    // is synchronous and this watcher flushes after it, so by now the splits
+    // store has closed that pane and focus has landed on a survivor: adopt it,
+    // rather than leave the app with no active buffer while a conversation is
+    // plainly on screen (no sidebar highlight, and type-ahead refusing to focus
+    // the composer). With no panes left there's nothing to adopt, and the
+    // land-on-system-buffer rule below takes it from here.
+    activateFocusedPane();
+  },
+  { immediate: true },
+);
 
 // Any modal open? Type-ahead must not steal focus from a modal's own fields.
 const anyModalOpen = computed(

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -93,7 +93,7 @@
         :focused="i === splits.focused"
         :pending-scroll-id="i === splits.focused ? pendingScrollId : null"
         @focus="onPaneFocus(i)"
-        @close="splits.closePane(i)"
+        @close="onPaneClose(i)"
         @maximize="splits.collapseTo(i)"
         @open-search="openSearch"
         @open-highlights="openHighlights"
@@ -267,20 +267,37 @@ const splits = useSplitsStore();
 // bar and "No messages yet." body), and it still does.
 const paneKeys = computed<(string | null)[]>(() => (splits.count ? splits.panes : [null]));
 
-// Focus follows the click, and the ACTIVE buffer follows focus — that's what
-// keeps a split frame coherent with everything outside it: the buffer-list
-// highlight, scoped search, the nav history, and the keyboard shortcuts all
-// still ask "what is the active buffer" and get the pane the user is in.
+// Point the app's active buffer at whatever the focused pane is showing. This
+// is what keeps a split frame coherent with everything outside it: the
+// buffer-list highlight, scoped search, the nav history and the keyboard
+// shortcuts all still ask "what is the active buffer" and get the pane the user
+// is in. It also keeps READ state honest — pushMessage advances the read
+// pointer of the active buffer, so leaving activeKey on a buffer no pane is
+// showing would mark it read while the user looks at something else.
 //
-// retainPrevious because nothing left the screen: the pane we focused away from
-// is still sitting there. The splits store owns that lifecycle now.
+// retainPrevious because nothing left the screen by getting here: either the
+// outgoing pane is still sitting there, or the splits store already tore it
+// down when it closed. That lifecycle is the store's, not activate()'s.
+function activateFocusedPane() {
+  const key = splits.focusedKey;
+  if (!key || key === networks.activeKey) return;
+  const buf = networks.bufferFor(key);
+  if (buf) buffers.activate(buf.networkId, buf.target, { retainPrevious: true });
+  else if (key === SYSTEM_KEY) buffers.activate(null, SYSTEM_KEY, { retainPrevious: true });
+}
+
 function onPaneFocus(index: number) {
   if (index === splits.focused) return;
   splits.focusPane(index);
-  const key = splits.panes[index];
-  const buf = key ? networks.bufferFor(key) : null;
-  if (buf) buffers.activate(buf.networkId, buf.target, { retainPrevious: true });
-  else if (key === SYSTEM_KEY) buffers.activate(null, SYSTEM_KEY, { retainPrevious: true });
+  activateFocusedPane();
+}
+
+// Closing the FOCUSED pane hands focus to a neighbour showing a different
+// buffer, so the active buffer has to follow it there. (Closing any other pane
+// leaves focus where it was, and this no-ops.)
+function onPaneClose(index: number) {
+  splits.closePane(index);
+  activateFocusedPane();
 }
 
 // The keyboard and the click-anywhere-to-type behavior address "the pane the

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -4,15 +4,7 @@
 -->
 
 <template>
-  <div
-    class="chat"
-    :class="{
-      'sidebar-collapsed': !showChannels,
-      'members-collapsed': !showMembers,
-      'system-active': isSystemBuffer,
-    }"
-    @click="onChatClick"
-  >
+  <div class="chat" :class="{ 'sidebar-collapsed': !showChannels }" @click="onChatClick">
     <aside class="sidebar" :class="{ collapsed: !showChannels }">
       <!-- The "lurker" header + connection dot live in BufferList's LURKER row
            (#355); the collapse control lives there too. When collapsed the list
@@ -82,155 +74,32 @@
       </div>
     </aside>
 
-    <!-- Topic bar: always rendered so the back/forward history controls (#411)
-         are present in every state, even before any buffer is selected. The nav
-         cluster is anchored at the far left, left of the buffer title; the meta
-         (name + topic) and per-buffer actions render conditionally beside it. -->
-    <header class="topic">
-      <div class="topic-nav">
-        <button
-          type="button"
-          class="link nav-btn"
-          title="Back"
-          aria-label="Back"
-          :disabled="!navHistory.canBack"
-          @click="navHistory.back()"
-        >
-          <i class="fa-solid fa-angle-left"></i>
-        </button>
-        <button
-          type="button"
-          class="link nav-btn"
-          title="Forward"
-          aria-label="Forward"
-          :disabled="!navHistory.canForward"
-          @click="navHistory.forward()"
-        >
-          <i class="fa-solid fa-angle-right"></i>
-        </button>
-      </div>
-      <div class="topic-meta">
-        <span v-if="isVirtual || active" class="buffer">{{ bufferLabel }}</span>
-        <template v-if="active && topic">
-          <!-- A channel topic is user prose: auto-link it and open the full
-               view on click. A DM's pseudo-topic is the peer's ident@host —
-               an identity string, not prose; auto-linking turns the host into
-               a bogus email/URL link, so it renders as plain static text. -->
-          <button
-            v-if="isChannel"
-            type="button"
-            class="topic-text"
-            title="View full topic"
-            @click="showTopic = true"
-          >
-            <LinkedText :text="topic" />
-          </button>
-          <span v-else class="topic-text">{{ topic }}</span>
-        </template>
-      </div>
-      <div class="topic-actions">
-        <template v-if="active && !isVirtual">
-          <!-- Search & highlights scoped to this buffer (channels/DMs only) —
-               parity with the mobile topic bar. The server buffer has no
-               per-buffer scope, so it's excluded. -->
-          <template v-if="!isServerBuffer">
-            <button
-              type="button"
-              class="link"
-              title="Search this buffer"
-              aria-label="Search this buffer"
-              @click="openSearch(true)"
-            >
-              <i class="fa-solid fa-magnifying-glass"></i>
-            </button>
-            <button
-              type="button"
-              class="link"
-              title="Highlights in this buffer"
-              aria-label="Highlights in this buffer"
-              @click="openHighlights(true)"
-            >
-              <i class="fa-regular fa-bell"></i>
-            </button>
-          </template>
-          <template v-if="isServerBuffer">
-            <button
-              type="button"
-              class="link"
-              title="Join channel"
-              aria-label="Join channel"
-              :disabled="serverConnectionState !== 'connected'"
-              @click="active && joinChannelModal.open(active.networkId)"
-            >
-              <i class="fa-solid fa-plus"></i>
-            </button>
-            <button
-              type="button"
-              class="link"
-              title="Channel list"
-              aria-label="Channel list"
-              @click="active && channelListModal.open(active.networkId)"
-            >
-              <i class="fa-solid fa-hashtag"></i>
-            </button>
-            <button
-              type="button"
-              class="link"
-              :title="serverConnectActionLabel"
-              :aria-label="serverConnectActionLabel"
-              @click="toggleServerConnection"
-            >
-              <i :class="serverConnectActionIcon"></i>
-            </button>
-            <button class="link" title="Edit network" @click="editActiveNetwork">
-              <i class="fa-solid fa-gear"></i>
-            </button>
-          </template>
-          <template v-else-if="isDmHeader">
-            <button
-              type="button"
-              class="link"
-              title="View profile"
-              aria-label="View profile"
-              @click="openDmProfile"
-            >
-              <i class="fa-solid fa-id-card"></i>
-            </button>
-            <button
-              type="button"
-              class="link"
-              :title="dmNoteLabel"
-              :aria-label="dmNoteLabel"
-              @click="openDmNote"
-            >
-              <i class="fa-solid fa-note-sticky"></i>
-            </button>
-          </template>
-          <template v-else-if="isChannel">
-            <button
-              class="link"
-              :title="showMembers ? 'Hide members' : 'Show members'"
-              :aria-label="showMembers ? 'Hide members' : 'Show members'"
-              @click="toggleMembers"
-            >
-              <i class="fa-solid fa-users"></i>
-            </button>
-            <span
-              v-if="memberCount != null"
-              class="member-count"
-              :title="`${memberCount} ${memberCount === 1 ? 'user' : 'users'} in channel`"
-              >{{ memberCount }}</span
-            >
-          </template>
-        </template>
-      </div>
-    </header>
-    <div class="topic-divider"></div>
+    <!-- The chat frame: one pane, or up to four sharing a 2x2 grid. The
+         container paints --border and leaves a 1px gap, so the separators
+         between panes come out of the gap itself and no pane has to know which
+         edges it has neighbours on.
 
-    <MessageList ref="messageListRef" :pending-scroll-id="pendingScrollId" />
-    <MemberList v-if="showMembers && hasNicklist" />
-    <StatusBar />
-    <MessageInput v-if="hasInput" ref="messageInputRef" />
+         Keyed by INDEX, not by buffer: a plain click swaps the focused pane's
+         buffer, and keying by buffer would tear the whole subtree down and
+         rebuild it on every switch. The single-pane view has always repointed
+         in place, and it has to keep doing that. -->
+    <div class="panes" :class="`panes-${paneKeys.length}`">
+      <BufferPane
+        v-for="(key, i) in paneKeys"
+        :key="i"
+        :style="{ gridArea: PANE_AREAS[i] }"
+        :pane-key="key"
+        :split="splits.isSplit"
+        :focused="i === splits.focused"
+        :pending-scroll-id="i === splits.focused ? pendingScrollId : null"
+        @focus="onPaneFocus(i)"
+        @close="splits.closePane(i)"
+        @maximize="splits.collapseTo(i)"
+        @open-search="openSearch"
+        @open-highlights="openHighlights"
+        @show-topic="showTopic = true"
+      />
+    </div>
 
     <NetworkForm
       v-if="networkEditor.isOpen"
@@ -302,8 +171,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import type { Network } from '../stores/networks.js';
-import { useBuffersStore, type Buffer } from '../stores/buffers.js';
+import { useBuffersStore } from '../stores/buffers.js';
 import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
 import { useSocket } from '../composables/useSocket.js';
 import { useNetworksStore } from '../stores/networks.js';
@@ -314,14 +182,10 @@ import { useHighlightChip } from '../composables/useHighlightChip.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useAuthStore } from '../stores/auth.js';
 import BufferList from '../components/BufferList.vue';
-import MessageList from '../components/MessageList.vue';
-import MessageInput from '../components/MessageInput.vue';
-import MemberList from '../components/MemberList.vue';
-import StatusBar from '../components/StatusBar.vue';
+import BufferPane from '../components/BufferPane.vue';
 import NetworkForm from '../components/NetworkForm.vue';
 import HighlightsModal from '../components/HighlightsModal.vue';
 import BookmarksModal from '../components/BookmarksModal.vue';
-import LinkedText from '../components/LinkedText.vue';
 import TopicModal from '../components/TopicModal.vue';
 import ChannelListModal from '../components/ChannelListModal.vue';
 import JoinChannelModal from '../components/JoinChannelModal.vue';
@@ -334,7 +198,6 @@ import NickNoteModal from '../components/NickNoteModal.vue';
 import UserProfileModal from '../components/UserProfileModal.vue';
 import MediaViewerModal from '../components/MediaViewerModal.vue';
 import { useKeyboardShortcuts } from '../composables/useKeyboardShortcuts.js';
-import { useNicklistCollapseStore } from '../stores/nicklistCollapse.js';
 import { shouldOpenSystemBufferOnLoad } from '../utils/defaultBuffer.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
 import { useDccStore } from '../stores/dcc.js';
@@ -344,7 +207,8 @@ import { useJoinChannelModal } from '../composables/useJoinChannelModal.js';
 import { useMediaViewer } from '../composables/useMediaViewer.js';
 import { useNetworkEditor } from '../composables/useNetworkEditor.js';
 import { useJumpToMessage } from '../composables/useJumpToMessage.js';
-import { useNavHistoryStore } from '../stores/navHistory.js';
+import { useSplitsStore, PANE_AREAS } from '../stores/splits.js';
+import { paneFor } from '../composables/usePaneRegistry.js';
 
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
@@ -354,22 +218,14 @@ const buffers = useBuffersStore();
 // the socket never opens: red status light + no buffers (#355 regression).
 useSocket();
 
-const {
-  active,
-  activeBuf,
-  topic,
-  isServerBuffer,
-  isChannel,
-  bufferLabel,
-  isSystemBuffer,
-  isVirtual,
-  hasInput,
-  hasNicklist,
-} = useActiveBuffer();
+// Un-provided, so this resolves through networks.activeKey — which follows pane
+// focus. The shell only needs the focused pane's buffer now: the topic modal it
+// hosts, and the type-ahead guard. Everything else that used to live here moved
+// into BufferPane, which resolves its own buffer instead.
+const { active, topic, bufferLabel } = useActiveBuffer();
 
 const settings = useSettingsStore();
 const auth = useAuthStore();
-const nicklistCollapse = useNicklistCollapseStore();
 const nickNotes = useNickNotesStore();
 const dcc = useDccStore();
 const dccTitle = computed(() =>
@@ -392,7 +248,6 @@ const channelListModal = reactive(useChannelListModal());
 const joinChannelModal = reactive(useJoinChannelModal());
 const viewer = reactive(useMediaViewer());
 const networkEditor = reactive(useNetworkEditor());
-const navHistory = useNavHistoryStore();
 const showBookmarks = ref(false);
 const showTopic = ref(false);
 const showUploads = ref(false);
@@ -404,8 +259,55 @@ const pendingScrollId = ref<number | null>(null);
 // MobileChat (#496).
 const { showSearch, showHighlights, searchScope, highlightScope, openSearch, openHighlights } =
   useBufferSearchScope();
-const messageInputRef = ref<{ focus: () => void } | null>(null);
-const messageListRef = ref<{ scrollByPage: (dir: number) => void } | null>(null);
+
+const splits = useSplitsStore();
+
+// One pane per open buffer, or a single empty pane before anything is active —
+// the shell has always rendered its frame with no buffer selected (the topic
+// bar and "No messages yet." body), and it still does.
+const paneKeys = computed<(string | null)[]>(() => (splits.count ? splits.panes : [null]));
+
+// Focus follows the click, and the ACTIVE buffer follows focus — that's what
+// keeps a split frame coherent with everything outside it: the buffer-list
+// highlight, scoped search, the nav history, and the keyboard shortcuts all
+// still ask "what is the active buffer" and get the pane the user is in.
+//
+// retainPrevious because nothing left the screen: the pane we focused away from
+// is still sitting there. The splits store owns that lifecycle now.
+function onPaneFocus(index: number) {
+  if (index === splits.focused) return;
+  splits.focusPane(index);
+  const key = splits.panes[index];
+  const buf = key ? networks.bufferFor(key) : null;
+  if (buf) buffers.activate(buf.networkId, buf.target, { retainPrevious: true });
+  else if (key === SYSTEM_KEY) buffers.activate(null, SYSTEM_KEY, { retainPrevious: true });
+}
+
+// The keyboard and the click-anywhere-to-type behavior address "the pane the
+// user is in", which is the focused one — look it up by buffer rather than
+// holding a template ref, since there are now up to four panes to hold one to.
+function focusedPane() {
+  return paneFor(splits.focusedKey);
+}
+
+// Activations that don't come through the pane controls — /query, the quick
+// switcher, a jump-to-message, a push deep link, the land-on-system-buffer rule
+// below — set networks.activeKey and expect the frame to follow. For a split
+// frame that means "show it in the focused pane", which is exactly what a plain
+// buffer-list click already does, so they share the one path.
+//
+// immediate, so a remount (a viewport flip back to desktop, coming back from
+// Settings) reconciles the frame with whatever is active instead of painting an
+// empty pane until the next click.
+watch(() => networks.activeKey, splits.syncActive, { immediate: true });
+
+// A buffer can stop existing while a pane is showing it — parted, closed, or
+// dropped by a reconnect snapshot. Those panes would render a shell no click
+// can fix, so drop them once the buffer is gone.
+watch(
+  () => Object.keys(buffers.buffers).length,
+  () => splits.pruneClosed(),
+);
 
 // Any modal open? Type-ahead must not steal focus from a modal's own fields.
 const anyModalOpen = computed(
@@ -436,11 +338,11 @@ useKeyboardShortcuts({
   },
   onTypeAhead: () => {
     if (anyModalOpen.value || !active.value) return;
-    messageInputRef.value?.focus();
+    focusedPane()?.focusInput();
   },
   onScrollMessages: (dir) => {
     if (anyModalOpen.value) return;
-    messageListRef.value?.scrollByPage(dir);
+    focusedPane()?.scrollByPage(dir);
   },
 });
 
@@ -490,65 +392,9 @@ watch(showChannels, async (open) => {
 });
 onMounted(measureFootWrap);
 
-// True when the active buffer is a DM (not a channel, not the network's
-// server buffer). Drives the clickable DM header that opens the user
-// profile modal — channel headers stay non-interactive.
-const isDmHeader = computed(() => {
-  if (!active.value) return false;
-  if (isChannel.value || isServerBuffer.value) return false;
-  return true;
-});
-function openDmProfile() {
-  if (!active.value) return;
-  whois.openViewer(active.value.networkId, active.value.target);
-}
-// DM note button — mirrors the old context-menu entry, surfaced inline so the
-// per-peer note is one click from the conversation. Label flips once a note
-// exists so the button doubles as a "has a note" tell.
-const dmNoteLabel = computed(() =>
-  active.value && nickNotes.hasNote(active.value.networkId, active.value.target)
-    ? 'Edit note'
-    : 'Add note',
-);
-function openDmNote() {
-  if (!active.value) return;
-  nickNotes.openEditor(active.value.networkId, active.value.target);
-}
-
-// Channel notification level (always/highlights/nothing/muted) now lives in the
-// buffer context-menu ladder (right-click the sidebar row, or the topic-bar cog),
-// so there is no dedicated topic-bar bell anymore (issue #359).
-
-// User count for the active channel buffer. Sits in the topic bar (next to
-// the members-toggle button) rather than the status bar — the count is a
-// property of the channel, so the channel header is the natural home.
-const memberCount = computed(() => {
-  if (!isChannel.value) return null;
-  return (activeBuf.value as Buffer | null)?.members?.length ?? null;
-});
-
-// Per-channel nicklist visibility. A channel the user has explicitly toggled
-// carries an override (true = collapsed); otherwise the global
-// look.layout.show_member_list default applies. DMs and server buffers have no
-// member list at all, so the toggle and panel are hidden for them entirely.
-const showMembers = computed(() => {
-  if (!isChannel.value || !active.value) return false;
-  const { networkId, target } = active.value;
-  const override = nicklistCollapse.override(networkId, target);
-  if (override !== undefined) return !override;
-  return settings.effective('look.layout.show_member_list');
-});
-
 function toggleChannels() {
   settings.setValue('look.layout.show_channel_list', !showChannels.value);
 }
-function toggleMembers() {
-  if (!isChannel.value || !active.value) return;
-  const { networkId, target } = active.value;
-  // Pass the current visibility through as the new collapsed flag — it flips.
-  nicklistCollapse.setCollapsed(networkId, target, !!showMembers.value);
-}
-
 // Forward stray clicks anywhere in the chat frame (topic bar, message list,
 // member list, sidebar gutter, etc.) into the message input. The selector
 // excludes anything genuinely interactive — buttons, links, form controls,
@@ -563,7 +409,7 @@ function onChatClick(e: MouseEvent) {
     return;
   const sel = window.getSelection();
   if (sel && sel.toString().length > 0) return;
-  messageInputRef.value?.focus();
+  focusedPane()?.focusInput();
 }
 
 const onJumpToMessage = useJumpToMessage({ pendingScrollId });
@@ -622,70 +468,22 @@ function closeNetworkForm() {
   networkEditor.close();
 }
 
-function editActiveNetwork() {
-  const net = active.value?.network as Network | undefined;
-  if (net) networkEditor.open(net);
-}
-
-// State-aware connect/disconnect for the server buffer header. We label the
-// button "Disconnect" only while we're confidently connected; every other
-// state (idle, connecting, reconnecting, disconnected, unknown) reads as
-// "Reconnect" because the action — fire a fresh connect — is the same in
-// each case, and "Reconnect" is what the user reaches for when something
-// looks stuck.
-const serverConnectionState = computed(() => {
-  if (!active.value || !isServerBuffer.value) return null;
-  return networks.states[active.value.networkId]?.state ?? null;
-});
-const serverConnectActionLabel = computed(() =>
-  serverConnectionState.value === 'connected' ? 'Disconnect' : 'Reconnect',
-);
-const serverConnectActionIcon = computed(() =>
-  serverConnectionState.value === 'connected'
-    ? 'fa-solid fa-plug-circle-xmark'
-    : 'fa-solid fa-plug',
-);
-function toggleServerConnection() {
-  if (!active.value) return;
-  const id = active.value.networkId;
-  // Fire-and-forget — the button's label is driven by networks.states so
-  // success reflects itself. A failed call stays observable via the state
-  // (label doesn't flip), so we just log and let the user retry rather
-  // than wiring a toast through the topic bar for this case.
-  const p =
-    serverConnectionState.value === 'connected' ? networks.disconnect(id) : networks.reconnect(id);
-  p.catch((err) => console.error('[DesktopChat] toggle server connection failed', err));
-}
-
 useChatBootstrap({ onJump: onJumpToMessage });
 </script>
 
 <style scoped>
-/* WeeChat-style frame: the sidebar runs full height on the left; the topic
-   and input bars span the full width to the right of it; and the message
-   list + nicklist sit between them.
-
-   The sidebar and member-list columns are sized via CSS custom properties
-   so the .sidebar-collapsed / .members-collapsed modifier classes can shrink
-   either side to a 36px rail without touching the rest of the grid. */
+/* WeeChat-style frame: the sidebar runs full height on the left, and the rest
+   of the width is the chat content. The shell used to own the whole five-row
+   topic/divider/messages/status/input grid; BufferPane owns that now, so what's
+   left here is just the two columns. The sidebar is sized via a custom property
+   so .sidebar-collapsed can shrink it to a 36px rail without touching the rest
+   of the grid. */
 .chat {
   --sidebar-w: 220px;
-  --members-w: 180px;
   display: grid;
-  grid-template-columns: var(--sidebar-w) 1fr var(--members-w);
-  /* The 1px row owns the topic/messages divider as its own grid track,
-     outside the scroll container. Putting the line inside .message-list
-     (border-top, inset box-shadow) lets row backgrounds and hover states
-     paint over it as content scrolls past — the line appears to be eaten
-     by the scrolling rows. A dedicated row sits between the two children
-     and nothing can paint on top of it. */
-  grid-template-rows: auto auto 1fr auto auto;
-  grid-template-areas:
-    'sidebar topic    topic'
-    'sidebar divider  divider'
-    'sidebar messages members'
-    'sidebar status   status'
-    'sidebar input    input';
+  grid-template-columns: var(--sidebar-w) 1fr;
+  grid-template-rows: 1fr;
+  grid-template-areas: 'sidebar content';
   /* Height sized to the dynamic viewport. iOS scrolls the page
      naturally when the keyboard opens; the input row at the bottom
      stays visible above the keyboard, and the upper portion (sidebar,
@@ -697,26 +495,60 @@ useChatBootstrap({ onJump: onJumpToMessage });
 .chat.sidebar-collapsed {
   --sidebar-w: 36px;
 }
-/* Members column fully collapses — no rail. The reopen toggle lives in the
-   topic bar on the right, so there's nothing to leave behind. */
-.chat.members-collapsed {
-  --members-w: 0px;
-}
-/* System console has no member list — collapse the rail so the log pane
-   spans the full content width instead of leaving an empty column. */
-.chat.system-active {
-  --members-w: 0px;
-}
-/* The status bar carries the separator border above the input, but it's hidden
-   in the system buffer (no network state to show). Give the input its own top
-   border there so it stays visually divided from the message list. */
-.chat.system-active .input {
-  border-top: 1px solid var(--border);
-}
 /* min-height/min-width 0 lets flex/scrolling children stay inside their row. */
 .chat > * {
   min-width: 0;
   min-height: 0;
+}
+
+/* The pane grid. Every layout is a way of filling a 2x2, so the pane count
+   picks a template rather than each count getting its own grid:
+
+     1 pane    2 panes   3 panes   4 panes
+     ┌─────┐   ┌─────┐   ┌─────┐   ┌──┬──┐
+     │  a  │   │  a  │   │  a  │   │a │b │
+     │     │   ├─────┤   ├──┬──┤   ├──┼──┤
+     │     │   │  b  │   │b │c │   │c │d │
+     └─────┘   └─────┘   └──┴──┘   └──┴──┘
+
+   The separators are the 1px grid gap over a --border background rather than
+   per-pane borders: which edges a pane needs a line on differs in all four
+   layouts, and a gap is right in every one of them without the pane knowing
+   anything about its neighbours. */
+.panes {
+  grid-area: content;
+  display: grid;
+  gap: 1px;
+  background: var(--border);
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+.panes-1 {
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
+  grid-template-areas: 'a';
+}
+.panes-2 {
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr 1fr;
+  grid-template-areas: 'a' 'b';
+}
+/* Splitting the BOTTOM half is what makes a third pane an addition rather than
+   a re-layout: a and b keep their full width and only b's height changes. */
+.panes-3 {
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  grid-template-areas:
+    'a a'
+    'b c';
+}
+.panes-4 {
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  grid-template-areas:
+    'a b'
+    'c d';
 }
 
 .sidebar {
@@ -843,112 +675,5 @@ useChatBootstrap({ onJump: onJumpToMessage });
    (0,3,0) beats the global `button:hover:not(:disabled)` (0,2,1). */
 .rail-toggle:hover:not(:disabled) {
   border-color: var(--border);
-}
-
-.topic {
-  grid-area: topic;
-  padding: var(--space-4) var(--space-6);
-  display: flex;
-  align-items: baseline;
-  gap: var(--space-4);
-  white-space: nowrap;
-  overflow: hidden;
-}
-/* Back/forward history controls (#411), anchored at the far left of the bar,
-   left of the buffer title. Same accent icon buttons as the rest of the bar;
-   disabled (dimmed, non-interactive) when there's nowhere to go that way. */
-.topic-nav {
-  display: flex;
-  align-items: baseline;
-  /* Match .topic-actions' gap so the back/forward pair is spaced like every
-     other button pair in the bar, not tighter. */
-  gap: var(--space-4);
-  flex-shrink: 0;
-}
-.nav-btn:disabled {
-  opacity: 0.35;
-  cursor: default;
-}
-.nav-btn:disabled:hover {
-  color: var(--accent);
-}
-.topic-divider {
-  grid-area: divider;
-  background: var(--border);
-  height: 1px;
-}
-.topic .buffer {
-  color: var(--accent);
-}
-.topic .topic-text {
-  color: var(--fg-muted);
-  text-overflow: ellipsis;
-  overflow: hidden;
-  background: none;
-  border: none;
-  padding: 0;
-  margin: 0;
-  font: inherit;
-  text-align: left;
-  white-space: nowrap;
-  min-width: 0;
-}
-/* Hover/click affordances belong to the clickable channel-topic BUTTON only;
-   the DM identity renders as a static span sharing the layout styles above. */
-button.topic-text {
-  cursor: pointer;
-}
-button.topic-text:hover {
-  color: var(--fg);
-}
-button.topic-text:focus-visible {
-  outline: 1px solid var(--accent);
-  outline-offset: 2px;
-}
-
-/* These selectors target the root elements of the imported components.
-   Vue 3 scoped CSS attaches the parent's data-v attribute to a child
-   component's root element, so .message-list / .members / .input here
-   match the rendered roots of MessageList / MemberList / MessageInput. */
-.message-list {
-  grid-area: messages;
-}
-.members {
-  grid-area: members;
-  border-left: 1px solid var(--border);
-}
-.status-bar {
-  grid-area: status;
-}
-.input {
-  grid-area: input;
-}
-
-/* Two-group layout for the topic bar: .topic-meta (name + topic text, spaced
-   by the 2ch gap — wider than the 1ch bar convention to give the name and
-   topic breathing room now that the │ divider is gone) sits left,
-   .topic-actions (buffer/network/channel buttons) sits right.
-   .topic uses justify-content:space-between to split them. .topic-meta
-   shrinks first via min-width:0 + topic-text ellipsis, so the action
-   cluster stays anchored to the right edge. */
-.topic-meta {
-  display: flex;
-  align-items: baseline;
-  gap: 2ch;
-  /* flex:1 so the meta absorbs the free space and keeps the action cluster
-     anchored to the right edge; min-width:0 lets the topic text ellipsis. */
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-}
-.topic-actions {
-  display: flex;
-  align-items: baseline;
-  gap: var(--space-4);
-  flex-shrink: 0;
-}
-.topic .member-count {
-  color: var(--fg-muted);
-  font-variant-numeric: tabular-nums;
 }
 </style>

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -301,14 +301,6 @@ function focusedPane() {
 // empty pane until the next click.
 watch(() => networks.activeKey, splits.syncActive, { immediate: true });
 
-// A buffer can stop existing while a pane is showing it — parted, closed, or
-// dropped by a reconnect snapshot. Those panes would render a shell no click
-// can fix, so drop them once the buffer is gone.
-watch(
-  () => Object.keys(buffers.buffers).length,
-  () => splits.pruneClosed(),
-);
-
 // Any modal open? Type-ahead must not steal focus from a modal's own fields.
 const anyModalOpen = computed(
   () =>

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -94,7 +94,7 @@
         :pending-scroll-id="i === splits.focused ? pendingScrollId : null"
         @focus="onPaneFocus(i)"
         @close="onPaneClose(i)"
-        @maximize="splits.collapseTo(i)"
+        @maximize="onPaneMaximize(i)"
         @open-search="openSearch"
         @open-highlights="openHighlights"
         @show-topic="showTopic = true"
@@ -297,6 +297,13 @@ function onPaneFocus(index: number) {
 // leaves focus where it was, and this no-ops.)
 function onPaneClose(index: number) {
   splits.closePane(index);
+  activateFocusedPane();
+}
+
+// Maximize is the same story: collapsing to one pane changes which buffer is
+// focused whenever the maximized pane wasn't the focused one.
+function onPaneMaximize(index: number) {
+  splits.collapseTo(index);
   activateFocusedPane();
 }
 


### PR DESCRIPTION
Prototype: cmd/ctrl-click a buffer in the sidebar and it opens *beside* the one
you're in instead of replacing it, up to four at once.

```
  1 pane      2 panes     3 panes     4 panes
  ┌───────┐   ┌───────┐   ┌───────┐   ┌───┬───┐
  │   a   │   │   a   │   │   a   │   │ a │ b │
  │       │   ├───────┤   ├───┬───┤   ├───┼───┤
  │       │   │   b   │   │ b │ c │   │ c │ d │
  └───────┘   └───────┘   └───┴───┘   └───┴───┘
```

Each pane is a whole buffer view — its own topic bar, message list, nicklist,
status bar and input. Splitting the **bottom** half first is what makes a third
pane an addition rather than a re-layout: the first two keep their width and
only the second changes height.

<img width="2048" height="1168" alt="image" src="https://github.com/user-attachments/assets/46ca7c89-9921-432d-ae93-d6eb34827992" />

## Try it

- **Cmd/Ctrl-click** a buffer → opens it in a new pane, focused.
- **Plain click** → swaps the focused pane's buffer. Does *not* collapse the
  split; that's what the maximize button is for.
- **Click a pane** → focuses it. The focused pane's topic divider goes accent;
  the others' headers dim.
- Per-pane **maximize** (collapse to just this one) and **close** in the topic
  bar, split-only.
- At four panes, a fifth cmd-click takes over the focused pane.

## How it works

The load-bearing change isn't the layout, it's that `MessageList`, `MemberList`,
`StatusBar` and `MessageInput` each read `networks.activeKey` directly — which
is what made them singletons. They now resolve "my buffer" through a
provide/inject'd key (`useBufferKey()`), falling back to `activeKey` when
un-provided, so anything outside a pane behaves exactly as before. That commit
is cherry-picked from the old, never-merged `windowed-buffers-prototype` branch;
the rest is new.

**A single pane is the pre-split view.** Same markup, same grid, same CSS — it
just lives in `BufferPane` now instead of in the shell, and the shell's own grid
collapses to `sidebar | content`.

**Focus and visibility come apart.** `activate()` used to tear down the previous
buffer's unread divider and detached slice on every switch, because switching
away *was* leaving. With panes, a buffer you focused away from is still on
screen. That teardown is now `buffers.leaveBuffer()`, and the splits store
decides who gets it: one `setPanes()` diffs the pane set, and whatever is no
longer in it has genuinely stopped being read. `activate()` additionally skips
its own teardown when the buffer being activated is *already* on screen — that's
a focus change, not a switch — which it reads from `useViewedBuffer`'s
refcounted set rather than a second registry.

**The active buffer follows pane focus**, so everything outside the frame that
asks "what's active" — the sidebar highlight, scoped search, nav history, the
shortcuts — keeps working untouched. Panes focus on `pointerdown`, before the
click reaches any button, which is what makes "search this buffer" in an
unfocused pane search the right buffer.

**The splits store joins `bufferLifecycle.ts`**, since panes are keyed by
buffer. Close a buffer and its pane closes; rename one and its pane follows in
place, keeping its slot and running no teardown.

## Testing

`npm run check` and `npm test` are clean (3925 tests). New: 19 store tests for
the layout/teardown/lifecycle rules, 9 **mount** tests for `BufferPane`, 6 for
the pane registry, 3 for the composer singleton gating and 3 for split read
state. The behavioural ones were each confirmed to fail against the unfixed
code before being kept.

The mount tests matter more than usual here. The decoupling commit underneath
this was written before the repo had `@vue/test-utils` and was never runtime-
verified — QA would have been the first time any of it executed. It executes in
CI now, including the load-bearing case: two panes on different buffers, with a
probe standing in for the message list asking the same question every real child
asks. A pane resolving through `activeKey` would render the same buffer in both.

## Review round

`/code-review high` found one theme worth naming: **other module-level
singletons written on the premise that only one composer / one message list is
ever mounted.** The decoupling commit fixed that for four components; several
more were still resolving through `networks.activeKey` while rendering once per
pane. Fixed here:

- An upload's URL was broadcast into **every** pane's draft, leaving the link
  sitting in channels the user never meant to put it in.
- `useComposerOverlay`'s handler slots went to whichever composer mounted
  **last**, so an emoji/colour/file pick or Reply spliced into the wrong pane.
- The composing chip, the self-label prompt, `NickRef`'s self test, and the
  nicklist's scroll reset all read the focused pane's buffer.
- Maximize stranded `activeKey` the same way closing the focused pane did.
- Closing a buffer left the app with **no** active buffer while other panes
  were still up.
- A visible-but-unfocused pane never marked read, even though its toasts were
  suppressed — the two halves of "can the user see this" disagreed.

One of these was **not split-only**: the scroll-request tokens became
per-buffer counters in the decoupling commit, so entering a buffer could run
its jump-to-unread unrequested. That regressed the plain single-pane shell and
is fixed here too.

## Known rough edges

- **Panes aren't resizable** — the splits are fixed at 50/50. This is the first
  thing I'd add next; it's the main thing that'll feel wrong in daily use.
- **Layout doesn't persist** across reloads. You come back to a single pane.
- **Back/forward are single-pane only.** They're global history controls and
  four copies of one control is worse than reaching for Cmd/Ctrl+`[` and `]`.
  If per-pane history is what's actually wanted, that's a real feature, not a
  tweak.
- **Desktop only.** `MobileChat` is untouched — `Chat.vue` already forks on
  viewport.
- **No virtualization**, so four panes is four message lists of up to 500 rows
  plus four inputs. That's the perf ceiling and why four is the cap.
- Two panes can't show the same buffer — cmd-clicking one that's already open
  focuses its pane instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)