### PR TITLE
Bump Lurker version to 2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Same shape as the 2.1.0 bump (#757): the four package files, nothing else. Headline change since 2.1.0 is the hosted preview byte cache dropper mode (#770).

🤖 Generated with [Claude Code](https://claude.com/claude-code)