### PR TITLE
Docs: link previews for operators and users

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Lurker is a beautiful self-hosted IRC client with a retro aesthetic and modern c
 
 - **Always-on and multi-user.** Each invited user connects to their own set of IRC networks, and Lurker stays connected when they're away. Admins can restrict which networks users can connect to, and make channel recommendations for newcomers.
 - **Fully working search.** Search your message history, filter by nick, channel, or network; and jump to any message instantly, no matter how old it is.
-- **Modern conveniences.** Peer presence, automatic nick regain, join/part summarization, tab nickname completion, message drafts, saved messages, user notes, and more.
+- **Modern conveniences.** Peer presence, automatic nick regain, join/part summarization, tab nickname completion, message drafts, saved messages, user notes, inline link and media previews, and more.
 - **Image uploads.** Paste an image into the input box, and Lurker optimizes it, sanitizes it, and uploads it to local storage, S3, Zipline, Chibisafe, or external services like x0.at or catbox.moe.
 - **Customizable UI.** The beautiful retro terminal-style PWA interface has 40+ settings to customize it how you want.
 - **Native Apps.** Lurker has official native apps [for iOS](https://github.com/amiantos/lurker-ios) (in beta) and Android (coming soon). There's also third party clients like [Spooky](https://github.com/JawshTheDark/lurker-android-upstream) (Android) and [Scully](https://github.com/JawshTheDark/scully) (PC).

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -224,6 +224,55 @@ If you set this rule up before Lurker 1.0 it will say `/uploads/local/`. Uploads
 See [Uploaded images are broken for other people](#uploaded-images-are-broken-for-other-people-403) if you've already hit this.
 :::
 
+### Link previews & inline media
+
+Off by default. When enabled, a link pasted into chat can unfurl into a preview card
+(title, description, image — the way Slack or Discord do it), and a link that points
+straight at an image or video can render inline. It's off by default because it makes
+your server fetch third-party URLs that appear in chat, which is a behavior an
+operator should choose, not inherit.
+
+Turn it on for the instance:
+
+```yaml
+environment:
+  - LURKER_LINK_PREVIEWS=on
+```
+
+**Enabling the instance flag doesn't show anyone a preview yet.** The feature is
+double-gated: each user also has two toggles in **Settings → Chat** — **Link
+previews** and **Inline media** — and both default to off. Those toggles only
+_appear_ once the instance flag is on, so if a user says they can't find the
+setting, this env var is the reason.
+
+The server fetches previews itself (the URL never leaves your instance to a
+third-party unfurler), identifies itself honestly in its User-Agent (see
+[Outbound contact info](#outbound-contact-info-user-agent)), and proxies preview
+images to your users so their browsers never touch the third-party host directly.
+
+#### Caching preview images (optional)
+
+Without a cache this already works — the server just re-fetches an image when
+nobody's browser has it cached. `LURKER_PREVIEW_CACHE_MODE` trades a little disk
+or a bucket for not re-fetching popular images:
+
+- **`off`** (default) — fetch through, store nothing.
+- **`local`** — the sensible self-host choice. Cached bytes live in a directory
+  next to the database (2 GiB cap by default, least-recently-used eviction).
+  It's a cache, not data: safe to delete while the server is stopped.
+- **`s3`** — for instances already running behind a CDN: cached images go to a
+  bucket you own and get served from its **public** base URL, so your server
+  ships zero bytes for an image it has already fetched. This one has real
+  operational requirements — the objects are publicly readable, the base URL
+  must be https, and **you** own eviction via a lifecycle rule on the bucket.
+- **`dropper`** — the hosted-fleet mode; not for self-hosters.
+
+Misconfiguration is never fatal: a bad cache config logs one warning, caching
+turns off, and previews keep working. The full per-mode reference — every
+variable, the s3 caveats, and the reasoning — lives in
+[`.env.example`](https://github.com/amiantos/lurker/blob/main/.env.example),
+which is worth reading in full before turning on `s3`.
+
 ### Secure cookies
 
 Lurker's session cookies are **not** flagged `Secure` by default. This sounds wrong but is correct for the common self-hosted shapes:

--- a/docs/guide/interface.md
+++ b/docs/guide/interface.md
@@ -20,6 +20,26 @@ A tour of the Lurker window and how messages are organized.
 
 - Starting a DM and reading peer presence (online / away / offline).
 
+## Link previews & inline media
+
+Links in chat can do more than sit there as text. Two toggles in
+**Settings → Chat** control it, and both start **off** — turn on what you want:
+
+- **Link previews** — a link to an article or video unfurls into a card below
+  the message: title, description, and a picture when the page offers one.
+- **Inline media** — a link that points straight at an image, video, or audio
+  file renders the media itself below the message instead of just the URL.
+
+They're independent: preview cards without inline images is a perfectly good
+combination, and so is the reverse. Turning both off returns every link to
+plain text.
+
+::: info Don't see these settings?
+The toggles only appear when your instance has link previews enabled. If they're
+missing from Settings → Chat, ask your operator — it's one environment variable
+on the server ([self-hosting docs](/SELF_HOSTING#link-previews-inline-media)).
+:::
+
 ## Customizing the look
 
 - The 40+ settings and the retro terminal theme.


### PR DESCRIPTION
`.env.example` was the only documentation for `LURKER_LINK_PREVIEWS` and the preview cache modes. This fills the two real gaps:

- **`docs/SELF_HOSTING.md`** — a "Link previews & inline media" section under Optional features, matching its neighbors' shape: the enable flag, the double gate (the per-user toggles only appear once the instance flag is on), why it's off by default, and a digest of `off | local | s3` (+`dropper` marked hosted-only) with `.env.example` as the full reference for the s3 fine print.
- **`docs/guide/interface.md`** — the user-side story: what the two **Settings → Chat** toggles do, that both default off and are independent, and a "don't see these settings?" note pointing at the self-hosting doc.

VitePress build passes; the cross-page anchor is verified in the rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)