### PR TITLE
Preview byte cache: a dropper mode for the hosted fleet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -305,7 +305,7 @@ VAPID_SUBJECT=mailto:you@example.com
 # off, and previews keep working.
 #
 # ---------------------------------------------------------------------------
-# LURKER_PREVIEW_CACHE_MODE=off          # off | local | s3
+# LURKER_PREVIEW_CACHE_MODE=off          # off | local | s3 | dropper
 # LURKER_PREVIEW_CACHE_DIR=              # default: <data dir>/preview-cache
 # LURKER_PREVIEW_CACHE_MAX_BYTES=        # default: 2147483648 (2 GiB), digits only
 #
@@ -350,6 +350,23 @@ VAPID_SUBJECT=mailto:you@example.com
 # LURKER_PREVIEW_CACHE_S3_PUBLIC_BASE_URL=https://cdn.example.com
 # LURKER_PREVIEW_CACHE_S3_PREFIX=previews   # optional; sanitized to [A-Za-z0-9._-]/
 # LURKER_PREVIEW_CACHE_S3_REGION=           # default: auto (correct for R2)
+#
+# --- mode=dropper ------------------------------------------------------------
+# The hosted-fleet mode (self-hosters want local or s3). Bytes go to the
+# operator-run dropper service's POST /api/previews — the same service and the
+# same Bearer key uploads use — which writes them under the fleet bucket's
+# previews/ prefix; readers get the public CDN URL. The cell never holds bucket
+# credentials, which is the point (CP #63). Every warning in the s3 section
+# above applies here too: the objects are PUBLIC, the CDN base must be https,
+# retention is the bucket's 30-day lifecycle rule.
+#
+# ⚠ PUBLIC_BASE_URL INCLUDES the prefix the dropper stores under — the server
+# mints <base>/<key> and never hears the dropper's own answer, so the two must
+# agree or every minted URL 404s.
+# ---------------------------------------------------------------------------
+# LURKER_PREVIEW_CACHE_DROPPER_URL=http://<cp-vpc-ip>:8025
+# LURKER_PREVIEW_CACHE_DROPPER_API_KEY=
+# LURKER_PREVIEW_CACHE_DROPPER_PUBLIC_BASE_URL=https://cdn.example.com/previews
 
 # ---------------------------------------------------------------------------
 # Built-in IRC bouncer (ZNC- and soju-compatible). OFF by default. When enabled,

--- a/.env.example
+++ b/.env.example
@@ -364,7 +364,7 @@ VAPID_SUBJECT=mailto:you@example.com
 # mints <base>/<key> and never hears the dropper's own answer, so the two must
 # agree or every minted URL 404s.
 # ---------------------------------------------------------------------------
-# LURKER_PREVIEW_CACHE_DROPPER_URL=http://<cp-vpc-ip>:8025
+# LURKER_PREVIEW_CACHE_DROPPER_URL=http://<cp-vpc-ip>:8025   # scheme://host[:port] ONLY — /api/previews is appended
 # LURKER_PREVIEW_CACHE_DROPPER_API_KEY=
 # LURKER_PREVIEW_CACHE_DROPPER_PUBLIC_BASE_URL=https://cdn.example.com/previews
 

--- a/server/routes/linkPreview.droppercache.test.ts
+++ b/server/routes/linkPreview.droppercache.test.ts
@@ -40,6 +40,9 @@ interface Stored {
 let stores: Stored[] = [];
 /** Flip to make every store fail, without changing anything else. */
 let dropperRejects = false;
+/** Flip to answer stores with a URL from a DIFFERENT layout — the KEY_PREFIX /
+ *  wrong-base misconfiguration the cell must refuse to record. */
+let dropperWrongLayout = false;
 
 let dropper: http.Server;
 let dropperBase: string;
@@ -90,7 +93,14 @@ beforeAll(async () => {
             .end('{"error":"storage error"}');
           return;
         }
-        res.writeHead(200, { 'content-type': 'application/json' }).end('{"url":"ignored"}');
+        // Answer the way the real dropper does: the public URL for the stored
+        // key, which the cell checks against its own mint before recording.
+        const match = /name="key"\r?\n\r?\n([0-9a-f]{64})/.exec(body.toString('latin1'));
+        const storedKey = match ? match[1] : 'unparsed';
+        const url = dropperWrongLayout
+          ? `https://cdn.example.com/uploads/previews/${storedKey}`
+          : `${CDN}/${storedKey}`;
+        res.writeHead(200, { 'content-type': 'application/json' }).end(JSON.stringify({ url }));
         return;
       }
       res.writeHead(404).end();
@@ -141,6 +151,7 @@ beforeEach(async () => {
   originHits = 0;
   stores = [];
   dropperRejects = false;
+  dropperWrongLayout = false;
   const { default: db } = await import('../db/index.js');
   db.prepare('DELETE FROM preview_cache').run();
 });
@@ -161,6 +172,9 @@ describe('the dropper byte cache, end to end', () => {
     expect(store.url).toBe('/api/previews');
     expect(store.headers.authorization).toBe(`Bearer ${API_KEY}`);
     expect(String(store.headers['content-type'])).toMatch(/^multipart\/form-data; boundary=/);
+    // Same protocol the upload driver speaks, down to the User-Agent — fleet
+    // logs must be able to attribute preview traffic the way they do uploads.
+    expect(String(store.headers['user-agent'])).toContain('Lurker');
 
     const raw = store.body.toString('latin1');
     const key = byteCacheKey(`${base}/stored.png`);
@@ -212,6 +226,30 @@ describe('the dropper byte cache, end to end', () => {
 
     expect(stores.some((s) => s.method === 'POST')).toBe(true);
     expect(countCached()).toBe(0);
+  });
+
+  it('refuses to record a store whose answered URL disagrees with the minted layout', async () => {
+    // ⚠⚠ The one misconfiguration the pure-function mint cannot see on its own:
+    // a KEY_PREFIX on the dropper (or a wrong PUBLIC_BASE_URL here) makes every
+    // store "succeed" while every minted URL 404s, with no request ever
+    // reaching the cell. The dropper's answered URL is the free cross-check.
+    const { resetWarnThrottleForTests } = await import('../services/previewCache/inflight.js');
+    resetWarnThrottleForTests();
+    const warns: string[] = [];
+    const spy = vi.spyOn(console, 'warn').mockImplementation((m) => void warns.push(String(m)));
+    try {
+      dropperWrongLayout = true;
+      servePng();
+      const res = await agent.get(`/api/link-preview/media/${tokenFor('/mislayout.png')}`);
+      // The reader is still served; only the row is refused.
+      expect(res.status).toBe(200);
+      await whenStoresSettle();
+      expect(stores.some((s) => s.method === 'POST')).toBe(true);
+      expect(countCached()).toBe(0);
+      expect(warns.some((w) => w.includes('layout mismatch'))).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('leaves no staging file behind, whether the store lands or fails', async () => {
@@ -359,16 +397,21 @@ describe('resource bounds and diagnostics', () => {
     const cfg = cacheConfig();
     if (cfg.mode !== 'dropper') throw new Error('unreachable');
 
+    // ⚠ Slots released in a FINALLY: the counter is module state with no reset
+    // seam, so an assertion failure that skipped the aborts would pin the shared
+    // ceiling at 16 and cascade into every later store test in this file.
     const opened = [];
-    for (let i = 0; i < 16; i++) {
-      const w = await openDropperWrite(cfg, `bound-${i}`);
-      expect(`writer ${i}: ${w ? 'open' : 'refused'}`).toBe(`writer ${i}: open`);
-      opened.push(w!);
+    try {
+      for (let i = 0; i < 16; i++) {
+        const w = await openDropperWrite(cfg, `bound-${i}`);
+        expect(`writer ${i}: ${w ? 'open' : 'refused'}`).toBe(`writer ${i}: open`);
+        if (w) opened.push(w);
+      }
+      expect(storesInFlightForTests()).toBe(16);
+      expect(await openDropperWrite(cfg, 'bound-over')).toBeNull();
+    } finally {
+      for (const w of opened) await w.abort();
     }
-    expect(storesInFlightForTests()).toBe(16);
-    expect(await openDropperWrite(cfg, 'bound-over')).toBeNull();
-
-    for (const w of opened) await w.abort();
     expect(storesInFlightForTests()).toBe(0);
     const after = await openDropperWrite(cfg, 'bound-after');
     expect(after).not.toBeNull();
@@ -409,8 +452,7 @@ describe('resource bounds and diagnostics', () => {
     };
     try {
       const ok = await readDropper(cfg, 'somekey', 1024 * 1024);
-      expect(ok.kind).toBe('ok');
-      if (ok.kind === 'ok') expect(ok.body.equals(PNG)).toBe(true);
+      expect(ok.kind === 'ok' && ok.body.equals(PNG)).toBe(true);
 
       mode = 'no-length';
       expect((await readDropper(cfg, 'somekey', 1024 * 1024)).kind).toBe('error');

--- a/server/routes/linkPreview.droppercache.test.ts
+++ b/server/routes/linkPreview.droppercache.test.ts
@@ -1,0 +1,472 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The `dropper` byte cache through the ROUTE, against a stub dropper service
+// that remembers what it was sent. The s3 suite is the template and the
+// rationale (see its header); this file holds the dropper mode to the same bar.
+//
+// ⚠ What's mocked is the POLICY and the far end, never the mechanism: the
+// address guard is inverted so a loopback origin is reachable, the dropper is a
+// stand-in http server, and — for the two read-back tests only — global fetch
+// stands in for the CDN, because config validation (rightly) refuses an http
+// public base URL and the real one would mean live network in a test. The
+// multipart encoding, the staging file, the index write, the descriptor mint,
+// Express, the token, the throttles and the pool are all shipping code.
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import type { Express } from 'express';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+import { setupTestDb, createTestApp, createAuthedAgent } from '../test-utils/testApp.js';
+
+vi.mock('../utils/ipGuard.js', () => ({
+  isBlockedIpLiteral: (host: string) => host.replace(/^\[|\]$/g, '') !== '127.0.0.1',
+  isBlockedIpv4: (ip: string) => ip !== '127.0.0.1',
+}));
+
+const ctx = setupTestDb('routes-link-preview-droppercache');
+
+/** What the stub dropper recorded for one request. */
+interface Stored {
+  method: string;
+  url: string;
+  headers: http.IncomingHttpHeaders;
+  body: Buffer;
+}
+
+let stores: Stored[] = [];
+/** Flip to make every store fail, without changing anything else. */
+let dropperRejects = false;
+
+let dropper: http.Server;
+let dropperBase: string;
+
+const API_KEY = 'test-upload-key';
+const CDN = 'https://cdn.example.com/previews';
+
+let app: Express;
+let agent: LurkerTestAgent;
+let mintProxyToken: typeof import('../services/mediaProxyToken.js').mintProxyToken;
+let countCached: typeof import('../db/previewCache.js').countCached;
+let whenStoresSettle: typeof import('../services/previewCache/index.js').whenStoresSettle;
+let byteCacheKey: typeof import('../services/previewCache/index.js').byteCacheKey;
+
+type Handler = (req: http.IncomingMessage, res: http.ServerResponse) => void;
+let handler: Handler;
+let origin: http.Server;
+let base: string;
+let originHits = 0;
+
+const tokenFor = (p: string): string => mintProxyToken(`${base}${p}`);
+
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+function servePng(body = PNG): void {
+  handler = (_req, res) => {
+    res.writeHead(200, { 'content-type': 'image/png', 'content-length': String(body.length) });
+    res.end(body);
+  };
+}
+
+beforeAll(async () => {
+  // The stub dropper. Started BEFORE the cache config is read, because the
+  // config is resolved once per process and has to point at a real port.
+  dropper = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks);
+      stores.push({ method: req.method || '', url: req.url || '', headers: req.headers, body });
+      if (req.method === 'POST' && req.url === '/api/previews') {
+        if (dropperRejects) {
+          res
+            .writeHead(500, { 'content-type': 'application/json' })
+            .end('{"error":"storage error"}');
+          return;
+        }
+        res.writeHead(200, { 'content-type': 'application/json' }).end('{"url":"ignored"}');
+        return;
+      }
+      res.writeHead(404).end();
+    });
+  });
+  await new Promise<void>((resolve) => dropper.listen(0, '127.0.0.1', resolve));
+  dropperBase = `http://127.0.0.1:${(dropper.address() as AddressInfo).port}`;
+
+  process.env.LURKER_LINK_PREVIEWS = 'on';
+  process.env.LURKER_PREVIEW_CACHE_MODE = 'dropper';
+  process.env.LURKER_PREVIEW_CACHE_DROPPER_URL = dropperBase;
+  process.env.LURKER_PREVIEW_CACHE_DROPPER_API_KEY = API_KEY;
+  process.env.LURKER_PREVIEW_CACHE_DROPPER_PUBLIC_BASE_URL = CDN;
+  process.env.LURKER_PREVIEW_CACHE_DIR = path.join(ctx.tmpDir, 'preview-staging');
+
+  const { createUser } = await import('../db/users.js');
+  ({ mintProxyToken } = await import('../services/mediaProxyToken.js'));
+  ({ countCached } = await import('../db/previewCache.js'));
+  ({ whenStoresSettle, byteCacheKey } = await import('../services/previewCache/index.js'));
+  const router = (await import('./linkPreview.js')).default;
+
+  const alice = createUser('alice-droppercache');
+  app = createTestApp({ '/api/link-preview': router });
+  agent = await createAuthedAgent(app, alice.id);
+
+  origin = http.createServer((req, res) => {
+    originHits++;
+    handler(req, res);
+  });
+  await new Promise<void>((resolve) => origin.listen(0, '127.0.0.1', resolve));
+  base = `http://localhost:${(origin.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => origin.close(() => resolve()));
+  dropper.closeAllConnections();
+  await new Promise<void>((resolve) => dropper.close(() => resolve()));
+  for (const k of Object.keys(process.env)) {
+    if (k.startsWith('LURKER_PREVIEW_CACHE')) delete process.env[k];
+  }
+  ctx.cleanup();
+});
+
+beforeEach(async () => {
+  // ⚠⚠ Drains BEFORE clearing — stores are fire-and-forget, so a write from the
+  // previous test can still be in flight and land in this one's clean state.
+  await whenStoresSettle();
+  originHits = 0;
+  stores = [];
+  dropperRejects = false;
+  const { default: db } = await import('../db/index.js');
+  db.prepare('DELETE FROM preview_cache').run();
+});
+
+describe('the dropper byte cache, end to end', () => {
+  it('POSTs the bytes to /api/previews with the key part FIRST, Bearer-keyed, and records a row', async () => {
+    servePng();
+    const first = await agent.get(`/api/link-preview/media/${tokenFor('/stored.png')}`);
+    expect(first.status).toBe(200);
+    expect(Buffer.from(first.body).equals(PNG)).toBe(true);
+    await whenStoresSettle();
+
+    expect(stores).toHaveLength(1);
+    const store = stores[0]!;
+    // ⚠ The METHOD and PATH are asserted — a stub that records everything cannot
+    // tell you it was written to wrongly unless you ask.
+    expect(store.method).toBe('POST');
+    expect(store.url).toBe('/api/previews');
+    expect(store.headers.authorization).toBe(`Bearer ${API_KEY}`);
+    expect(String(store.headers['content-type'])).toMatch(/^multipart\/form-data; boundary=/);
+
+    const raw = store.body.toString('latin1');
+    const key = byteCacheKey(`${base}/stored.png`);
+    // The key field, the file part, and the ordering rule: the text part must
+    // arrive BEFORE the file so the dropper's parser has req.body.key populated.
+    const keyAt = raw.indexOf('name="key"');
+    const fileAt = raw.indexOf('name="file"');
+    expect(keyAt).toBeGreaterThan(-1);
+    expect(fileAt).toBeGreaterThan(-1);
+    expect(keyAt).toBeLessThan(fileAt);
+    expect(raw).toContain(key);
+    expect(raw).toContain('Content-Type: image/png');
+    expect(store.body.includes(PNG)).toBe(true);
+
+    expect(countCached()).toBe(1);
+  });
+
+  it('mints the CDN URL in the descriptor once the object is stored', async () => {
+    // ⚠⚠ THE HEADLINE PROPERTY OF THE MODE: a client is handed the public URL at
+    // DESCRIPTOR-MINT time, so a cached image costs the cell nothing at all. The
+    // URL is a pure function of config + key — the dropper's response body is
+    // deliberately never consulted.
+    servePng();
+    const imageUrl = `${base}/minted.png`;
+
+    const cold = await agent.post('/api/link-preview/resolve').send({ urls: [imageUrl] });
+    expect(cold.status).toBe(200);
+    expect(cold.body.previews[0].src).toMatch(/^\/api\/link-preview\/media\//);
+
+    await agent.get(`/api/link-preview/media/${mintProxyToken(imageUrl)}`);
+    await whenStoresSettle();
+    expect(countCached()).toBe(1);
+
+    const warm = await agent.post('/api/link-preview/resolve').send({ urls: [imageUrl] });
+    expect(warm.status).toBe(200);
+    expect(warm.body.previews[0].src).toBe(`${CDN}/${byteCacheKey(imageUrl)}`);
+  });
+
+  it('leaves NO ROW when the dropper refuses the store, and still serves the reader', async () => {
+    // ⚠⚠ An index entry for an object that does not exist makes `publicByteUrl`
+    // mint a public URL that 404s for everyone, with no request reaching the cell
+    // to notice.
+    dropperRejects = true;
+    servePng();
+    const res = await agent.get(`/api/link-preview/media/${tokenFor('/denied.png')}`);
+    expect(res.status).toBe(200);
+    expect(Buffer.from(res.body).equals(PNG)).toBe(true);
+    await whenStoresSettle();
+
+    expect(stores.some((s) => s.method === 'POST')).toBe(true);
+    expect(countCached()).toBe(0);
+  });
+
+  it('leaves no staging file behind, whether the store lands or fails', async () => {
+    const stagingDir = process.env.LURKER_PREVIEW_CACHE_DIR!;
+    servePng();
+    await agent.get(`/api/link-preview/media/${tokenFor('/kept.png')}`);
+    await whenStoresSettle();
+
+    dropperRejects = true;
+    await agent.get(`/api/link-preview/media/${tokenFor('/dropped.png')}`);
+    await whenStoresSettle();
+
+    const stray = fs.existsSync(stagingDir) ? fs.readdirSync(stagingDir) : [];
+    expect(stray).toEqual([]);
+  });
+
+  it('serves a proxy request for a stored object from the CDN, not the origin', async () => {
+    // A client holding a descriptor minted before the store landed still arrives
+    // at the proxy; that read should cost a CDN GET, not another third-party
+    // fetch. The CDN is global fetch here (config rightly refuses an http public
+    // base); the origin path uses node:http, so the spy sees only the cache read.
+    servePng();
+    const token = tokenFor('/reread.png');
+    await agent.get(`/api/link-preview/media/${token}`);
+    await whenStoresSettle();
+    expect(originHits).toBe(1);
+
+    const key = byteCacheKey(`${base}/reread.png`);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      expect(String(input)).toBe(`${CDN}/${key}`);
+      return new Response(PNG, {
+        status: 200,
+        headers: { 'content-type': 'image/png', 'content-length': String(PNG.length) },
+      });
+    });
+    try {
+      const second = await agent.get(`/api/link-preview/media/${token}`);
+      expect(second.status).toBe(200);
+      expect(Buffer.from(second.body).equals(PNG)).toBe(true);
+      // ⚠ THE assertion: one origin hit for two reads is the feature.
+      expect(originHits).toBe(1);
+      expect(fetchSpy).toHaveBeenCalledOnce();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('repairs the row and re-fetches when the lifecycle rule has taken the object', async () => {
+    // ⚠⚠ The 30-day lifecycle rule deletes objects the cell does not run and
+    // cannot observe; a proxy read is the only moment we ever learn one has gone
+    // early, and a genuine 404 must forget the row rather than 404 forever. The
+    // origin is taken away too, so the forget is the only thing that could have
+    // emptied the table (see the s3 suite for why that matters).
+    servePng();
+    const token = tokenFor('/vanished.png');
+    await agent.get(`/api/link-preview/media/${token}`);
+    await whenStoresSettle();
+    expect(countCached()).toBe(1);
+
+    handler = (_req, res) => res.writeHead(404).end();
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('gone', { status: 404 }));
+    try {
+      const after = await agent.get(`/api/link-preview/media/${token}`);
+      expect(after.status).toBe(404);
+      expect(originHits).toBe(2);
+      await whenStoresSettle();
+      expect(countCached()).toBe(0);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+
+    // ...and with a working origin it heals completely.
+    servePng();
+    const healed = await agent.get(`/api/link-preview/media/${token}`);
+    expect(healed.status).toBe(200);
+    await whenStoresSettle();
+    expect(countCached()).toBe(1);
+  });
+
+  it('does not mint a CDN URL for a row past its age bound', async () => {
+    // Seven days against the bucket rule's thirty is the margin that makes the
+    // row provably the shorter-lived of the two — same bound, same reasoning,
+    // same test as s3, because the dropper's objects die by the same rule.
+    servePng();
+    const imageUrl = `${base}/ageing.png`;
+    await agent.get(`/api/link-preview/media/${mintProxyToken(imageUrl)}`);
+    await whenStoresSettle();
+
+    const warm = await agent.post('/api/link-preview/resolve').send({ urls: [imageUrl] });
+    expect(warm.body.previews[0].src).toBe(`${CDN}/${byteCacheKey(imageUrl)}`);
+
+    const { default: db } = await import('../db/index.js');
+    const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare('UPDATE preview_cache SET created_at = ?').run(old);
+
+    const stale = await agent.post('/api/link-preview/resolve').send({ urls: [imageUrl] });
+    expect(stale.body.previews[0].src).toMatch(/^\/api\/link-preview\/media\//);
+  });
+
+  it('stays a miss, not an error, when the dropper is unreachable', async () => {
+    const { resetCacheConfigForTests } = await import('../services/previewCache/index.js');
+    const realUrl = process.env.LURKER_PREVIEW_CACHE_DROPPER_URL!;
+    const dead = http.createServer();
+    await new Promise<void>((r) => dead.listen(0, '127.0.0.1', r));
+    const deadPort = (dead.address() as AddressInfo).port;
+    await new Promise<void>((r) => dead.close(() => r()));
+
+    process.env.LURKER_PREVIEW_CACHE_DROPPER_URL = `http://127.0.0.1:${deadPort}`;
+    resetCacheConfigForTests();
+    try {
+      servePng();
+      const res = await agent.get(`/api/link-preview/media/${tokenFor('/nodropper.png')}`);
+      expect(res.status).toBe(200);
+      expect(Buffer.from(res.body).equals(PNG)).toBe(true);
+      await whenStoresSettle();
+      expect(countCached()).toBe(0);
+    } finally {
+      process.env.LURKER_PREVIEW_CACHE_DROPPER_URL = realUrl;
+      resetCacheConfigForTests();
+    }
+  });
+
+  it('does not cache a video, and sends nothing to the dropper for one', async () => {
+    const MP4 = Buffer.alloc(2048, 7);
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'video/mp4', 'content-length': String(MP4.length) });
+      res.end(MP4);
+    };
+    await agent.get(`/api/link-preview/media/${tokenFor('/clip.mp4')}`);
+    await whenStoresSettle();
+    expect(countCached()).toBe(0);
+    expect(stores).toHaveLength(0);
+  });
+});
+
+describe('resource bounds and diagnostics', () => {
+  it('declines a store rather than queueing when too many are already in flight', async () => {
+    // The ceiling lives in ./inflight.ts and is SHARED with the s3 backend — one
+    // process, one set of outbound stores — so the seams are imported from there.
+    const { openDropperWrite } = await import('../services/previewCache/dropper.js');
+    const { storesInFlightForTests } = await import('../services/previewCache/inflight.js');
+    const { cacheConfig } = await import('../services/previewCache/index.js');
+    const cfg = cacheConfig();
+    if (cfg.mode !== 'dropper') throw new Error('unreachable');
+
+    const opened = [];
+    for (let i = 0; i < 16; i++) {
+      const w = await openDropperWrite(cfg, `bound-${i}`);
+      expect(`writer ${i}: ${w ? 'open' : 'refused'}`).toBe(`writer ${i}: open`);
+      opened.push(w!);
+    }
+    expect(storesInFlightForTests()).toBe(16);
+    expect(await openDropperWrite(cfg, 'bound-over')).toBeNull();
+
+    for (const w of opened) await w.abort();
+    expect(storesInFlightForTests()).toBe(0);
+    const after = await openDropperWrite(cfg, 'bound-after');
+    expect(after).not.toBeNull();
+    await after!.abort();
+  });
+
+  it('readDropper declines a CDN read without a Content-Length, and only a 404 is "missing"', async () => {
+    // Unit-level, with a hand-built plain-http config: readDropper takes the
+    // config as a parameter, and the route-level config (rightly) refuses an
+    // http public base. Same guards as readS3, asserted against the same traps:
+    // `Number(null)` is 0, which is finite and under any cap.
+    const { readDropper } = await import('../services/previewCache/dropper.js');
+
+    let mode: 'ok' | 'no-length' | 'missing' | 'denied' | 'oversize' = 'ok';
+    const cdn = http.createServer((_req, res) => {
+      if (mode === 'missing') return void res.writeHead(404).end('no such key');
+      if (mode === 'denied') return void res.writeHead(403).end('denied');
+      if (mode === 'no-length') {
+        res.writeHead(200, { 'content-type': 'image/png' });
+        return void res.end(PNG);
+      }
+      if (mode === 'oversize') {
+        // Headers promising far more than the cap, then silence — the client has
+        // to walk away on the declared length, not read to find out.
+        res.writeHead(200, { 'content-type': 'image/png', 'content-length': '999999999' });
+        return void res.flushHeaders();
+      }
+      res.writeHead(200, { 'content-type': 'image/png', 'content-length': String(PNG.length) });
+      res.end(PNG);
+    });
+    await new Promise<void>((r) => cdn.listen(0, '127.0.0.1', r));
+    const cfg = {
+      mode: 'dropper' as const,
+      url: 'http://127.0.0.1:1',
+      apiKey: 'k',
+      publicBaseUrl: `http://127.0.0.1:${(cdn.address() as AddressInfo).port}`,
+      stagingDir: path.join(ctx.tmpDir, 'unit-staging'),
+    };
+    try {
+      const ok = await readDropper(cfg, 'somekey', 1024 * 1024);
+      expect(ok.kind).toBe('ok');
+      if (ok.kind === 'ok') expect(ok.body.equals(PNG)).toBe(true);
+
+      mode = 'no-length';
+      expect((await readDropper(cfg, 'somekey', 1024 * 1024)).kind).toBe('error');
+
+      // ⚠⚠ GONE vs BROKEN: only a genuine 404 may forget an index row.
+      mode = 'missing';
+      expect((await readDropper(cfg, 'somekey', 1024 * 1024)).kind).toBe('missing');
+      mode = 'denied';
+      expect((await readDropper(cfg, 'somekey', 1024 * 1024)).kind).toBe('error');
+
+      mode = 'oversize';
+      const started = Date.now();
+      const over = await readDropper(cfg, 'somekey', 1024 * 1024);
+      expect(over.kind).toBe('error');
+      // Cancelled on the declared length — reading the promised ~1 GB of silence
+      // would block until the 30 s request timeout.
+      expect(`${Date.now() - started < 3000 ? 'prompt' : 'blocked'}`).toBe('prompt');
+    } finally {
+      cdn.closeAllConnections();
+      await new Promise<void>((r) => cdn.close(() => r()));
+    }
+  });
+
+  it('sweeps rows left behind by a backend that is no longer configured', async () => {
+    const { sweepPreviewCache } = await import('../services/previewCache/index.js');
+    const { recordCached, countCached } = await import('../db/previewCache.js');
+
+    recordCached({ key: 'leftover-s3', backend: 's3', contentType: 'image/png', size: 10 });
+    recordCached({
+      key: 'current-dropper',
+      backend: 'dropper',
+      contentType: 'image/png',
+      size: 10,
+    });
+    expect(countCached()).toBe(2);
+
+    await sweepPreviewCache();
+    // The foreign row goes — and nothing was asked to DELETE any bytes: the cell
+    // holds no delete capability, the lifecycle rule owns retention.
+    expect(countCached()).toBe(1);
+    expect(stores).toHaveLength(0);
+  });
+
+  it('says something when the dropper refuses every store, instead of failing silently', async () => {
+    const { resetWarnThrottleForTests } = await import('../services/previewCache/inflight.js');
+    resetWarnThrottleForTests();
+    const warns: string[] = [];
+    const spy = vi.spyOn(console, 'warn').mockImplementation((m) => void warns.push(String(m)));
+    try {
+      dropperRejects = true;
+      servePng();
+      await agent.get(`/api/link-preview/media/${tokenFor('/loud.png')}`);
+      await whenStoresSettle();
+      expect(warns.some((w) => w.includes('[preview-cache]') && w.includes('500'))).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/server/routes/linkPreview.s3cache.test.ts
+++ b/server/routes/linkPreview.s3cache.test.ts
@@ -447,18 +447,23 @@ describe('resource bounds and diagnostics', () => {
     const cfg = cacheConfig();
     if (cfg.mode !== 's3') throw new Error('unreachable');
 
+    // ⚠ Slots released in a FINALLY: the counter is module state with no reset
+    // seam, so an assertion failure that skipped the aborts would pin the shared
+    // ceiling at 16 and cascade into every later store test in this file.
     const opened = [];
-    for (let i = 0; i < 16; i++) {
-      const w = await openS3Write(cfg, `bound-${i}`);
-      expect(`writer ${i}: ${w ? 'open' : 'refused'}`).toBe(`writer ${i}: open`);
-      opened.push(w!);
+    try {
+      for (let i = 0; i < 16; i++) {
+        const w = await openS3Write(cfg, `bound-${i}`);
+        expect(`writer ${i}: ${w ? 'open' : 'refused'}`).toBe(`writer ${i}: open`);
+        if (w) opened.push(w);
+      }
+      expect(storesInFlightForTests()).toBe(16);
+      // ⚠ The 17th is REFUSED, not queued — a queue would bound sockets and not files.
+      expect(await openS3Write(cfg, 'bound-over')).toBeNull();
+    } finally {
+      // ...and the ceiling is released, not leaked, so the next request can store.
+      for (const w of opened) await w.abort();
     }
-    expect(storesInFlightForTests()).toBe(16);
-    // ⚠ The 17th is REFUSED, not queued — a queue would bound sockets and not files.
-    expect(await openS3Write(cfg, 'bound-over')).toBeNull();
-
-    // ...and the ceiling is released, not leaked, so the next request can store.
-    for (const w of opened) await w.abort();
     expect(storesInFlightForTests()).toBe(0);
     const after = await openS3Write(cfg, 'bound-after');
     expect(after).not.toBeNull();

--- a/server/services/linkPreview.ts
+++ b/server/services/linkPreview.ts
@@ -39,9 +39,10 @@ import {
   type PreviewKind,
 } from '../db/linkPreviews.js';
 import { mintProxyToken } from './mediaProxyToken.js';
-// ⚠ From `previewCache/s3.js`, not `previewCache/index.js`. The index imports this
-// module for `kindForContentType`, so reaching back through it would close a cycle.
-import { publicByteUrl } from './previewCache/s3.js';
+// ⚠ From `previewCache/publicUrl.js`, not `previewCache/index.js`. The index
+// imports this module for `kindForContentType`, so reaching back through it would
+// close a cycle.
+import { publicByteUrl } from './previewCache/publicUrl.js';
 
 /** Clamps, applied server-side so no client has to think about them and no
  *  client can be surprised by a 40 KB og:description. */

--- a/server/services/previewCache/config.test.ts
+++ b/server/services/previewCache/config.test.ts
@@ -239,6 +239,30 @@ describe('resolveCacheConfig', () => {
       expect(warnings.length).toBeGreaterThan(0);
     });
 
+    // ⚠ The backend appends /api/previews itself, so a pasted full endpoint (a
+    // natural misread of "the dropper URL") would make every store POST to
+    // /api/previews/api/previews — a working-looking mode where every store
+    // fails. Caught at boot instead.
+    it('refuses a service URL carrying a path, query or fragment', () => {
+      for (const bad of [
+        'http://10.0.0.2:8025/api/previews',
+        'http://10.0.0.2:8025/dropper',
+        'http://10.0.0.2:8025?token=x',
+        'http://10.0.0.2:8025#frag',
+      ]) {
+        setDropperEnv();
+        process.env.LURKER_PREVIEW_CACHE_DROPPER_URL = bad;
+        const warnings: string[] = [];
+        const cfg = resolveCacheConfig((m) => warnings.push(m));
+        expect(`${bad} → ${cfg.mode}`).toBe(`${bad} → off`);
+        expect(`${bad}: ${warnings.length > 0 ? 'warned' : 'silent'}`).toBe(`${bad}: warned`);
+      }
+      // ...but a bare trailing slash is the pathname '/', which is fine.
+      setDropperEnv();
+      process.env.LURKER_PREVIEW_CACHE_DROPPER_URL = 'http://10.0.0.2:8025/';
+      expect(resolveCacheConfig().mode).toBe('dropper');
+    });
+
     it('trims trailing slashes so minted URLs never double up a separator', () => {
       setDropperEnv();
       process.env.LURKER_PREVIEW_CACHE_DROPPER_URL = 'http://10.0.0.2:8025/';

--- a/server/services/previewCache/config.test.ts
+++ b/server/services/previewCache/config.test.ts
@@ -15,6 +15,9 @@ const KEYS = [
   'LURKER_PREVIEW_CACHE_S3_SECRET_ACCESS_KEY',
   'LURKER_PREVIEW_CACHE_S3_PUBLIC_BASE_URL',
   'LURKER_PREVIEW_CACHE_S3_PREFIX',
+  'LURKER_PREVIEW_CACHE_DROPPER_URL',
+  'LURKER_PREVIEW_CACHE_DROPPER_API_KEY',
+  'LURKER_PREVIEW_CACHE_DROPPER_PUBLIC_BASE_URL',
 ];
 
 /** Every field `s3` requires, so a test can remove exactly one. */
@@ -25,6 +28,14 @@ function setS3Env(): void {
   process.env.LURKER_PREVIEW_CACHE_S3_ACCESS_KEY_ID = 'key';
   process.env.LURKER_PREVIEW_CACHE_S3_SECRET_ACCESS_KEY = 'secret';
   process.env.LURKER_PREVIEW_CACHE_S3_PUBLIC_BASE_URL = 'https://cdn.example.com';
+}
+
+/** Every field `dropper` requires, so a test can remove exactly one. */
+function setDropperEnv(): void {
+  process.env.LURKER_PREVIEW_CACHE_MODE = 'dropper';
+  process.env.LURKER_PREVIEW_CACHE_DROPPER_URL = 'http://10.0.0.2:8025';
+  process.env.LURKER_PREVIEW_CACHE_DROPPER_API_KEY = 'upload-key';
+  process.env.LURKER_PREVIEW_CACHE_DROPPER_PUBLIC_BASE_URL = 'https://cdn.example.com/previews';
 }
 
 afterEach(() => {
@@ -39,7 +50,7 @@ describe('resolveCacheConfig', () => {
   });
 
   it('rejects an unknown mode rather than guessing at it, and says so', () => {
-    for (const mode of ['r2', 'bucket', 'dropper']) {
+    for (const mode of ['r2', 'bucket', 'hoarder']) {
       process.env.LURKER_PREVIEW_CACHE_MODE = mode;
       const warnings: string[] = [];
       expect(`${mode} → ${resolveCacheConfig((m) => warnings.push(m)).mode}`).toBe(`${mode} → off`);
@@ -173,6 +184,78 @@ describe('resolveCacheConfig', () => {
       if (cfg.mode !== 's3') throw new Error('unreachable');
       expect(cfg.endpoint).toBe('https://endpoint.example.com');
       expect(cfg.publicBaseUrl).toBe('https://cdn.example.com');
+    });
+  });
+
+  describe('mode dropper', () => {
+    it('resolves a complete config', () => {
+      setDropperEnv();
+      const cfg = resolveCacheConfig();
+      if (cfg.mode !== 'dropper') throw new Error('unreachable');
+      expect(cfg.url).toBe('http://10.0.0.2:8025');
+      expect(cfg.apiKey).toBe('upload-key');
+      expect(cfg.publicBaseUrl).toBe('https://cdn.example.com/previews');
+      expect(cfg.stagingDir).toMatch(/preview-cache$/);
+    });
+
+    it('falls back to OFF, loudly, when any required field is missing', () => {
+      for (const key of [
+        'LURKER_PREVIEW_CACHE_DROPPER_URL',
+        'LURKER_PREVIEW_CACHE_DROPPER_API_KEY',
+        'LURKER_PREVIEW_CACHE_DROPPER_PUBLIC_BASE_URL',
+      ]) {
+        setDropperEnv();
+        delete process.env[key];
+        const warnings: string[] = [];
+        const cfg = resolveCacheConfig((m) => warnings.push(m));
+        expect(`${key} → ${cfg.mode}`).toBe(`${key} → off`);
+        expect(`${key} named: ${warnings.some((w) => w.includes(key))}`).toBe(`${key} named: true`);
+      }
+    });
+
+    // The service URL is dialled over the fleet's private VPC — plain http is the
+    // genuinely provisioned shape — but the PUBLIC base is handed to browsers on an
+    // https page, where an http image is mixed content that never renders.
+    it('accepts an http service URL but refuses an http public base', () => {
+      setDropperEnv();
+      const ok = resolveCacheConfig();
+      expect(ok.mode).toBe('dropper');
+
+      for (const bad of ['http://cdn.example.com/previews', 'not a url', 'ftp://cdn/previews']) {
+        setDropperEnv();
+        process.env.LURKER_PREVIEW_CACHE_DROPPER_PUBLIC_BASE_URL = bad;
+        const warnings: string[] = [];
+        const cfg = resolveCacheConfig((m) => warnings.push(m));
+        expect(`${bad} → ${cfg.mode}`).toBe(`${bad} → off`);
+        expect(`${bad}: ${warnings.length > 0 ? 'warned' : 'silent'}`).toBe(`${bad}: warned`);
+      }
+    });
+
+    it('refuses a service URL that is not a URL at all', () => {
+      setDropperEnv();
+      process.env.LURKER_PREVIEW_CACHE_DROPPER_URL = 'not a url';
+      const warnings: string[] = [];
+      expect(resolveCacheConfig((m) => warnings.push(m)).mode).toBe('off');
+      expect(warnings.length).toBeGreaterThan(0);
+    });
+
+    it('trims trailing slashes so minted URLs never double up a separator', () => {
+      setDropperEnv();
+      process.env.LURKER_PREVIEW_CACHE_DROPPER_URL = 'http://10.0.0.2:8025/';
+      process.env.LURKER_PREVIEW_CACHE_DROPPER_PUBLIC_BASE_URL =
+        'https://cdn.example.com/previews//';
+      const cfg = resolveCacheConfig();
+      if (cfg.mode !== 'dropper') throw new Error('unreachable');
+      expect(cfg.url).toBe('http://10.0.0.2:8025');
+      expect(cfg.publicBaseUrl).toBe('https://cdn.example.com/previews');
+    });
+
+    it('honours an explicit staging directory', () => {
+      setDropperEnv();
+      process.env.LURKER_PREVIEW_CACHE_DIR = '/tmp/somewhere-else';
+      const cfg = resolveCacheConfig();
+      if (cfg.mode !== 'dropper') throw new Error('unreachable');
+      expect(cfg.stagingDir).toBe('/tmp/somewhere-else');
     });
   });
 });

--- a/server/services/previewCache/config.ts
+++ b/server/services/previewCache/config.ts
@@ -70,10 +70,12 @@ export interface DropperCacheConfig {
    *  presents to POST /api/upload. Never a delete-capable key, by design. */
   apiKey: string;
   /**
-   * Where readers are sent, INCLUDING the prefix the dropper stores under —
-   * e.g. `https://cdn.lurker.chat/previews`. The cell mints `${base}/${key}`
-   * as a pure function of config, so this must agree with the dropper's
-   * `KEY_PREFIX` + `previews/` layout or every minted URL 404s.
+   * Where readers are sent, INCLUDING the `/previews` prefix — e.g.
+   * `https://cdn.lurker.chat/previews`. The dropper always stores previews at
+   * the literal `previews/<key>` (its KEY_PREFIX deliberately does not apply),
+   * and the cell mints `${base}/${key}` as a pure function of config — a
+   * disagreement is caught at store time, when the dropper's answered URL is
+   * compared against the mint (see dropper.ts).
    */
   publicBaseUrl: string;
   /** Where bytes are staged before the multipart POST. Same reasoning as the s3
@@ -160,23 +162,7 @@ function resolveS3(warn: (msg: string) => void): CacheConfig {
     return { mode: 'off' };
   }
 
-  // ⚠⚠ https, not merely a valid URL. These URLs are handed to browsers as image
-  // sources on a page served over https, where an http:// image is blocked as
-  // mixed content and simply never renders. Refusing here makes that a warning at
-  // boot instead of every cached preview silently going blank.
-  let base: URL;
-  try {
-    base = new URL(publicBaseUrl);
-  } catch {
-    warn(`[preview-cache] S3_PUBLIC_BASE_URL "${publicBaseUrl}" is not a URL — caching is OFF.`);
-    return { mode: 'off' };
-  }
-  if (base.protocol !== 'https:') {
-    warn(
-      `[preview-cache] S3_PUBLIC_BASE_URL must be https (got "${base.protocol}") — caching is OFF.`,
-    );
-    return { mode: 'off' };
-  }
+  if (!validHttpsBase(publicBaseUrl, 'S3_PUBLIC_BASE_URL', warn)) return { mode: 'off' };
 
   // ⚠ SANITISED, per segment, with the uploader's own function. An operator's
   // prefix reaches `new URL()` and an S3 key; left raw, a '#' in it truncates the
@@ -241,25 +227,21 @@ function resolveDropper(warn: (msg: string) => void): CacheConfig {
     );
     return { mode: 'off' };
   }
+  // ⚠ Scheme://host[:port] ONLY. The backend appends `/api/previews` itself, so
+  // an operator who pastes the full endpoint (a natural misread of "the dropper
+  // URL") would have every store POST to /api/previews/api/previews and fail —
+  // for the life of the process, surfaced only as one throttled warning a
+  // minute. That is exactly the working-looking-but-broken state this
+  // validation exists to catch at boot instead.
+  if ((service.pathname !== '/' && service.pathname !== '') || service.search || service.hash) {
+    warn(
+      `[preview-cache] DROPPER_URL must have no path, query or fragment (got "${url}") — ` +
+        `the /api/previews path is appended automatically. Caching is OFF.`,
+    );
+    return { mode: 'off' };
+  }
 
-  // ⚠⚠ https, not merely a valid URL — same rationale as the s3 mode: these URLs
-  // are handed to browsers as image sources on a page served over https, where an
-  // http:// image is blocked as mixed content and simply never renders.
-  let base: URL;
-  try {
-    base = new URL(publicBaseUrl);
-  } catch {
-    warn(
-      `[preview-cache] DROPPER_PUBLIC_BASE_URL "${publicBaseUrl}" is not a URL — caching is OFF.`,
-    );
-    return { mode: 'off' };
-  }
-  if (base.protocol !== 'https:') {
-    warn(
-      `[preview-cache] DROPPER_PUBLIC_BASE_URL must be https (got "${base.protocol}") — caching is OFF.`,
-    );
-    return { mode: 'off' };
-  }
+  if (!validHttpsBase(publicBaseUrl, 'DROPPER_PUBLIC_BASE_URL', warn)) return { mode: 'off' };
 
   return {
     mode: 'dropper',
@@ -268,6 +250,28 @@ function resolveDropper(warn: (msg: string) => void): CacheConfig {
     publicBaseUrl: publicBaseUrl.replace(/\/+$/, ''),
     stagingDir: env('LURKER_PREVIEW_CACHE_DIR') || path.join(resolveDataDir(), 'preview-cache'),
   };
+}
+
+/**
+ * ⚠⚠ https, not merely a valid URL — shared by every remote mode's PUBLIC base,
+ * because the rationale is identical: these URLs are handed to browsers as image
+ * sources on a page served over https, where an http:// image is blocked as
+ * mixed content and simply never renders. Refusing here makes that one warning
+ * at boot instead of every cached preview silently going blank.
+ */
+function validHttpsBase(raw: string, label: string, warn: (msg: string) => void): boolean {
+  let base: URL;
+  try {
+    base = new URL(raw);
+  } catch {
+    warn(`[preview-cache] ${label} "${raw}" is not a URL — caching is OFF.`);
+    return false;
+  }
+  if (base.protocol !== 'https:') {
+    warn(`[preview-cache] ${label} must be https (got "${base.protocol}") — caching is OFF.`);
+    return false;
+  }
+  return true;
 }
 
 function defaultWarn(msg: string): void {

--- a/server/services/previewCache/config.ts
+++ b/server/services/previewCache/config.ts
@@ -162,7 +162,9 @@ function resolveS3(warn: (msg: string) => void): CacheConfig {
     return { mode: 'off' };
   }
 
-  if (!validHttpsBase(publicBaseUrl, 'S3_PUBLIC_BASE_URL', warn)) return { mode: 'off' };
+  if (!validHttpsBase(publicBaseUrl, 'LURKER_PREVIEW_CACHE_S3_PUBLIC_BASE_URL', warn)) {
+    return { mode: 'off' };
+  }
 
   // ⚠ SANITISED, per segment, with the uploader's own function. An operator's
   // prefix reaches `new URL()` and an S3 key; left raw, a '#' in it truncates the
@@ -214,16 +216,20 @@ function resolveDropper(warn: (msg: string) => void): CacheConfig {
     return { mode: 'off' };
   }
 
+  // ⚠ Warnings name the FULL env var, so the log line an operator greps for is
+  // the line in their env file.
   let service: URL;
   try {
     service = new URL(url);
   } catch {
-    warn(`[preview-cache] DROPPER_URL "${url}" is not a URL — caching is OFF.`);
+    warn(
+      `[preview-cache] LURKER_PREVIEW_CACHE_DROPPER_URL "${url}" is not a URL — caching is OFF.`,
+    );
     return { mode: 'off' };
   }
   if (service.protocol !== 'https:' && service.protocol !== 'http:') {
     warn(
-      `[preview-cache] DROPPER_URL must be http(s) (got "${service.protocol}") — caching is OFF.`,
+      `[preview-cache] LURKER_PREVIEW_CACHE_DROPPER_URL must be http(s) (got "${service.protocol}") — caching is OFF.`,
     );
     return { mode: 'off' };
   }
@@ -235,13 +241,15 @@ function resolveDropper(warn: (msg: string) => void): CacheConfig {
   // validation exists to catch at boot instead.
   if ((service.pathname !== '/' && service.pathname !== '') || service.search || service.hash) {
     warn(
-      `[preview-cache] DROPPER_URL must have no path, query or fragment (got "${url}") — ` +
-        `the /api/previews path is appended automatically. Caching is OFF.`,
+      `[preview-cache] LURKER_PREVIEW_CACHE_DROPPER_URL must have no path, query or fragment ` +
+        `(got "${url}") — the /api/previews path is appended automatically. Caching is OFF.`,
     );
     return { mode: 'off' };
   }
 
-  if (!validHttpsBase(publicBaseUrl, 'DROPPER_PUBLIC_BASE_URL', warn)) return { mode: 'off' };
+  if (!validHttpsBase(publicBaseUrl, 'LURKER_PREVIEW_CACHE_DROPPER_PUBLIC_BASE_URL', warn)) {
+    return { mode: 'off' };
+  }
 
   return {
     mode: 'dropper',

--- a/server/services/previewCache/config.ts
+++ b/server/services/previewCache/config.ts
@@ -22,7 +22,7 @@ import path from 'path';
 import { resolveDataDir } from '../../utils/dataDir.js';
 import { sanitizeSegment } from '../uploadProviders/s3.js';
 
-export type CacheMode = 'off' | 'local' | 's3';
+export type CacheMode = 'off' | 'local' | 's3' | 'dropper';
 
 export interface LocalCacheConfig {
   mode: 'local';
@@ -55,7 +55,33 @@ export interface S3CacheConfig {
   stagingDir: string;
 }
 
-export type CacheConfig = { mode: 'off' } | LocalCacheConfig | S3CacheConfig;
+/**
+ * The hosted backend: the operator-run dropper service stores the bytes in the
+ * fleet's bucket and the CDN serves them. This mode exists because hosted cells
+ * deliberately hold NO bucket credentials (CP #63) — the dropper is the only
+ * thing that writes to R2, cells only hold an upload key for it.
+ */
+export interface DropperCacheConfig {
+  mode: 'dropper';
+  /** The dropper service base, e.g. `http://10.0.0.2:8025`. May be plain http —
+   *  this URL is dialled over the fleet's private VPC, never by a browser. */
+  url: string;
+  /** Bearer key for POST /api/previews — the same upload key the cell already
+   *  presents to POST /api/upload. Never a delete-capable key, by design. */
+  apiKey: string;
+  /**
+   * Where readers are sent, INCLUDING the prefix the dropper stores under —
+   * e.g. `https://cdn.lurker.chat/previews`. The cell mints `${base}/${key}`
+   * as a pure function of config, so this must agree with the dropper's
+   * `KEY_PREFIX` + `previews/` layout or every minted URL 404s.
+   */
+  publicBaseUrl: string;
+  /** Where bytes are staged before the multipart POST. Same reasoning as the s3
+   *  mode's staging file: the POST needs an exact Content-Length up front. */
+  stagingDir: string;
+}
+
+export type CacheConfig = { mode: 'off' } | LocalCacheConfig | S3CacheConfig | DropperCacheConfig;
 
 /** 2 GiB. Big enough that a normal instance never evicts, small enough to notice. */
 const DEFAULT_LOCAL_MAX_BYTES = 2 * 1024 * 1024 * 1024;
@@ -100,6 +126,7 @@ export function resolveCacheConfig(warn: (msg: string) => void = defaultWarn): C
   }
 
   if (mode === 's3') return resolveS3(warn);
+  if (mode === 'dropper') return resolveDropper(warn);
 
   warn(`[preview-cache] unknown LURKER_PREVIEW_CACHE_MODE "${mode}" — caching is OFF.`);
   return { mode: 'off' };
@@ -173,6 +200,72 @@ function resolveS3(warn: (msg: string) => void): CacheConfig {
     secretAccessKey,
     publicBaseUrl: publicBaseUrl.replace(/\/+$/, ''),
     prefix,
+    stagingDir: env('LURKER_PREVIEW_CACHE_DIR') || path.join(resolveDataDir(), 'preview-cache'),
+  };
+}
+
+/**
+ * The hosted backend. Same validation posture as `resolveS3`, and for the same
+ * reason: `publicBaseUrl` is handed to browsers as an image source, so a
+ * half-configured mode degrades to a public URL that 404s for everyone, not to
+ * slow. The one deliberate difference: `url` (the dropper service itself) may be
+ * plain http — it is dialled over the fleet's private VPC, never by a browser,
+ * and the fleet's provisioning genuinely uses `http://<vpc-ip>:8025`.
+ */
+function resolveDropper(warn: (msg: string) => void): CacheConfig {
+  const missing: string[] = [];
+  const required = (name: string): string => {
+    const value = env(name);
+    if (!value) missing.push(name);
+    return value;
+  };
+  const url = required('LURKER_PREVIEW_CACHE_DROPPER_URL');
+  const apiKey = required('LURKER_PREVIEW_CACHE_DROPPER_API_KEY');
+  const publicBaseUrl = required('LURKER_PREVIEW_CACHE_DROPPER_PUBLIC_BASE_URL');
+
+  if (missing.length) {
+    warn(`[preview-cache] mode "dropper" needs ${missing.join(', ')} — caching is OFF.`);
+    return { mode: 'off' };
+  }
+
+  let service: URL;
+  try {
+    service = new URL(url);
+  } catch {
+    warn(`[preview-cache] DROPPER_URL "${url}" is not a URL — caching is OFF.`);
+    return { mode: 'off' };
+  }
+  if (service.protocol !== 'https:' && service.protocol !== 'http:') {
+    warn(
+      `[preview-cache] DROPPER_URL must be http(s) (got "${service.protocol}") — caching is OFF.`,
+    );
+    return { mode: 'off' };
+  }
+
+  // ⚠⚠ https, not merely a valid URL — same rationale as the s3 mode: these URLs
+  // are handed to browsers as image sources on a page served over https, where an
+  // http:// image is blocked as mixed content and simply never renders.
+  let base: URL;
+  try {
+    base = new URL(publicBaseUrl);
+  } catch {
+    warn(
+      `[preview-cache] DROPPER_PUBLIC_BASE_URL "${publicBaseUrl}" is not a URL — caching is OFF.`,
+    );
+    return { mode: 'off' };
+  }
+  if (base.protocol !== 'https:') {
+    warn(
+      `[preview-cache] DROPPER_PUBLIC_BASE_URL must be https (got "${base.protocol}") — caching is OFF.`,
+    );
+    return { mode: 'off' };
+  }
+
+  return {
+    mode: 'dropper',
+    url: url.replace(/\/+$/, ''),
+    apiKey,
+    publicBaseUrl: publicBaseUrl.replace(/\/+$/, ''),
     stagingDir: env('LURKER_PREVIEW_CACHE_DIR') || path.join(resolveDataDir(), 'preview-cache'),
   };
 }

--- a/server/services/previewCache/dropper.ts
+++ b/server/services/previewCache/dropper.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The hosted backend (CP #63). Bytes go to the operator-run dropper service —
+// POST /api/previews with the cell-computed key — which writes them under the
+// fleet bucket's `previews/` prefix, and browsers read them DIRECTLY from the
+// CDN in front of that bucket. The cell holds an upload key and nothing else:
+// no bucket credentials, no delete capability, by design. Everything this
+// module says about resource bounds is inherited from the s3 backend, whose
+// docblocks are the reference; the only genuine difference is the transport
+// (a Bearer-keyed multipart POST instead of a SigV4 PUT).
+//
+// ⚠ The key is the SAME `byteCacheKey` digest every cell computes for a URL, so
+// the cache is shared fleet-wide: cell B re-storing what cell A already stored
+// is an idempotent overwrite of the same object, not a conflict.
+//
+// ⚠ Everything the s3 module's header says about WHAT A PUBLIC OBJECT CAN AND
+// CANNOT CARRY applies verbatim here — same bucket, same CDN, same three
+// replayable headers. The dropper sets Content-Type, Content-Disposition and
+// Cache-Control on the object at store time; nosniff and the CSP sandbox are
+// not expressible, and the bound on that is the dropper's own image-only,
+// magic-byte-verified allowlist.
+
+import fs from 'fs/promises';
+import { fileSource } from '../uploadProviders/source.js';
+import { postMultipart, type StreamPart } from '../uploadProviders/multipart.js';
+import { openTempFile } from './tempFile.js';
+import { tryAcquireStoreSlot, warnOnce } from './inflight.js';
+import { discard, type S3Read, type S3Writer } from './s3.js';
+import type { DropperCacheConfig } from './config.js';
+
+/** Where a reader is sent. Public by construction — that is the point of the
+ *  mode. `publicBaseUrl` already contains the dropper's key prefix, and the key
+ *  is a hex digest, so no joining logic and no percent-encoding is needed. */
+export function publicDropperUrl(cfg: DropperCacheConfig, key: string): string {
+  return `${cfg.publicBaseUrl}/${key}`;
+}
+
+/**
+ * Read one object back through the CDN.
+ *
+ * ⚠ NOT the common path, same as the s3 backend's read: once an object is
+ * stored, the descriptor mints its public URL and clients fetch it without
+ * touching the cell. This exists for a client holding a descriptor minted
+ * BEFORE the store landed — serve them, and on a genuine 404 repair the row
+ * that said the object was there.
+ *
+ * ⚠⚠ Distinguishes GONE from BROKEN, exactly as `readS3` does: only a genuine
+ * 404 may forget an index row. A 403, a timeout or a DNS failure is a miss and
+ * nothing more. (One nuance the s3 backend does not have: this GET goes through
+ * the CDN, so an edge-cached 404 from just before the store landed can look
+ * genuine. The cost is only a redundant re-store, and the window is tiny —
+ * descriptors mint only after the row exists.)
+ */
+export async function readDropper(
+  cfg: DropperCacheConfig,
+  key: string,
+  maxBytes: number,
+): Promise<S3Read> {
+  try {
+    const res = await fetch(publicDropperUrl(cfg, key), {
+      method: 'GET',
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (res.status === 404) {
+      await discard(res);
+      return { kind: 'missing' };
+    }
+    if (!res.ok) {
+      await discard(res);
+      return { kind: 'error' };
+    }
+    // ⚠⚠ Bounded before reading, not after — and an ABSENT length is declined,
+    // not waved through. `Number(null)` is 0, which is finite and under any cap,
+    // so a plain isFinite test passes exactly the responses it cannot bound.
+    // Same guard, same reasoning as `readS3`.
+    const raw = res.headers.get('content-length');
+    const declared = raw === null ? Number.NaN : Number(raw);
+    if (!Number.isFinite(declared) || declared > maxBytes) {
+      await discard(res);
+      return { kind: 'error' };
+    }
+    const body = Buffer.from(await res.arrayBuffer());
+    if (body.length > maxBytes) return { kind: 'error' };
+    return {
+      kind: 'ok',
+      body,
+      contentType: res.headers.get('content-type') || 'application/octet-stream',
+    };
+  } catch {
+    return { kind: 'error' };
+  }
+}
+
+/**
+ * Begin storing an object whose bytes are still arriving.
+ *
+ * ⚠⚠ STAGED TO A FILE, never collected in memory — `postMultipart` computes an
+ * exact Content-Length from the staged file's size, which is what lets the POST
+ * go out as a plain framed request instead of buffering in the heap. The route
+ * deliberately does not await `commit`, so the send runs OUTSIDE the mediaPool
+ * slots for up to the multipart module's 60 s timeout — which is why the shared
+ * in-flight ceiling (./inflight.ts) bounds it, exactly as it bounds the s3 PUT.
+ */
+export async function openDropperWrite(
+  cfg: DropperCacheConfig,
+  key: string,
+): Promise<S3Writer | null> {
+  const settle = tryAcquireStoreSlot();
+  if (!settle) return null;
+
+  const staged = await openTempFile(cfg.stagingDir, key);
+  if (!staged) {
+    settle();
+    return null;
+  }
+
+  return {
+    write(chunk: Buffer): void {
+      staged.write(chunk);
+    },
+    async commit(contentType: string): Promise<boolean> {
+      if (!(await staged.close())) {
+        settle();
+        return false;
+      }
+      try {
+        const { size } = await fs.stat(staged.path);
+        const source = fileSource(staged.path, size);
+        const parts: StreamPart[] = [
+          // ⚠ The text part goes BEFORE the file part, so the dropper's multipart
+          // parser has the key in req.body by the time the file lands — the same
+          // ordering rule the upload driver documents.
+          { name: 'key', value: key },
+          { name: 'file', filename: key, contentType, source },
+        ];
+        const resp = await postMultipart(`${cfg.url}/api/previews`, parts, {
+          headers: { Authorization: `Bearer ${cfg.apiKey}` },
+        });
+        if (resp.status >= 200 && resp.status < 300) return true;
+        warnOnce(`dropper refused a store: ${resp.status} ${resp.text.slice(0, 200)}`);
+        return false;
+      } catch (err) {
+        warnOnce(`dropper store failed: ${(err as Error)?.message ?? err}`);
+        return false;
+      } finally {
+        // ⚠ ALWAYS, on every exit. The staging file is ours and nothing else
+        // knows it exists — not the index, not eviction — so a leak here is
+        // bytes on the volume that no later pass can find.
+        await fs.unlink(staged.path).catch(() => {});
+        settle();
+      }
+    },
+    async abort(): Promise<void> {
+      await staged.discard();
+      settle();
+    },
+  };
+}

--- a/server/services/previewCache/dropper.ts
+++ b/server/services/previewCache/dropper.ts
@@ -5,28 +5,27 @@
 // POST /api/previews with the cell-computed key — which writes them under the
 // fleet bucket's `previews/` prefix, and browsers read them DIRECTLY from the
 // CDN in front of that bucket. The cell holds an upload key and nothing else:
-// no bucket credentials, no delete capability, by design. Everything this
-// module says about resource bounds is inherited from the s3 backend, whose
-// docblocks are the reference; the only genuine difference is the transport
-// (a Bearer-keyed multipart POST instead of a SigV4 PUT).
+// no bucket credentials, no delete capability, by design. The staging, ceiling
+// and bounded-read machinery is shared with the s3 backend (./remoteWrite.ts,
+// `readRemote`); this module's own parts are the multipart POST and the CDN GET.
 //
 // ⚠ The key is the SAME `byteCacheKey` digest every cell computes for a URL, so
 // the cache is shared fleet-wide: cell B re-storing what cell A already stored
 // is an idempotent overwrite of the same object, not a conflict.
 //
-// ⚠ Everything the s3 module's header says about WHAT A PUBLIC OBJECT CAN AND
+// ⚠⚠ Everything the s3 module's header says about WHAT A PUBLIC OBJECT CAN AND
 // CANNOT CARRY applies verbatim here — same bucket, same CDN, same three
 // replayable headers. The dropper sets Content-Type, Content-Disposition and
 // Cache-Control on the object at store time; nosniff and the CSP sandbox are
 // not expressible, and the bound on that is the dropper's own image-only,
-// magic-byte-verified allowlist.
+// signature-verified allowlist.
 
-import fs from 'fs/promises';
 import { fileSource } from '../uploadProviders/source.js';
-import { postMultipart, type StreamPart } from '../uploadProviders/multipart.js';
-import { openTempFile } from './tempFile.js';
-import { tryAcquireStoreSlot, warnOnce } from './inflight.js';
-import { discard, type S3Read, type S3Writer } from './s3.js';
+import { postMultipart, isOk, jsonBody, type StreamPart } from '../uploadProviders/multipart.js';
+import { USER_AGENT } from '../../utils/userAgent.js';
+import { warnOnce } from './inflight.js';
+import { openStagedRemoteWrite, type RemoteWriter } from './remoteWrite.js';
+import { readRemote, type S3Read } from './s3.js';
 import type { DropperCacheConfig } from './config.js';
 
 /** Where a reader is sent. Public by construction — that is the point of the
@@ -43,117 +42,75 @@ export function publicDropperUrl(cfg: DropperCacheConfig, key: string): string {
  * stored, the descriptor mints its public URL and clients fetch it without
  * touching the cell. This exists for a client holding a descriptor minted
  * BEFORE the store landed — serve them, and on a genuine 404 repair the row
- * that said the object was there.
+ * that said the object was there. Only a genuine 404 may do that; every other
+ * failure is a miss (`readRemote` draws that line).
  *
- * ⚠⚠ Distinguishes GONE from BROKEN, exactly as `readS3` does: only a genuine
- * 404 may forget an index row. A 403, a timeout or a DNS failure is a miss and
- * nothing more. (One nuance the s3 backend does not have: this GET goes through
- * the CDN, so an edge-cached 404 from just before the store landed can look
- * genuine. The cost is only a redundant re-store, and the window is tiny —
- * descriptors mint only after the row exists.)
+ * ⚠ `accept-encoding: identity`, unlike the s3 read, because this GET goes
+ * through a CDN rather than a bucket API. An edge that compressed the response
+ * would make `readRemote`'s Content-Length bound test the WIRE size while the
+ * decompressed body inflates past it in the heap — and the inflated length
+ * would no longer equal the index row's recorded size, so every proxy read of a
+ * perfectly good row would be treated as corrupt and forgotten. Identity makes
+ * the declared length the body length again.
  */
 export async function readDropper(
   cfg: DropperCacheConfig,
   key: string,
   maxBytes: number,
 ): Promise<S3Read> {
-  try {
-    const res = await fetch(publicDropperUrl(cfg, key), {
-      method: 'GET',
-      signal: AbortSignal.timeout(30_000),
-    });
-    if (res.status === 404) {
-      await discard(res);
-      return { kind: 'missing' };
-    }
-    if (!res.ok) {
-      await discard(res);
-      return { kind: 'error' };
-    }
-    // ⚠⚠ Bounded before reading, not after — and an ABSENT length is declined,
-    // not waved through. `Number(null)` is 0, which is finite and under any cap,
-    // so a plain isFinite test passes exactly the responses it cannot bound.
-    // Same guard, same reasoning as `readS3`.
-    const raw = res.headers.get('content-length');
-    const declared = raw === null ? Number.NaN : Number(raw);
-    if (!Number.isFinite(declared) || declared > maxBytes) {
-      await discard(res);
-      return { kind: 'error' };
-    }
-    const body = Buffer.from(await res.arrayBuffer());
-    if (body.length > maxBytes) return { kind: 'error' };
-    return {
-      kind: 'ok',
-      body,
-      contentType: res.headers.get('content-type') || 'application/octet-stream',
-    };
-  } catch {
-    return { kind: 'error' };
-  }
+  return readRemote(publicDropperUrl(cfg, key), { 'accept-encoding': 'identity' }, maxBytes);
 }
 
 /**
- * Begin storing an object whose bytes are still arriving.
- *
- * ⚠⚠ STAGED TO A FILE, never collected in memory — `postMultipart` computes an
- * exact Content-Length from the staged file's size, which is what lets the POST
- * go out as a plain framed request instead of buffering in the heap. The route
- * deliberately does not await `commit`, so the send runs OUTSIDE the mediaPool
- * slots for up to the multipart module's 60 s timeout — which is why the shared
- * in-flight ceiling (./inflight.ts) bounds it, exactly as it bounds the s3 PUT.
+ * Begin storing an object whose bytes are still arriving. The staging, the
+ * in-flight ceiling and the always-unlink discipline are `openStagedRemoteWrite`'s;
+ * this backend's own part is the Bearer-keyed multipart POST — the same protocol
+ * the upload driver speaks, down to the User-Agent, so fleet logs can attribute
+ * the traffic.
  */
 export async function openDropperWrite(
   cfg: DropperCacheConfig,
   key: string,
-): Promise<S3Writer | null> {
-  const settle = tryAcquireStoreSlot();
-  if (!settle) return null;
-
-  const staged = await openTempFile(cfg.stagingDir, key);
-  if (!staged) {
-    settle();
-    return null;
-  }
-
-  return {
-    write(chunk: Buffer): void {
-      staged.write(chunk);
-    },
-    async commit(contentType: string): Promise<boolean> {
-      if (!(await staged.close())) {
-        settle();
-        return false;
-      }
-      try {
-        const { size } = await fs.stat(staged.path);
-        const source = fileSource(staged.path, size);
-        const parts: StreamPart[] = [
-          // ⚠ The text part goes BEFORE the file part, so the dropper's multipart
-          // parser has the key in req.body by the time the file lands — the same
-          // ordering rule the upload driver documents.
-          { name: 'key', value: key },
-          { name: 'file', filename: key, contentType, source },
-        ];
-        const resp = await postMultipart(`${cfg.url}/api/previews`, parts, {
-          headers: { Authorization: `Bearer ${cfg.apiKey}` },
-        });
-        if (resp.status >= 200 && resp.status < 300) return true;
+): Promise<RemoteWriter | null> {
+  return openStagedRemoteWrite(
+    cfg.stagingDir,
+    key,
+    'dropper',
+    async (stagedPath, size, contentType) => {
+      const source = fileSource(stagedPath, size);
+      const parts: StreamPart[] = [
+        // ⚠ The text part goes BEFORE the file part, so the dropper's multipart
+        // parser has the key in req.body by the time the file lands — the same
+        // ordering rule the upload driver documents.
+        { name: 'key', value: key },
+        { name: 'file', filename: key, contentType, source },
+      ];
+      // 60 s default timeout from postMultipart, same bound as the s3 PUT.
+      const resp = await postMultipart(`${cfg.url}/api/previews`, parts, {
+        headers: { Authorization: `Bearer ${cfg.apiKey}`, 'User-Agent': USER_AGENT },
+      });
+      if (!isOk(resp)) {
         warnOnce(`dropper refused a store: ${resp.status} ${resp.text.slice(0, 200)}`);
         return false;
-      } catch (err) {
-        warnOnce(`dropper store failed: ${(err as Error)?.message ?? err}`);
-        return false;
-      } finally {
-        // ⚠ ALWAYS, on every exit. The staging file is ours and nothing else
-        // knows it exists — not the index, not eviction — so a leak here is
-        // bytes on the volume that no later pass can find.
-        await fs.unlink(staged.path).catch(() => {});
-        settle();
       }
+      // ⚠⚠ The dropper's answer carries the ONE fact the cell otherwise takes on
+      // faith: the public URL the object actually lives at. The cell mints its
+      // own URLs as a pure function of config — that is the design — so a layout
+      // disagreement (a KEY_PREFIX on the dropper, a wrong PUBLIC_BASE_URL here)
+      // would mean every store "succeeds" while every minted URL 404s, with no
+      // request ever reaching the cell to notice. Refusing to record the row
+      // keeps the proxy fallback serving readers and turns silent fleet-wide
+      // blank images into one warning a minute.
+      const body = jsonBody(resp) as { url?: unknown } | null;
+      const expected = publicDropperUrl(cfg, key);
+      if (!body || body.url !== expected) {
+        warnOnce(
+          `dropper stored at "${body && typeof body.url === 'string' ? body.url : '<no url>'}" ` +
+            `but this cell would mint "${expected}" — URL layout mismatch, not recording the store.`,
+        );
+        return false;
+      }
+      return true;
     },
-    async abort(): Promise<void> {
-      await staged.discard();
-      settle();
-    },
-  };
+  );
 }

--- a/server/services/previewCache/index.ts
+++ b/server/services/previewCache/index.ts
@@ -32,6 +32,7 @@ import { imageSignatureOf, SIGNATURE_BYTES } from '../../utils/imageSignature.js
 import { cacheConfig, cacheEnabled, expired, MAX_AGE_MS } from './config.js';
 import { evictLocal, objectPath, openLocalWrite, readLocal, removeLocal } from './local.js';
 import { openS3Write, readS3, removeS3, type S3Writer } from './s3.js';
+import { openDropperWrite, readDropper } from './dropper.js';
 
 export type { CacheConfig, CacheMode } from './config.js';
 export { objectPath };
@@ -40,7 +41,7 @@ export { objectPath };
 // `kindForContentType` — so anything the resolver has to reach must sit BELOW that
 // import or the two modules form a cycle. Callers still see one surface.
 export { byteCacheKey, cacheConfig, cacheEnabled, resetCacheConfigForTests } from './config.js';
-export { publicByteUrl } from './s3.js';
+export { publicByteUrl } from './publicUrl.js';
 
 /**
  * Served from bytes we hold.
@@ -202,7 +203,9 @@ export async function lookup(key: string): Promise<CacheHit | null> {
     const read =
       cfg.mode === 'local'
         ? await readLocal(cfg, key)
-        : await readS3(cfg, key, MAX_IMAGE_PROXY_BYTES);
+        : cfg.mode === 's3'
+          ? await readS3(cfg, key, MAX_IMAGE_PROXY_BYTES)
+          : await readDropper(cfg, key, MAX_IMAGE_PROXY_BYTES);
     // ⚠⚠ Only a GENUINELY MISSING object forgets its row. `readLocal` used to
     // collapse every errno to null, so a transient EMFILE — 24 concurrent reads is
     // within this pool's own budget — or an EACCES after a permissions change
@@ -327,7 +330,8 @@ export async function beginStore(key: string, expected: number): Promise<StoreWr
         abort: () => local.abort(),
       };
     } else {
-      const remote = await openS3Write(cfg, key);
+      const remote =
+        cfg.mode === 's3' ? await openS3Write(cfg, key) : await openDropperWrite(cfg, key);
       if (!remote) return null;
       writer = remote;
     }
@@ -405,8 +409,13 @@ export async function beginStore(key: string, expected: number): Promise<StoreWr
             // file is dead weight on a volume the operator can see and reclaim, but
             // an unindexed object is dead weight they are billed for until a
             // lifecycle rule they may not have set gets round to it.
+            // ⚠ `dropper` gets NO rollback, and that is a capability fact, not an
+            // oversight: the cell holds an upload key only — the split key sets
+            // exist so a compromised cell cannot delete from the fleet's bucket —
+            // and hosted previews/ always has the 30-day lifecycle rule to reclaim
+            // an unindexed object.
             if (cfg.mode === 'local') await removeLocal(cfg, key);
-            else await removeS3(cfg, key);
+            else if (cfg.mode === 's3') await removeS3(cfg, key);
             return false;
           }
           return true;

--- a/server/services/previewCache/inflight.ts
+++ b/server/services/previewCache/inflight.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The store-side resource bounds every REMOTE cache backend shares. Extracted
+// from the s3 module when the dropper backend arrived, because two copies would
+// mean two counters and two throttles in a process that only ever runs ONE
+// backend — the ceiling is a fact about this process's outbound stores, not
+// about any particular bucket.
+
+/**
+ * Stores whose bytes are still moving — staged, hashing, or mid-send.
+ *
+ * ⚠ Module state rather than a field on the config, because the config is a plain
+ * value that is re-resolved by tests and the bound has to survive that. One
+ * process, one backend, one ceiling.
+ */
+let storesInFlight = 0;
+/** Generous next to `mediaPool`'s 24, because these are meant to be short — the
+ *  ceiling is a backstop against a stalled remote, not a throughput knob. */
+const MAX_STORES_IN_FLIGHT = 16;
+
+/**
+ * Claim a store slot, or null at the ceiling.
+ *
+ * ⚠ DECLINED at the ceiling, never queued. A queue would bound the sockets and
+ * not the staged files, and would make an already-slow remote slower still;
+ * declining is free, because the reader has their bytes and all that is lost is
+ * the saving on the next read. The returned settle is idempotent — commit and
+ * abort paths can both call it without double-freeing the slot.
+ */
+export function tryAcquireStoreSlot(): (() => void) | null {
+  if (storesInFlight >= MAX_STORES_IN_FLIGHT) return null;
+  storesInFlight++;
+  let settled = false;
+  return (): void => {
+    if (settled) return;
+    settled = true;
+    storesInFlight--;
+  };
+}
+
+/** Test seam: the bound is invisible from outside until it bites. */
+export function storesInFlightForTests(): number {
+  return storesInFlight;
+}
+
+/**
+ * ⚠ A cache is not a failure path, but a cache that fails FOREVER and SILENTLY is
+ * an operator support burden. Config validation only proves the env vars are
+ * present — a wrong secret, a policy denial, a typo'd bucket or endpoint all
+ * resolve to a working-looking mode where every store fails, nothing populates,
+ * and no line is ever logged. `local` at least leaves errno-shaped evidence on
+ * the volume.
+ *
+ * ⚠ Throttled to once a minute, and deliberately not per-key: the failure mode
+ * this exists for is EVERY store failing, so an unthrottled warning would be one
+ * line per image request in the log of a server that is otherwise fine.
+ */
+let lastWarnAt = 0;
+
+/** Test seam: the throttle is global, so one test warning silences the next. */
+export function resetWarnThrottleForTests(): void {
+  lastWarnAt = 0;
+}
+
+export function warnOnce(message: string): void {
+  const now = Date.now();
+  if (now - lastWarnAt < 60_000) return;
+  lastWarnAt = now;
+  console.warn(`[preview-cache] ${message}`);
+}

--- a/server/services/previewCache/publicUrl.ts
+++ b/server/services/previewCache/publicUrl.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The mint decision for every remote backend. A leaf module (below the resolver
+// in the import graph) because `toDescriptor` has to call it and ./index.ts
+// imports the resolver — the same cycle rule that once put this function in the
+// s3 module. It moved here when the dropper backend arrived: which backend can
+// mint a public URL is a dispatch, not an s3 fact.
+
+import { peekCached } from '../../db/previewCache.js';
+import { byteCacheKey, cacheConfig, expired } from './config.js';
+import { publicUrl as s3PublicUrl } from './s3.js';
+import { publicDropperUrl } from './dropper.js';
+
+/**
+ * The public URL for a cached image, or null to use the proxy.
+ *
+ * ⚠⚠ THIS IS THE WHOLE POINT OF THE REMOTE MODES, and it is the reason there is
+ * no redirect anywhere in this feature. `toDescriptor` mints `src`/`thumb` per
+ * request and clients treat both as opaque, so the cheapest place to send a reader
+ * to the CDN is at MINT time: no 302, no second round trip through the cell, and
+ * no chance of a client forwarding its `Authorization` header to a third-party
+ * host, which is what a redirect would have invited.
+ *
+ * ⚠ Returning null is always SAFE, and that property is what makes this
+ * comfortable. The caller falls back to the proxy path, which works regardless of
+ * cache state — an empty bucket, a stale index, a mode change mid-flight all
+ * degrade to exactly the behaviour that shipped before any of this existed. The
+ * one shape that CANNOT self-correct is minting a URL for an object that is not
+ * there: the client fetches the CDN directly, so its 404 never reaches us. That is
+ * why the age bound is enforced here and not only on the read path.
+ *
+ * ⚠ `peekCached`, never `lookupCached`: this runs once per image per resolve, and
+ * once per image per row once Part 2's `previewsForTexts` ships it into snapshot
+ * building. The `last_access` touch is a WAL write on the shared connection.
+ *
+ * ⚠ Never throws — same promise the rest of the cache makes. It sits in the middle
+ * of `toDescriptor`, which has no business failing because a cache lookup did.
+ */
+export function publicByteUrl(imageUrl: string): string | null {
+  try {
+    const cfg = cacheConfig();
+    if (cfg.mode !== 's3' && cfg.mode !== 'dropper') return null;
+
+    const key = byteCacheKey(imageUrl);
+    const entry = peekCached(key);
+    if (!entry || entry.backend !== cfg.mode || expired(entry.createdAt)) return null;
+    return cfg.mode === 's3' ? s3PublicUrl(cfg, key) : publicDropperUrl(cfg, key);
+  } catch {
+    return null;
+  }
+}

--- a/server/services/previewCache/remoteWrite.ts
+++ b/server/services/previewCache/remoteWrite.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The staged-write scaffold every remote backend shares. Two invariants live in
+// it, and they are the reason it is ONE function rather than a per-backend
+// copy: the staging file is unlinked on EVERY commit exit (nothing else — not
+// the index, not eviction — knows it exists, so a leak is bytes no later pass
+// can find), and the in-flight slot is settled exactly once on every path.
+// A fix to either must reach every backend at the same moment.
+
+import fs from 'fs/promises';
+import { openTempFile } from './tempFile.js';
+import { tryAcquireStoreSlot, warnOnce } from './inflight.js';
+
+/** A store in progress. The one writer shape every backend adapts to; `commit`
+ *  needs the content type because remote backends put it ON the object. */
+export interface RemoteWriter {
+  write(chunk: Buffer): void;
+  commit(contentType: string): Promise<boolean>;
+  abort(): Promise<void>;
+}
+
+/**
+ * Begin storing an object whose bytes are still arriving.
+ *
+ * ⚠⚠ STAGED TO A FILE, never collected in memory — the backends need the full
+ * payload before they can send (SigV4 hashes it; multipart declares an exact
+ * Content-Length), and the route streams it in chunk by chunk. Collecting it in
+ * the heap would cost the 8 MB per-request image ceiling times `mediaPool`'s 24
+ * slots, and worse: the route deliberately does not await a store, so a buffer
+ * outlives the pool slot that bounded it and nothing caps how many accumulate.
+ *
+ * ⚠⚠ ITS OWN BOUND (the shared slot ceiling), because `mediaPool`'s does not
+ * reach this far. The route calls `commit` without awaiting it and hands its
+ * pool slot back on the response's `close` at the same moment, so `send` runs
+ * entirely OUTSIDE the 24 slots for up to its transport timeout, each call
+ * pinning a staged file and an outbound socket.
+ *
+ * `send` is the ONLY per-backend part: given the staged file and its size, ship
+ * the bytes and answer whether the remote accepted them (doing its own
+ * `warnOnce` for a refusal it can describe better than we can).
+ */
+export async function openStagedRemoteWrite(
+  stagingDir: string,
+  key: string,
+  label: string,
+  send: (stagedPath: string, size: number, contentType: string) => Promise<boolean>,
+): Promise<RemoteWriter | null> {
+  // ⚠ Acquired BEFORE the staging file is opened, so the ceiling can never be
+  // overshot by concurrent opens — and released if staging fails.
+  const settle = tryAcquireStoreSlot();
+  if (!settle) return null;
+
+  const staged = await openTempFile(stagingDir, key);
+  if (!staged) {
+    settle();
+    return null;
+  }
+
+  return {
+    write(chunk: Buffer): void {
+      staged.write(chunk);
+    },
+    async commit(contentType: string): Promise<boolean> {
+      if (!(await staged.close())) {
+        settle();
+        return false;
+      }
+      try {
+        const { size } = await fs.stat(staged.path);
+        return await send(staged.path, size, contentType);
+      } catch (err) {
+        warnOnce(`${label} store failed: ${(err as Error)?.message ?? err}`);
+        return false;
+      } finally {
+        // ⚠ ALWAYS, on every exit. The staging file is ours and nothing else knows
+        // it exists — not the index, not eviction — so a leak here is bytes on the
+        // volume that no later pass can find.
+        await fs.unlink(staged.path).catch(() => {});
+        settle();
+      }
+    },
+    async abort(): Promise<void> {
+      await staged.discard();
+      settle();
+    },
+  };
+}

--- a/server/services/previewCache/s3.ts
+++ b/server/services/previewCache/s3.ts
@@ -113,7 +113,7 @@ const OBJECT_CONTENT_DISPOSITION = 'inline';
  * request timeout, inside a `mediaPool` slot, for bytes nobody wants. Cancelling
  * releases the socket without reading a byte. (Copilot.)
  */
-export async function discard(res: Response): Promise<void> {
+async function discard(res: Response): Promise<void> {
   try {
     await res.body?.cancel();
   } catch {

--- a/server/services/previewCache/s3.ts
+++ b/server/services/previewCache/s3.ts
@@ -74,12 +74,11 @@
 // Transform Rules and equivalents do this), which is a deployment choice we can
 // document but cannot enforce from here.
 
-import fs from 'fs/promises';
 import { fileSource, hashOf } from '../uploadProviders/source.js';
 import { putSource } from '../uploadProviders/multipart.js';
 import { signObjectRequest } from '../uploadProviders/s3.js';
-import { openTempFile } from './tempFile.js';
-import { tryAcquireStoreSlot, warnOnce } from './inflight.js';
+import { warnOnce } from './inflight.js';
+import { openStagedRemoteWrite } from './remoteWrite.js';
 import type { S3CacheConfig } from './config.js';
 
 // The store bounds and the warn throttle moved to ./inflight.ts when the dropper
@@ -152,34 +151,26 @@ export type S3Read =
   | { kind: 'error' };
 
 /**
- * Read one object back through the bucket's API.
- *
- * ⚠ This is NOT the common path, and it is worth knowing why it exists at all.
- * Once an object is stored, the descriptor mints its public URL and clients fetch
- * it without touching the cell. A request arriving at the proxy for a key we have
- * therefore means a client is holding a descriptor minted BEFORE the store landed
- * — so this both serves them without a third-party round trip and, on a 404,
- * repairs the row that told us the object was there.
+ * One bounded GET, shared by every remote backend. The caller supplies the URL
+ * and headers (SigV4 for the bucket, plain for the CDN); everything about how a
+ * response may be trusted lives HERE, once, because the two subtlest guards in
+ * this feature are in it and a hand-synced copy is how one of them quietly
+ * stops applying.
  *
  * ⚠ `fetch` rather than `node:http` deliberately, unlike the write path. The
  * memory hazard measured in #543 is undici buffering REQUEST bodies; a response
  * body is read once into a bounded buffer here, the same shape as `local`'s
  * `readFile`, and bounded by the same `mediaPool`.
  */
-export async function readS3(cfg: S3CacheConfig, key: string, maxBytes: number): Promise<S3Read> {
+export async function readRemote(
+  url: string,
+  headers: Record<string, string>,
+  maxBytes: number,
+): Promise<S3Read> {
   try {
-    const signed = signObjectRequest({
+    const res = await fetch(url, {
       method: 'GET',
-      endpoint: cfg.endpoint,
-      bucket: cfg.bucket,
-      key: objectKey(cfg, key),
-      region: cfg.region,
-      accessKeyId: cfg.accessKeyId,
-      secretAccessKey: cfg.secretAccessKey,
-    });
-    const res = await fetch(signed.url, {
-      method: 'GET',
-      headers: signed.headers,
+      headers,
       signal: AbortSignal.timeout(30_000),
     });
     if (res.status === 404) {
@@ -220,6 +211,33 @@ export async function readS3(cfg: S3CacheConfig, key: string, maxBytes: number):
 }
 
 /**
+ * Read one object back through the bucket's API.
+ *
+ * ⚠ This is NOT the common path, and it is worth knowing why it exists at all.
+ * Once an object is stored, the descriptor mints its public URL and clients fetch
+ * it without touching the cell. A request arriving at the proxy for a key we have
+ * therefore means a client is holding a descriptor minted BEFORE the store landed
+ * — so this both serves them without a third-party round trip and, on a 404,
+ * repairs the row that told us the object was there.
+ */
+export async function readS3(cfg: S3CacheConfig, key: string, maxBytes: number): Promise<S3Read> {
+  try {
+    const signed = signObjectRequest({
+      method: 'GET',
+      endpoint: cfg.endpoint,
+      bucket: cfg.bucket,
+      key: objectKey(cfg, key),
+      region: cfg.region,
+      accessKeyId: cfg.accessKeyId,
+      secretAccessKey: cfg.secretAccessKey,
+    });
+    return await readRemote(signed.url, signed.headers, maxBytes);
+  } catch {
+    return { kind: 'error' };
+  }
+}
+
+/**
  * Delete one object.
  *
  * ⚠ Reports whether it is actually GONE, the same contract as `removeLocal`, and
@@ -250,102 +268,51 @@ export async function removeS3(cfg: S3CacheConfig, key: string): Promise<boolean
   }
 }
 
-/** A store in progress. Mirrors `LocalWriter`, except `commit` needs the content
- *  type: it goes ON the object rather than only into the index row. */
-export interface S3Writer {
-  write(chunk: Buffer): void;
-  commit(contentType: string): Promise<boolean>;
-  abort(): Promise<void>;
-}
+// The writer shape and the staged-write scaffold live in ./remoteWrite.ts,
+// shared with every remote backend; the alias keeps this module's public
+// surface (and the route suite that imports from it) unchanged.
+export type { RemoteWriter as S3Writer } from './remoteWrite.js';
 
 /**
- * Begin storing an object whose bytes are still arriving.
- *
- * ⚠⚠ STAGED TO A FILE, never collected in memory. SigV4 has to hash the payload
- * before it can sign, so the bytes are read twice — and the route hands them over
- * chunk by chunk as they stream from the origin. Buffering would cost the 8 MB
- * per-request image ceiling times `mediaPool`'s 24 slots, and worse: the route
- * deliberately does not await a store, so a buffer outlives the pool slot that
- * bounded it and nothing caps how many accumulate. The reference implementation
- * did exactly this, via `fetch` with `new Uint8Array(body)` — the shape measured
- * at FIVE TIMES the payload in live bytes (#543), and the reason
- * `uploadProviders/multipart.ts` exists at all.
+ * Begin storing an object whose bytes are still arriving. The staging, the
+ * in-flight ceiling and the always-unlink discipline are `openStagedRemoteWrite`'s
+ * (see ./remoteWrite.ts); this backend's own part is the SigV4 PUT.
  */
-export async function openS3Write(cfg: S3CacheConfig, key: string): Promise<S3Writer | null> {
-  // ⚠⚠ ITS OWN BOUND, because `mediaPool`'s does not reach this far. The route
-  // calls `commit` without awaiting it — deliberately, so a slow bucket cannot
-  // hold a reader's response open — and hands its pool slot back on the response's
-  // `close` at the same moment. The hash pass and the PUT therefore run entirely
-  // OUTSIDE the 24 slots, for up to `putSource`'s 60 s timeout, each one pinning a
-  // staged file and an outbound socket. Without this, one authenticated session at
-  // the route's own rate limit accumulates hundreds of staged files (gigabytes in
-  // a directory nothing sweeps for `s3`) and hundreds of simultaneous sockets, in
-  // the process running every tenant's IRC connections.
-  //
-  // ⚠ DECLINED at the ceiling, never queued (see ./inflight.ts). A queue would
-  // bound the sockets and not the files, and would make an already-slow bucket
-  // slower still; declining is free, because the reader has their bytes and all
-  // that is lost is the saving on the next read.
-  const settle = tryAcquireStoreSlot();
-  if (!settle) return null;
-
-  const staged = await openTempFile(cfg.stagingDir, key);
-  if (!staged) {
-    settle();
-    return null;
-  }
-
-  return {
-    write(chunk: Buffer): void {
-      staged.write(chunk);
+export async function openS3Write(
+  cfg: S3CacheConfig,
+  key: string,
+): Promise<import('./remoteWrite.js').RemoteWriter | null> {
+  return openStagedRemoteWrite(
+    cfg.stagingDir,
+    key,
+    'bucket',
+    async (stagedPath, size, contentType) => {
+      const source = fileSource(stagedPath, size);
+      // Two streamed passes over a warm temp file — one to hash, one to send —
+      // rather than one pass through the heap. Same trade the uploader makes.
+      const payloadHash = await hashOf(source);
+      const signed = signObjectRequest({
+        method: 'PUT',
+        endpoint: cfg.endpoint,
+        bucket: cfg.bucket,
+        key: objectKey(cfg, key),
+        payloadHash,
+        contentType,
+        cacheControl: OBJECT_CACHE_CONTROL,
+        contentDisposition: OBJECT_CONTENT_DISPOSITION,
+        region: cfg.region,
+        accessKeyId: cfg.accessKeyId,
+        secretAccessKey: cfg.secretAccessKey,
+      });
+      // ⚠ `putSource` is node:http with a 60 s default timeout, so a bucket that
+      // accepts the connection and never replies cannot pin a staged file
+      // forever. The reference used bare `fetch` with no signal at all: one
+      // stalled PUT per miss, each holding its payload, in the process running
+      // every tenant's IRC connections — an OOM reachable from a config typo.
+      const resp = await putSource(signed.url, source, { headers: signed.headers });
+      if (resp.status >= 200 && resp.status < 300) return true;
+      warnOnce(`bucket refused a store: ${resp.status} ${resp.text.slice(0, 200)}`);
+      return false;
     },
-    async commit(contentType: string): Promise<boolean> {
-      if (!(await staged.close())) {
-        settle();
-        return false;
-      }
-      try {
-        const { size } = await fs.stat(staged.path);
-        const source = fileSource(staged.path, size);
-        // Two streamed passes over a warm temp file — one to hash, one to send —
-        // rather than one pass through the heap. Same trade the uploader makes.
-        const payloadHash = await hashOf(source);
-        const signed = signObjectRequest({
-          method: 'PUT',
-          endpoint: cfg.endpoint,
-          bucket: cfg.bucket,
-          key: objectKey(cfg, key),
-          payloadHash,
-          contentType,
-          cacheControl: OBJECT_CACHE_CONTROL,
-          contentDisposition: OBJECT_CONTENT_DISPOSITION,
-          region: cfg.region,
-          accessKeyId: cfg.accessKeyId,
-          secretAccessKey: cfg.secretAccessKey,
-        });
-        // ⚠ `putSource` is node:http with a 60 s default timeout, so a bucket that
-        // accepts the connection and never replies cannot pin a staged file
-        // forever. The reference used bare `fetch` with no signal at all: one
-        // stalled PUT per miss, each holding its payload, in the process running
-        // every tenant's IRC connections — an OOM reachable from a config typo.
-        const resp = await putSource(signed.url, source, { headers: signed.headers });
-        if (resp.status >= 200 && resp.status < 300) return true;
-        warnOnce(`bucket refused a store: ${resp.status} ${resp.text.slice(0, 200)}`);
-        return false;
-      } catch (err) {
-        warnOnce(`store failed: ${(err as Error)?.message ?? err}`);
-        return false;
-      } finally {
-        // ⚠ ALWAYS, on every exit. The staging file is ours and nothing else knows
-        // it exists — not the index, not eviction — so a leak here is bytes on the
-        // volume that no later pass can find.
-        await fs.unlink(staged.path).catch(() => {});
-        settle();
-      }
-    },
-    async abort(): Promise<void> {
-      await staged.discard();
-      settle();
-    },
-  };
+  );
 }

--- a/server/services/previewCache/s3.ts
+++ b/server/services/previewCache/s3.ts
@@ -4,8 +4,9 @@
 // The bucket backend. Objects are PUT with SigV4 and then read DIRECTLY by
 // browsers from the bucket's public base URL — the descriptor hands out that URL
 // instead of a proxy path once an object is known to exist, so the cell ships
-// zero bytes for a cached image. `publicByteUrl` below is where that decision is
-// made; it lives here rather than in ./index.ts because the resolver has to call
+// zero bytes for a cached image. That decision is made in ./publicUrl.ts
+// (`publicByteUrl`), which dispatches to this module's `publicUrl` formatter; it
+// lives in a leaf module rather than ./index.ts because the resolver has to call
 // it, and ./index.ts imports the resolver.
 //
 // ⚠ Reuses the UPLOADER's `signObjectRequest`, `hashOf` and `putSource` rather
@@ -74,12 +75,17 @@
 // document but cannot enforce from here.
 
 import fs from 'fs/promises';
-import { peekCached } from '../../db/previewCache.js';
 import { fileSource, hashOf } from '../uploadProviders/source.js';
 import { putSource } from '../uploadProviders/multipart.js';
 import { signObjectRequest } from '../uploadProviders/s3.js';
 import { openTempFile } from './tempFile.js';
-import { byteCacheKey, cacheConfig, expired, type S3CacheConfig } from './config.js';
+import { tryAcquireStoreSlot, warnOnce } from './inflight.js';
+import type { S3CacheConfig } from './config.js';
+
+// The store bounds and the warn throttle moved to ./inflight.ts when the dropper
+// backend arrived (they are per-process, not per-backend). Re-exported here so
+// the s3 route suite — which imports its seams from this module — is untouched.
+export { storesInFlightForTests, resetWarnThrottleForTests } from './inflight.js';
 
 /**
  * What a CACHED object advertises to the browsers that read it directly.
@@ -97,49 +103,6 @@ const OBJECT_CACHE_CONTROL = 'public, max-age=86400';
 const OBJECT_CONTENT_DISPOSITION = 'inline';
 
 /**
- * Stores whose bytes are still moving — staged, hashing, or mid-PUT.
- *
- * ⚠ Module state rather than a field on the config, because the config is a plain
- * value that is re-resolved by tests and the bound has to survive that. One
- * process, one bucket, one ceiling.
- */
-let storesInFlight = 0;
-/** Generous next to `mediaPool`'s 24, because these are meant to be short — the
- *  ceiling is a backstop against a stalled bucket, not a throughput knob. */
-const MAX_STORES_IN_FLIGHT = 16;
-
-/** Test seam: the bound is invisible from outside until it bites. */
-export function storesInFlightForTests(): number {
-  return storesInFlight;
-}
-
-/**
- * ⚠ A cache is not a failure path, but a cache that fails FOREVER and SILENTLY is
- * an operator support burden. Config validation only proves the five env vars are
- * present — a wrong secret, a bucket policy denial, a typo'd bucket name or a
- * scheme-less endpoint all resolve to a working-looking `s3` mode where every
- * store fails, nothing populates, and no line is ever logged. `local` at least
- * leaves errno-shaped evidence on the volume.
- *
- * ⚠ Throttled to once a minute, and deliberately not per-key: the failure mode
- * this exists for is EVERY store failing, so an unthrottled warning would be one
- * line per image request in the log of a server that is otherwise fine.
- */
-let lastWarnAt = 0;
-
-/** Test seam: the throttle is global, so one test warning silences the next. */
-export function resetWarnThrottleForTests(): void {
-  lastWarnAt = 0;
-}
-
-function warnOnce(message: string): void {
-  const now = Date.now();
-  if (now - lastWarnAt < 60_000) return;
-  lastWarnAt = now;
-  console.warn(`[preview-cache] ${message}`);
-}
-
-/**
  * Let go of a response we are not going to read.
  *
  * ⚠⚠ CANCEL, never `res.text()`. Undici keeps the connection alive for an unread
@@ -151,7 +114,7 @@ function warnOnce(message: string): void {
  * request timeout, inside a `mediaPool` slot, for bytes nobody wants. Cancelling
  * releases the socket without reading a byte. (Copilot.)
  */
-async function discard(res: Response): Promise<void> {
+export async function discard(res: Response): Promise<void> {
   try {
     await res.body?.cancel();
   } catch {
@@ -164,45 +127,6 @@ async function discard(res: Response): Promise<void> {
 /** Where a reader is sent. Public by construction — that is the point of the mode. */
 export function publicUrl(cfg: S3CacheConfig, key: string): string {
   return `${cfg.publicBaseUrl}/${objectKey(cfg, key)}`;
-}
-
-/**
- * The public URL for a cached image, or null to use the proxy.
- *
- * ⚠⚠ THIS IS THE WHOLE POINT OF THE `s3` MODE, and it is the reason there is no
- * redirect anywhere in this feature. `toDescriptor` mints `src`/`thumb` per
- * request and clients treat both as opaque, so the cheapest place to send a reader
- * to the CDN is at MINT time: no 302, no second round trip through the cell, and
- * no chance of a client forwarding its `Authorization` header to a third-party
- * host, which is what a redirect would have invited.
- *
- * ⚠ Returning null is always SAFE, and that property is what makes this
- * comfortable. The caller falls back to the proxy path, which works regardless of
- * cache state — an empty bucket, a stale index, a mode change mid-flight all
- * degrade to exactly the behaviour that shipped before any of this existed. The
- * one shape that CANNOT self-correct is minting a URL for an object that is not
- * there: the client fetches the CDN directly, so its 404 never reaches us. That is
- * why the age bound is enforced here and not only on the read path.
- *
- * ⚠ `peekCached`, never `lookupCached`: this runs once per image per resolve, and
- * once per image per row once Part 2's `previewsForTexts` ships it into snapshot
- * building. The `last_access` touch is a WAL write on the shared connection.
- *
- * ⚠ Never throws — same promise the rest of the cache makes. It sits in the middle
- * of `toDescriptor`, which has no business failing because a cache lookup did.
- */
-export function publicByteUrl(imageUrl: string): string | null {
-  try {
-    const cfg = cacheConfig();
-    if (cfg.mode !== 's3') return null;
-
-    const key = byteCacheKey(imageUrl);
-    const entry = peekCached(key);
-    if (!entry || entry.backend !== 's3' || expired(entry.createdAt)) return null;
-    return publicUrl(cfg, key);
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -358,22 +282,18 @@ export async function openS3Write(cfg: S3CacheConfig, key: string): Promise<S3Wr
   // a directory nothing sweeps for `s3`) and hundreds of simultaneous sockets, in
   // the process running every tenant's IRC connections.
   //
-  // ⚠ DECLINED at the ceiling, never queued. A queue would bound the sockets and
-  // not the files, and would make an already-slow bucket slower still; declining
-  // is free, because the reader has their bytes and all that is lost is the saving
-  // on the next read.
-  if (storesInFlight >= MAX_STORES_IN_FLIGHT) return null;
+  // ⚠ DECLINED at the ceiling, never queued (see ./inflight.ts). A queue would
+  // bound the sockets and not the files, and would make an already-slow bucket
+  // slower still; declining is free, because the reader has their bytes and all
+  // that is lost is the saving on the next read.
+  const settle = tryAcquireStoreSlot();
+  if (!settle) return null;
 
   const staged = await openTempFile(cfg.stagingDir, key);
-  if (!staged) return null;
-
-  storesInFlight++;
-  let settled = false;
-  const settle = (): void => {
-    if (settled) return;
-    settled = true;
-    storesInFlight--;
-  };
+  if (!staged) {
+    settle();
+    return null;
+  }
 
   return {
     write(chunk: Buffer): void {


### PR DESCRIPTION
Closes the cell side of the hosted preview byte cache (control-plane #63, companion PR amiantos/lurker-control-plane#64). Follows #681's shipped `local`/`s3` modes.

## What

Hosted cells deliberately hold no bucket credentials, so `s3` can never serve them. The new `dropper` mode stores bytes through the operator-run dropper service's `POST /api/previews` — Bearer-keyed with the same upload key the cell already presents — and mints the public CDN URL as a pure function of config + key, exactly as `s3` does. No route changes, no schema changes, no new wire fields.

- `previewCache/config.ts`: `dropper` mode + `resolveDropper` (required-field collector; service URL must be bare `scheme://host[:port]` — a pasted `/api/previews` endpoint is refused at boot; public base must be https and includes the `/previews` prefix).
- `previewCache/dropper.ts`: the backend — multipart POST speaking the upload driver's exact protocol (`USER_AGENT`, `isOk`), CDN read with `accept-encoding: identity` (an edge that compressed responses would break the Content-Length bound and the row-size check), and a store-time cross-check of the dropper's answered URL against the cell's mint — a layout disagreement refuses the row and warns instead of recording stores whose minted URLs all 404.
- Extractions (each shared with `s3`, proven behavior-preserving by the untouched s3 route suite): `inflight.ts` (store ceiling + warn throttle), `remoteWrite.ts` (staged writer: always-unlink, settle-exactly-once), `readRemote` (the bounded GET), `publicUrl.ts` (the mint dispatch).
- Rollback on index-write failure is deliberately absent for `dropper`: the split key sets exist so a compromised cell cannot delete from the fleet bucket; the 30-day lifecycle rule reclaims unindexed objects.

## Review

`/code-review high` ran; all CONFIRMED/PLAUSIBLE findings addressed in the second commit (identity encoding, URL validation, layout cross-check, ceiling-test try/finally, the extractions). Declined as out of scope: per-backend strategy record; rows recording their base URL (bounded by the 7-day TTL, same as s3).

## Tests

Full suite green (274 files / 3904 tests), including the new `linkPreview.droppercache.test.ts` mirroring the s3 harness checklist and dropper-mode config cases. `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)