### PR TITLE
Link previews: stop relaying video and audio

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -233,12 +233,17 @@ your server fetch third-party URLs that appear in chat, which is a behavior an
 operator should choose, not inherit.
 
 A link to a **video or audio file** gets a card naming the file and its type, not an
-inline player. Your server never relays those bytes: the card links straight to the
-origin, and nothing is fetched from it until someone chooses to open it. The proxy
-below exists to stop a card that renders _by itself_ from reporting your users to a
-stranger's server — it was never meant to anonymize a download somebody deliberately
-started, and relaying whole videos through your instance costs bandwidth and memory
-for a privacy gain that ends the moment the reader clicks anyway.
+inline player. Your server never relays those bytes — the card links straight to the
+origin — though it does still make one request to the host when the link is first
+posted, reading only the response headers to find out what the URL is and then
+dropping the connection. That classifying request is the same one every link costs;
+what's gone is the transfer of the file itself.
+
+The proxy below exists to stop a card that renders _by itself_ from reporting your
+users to a stranger's server. It was never meant to anonymize a download somebody
+deliberately started — and relaying whole videos through your instance costs
+bandwidth and memory for a privacy gain that ends the moment the reader clicks
+anyway.
 
 Turn it on for the instance:
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -228,9 +228,17 @@ See [Uploaded images are broken for other people](#uploaded-images-are-broken-fo
 
 Off by default. When enabled, a link pasted into chat can unfurl into a preview card
 (title, description, image — the way Slack or Discord do it), and a link that points
-straight at an image or video can render inline. It's off by default because it makes
+straight at an image can render inline. It's off by default because it makes
 your server fetch third-party URLs that appear in chat, which is a behavior an
 operator should choose, not inherit.
+
+A link to a **video or audio file** gets a card naming the file and its type, not an
+inline player. Your server never relays those bytes: the card links straight to the
+origin, and nothing is fetched from it until someone chooses to open it. The proxy
+below exists to stop a card that renders _by itself_ from reporting your users to a
+stranger's server — it was never meant to anonymize a download somebody deliberately
+started, and relaying whole videos through your instance costs bandwidth and memory
+for a privacy gain that ends the moment the reader clicks anyway.
 
 Turn it on for the instance:
 
@@ -248,7 +256,8 @@ setting, this env var is the reason.
 The server fetches previews itself (the URL never leaves your instance to a
 third-party unfurler), identifies itself honestly in its User-Agent (see
 [Outbound contact info](#outbound-contact-info-user-agent)), and proxies preview
-images to your users so their browsers never touch the third-party host directly.
+**images** to your users so their browsers never touch the third-party host when a
+card draws itself. Video and audio are named rather than relayed — see above.
 
 #### Caching preview images (optional)
 

--- a/docs/guide/interface.md
+++ b/docs/guide/interface.md
@@ -27,8 +27,9 @@ Links in chat can do more than sit there as text. Two toggles in
 
 - **Link previews** — a link to an article or video unfurls into a card below
   the message: title, description, and a picture when the page offers one.
-- **Inline media** — a link that points straight at an image, video, or audio
-  file renders the media itself below the message instead of just the URL.
+- **Inline media** — a link that points straight at an image renders the picture
+  itself below the message instead of just the URL. A link to a video or audio
+  file gets a card naming it; opening one goes to the site hosting it.
 
 They're independent: preview cards without inline images is a perfectly good
 combination, and so is the reverse. Turning both off returns every link to

--- a/server/routes/linkPreview.media.test.ts
+++ b/server/routes/linkPreview.media.test.ts
@@ -100,7 +100,8 @@ describe('serving bytes', () => {
   // nothing asks — but a token is a pure HMAC of the URL, so a descriptor minted before the
   // change (sitting in an open tab, or replayed by anyone who kept one) still verifies. The
   // route is what has to say no, and saying no here is what makes the relay actually gone
-  // rather than merely unadvertised. See lurker-dev/LINK_PREVIEWS_MEDIA_POLICY.md.
+  // rather than merely unadvertised. The policy is stated for operators under "Link previews
+  // & inline media" in docs/SELF_HOSTING.md.
   for (const [kind, contentType, path] of [
     ['video', 'video/mp4', '/clip.mp4'],
     ['video', 'video/quicktime', '/phone.mov'],

--- a/server/routes/linkPreview.media.test.ts
+++ b/server/routes/linkPreview.media.test.ts
@@ -95,6 +95,37 @@ describe('serving bytes', () => {
     expect(res.status).toBe(404);
   });
 
+  // ⚠⚠ THE MEDIA-POLICY CONTRACT, asserted at the enforcement point rather than only at the
+  // mint. `toDescriptor` no longer hands out a `src` for these kinds, so in normal operation
+  // nothing asks — but a token is a pure HMAC of the URL, so a descriptor minted before the
+  // change (sitting in an open tab, or replayed by anyone who kept one) still verifies. The
+  // route is what has to say no, and saying no here is what makes the relay actually gone
+  // rather than merely unadvertised. See lurker-dev/LINK_PREVIEWS_MEDIA_POLICY.md.
+  for (const [kind, contentType, path] of [
+    ['video', 'video/mp4', '/clip.mp4'],
+    ['video', 'video/quicktime', '/phone.mov'],
+    ['audio', 'audio/mpeg', '/song.mp3'],
+  ] as const) {
+    it(`refuses ${contentType}: ${kind} is never relayed, at any size`, async () => {
+      // ⚠ A TINY body, deliberately. Refusing a 44 MB clip could be explained by a size
+      // ceiling; refusing five bytes can only be explained by the kind. That is the property
+      // under test — there is no longer a size at which video is served.
+      handler = (_req, res) => {
+        res.writeHead(200, { 'content-type': contentType, 'content-length': '5' });
+        res.end('bytes');
+      };
+      const res = await agent.get(`/api/link-preview/media/${tokenFor(path)}`);
+      // ⚠ 404, not 413. A size ceiling would be the wrong answer twice over: it implies a
+      // smaller clip would be served, and `MAX_MEDIA_PROXY_BYTES` no longer exists to name one.
+      expect(res.status).toBe(404);
+      // ⚠⚠ None of the origin's bytes reached the client, and the response does not wear the
+      // media type. Status alone would pass if the route 404'd a header while still piping the
+      // body — which is exactly the shape of the bug this whole change is about.
+      expect(res.text ?? '').not.toContain('bytes');
+      expect(res.headers['content-type'] ?? '').not.toContain(contentType);
+    });
+  }
+
   it('refuses text/html, which is the other way to get script into our origin', async () => {
     handler = (_req, res) => {
       res.writeHead(200, { 'content-type': 'text/html' });
@@ -119,12 +150,12 @@ describe('serving bytes', () => {
   it('forwards a range, and says so, when the origin honours one', async () => {
     handler = (req, res) => {
       if (!req.headers.range) {
-        res.writeHead(200, { 'content-type': 'video/mp4' });
+        res.writeHead(200, { 'content-type': 'image/png' });
         res.end('whole');
         return;
       }
       res.writeHead(206, {
-        'content-type': 'video/mp4',
+        'content-type': 'image/png',
         'content-range': `bytes 0-4/1000`,
         'content-length': '5',
       });
@@ -132,7 +163,7 @@ describe('serving bytes', () => {
     };
 
     const res = await agent
-      .get(`/api/link-preview/media/${tokenFor('/clip.mp4')}`)
+      .get(`/api/link-preview/media/${tokenFor('/clip.png')}`)
       .set('Range', 'bytes=0-4')
       .expect(206);
     expect(res.headers['content-range']).toBe('bytes 0-4/1000');
@@ -146,7 +177,7 @@ describe('serving bytes', () => {
     // resource. The real size is the figure after the slash in Content-Range.
     handler = (_req, res) => {
       res.writeHead(206, {
-        'content-type': 'video/mp4',
+        'content-type': 'image/png',
         'content-range': `bytes 0-1023/${1024 * 1024 * 1024}`,
         'content-length': '1024',
       });
@@ -154,7 +185,7 @@ describe('serving bytes', () => {
     };
 
     const res = await agent
-      .get(`/api/link-preview/media/${tokenFor('/huge.mp4')}`)
+      .get(`/api/link-preview/media/${tokenFor('/huge.png')}`)
       .set('Range', 'bytes=0-1023');
     expect(res.status).toBe(413);
   });
@@ -179,7 +210,7 @@ describe('serving bytes', () => {
       res.end();
     };
     const res = await agent
-      .get(`/api/link-preview/media/${tokenFor('/short.mp4')}`)
+      .get(`/api/link-preview/media/${tokenFor('/short.png')}`)
       .set('Range', 'bytes=9999-')
       .expect(416);
     expect(res.headers['content-range']).toBe('bytes */500');
@@ -235,7 +266,7 @@ describe('holding and releasing the fetch slot', () => {
         // Deliberately slow: the fetch is still in flight when the client leaves.
         setTimeout(() => {
           if (!res.destroyed) {
-            res.writeHead(200, { 'content-type': 'video/mp4' });
+            res.writeHead(200, { 'content-type': 'image/png' });
             res.end('too late');
           }
         }, 3_000).unref();
@@ -245,7 +276,7 @@ describe('holding and releasing the fetch slot', () => {
     // ⚠ `.end()` to DISPATCH. A superagent request is lazy — it isn't sent until something
     // subscribes — so building one and aborting it proves nothing at all; the origin never sees
     // a connection and the assertion below waits forever for a close that cannot come.
-    const req = agent.get(`/api/link-preview/media/${tokenFor('/abandoned.mp4')}`);
+    const req = agent.get(`/api/link-preview/media/${tokenFor('/abandoned.png')}`);
     req.end(() => {});
     await new Promise((r) => setTimeout(r, 150));
     req.abort();
@@ -295,7 +326,7 @@ describe('the resource-size cap on a partial response', () => {
   const partial = (contentRange: string): void => {
     handler = (_req, res) => {
       res.writeHead(206, {
-        'content-type': 'video/mp4',
+        'content-type': 'image/png',
         'content-range': contentRange,
         'content-length': '1024',
       });
@@ -308,7 +339,7 @@ describe('the resource-size cap on a partial response', () => {
     // that as "no total stated, carry on".
     partial(`bytes 0-1023/${'9'.repeat(400)}`);
     const res = await agent
-      .get(`/api/link-preview/media/${tokenFor('/absurd.mp4')}`)
+      .get(`/api/link-preview/media/${tokenFor('/absurd.png')}`)
       .set('Range', 'bytes=0-1023');
     expect(res.status).toBe(413);
   });
@@ -316,7 +347,7 @@ describe('the resource-size cap on a partial response', () => {
   it('refuses a Content-Range it cannot parse', async () => {
     partial('bytes 0-1023/not-a-number');
     const res = await agent
-      .get(`/api/link-preview/media/${tokenFor('/garbage.mp4')}`)
+      .get(`/api/link-preview/media/${tokenFor('/garbage.png')}`)
       .set('Range', 'bytes=0-1023');
     expect(res.status).toBe(413);
   });
@@ -326,7 +357,7 @@ describe('the resource-size cap on a partial response', () => {
     // origin could state an acceptable size second and be believed.
     partial(`bytes 0-1023/${1024 * 1024 * 1024}, bytes 0-1023/1024`);
     const res = await agent
-      .get(`/api/link-preview/media/${tokenFor('/twohdr.mp4')}`)
+      .get(`/api/link-preview/media/${tokenFor('/twohdr.png')}`)
       .set('Range', 'bytes=0-1023');
     expect(res.status).toBe(413);
   });
@@ -336,7 +367,7 @@ describe('the resource-size cap on a partial response', () => {
     // outright would be the other failure: the per-response byte counter is what bounds it.
     partial('bytes 0-1023/*');
     const res = await agent
-      .get(`/api/link-preview/media/${tokenFor('/unknown.mp4')}`)
+      .get(`/api/link-preview/media/${tokenFor('/unknown.png')}`)
       .set('Range', 'bytes=0-1023');
     expect(res.status).toBe(206);
   });
@@ -350,10 +381,10 @@ describe('range advertisement', () => {
     handler = (_req, res) => {
       // Set as an array so node emits the header twice, which is the case under test.
       res.setHeader('Accept-Ranges', ['bytes', 'bytes']);
-      res.writeHead(200, { 'content-type': 'video/mp4', 'content-length': '5' });
+      res.writeHead(200, { 'content-type': 'image/png', 'content-length': '5' });
       res.end('whole');
     };
-    const res = await agent.get(`/api/link-preview/media/${tokenFor('/dupehdr.mp4')}`);
+    const res = await agent.get(`/api/link-preview/media/${tokenFor('/dupehdr.png')}`);
     expect(res.status).toBe(200);
     expect(res.headers['accept-ranges']).toBe('bytes');
   });

--- a/server/routes/linkPreview.ts
+++ b/server/routes/linkPreview.ts
@@ -28,7 +28,6 @@ import {
   toDescriptor,
   proxyableContentType,
   MAX_IMAGE_PROXY_BYTES,
-  MAX_MEDIA_PROXY_BYTES,
   MAX_URLS_PER_REQUEST,
 } from '../services/linkPreview.js';
 import { verifyProxyToken } from '../services/mediaProxyToken.js';
@@ -336,10 +335,14 @@ router.get('/media/:token', async (req: Request, res: Response) => {
 
   try {
     upstream = await safeRequest(url, {
-      accept: 'image/*,video/*,audio/*;q=0.9,*/*;q=0.5',
-      // Forwarded so inline video works at all. Safari (iOS and macOS) refuses to play a
-      // <video> whose source doesn't honour byte ranges, and seeking is broken everywhere
-      // without it — and this route is what serves `kind === 'video'`.
+      // ⚠ Images only — the route refuses everything else at `proxyableContentType` below, so
+      // asking for video/audio would only invite a body we are going to destroy at its headers.
+      accept: 'image/*,*/*;q=0.5',
+      // ⚠ Still forwarded, though no media element reaches here any more. An origin may answer
+      // a plain GET with a 206 of its own accord, and a request that arrives with a Range (an
+      // old descriptor's token replayed, a resumed download) must be asked about the SAME bytes
+      // the client wants — not silently answered from byte zero, which is the bug that made a
+      // seek look like a jump back to the start.
       range: typeof req.headers.range === 'string' ? req.headers.range : undefined,
       // Piped, not buffered: the scrape-tuned deadlines cut a healthy media transfer at 20 s
       // and read a backpressured <video> as a dead origin. See FetchOptions.streaming.
@@ -402,14 +405,14 @@ router.get('/media/:token', async (req: Request, res: Response) => {
     // together, several are refused and arm the hold, and a single success then
     // tears it down before it can stop anything. The hold expires on its own
     // clock, which is short by design.
-    // ⚠ Per-KIND cap. The single 8 MB ceiling was named for images and silently applied to
-    // everything, so a 30 MB mp4 rendered inline was streamed to 8 MB and then had both ends
-    // destroyed — the <video> died with a network error partway through, and since the
-    // `immutable` Cache-Control had already gone out the browser could cache the truncated
-    // body. Video and audio are streamed to a media element and are legitimately larger.
-    const cap = upstream.contentType.startsWith('image/')
-      ? MAX_IMAGE_PROXY_BYTES
-      : MAX_MEDIA_PROXY_BYTES;
+    // ⚠ ONE cap again, and this time it is honest: `proxyableContentType` has already refused
+    // anything that is not an image, so there is no larger kind for a second ceiling to
+    // describe. The per-kind split this replaces existed because a single 8 MB ceiling named
+    // for images was silently applied to video too — a 30 MB mp4 was streamed to 8 MB and then
+    // had both ends destroyed, dying mid-playback with the `immutable` Cache-Control already
+    // sent, so the browser could cache the stump. Video is no longer relayed at all, which
+    // dissolves that failure rather than re-tuning around it.
+    const cap = MAX_IMAGE_PROXY_BYTES;
     const declared = Number(upstream.headers['content-length']);
     // ⚠ On a 206 the declared length is the length of the PART, so checking it alone let the
     // cap be walked straight past: a client asking for a gigabyte 1 MB at a time satisfies

--- a/server/services/linkFetch.ts
+++ b/server/services/linkFetch.ts
@@ -48,13 +48,16 @@ const HOP_DEADLINE_MS = 20_000;
 /**
  * Idle allowance once a STREAMING consumer has its headers — see `FetchOptions.streaming`.
  *
- * ⚠ Both of the bounds above are wrong for a body that is piped rather than buffered, and the
- * combination made `MAX_MEDIA_PROXY_BYTES` unreachable. `HOP_DEADLINE_MS` is cleared on the
- * request's `close`, which does not fire during a body transfer, so any response still
- * streaming at 20 s was cut — 64 MB inside 20 s needs ~26 Mbit/s sustained, so ordinary inline
- * video died mid-playback. And `IDLE_TIMEOUT_MS` fires on a backpressured pipe: a <video> that
- * has filled its buffer and stopped reading is normal playback, not a stall, but no bytes move
- * and the socket times out.
+ * ⚠ Both of the bounds above are wrong for a body that is piped rather than buffered.
+ * `HOP_DEADLINE_MS` is cleared on the request's `close`, which does not fire during a body
+ * transfer, so any response still streaming at 20 s was cut. And `IDLE_TIMEOUT_MS` fires on a
+ * backpressured pipe: a consumer that has filled its buffer and stopped reading is behaving
+ * normally, but no bytes move and the socket times out.
+ *
+ * ⚠ The example this was written for is gone: the ceiling it named (`MAX_MEDIA_PROXY_BYTES`,
+ * 64 MB, needing ~26 Mbit/s sustained to land inside 20 s) belonged to inline video, which the
+ * proxy no longer relays at all. The bound still earns its place for images — 8 MB over a slow
+ * link crosses 20 s easily — so what changed is the size of the problem, not its shape.
  *
  * So a streaming caller keeps the deadline for connect-and-headers — the part that can hang
  * with nothing to show for it — and then trades it for this, which bounds a genuinely dead

--- a/server/services/linkPreview.test.ts
+++ b/server/services/linkPreview.test.ts
@@ -169,12 +169,33 @@ describe('toDescriptor', () => {
     expect(JSON.stringify(d)).not.toContain('cdn.example.com');
   });
 
-  it('puts direct media in src, because the bytes ARE the content', () => {
-    for (const kind of ['image', 'video', 'audio'] as const) {
-      const d = toDescriptor(record({ kind, imageUrl: 'https://cdn.example.com/a.bin' }));
-      expect(d.src).toMatch(/^\/api\/link-preview\/media\//);
+  it('puts a direct IMAGE in src, because the bytes ARE the content', () => {
+    const d = toDescriptor(record({ kind: 'image', imageUrl: 'https://cdn.example.com/a.png' }));
+    expect(d.src).toMatch(/^\/api\/link-preview\/media\//);
+    expect(d.thumb).toBeUndefined();
+  });
+
+  // ⚠⚠ The media-policy change, and the reason it is asserted on BOTH fields: an earlier shape
+  // of this could plausibly have demoted video to `thumb` rather than dropping it, which would
+  // have rendered a card with a 44 MB "thumbnail" — the relay this exists to end, wearing a
+  // different field name. Neither slot may carry a byte URL for these kinds.
+  it('gives video and audio NO byte url at all, in either slot', () => {
+    for (const kind of ['video', 'audio'] as const) {
+      const d = toDescriptor(record({ kind, imageUrl: 'https://cdn.example.com/a.mp4' }));
+      expect(d.src).toBeUndefined();
       expect(d.thumb).toBeUndefined();
+      // The card still has to be drawable: the origin URL and the measured type survive.
+      expect(d.url).toBe('https://example.com/a');
+      expect(d.kind).toBe(kind);
     }
+  });
+
+  // ⚠ The whole descriptor, not just the two byte fields. `mintProxyToken` is an HMAC of the
+  // URL, so a leak here would be a token that still resolves — and the point of withholding
+  // `src` is that nothing reaches the client that a player could be pointed at.
+  it('leaks no proxy path anywhere in a video descriptor', () => {
+    const d = toDescriptor(record({ kind: 'video', imageUrl: 'https://cdn.example.com/a.mp4' }));
+    expect(JSON.stringify(d)).not.toContain('/api/link-preview/media/');
   });
 
   it('withholds thumb dimensions when there is no thumb to describe', () => {

--- a/server/services/linkPreview.ts
+++ b/server/services/linkPreview.ts
@@ -744,7 +744,8 @@ export function toDescriptor(record: PreviewRecord): PreviewDescriptor {
   // the byte cache stores images only (`previewCache/index.ts`), so video never became cheap
   // on the second read the way an image does. On 2026-08-10 that relay exhausted the control
   // plane's kernel socket memory and capped EVERY connection on the box — chat included — at
-  // ~7 KB/s. See lurker-dev/LINK_PREVIEWS_MEDIA_POLICY.md.
+  // ~7 KB/s. The user-facing half of this policy is in docs/SELF_HOSTING.md, under "Link
+  // previews & inline media".
   //
   // ⚠ No migration and no RESOLVER_VERSION bump accompany this. The record is unchanged —
   // `imageUrl`, `mime` and `kind` all still mean what they meant — and descriptors are minted

--- a/server/services/linkPreview.ts
+++ b/server/services/linkPreview.ts
@@ -728,7 +728,29 @@ export function toDescriptor(record: PreviewRecord): PreviewDescriptor {
     d.kind = 'page';
   }
 
-  if (record.imageUrl) {
+  // ⚠⚠ VIDEO AND AUDIO ARE GIVEN NO BYTE URL AT ALL, AND THAT IS THE FEATURE.
+  //
+  // The proxy exists to stop a card the reader never asked for from telling a stranger's
+  // server who is reading — unintended view stats. It was never meant to be an anonymizing
+  // relay for content someone deliberately plays: hiding an IP at the moment a reader presses
+  // play conceals nothing that clicking the link itself wouldn't reveal a second later.
+  //
+  // ⚠ Withholding `src` is what makes the card click-to-activate. A `<video src>` fetches
+  // unasked — metadata at minimum, and the `#t=` poster trick the clients used to run made it
+  // a range request for real frames — so emitting one is itself the involuntary fetch this
+  // rule is about. There is no "don't preload" flag that survives every client.
+  //
+  // ⚠⚠ It is also what stops one 44 MB clip being relayed once PER VIEWER, PER VIEW, forever:
+  // the byte cache stores images only (`previewCache/index.ts`), so video never became cheap
+  // on the second read the way an image does. On 2026-08-10 that relay exhausted the control
+  // plane's kernel socket memory and capped EVERY connection on the box — chat included — at
+  // ~7 KB/s. See lurker-dev/LINK_PREVIEWS_MEDIA_POLICY.md.
+  //
+  // ⚠ No migration and no RESOLVER_VERSION bump accompany this. The record is unchanged —
+  // `imageUrl`, `mime` and `kind` all still mean what they meant — and descriptors are minted
+  // per request, so rows cached under the old behaviour render the new card on the next read.
+  const relaysBytes = record.kind !== 'video' && record.kind !== 'audio';
+  if (record.imageUrl && relaysBytes) {
     // ⚠⚠ A CACHED object is served from its own public URL, and only the mint site
     // knows that. `src`/`thumb` are opaque to every client — nothing constructs one,
     // nothing parses one — so substituting a CDN URL for a proxy path here is
@@ -749,7 +771,9 @@ export function toDescriptor(record: PreviewRecord): PreviewDescriptor {
     // For direct media the bytes ARE the content (`src`); for a page they're
     // decoration on a card (`thumb`). Same proxy, different slot, so a client
     // never has to re-derive which one it's looking at from `kind`.
-    if (record.kind === 'image' || record.kind === 'video' || record.kind === 'audio') {
+    // ⚠ `image` is now the ONLY direct-media kind that reaches here — video and audio were
+    // filtered out above — so this is a two-way split, not the three-kind test it replaced.
+    if (record.kind === 'image') {
       d.src = proxied;
     } else {
       d.thumb = proxied;
@@ -764,11 +788,8 @@ export function toDescriptor(record: PreviewRecord): PreviewDescriptor {
   return d;
 }
 
-/** Ceiling on preview IMAGE bytes the proxy will serve. */
+/** Ceiling on preview IMAGE bytes the proxy will serve — now the ONLY ceiling it has. */
 export const MAX_IMAGE_PROXY_BYTES = 8 * 1024 * 1024;
-/** Ceiling on VIDEO/AUDIO bytes. Larger because these stream to a media element rather than
- *  being decoded whole — an 8 MB cut-off truncated ordinary clips mid-playback. */
-export const MAX_MEDIA_PROXY_BYTES = 64 * 1024 * 1024;
 
 /**
  * Whether the byte proxy will serve this content type.
@@ -778,8 +799,13 @@ export const MAX_MEDIA_PROXY_BYTES = 64 * 1024 * 1024;
  * format wearing a picture's clothes, served under OUR origin — existed in two places that had
  * to be kept in step by hand. One definition, and the proxy serves exactly the kinds the
  * resolver is willing to call media.
+ *
+ * ⚠⚠ IMAGES ONLY, as of the media-policy change. The former `MAX_MEDIA_PROXY_BYTES` (64 MB)
+ * was deleted rather than lowered: video and audio are not relayed at any size now, so a
+ * ceiling for them would only describe a path that no longer exists. `toDescriptor` stops
+ * minting a `src` for those kinds, so nothing should ask — but this is the enforcement point,
+ * and it has to refuse a replayed token from a client holding an older descriptor.
  */
 export function proxyableContentType(contentType: string): boolean {
-  const kind = kindForContentType(contentType);
-  return kind === 'image' || kind === 'video' || kind === 'audio';
+  return kindForContentType(contentType) === 'image';
 }

--- a/server/services/previewCache/index.ts
+++ b/server/services/previewCache/index.ts
@@ -14,11 +14,15 @@
 // an image request that would have succeeded with caching switched off. The guard
 // now lives in this module, where the promise is made.
 //
-// ⚠ IMAGES ONLY, deliberately. Video and audio are capped at MAX_MEDIA_PROXY_BYTES
-// (64 MB) against images' 8 MB, they are served with RANGE requests so a cached
-// copy would have to answer partial reads, and one seek in a video is many
-// requests for one object. Buffering 64 MB per miss would trade the bandwidth this
-// feature saves for memory it cannot bound.
+// ⚠ IMAGES ONLY, deliberately — and this scope is now enforced upstream rather than
+// merely observed here. Video and audio used to be proxied but never cached (they
+// are fetched with RANGE requests, so a cached copy would have to answer partial
+// reads, and one seek is many requests for one object), which meant the ONE
+// mechanism making this feature affordable — store once, then mint a CDN URL —
+// covered only the cheap kind. That asymmetry is what exhausted the control
+// plane's socket memory on 2026-08-10. Video and audio are no longer relayed at
+// all (`proxyableContentType`), so "images only" is no longer a gap: it is the
+// whole set of things the proxy serves. See lurker-dev/LINK_PREVIEWS_MEDIA_POLICY.md.
 
 import {
   expiredCached,

--- a/server/services/previewCache/index.ts
+++ b/server/services/previewCache/index.ts
@@ -22,7 +22,8 @@
 // covered only the cheap kind. That asymmetry is what exhausted the control
 // plane's socket memory on 2026-08-10. Video and audio are no longer relayed at
 // all (`proxyableContentType`), so "images only" is no longer a gap: it is the
-// whole set of things the proxy serves. See lurker-dev/LINK_PREVIEWS_MEDIA_POLICY.md.
+// whole set of things the proxy serves. See "Link previews & inline media" in
+// docs/SELF_HOSTING.md.
 
 import {
   expiredCached,

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1078,10 +1078,19 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     group: 'viewing',
     type: 'bool',
     default: false,
+    // ⚠⚠ THE PRIVACY SENTENCE IS SCOPED TO IMAGES, and the scoping is the point rather than
+    // pedantry. This string is the whole basis on which someone decides to turn the setting on,
+    // and it used to promise that "the file is fetched and served by your Lurker server" for
+    // video and audio too. That stopped being true when those kinds stopped being relayed: the
+    // card links straight to the origin, so a reader who enabled this on the old promise would
+    // hand their address to a stranger's host the moment they pressed the filename. A guarantee
+    // a user acts on has to be narrower than the truth, never wider.
     description:
-      'When enabled, a link that points straight at an image, video, or audio file ' +
-      'renders under the message instead of showing only as a link. The file is fetched ' +
-      'and served by your Lurker server, so the site hosting it never sees your device.',
+      'When enabled, a link that points straight at an image renders under the message ' +
+      'instead of showing only as a link, and the image is fetched and served by your ' +
+      'Lurker server, so the site hosting it never sees your device. Video and audio ' +
+      'links get a card naming the file — opening one goes to the site hosting it, ' +
+      'like any other link.',
   },
   {
     key: 'chat.link_previews.enabled',

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -524,7 +524,7 @@ describe('MessageAttachment — growth the list can react to', () => {
   // existing IS the involuntary fetch the proxy is meant to prevent. It is also what had one
   // clip relayed per viewer, per view, forever — the byte cache stores images only — which
   // exhausted the control plane's socket memory on 2026-08-10.
-  // See lurker-dev/LINK_PREVIEWS_MEDIA_POLICY.md.
+  // The policy is stated for operators in docs/SELF_HOSTING.md.
   //
   // ⚠ `src` is set on the fixture DELIBERATELY, though the server no longer mints one. A
   // descriptor from before the change may still be in an open tab, and honouring it would mount
@@ -747,7 +747,7 @@ describe('MessageAttachments — arrangement', () => {
   // Video and audio crossed from "the file, on screen" to "a card about a file", and every rule
   // keyed on the old meaning had to cross with them. Neither failure was visible from the
   // component's own tests, because both live in MessageBody's arrangement rather than in the
-  // card. See LINK_PREVIEWS_MEDIA_POLICY.md.
+  // card.
   it('charges video cards to the CARD cap, not the generous media budget', () => {
     // A card costs real vertical space whatever kind produced it. Charged to the media budget
     // (20) and skipped by the card counter, a message of pasted clips rendered a full-width

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -518,41 +518,58 @@ describe('MessageAttachment — the click must not be eaten', () => {
 });
 
 describe('MessageAttachment — growth the list can react to', () => {
-  it('asks the browser to seek, which is the only poster frame available', async () => {
-    // ⚠⚠ Without this a `<video>` paints nothing until it decodes, so an unplayed clip is a black
-    // rectangle with controls on it. There is no ffmpeg to make a real poster with, and no
-    // lightbox behind the player to recover from a bad guess — the inline element is the whole
-    // affordance. `#t=0.1` seeks on load, forcing a decode.
-    //
-    // ⚠ Asserted on the ELEMENT, not on the computed: a fragment appended to the wrong attribute
-    // (or dropped by a template refactor) is invisible to a type check and silent at runtime.
-    // ⚠ And the token path must survive intact ahead of the `#` — the proxy URL is an HMAC over
-    // the URL, so mangling it 404s every video rather than merely losing the poster.
+  // ⚠⚠ MOUNTS NO PLAYER AT ALL — the media-policy change, and the reason it is asserted as an
+  // ABSENCE. A `<video>` fetches before anyone asks (`preload="metadata"` at minimum, and the
+  // `#t=0.1` poster trick this replaces made it a range request for real frames), so the element
+  // existing IS the involuntary fetch the proxy is meant to prevent. It is also what had one
+  // clip relayed per viewer, per view, forever — the byte cache stores images only — which
+  // exhausted the control plane's socket memory on 2026-08-10.
+  // See lurker-dev/LINK_PREVIEWS_MEDIA_POLICY.md.
+  //
+  // ⚠ `src` is set on the fixture DELIBERATELY, though the server no longer mints one. A
+  // descriptor from before the change may still be in an open tab, and honouring it would mount
+  // a player against a token the route now 404s — a broken source instead of a card.
+  for (const [kind, url, glyph] of [
+    ['video', 'https://e.test/c.mp4', '▶'],
+    ['audio', 'https://e.test/s.mp3', '♪'],
+  ] as const) {
+    it(`renders ${kind} as a file card, never a player, even with a stale src`, () => {
+      seedSettings();
+      const p = preview({ url, kind, src: '/api/lp/media/x', mime: `${kind}/mp4` });
+      const wrapper = mount(MessageAttachment, { props: { preview: p } });
+      expect(wrapper.find('video').exists()).toBe(false);
+      expect(wrapper.find('audio').exists()).toBe(false);
+      expect(wrapper.find('.card-file').exists()).toBe(true);
+      expect(wrapper.find('.file-badge').text()).toBe(glyph);
+      // ⚠ The link points at the ORIGIN, not at the proxy. That is the whole hand-off: a
+      // deliberate click goes where the bytes actually live.
+      expect(wrapper.find('.card-file .card-title').attributes('href')).toBe(url);
+    });
+  }
+
+  it('names a media file by its filename, not by its hostname', () => {
+    // ⚠ These records have no title and no siteName — nothing was scraped, because the URL IS
+    // the content — so the shared `heading` falls through to the hostname. Three clips from one
+    // CDN would then present as three identical cards.
     seedSettings();
-    const video = preview({ url: 'https://e.test/c.mp4', kind: 'video', src: '/api/lp/media/v' });
-    const wrapper = mount(MessageAttachment, { props: { preview: video } });
-    expect(wrapper.find('video').attributes('src')).toBe('/api/lp/media/v#t=0.1');
+    const p = preview({
+      url: 'https://cdn.e.test/holiday%20clip.mp4',
+      kind: 'video',
+      mime: 'video/mp4',
+    });
+    const wrapper = mount(MessageAttachment, { props: { preview: p } });
+    expect(wrapper.find('.card-file .card-title').text()).toBe('holiday clip.mp4');
+    expect(wrapper.find('.card-file .card-desc').text()).toBe('Video · MP4');
   });
 
-  it('leaves AUDIO alone, which has no frame to paint', () => {
-    // A seek buys nothing for a waveform-less transport bar, and it would spend the bandwidth
-    // anyway.
+  it('emits no measurement for a file card, which has nothing to load', () => {
+    // The player it replaces laid out at the UA default 300x150 and jumped when metadata
+    // arrived, which is what `measured` existed to report. A card's height is final at first
+    // paint, so there is no late growth for the scroller to chase.
     seedSettings();
-    const audio = preview({ url: 'https://e.test/s.mp3', kind: 'audio', src: '/api/lp/media/a' });
-    const wrapper = mount(MessageAttachment, { props: { preview: audio } });
-    expect(wrapper.find('audio').attributes('src')).toBe('/api/lp/media/a');
-  });
-
-  it('tells the list when a video finally reports its size', async () => {
-    // ⚠ The server measures dimensions for IMAGES only, so a video has no width/height to
-    // reserve a box with: it lays out at the UA default 300x150 and jumps to full size when
-    // metadata arrives. `previewRevision` has already fired by then and the scroller's
-    // ResizeObserver watches its own box rather than its content, so nothing else notices.
-    seedSettings();
-    const video = preview({ url: 'https://e.test/c.mp4', kind: 'video', src: '/api/lp/media/v' });
-    const wrapper = mount(MessageAttachment, { props: { preview: video } });
-    await wrapper.find('video').trigger('loadedmetadata');
-    expect(wrapper.emitted('measured')).toHaveLength(1);
+    const p = preview({ url: 'https://e.test/c.mp4', kind: 'video', mime: 'video/mp4' });
+    const wrapper = mount(MessageAttachment, { props: { preview: p } });
+    expect(wrapper.emitted('measured')).toBeUndefined();
   });
 
   it('tells the list when an image decodes, even though its box was reserved', async () => {
@@ -713,16 +730,17 @@ describe('MessageAttachments — arrangement', () => {
     expect(wrapper.find('.card').exists()).toBe(true);
   });
 
-  it('stacks a video at full width instead of cropping it into a cell', () => {
-    // ⚠ A player reduced to a mosaic cell loses its controls, which are the part that matters.
-    // Two images plus a video is a two-cell mosaic and a stacked player, not a three-cell grid.
+  it('stacks a video card at full width instead of cropping it into a cell', () => {
+    // ⚠ The mosaic is a grid of PICTURES and a file card is not one — cropped into a cell it
+    // would lose the filename, which is the whole of it. Two images plus a video is a two-cell
+    // mosaic and a stacked card, not a three-cell grid.
     seed(img(1, 800, 600), img(2, 800, 600));
-    const video = preview({ url: 'https://e.test/c.mp4', kind: 'video', src: '/api/lp/media/v' });
+    const video = preview({ url: 'https://e.test/c.mp4', kind: 'video', mime: 'video/mp4' });
     seed(video);
     const wrapper = mountFor(`https://e.test/1.png https://e.test/2.png ${video.url}`);
     expect(wrapper.findAll('.mosaic .tile')).toHaveLength(2);
-    expect(wrapper.find('.mosaic video').exists()).toBe(false);
-    expect(wrapper.find('video.inline-video').exists()).toBe(true);
+    expect(wrapper.find('.mosaic .card-file').exists()).toBe(false);
+    expect(wrapper.find('.card-file').exists()).toBe(true);
   });
 
   it('renders nothing at all when both settings are off', () => {

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -743,6 +743,56 @@ describe('MessageAttachments — arrangement', () => {
     expect(wrapper.find('.card-file').exists()).toBe(true);
   });
 
+  // ⚠⚠ Both of these are regressions the media-policy change introduced and a review caught.
+  // Video and audio crossed from "the file, on screen" to "a card about a file", and every rule
+  // keyed on the old meaning had to cross with them. Neither failure was visible from the
+  // component's own tests, because both live in MessageBody's arrangement rather than in the
+  // card. See LINK_PREVIEWS_MEDIA_POLICY.md.
+  it('charges video cards to the CARD cap, not the generous media budget', () => {
+    // A card costs real vertical space whatever kind produced it. Charged to the media budget
+    // (20) and skipped by the card counter, a message of pasted clips rendered a full-width
+    // card per link — the screenful MAX_CARDS_PER_MESSAGE exists to prevent, and which the
+    // same count of images (a 4-tile mosaic) or pages (3 cards) both avoid.
+    const clips = Array.from({ length: 8 }, (_, i) =>
+      preview({ url: `https://e.test/clip${i}.mp4`, kind: 'video', mime: 'video/mp4' }),
+    );
+    seed(...clips);
+    const wrapper = mountFor(clips.map((c) => c.url).join(' '));
+    expect(wrapper.findAll('.card-file').length).toBe(MAX_CARDS_PER_MESSAGE);
+  });
+
+  // ⚠ These two mount with real SEGMENTS. `mountFor` passes `segments: []` because the tests
+  // around it are about arrangement, and with no segments there is no body text for a URL to be
+  // kept in or dropped from — the assertion would pass vacuously either way.
+  function mountWithBody(url: string) {
+    seedSettings();
+    return mount(MessageBody, {
+      props: {
+        text: `look at this ${url}`,
+        segments: [{ text: 'look at this ' }, { text: url, url }],
+      },
+    });
+  }
+
+  it('keeps the address in the text for a video, the way it does for any other card', () => {
+    // ⚠ The URL is dropped from the body only when the thing itself is on screen. A card names
+    // a file — it is not the file — so removing the address leaves a reader with "look at this"
+    // and a filename, unable to read or copy where it points.
+    const video = preview({ url: 'https://e.test/a1b2c3.mp4', kind: 'video', mime: 'video/mp4' });
+    seed(video);
+    const wrapper = mountWithBody(video.url);
+    expect(wrapper.find('.card-file').exists()).toBe(true);
+    expect(wrapper.text()).toContain(video.url);
+  });
+
+  it('still drops the address for an image, which IS on screen', () => {
+    // The other half of the same rule — asserted so a fix for the above can't quietly delete it.
+    seed(img(1, 800, 600));
+    const wrapper = mountWithBody('https://e.test/1.png');
+    expect(wrapper.find('img.inline-image').exists()).toBe(true);
+    expect(wrapper.text()).not.toContain('https://e.test/1.png');
+  });
+
   it('renders nothing at all when both settings are off', () => {
     seed(img(1, 800, 600), YOUTUBE);
     const wrapper = mountFor(`https://e.test/1.png ${YOUTUBE.url}`, {

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -62,7 +62,7 @@
        relay exhausted the control plane's socket memory on 2026-08-10. Pressing the link is a
        deliberate act and goes straight to the origin, where a hidden IP was never buying the
        reader anything a click wouldn't reveal a second later.
-       See lurker-dev/LINK_PREVIEWS_MEDIA_POLICY.md.
+       The operator-facing statement of this is in docs/SELF_HOSTING.md.
        ⚠ Only the TITLE is a link, not the whole card. A full-card anchor would swallow the row
        click, which on touch is the only thing that opens the message-actions sheet — the same
        defect the wrapper note above is written about.

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -53,34 +53,35 @@
       @keydown.space.prevent="activate"
     />
   </span>
-  <!-- ⚠ `@loadedmetadata` matters more here than the image's `@load` does. The server measures
-       dimensions for images only, so a video has NO width/height to reserve a box with and lays
-       out at the UA default 300x150 until its metadata arrives — then jumps to full size. The
-       resolve-time `previewRevision` has already fired by then, and the scroller's ResizeObserver
-       watches its own box rather than its content, so without this nothing at all notices. -->
-  <!-- ⚠ Never tiled. A player cropped into a grid cell loses its controls, which are the part
-       that matters, so MessageAttachments stacks video and audio at full width and the mosaic
-       is images only. -->
-  <!-- ⚠ `videoSrc`, not `preview.src` — it carries a `#t=` fragment that stands in for the poster
-       frame we have no ffmpeg to generate. See the computed. -->
-  <video
-    v-else-if="preview.kind === 'video' && preview.src"
-    class="inline-video"
-    :src="videoSrc"
-    controls
-    preload="metadata"
-    @click.stop
-    @loadedmetadata="$emit('measured')"
-  />
-  <audio
-    v-else-if="preview.kind === 'audio' && preview.src"
-    class="inline-audio"
-    :src="preview.src"
-    controls
-    preload="metadata"
-    @click.stop
-    @loadedmetadata="$emit('measured')"
-  />
+  <!-- ⚠⚠ A FILE CARD, not a player, and the absence of a `src` is the whole point. An inline
+       `<video>` fetches before anyone asks — `preload="metadata"` at minimum, and the `#t=`
+       poster trick this replaces made it a range request for real frames — so the element
+       itself was the involuntary fetch. The server no longer mints `src` for these kinds
+       (`toDescriptor`), which also stops one clip being relayed per viewer, per view, forever:
+       the byte cache stores images only, so video never got cheap on the second read. That
+       relay exhausted the control plane's socket memory on 2026-08-10. Pressing the link is a
+       deliberate act and goes straight to the origin, where a hidden IP was never buying the
+       reader anything a click wouldn't reveal a second later.
+       See lurker-dev/LINK_PREVIEWS_MEDIA_POLICY.md.
+       ⚠ Only the TITLE is a link, not the whole card. A full-card anchor would swallow the row
+       click, which on touch is the only thing that opens the message-actions sheet — the same
+       defect the wrapper note above is written about.
+       ⚠ No `measured` emit: unlike an image or a player this box has no bytes coming, so its
+       height is final at first paint and there is no late growth for the scroller to chase. -->
+  <div v-else-if="isMediaFile" class="card card-file">
+    <span class="file-badge" aria-hidden="true">{{ preview.kind === 'video' ? '▶' : '♪' }}</span>
+    <div class="card-text">
+      <a
+        class="card-title"
+        :href="preview.url"
+        target="_blank"
+        rel="noreferrer noopener"
+        @click.stop
+        >{{ mediaName }}</a
+      >
+      <div class="card-desc">{{ mediaTypeLabel }}</div>
+    </div>
+  </div>
 
   <!-- A page, or a video page. Discord's panel treatment: the card sits on its own slightly
        raised background so it reads as a distinct object rather than as more chat text.
@@ -235,7 +236,8 @@ const props = defineProps<{
   tiled?: boolean;
 }>();
 
-// ⚠⚠ `measured` is emitted by IMAGE, VIDEO and AUDIO. The image `@load` emit was removed once,
+// ⚠⚠ `measured` is emitted by the IMAGE only, now that video and audio render as a static file
+// card with nothing to load — see the template. The image `@load` emit was removed once,
 // on the reasoning that "every rendered image now has its box before any bytes" and so `@load`
 // could no longer report growth — the cost cited was five idempotent scroll corrections for a
 // five-image message. The premise was false in Blink (see the template: pending 0x0), the
@@ -257,37 +259,6 @@ const playing = ref(false);
 const embedEl = useTemplateRef<HTMLIFrameElement>('embedEl');
 
 const isVideo = computed(() => props.preview.kind === 'video-embed' && !!props.preview.embedUrl);
-
-/**
- * The player's source, with a Media Fragment asking the browser to start at 0.1s.
- *
- * ⚠⚠ THIS IS THE POSTER FRAME, and it is a substitute for one. A `<video>` with no `poster`
- * paints nothing until it has decoded a frame, so an unplayed clip is a black rectangle with
- * controls on it — you cannot tell one video in a buffer from another. Discord does not have
- * this problem because it decodes the first frame SERVER-side: their media library (Lilliput,
- * open source) bundles libavcodec precisely to thumbnail MP4. We have no ffmpeg anywhere — see
- * `uploads.test.ts`, which asserts an empty `thumbnail_url` for exactly that reason — and adding
- * it would mean decoding arbitrary third-party video on the server, a far larger parser surface
- * than sharp reading 64 KB of image header.
- *
- * `#t=0.1` seeks on load, which forces a decode, which paints. It works only because the media
- * proxy does real Range plumbing (`routes/linkPreview.ts`) — a source that ignores byte ranges
- * cannot be seeked, so this would be inert against a naive proxy.
- *
- * ⚠ A fragment is never transmitted, so the HMAC token in the path and the request the server
- * sees are both untouched. This cannot invalidate a proxy URL.
- *
- * ⚠ It COSTS BANDWIDTH, per viewer rather than once per cell: `preload="metadata"` alone fetches
- * roughly the container header, and this makes the browser pull far enough in to decode. The
- * trade was taken deliberately — inline images already spend per-viewer bytes on exactly this
- * kind of at-a-glance legibility, and a video is the one attachment with no lightbox behind it
- * to recover from a bad guess.
- *
- * ⚠ 0.1s rather than 0: some encoders have no decodable frame exactly at zero, and a seek to 0
- * is frequently a no-op that paints nothing. The cost is that playback and replay both begin
- * 100ms in.
- */
-const videoSrc = computed(() => `${props.preview.src ?? ''}#t=0.1`);
 
 /**
  * What the card is called, and what its link says. Never empty.
@@ -325,6 +296,51 @@ const heading = computed(() => {
     // A URL that won't parse is still a string worth showing over an empty card.
     return p.url;
   }
+});
+
+/** A bare media FILE — a link that resolved to video or audio bytes rather than to a page.
+ *
+ * ⚠ Keyed on `kind` alone, deliberately, and not on `!preview.src`. A descriptor minted before
+ * the media-policy change may still be sitting in an open tab's memory with a `src` on it, and
+ * the point is that those stop being played inline too — the server would answer that token
+ * with a 404 now (`proxyableContentType` is images-only), so honouring it would render a player
+ * wired to a broken source. Descriptors are minted per request and never persisted, so this
+ * window closes at the next resolve either way. */
+const isMediaFile = computed(
+  () => props.preview.kind === 'video' || props.preview.kind === 'audio',
+);
+
+/**
+ * What to call the file.
+ *
+ * ⚠ The last path segment, not `heading`. These records have no title and no siteName — nothing
+ * was scraped, because the URL *is* the content — so `heading` falls all the way through to the
+ * hostname, and a card reading "cdn.lurker.chat" tells a reader nothing about which of three
+ * clips it is. The filename is the only distinguishing thing a bare media URL carries.
+ *
+ * ⚠ Decoded, and length-clamped. A percent-encoded name is unreadable, and an over-long one
+ * would push the card's layout around before `.card-title`'s clamp could catch it.
+ */
+const mediaName = computed(() => {
+  try {
+    const path = new URL(props.preview.url).pathname;
+    const last = path.slice(path.lastIndexOf('/') + 1);
+    const name = last ? decodeURIComponent(last) : '';
+    if (name) return name.length > 80 ? `${name.slice(0, 79)}…` : name;
+  } catch {
+    // Falls through to the heading, which is itself guaranteed non-empty.
+  }
+  return heading.value;
+});
+
+/** The second line: what kind of thing this is, from the server's measured content type.
+ *  ⚠ `mime` is the server's, read off the response rather than guessed from the extension, so
+ *  it is trustworthy in the one place a filename is not. Subtype only — "Video · MP4" reads,
+ *  "Video · video/mp4" is redundant twice over. */
+const mediaTypeLabel = computed(() => {
+  const noun = props.preview.kind === 'video' ? 'Video' : 'Audio';
+  const sub = props.preview.mime?.split('/')[1]?.split(';')[0]?.trim();
+  return sub ? `${noun} · ${sub.toUpperCase()}` : noun;
 });
 
 /**
@@ -602,42 +618,35 @@ function activate(): void {
 .inline-image[role='button'] {
   cursor: pointer;
 }
-.inline-video,
-.inline-audio {
-  max-width: 100%;
-  width: auto;
-  border-radius: var(--radius-md);
-  display: block;
+/* The media FILE card — a video or audio link that is named rather than played.
+   ⚠ It reuses `.card` wholesale, so it sits on the same panel, at the same inset, with the same
+   mobile left rule as a page card. That is the point: these are the same KIND of object now —
+   something the reader may choose to open — and a second visual language for them would only
+   say "this one is special" about the case that is now the most ordinary.
+   ⚠ No fixed height and no reserved box, unlike the player this replaces. That whole apparatus
+   (a pinned 300px, so a `loadedmetadata` jump could not move a scrolled-up reader) existed
+   because the element's size arrived with its bytes. Nothing here is fetched, so the card's
+   height is known at first paint and R1 is satisfied by construction rather than by a pin. */
+.card-file {
+  align-items: center;
 }
-/* ⚠ A FIXED height, not a max. The server measures dimensions for images only, so a video has
-   no intrinsic ratio to reserve a box from: it lays out at the UA default 300x150 and jumps to
-   its real size when `loadedmetadata` fires. `@loadedmetadata` lets the list re-pin, but that is
-   only a mitigation — the re-pin can follow the bottom and cannot hold a scrolled-up reader
-   still, because by the time we hear about the growth it has already happened.
-   Pinning the height removes the jump instead of compensating for it: the box is correct before
-   a single byte arrives. Width still settles when the ratio is known, which costs nothing —
-   only vertical movement disturbs a scroll position.
-
-   ⚠⚠ 300px, half as much again as the 200px it replaced, and the reason is that THIS IS THE ONLY
-   PLACE A VIDEO IS EVER WATCHED. The media viewer is images-only — `openAt` filters on
-   `kind === 'image'`, because MediaViewerModal picks its element from the URL's extension and a
-   proxy path has none, so a video handed to it mounts MP4 bytes in an `<img>` and fails. Discord
-   is the same: its inline player has no lightbox behind it either. An image can afford to be a
-   thumbnail because a click opens the real thing; a video at thumbnail size is just small.
-
-   ⚠ The cost is on a narrow column, and it grows with this number. `max-width: 100%` clamps the
-   width while this height stays put, so a 16:9 clip on a phone letterboxes — ~49px of bar top
-   and bottom at 360px wide, where at 200px there was none. That is the thing to look at before
-   raising this again. Accepted rather than fixed, because every fix trades it for something
-   worse: `max-height` restores the 300x150 jump this rule exists to remove, and a fixed
-   `aspect-ratio` box (the mosaic's trick) would letterbox every phone-shot VERTICAL video down
-   its sides instead, which is the more common shape on IRC. Letting the width follow the real
-   ratio is what makes a portrait clip render as a portrait clip. */
-.inline-video {
-  height: 300px;
-}
-.inline-audio {
-  width: 100%;
+/* ⚠ Sized and centred like `.play-badge`, and for the same reason: it is the only thing on a
+   card with no picture that says at a glance what sort of file this is. It is NOT a control —
+   the title is the link — so it is `aria-hidden` and carries no focus ring; a badge that looked
+   pressable but wasn't is worse than one that plainly isn't. */
+.file-badge {
+  flex: none;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in srgb, var(--fg) 25%, transparent);
+  color: var(--fg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* Optically centred: a triangle glyph's visual mass sits left of its box. Applied to both
+     glyphs so the two badges are the same object at different labels. */
+  padding-left: 3px;
 }
 
 /* A mosaic cell: fill it exactly, whatever shape the picture is.

--- a/vue_client/src/components/MessageAttachments.vue
+++ b/vue_client/src/components/MessageAttachments.vue
@@ -80,14 +80,16 @@ const MOSAIC_CELLS = 4;
 /**
  * Every image in the message, in order.
  *
- * ⚠ IMAGES only, and video is the deliberate omission. MediaViewerModal derives which element to
- * render from the URL's extension, and a proxy path has none — `mediaKindForUrl` returns null for
- * a relative URL — so it falls back to `image` and would mount a video's bytes in an `<img>`,
- * producing the "open in browser" failure card for a file that plays fine inline.
+ * ⚠ IMAGES only, and video is the deliberate omission — but no longer for the reason this
+ * comment used to give. The old hazard was that MediaViewerModal derives its element from the
+ * URL's extension, a proxy path has none, and a video handed to it mounted MP4 bytes in an
+ * `<img>`. That cannot arise now: the server mints no `src` for video or audio at all, so there
+ * are no bytes to hand anywhere. The filter stays because the mosaic is a grid of PICTURES, and
+ * a file card is not one.
  *
- * ⚠ It is also why a video is never a mosaic tile. A player cropped into a grid cell is not a
- * player: its controls are the part that gets cut. Video and audio stack at full width, where
- * their transport has room, which is what audio has always done.
+ * ⚠ It is also why video and audio are never mosaic tiles. They render as full-width file cards
+ * (see MessageAttachment), and a card cropped into a grid cell loses the text that is the whole
+ * of it.
  */
 const images = computed(() => props.previews.filter((p) => p.kind === 'image'));
 

--- a/vue_client/src/components/MessageBody.vue
+++ b/vue_client/src/components/MessageBody.vue
@@ -210,7 +210,7 @@ const visible = computed<LinkPreview[]>(() => {
  * even though they no longer render inline, because `previewableUrls` charges them to the same
  * toggle on the way in — moving them to the card toggle would start showing cards to people who
  * turned inline media off and stop showing them to people who turned it on, which is a product
- * decision and not this change's to make. See LINK_PREVIEWS_MEDIA_POLICY.md, open question 6. */
+ * decision and not this change's to make. */
 function isMedia(p: LinkPreview): boolean {
   return p.kind === 'image' || p.kind === 'video' || p.kind === 'audio';
 }

--- a/vue_client/src/components/MessageBody.vue
+++ b/vue_client/src/components/MessageBody.vue
@@ -195,7 +195,7 @@ const visible = computed<LinkPreview[]>(() => {
     // extensionless CDN links, a `.png` that redirects to an HTML login page — arrived as twenty
     // stacked cards and took over the screen. The tight cap exists because a card costs real
     // vertical space, and only the resolved kind knows whether one is being built.
-    if (!isMedia(p)) {
+    if (!rendersInline(p)) {
       if (cards >= MAX_CARDS_PER_MESSAGE) continue;
       cards++;
     }
@@ -204,26 +204,54 @@ const visible = computed<LinkPreview[]>(() => {
   return out;
 });
 
-/** A link that IS a file, as the SERVER classified it — never as the extension guessed. */
+/** A link that IS a file, as the SERVER classified it — never as the extension guessed.
+ *
+ * ⚠ This answers "which SETTING governs it", and nothing else. It still counts video and audio
+ * even though they no longer render inline, because `previewableUrls` charges them to the same
+ * toggle on the way in — moving them to the card toggle would start showing cards to people who
+ * turned inline media off and stop showing them to people who turned it on, which is a product
+ * decision and not this change's to make. See LINK_PREVIEWS_MEDIA_POLICY.md, open question 6. */
 function isMedia(p: LinkPreview): boolean {
   return p.kind === 'image' || p.kind === 'video' || p.kind === 'audio';
+}
+
+/** A link whose CONTENT is put on screen, rather than a card describing it.
+ *
+ * ⚠⚠ IMAGES ONLY, and the split from `isMedia` is the whole point. Video and audio used to be
+ * players — the file itself, on screen — and are now cards naming a file, so every rule that
+ * asks "is the thing itself visible?" has to follow them across. Two rules did, and both broke
+ * quietly when the kinds moved:
+ *
+ *   · the card cap (below) counted only `!isMedia`, so twenty pasted `.mp4` links rendered
+ *     twenty uncapped full-width cards — the exact screenful MAX_CARDS_PER_MESSAGE exists to
+ *     prevent, and which twenty page links or twenty images both avoid.
+ *   · `hiddenUrls` dropped their address from the message, on the reasoning that the file was
+ *     already on screen. Nothing is on screen now but a filename, so the address became
+ *     unreadable and uncopyable — and this file's own rule is that a card never takes its
+ *     link away. */
+function rendersInline(p: LinkPreview): boolean {
+  return p.kind === 'image';
 }
 
 /**
  * URLs whose address is dropped from the body because the thing itself is on screen.
  *
- * ⚠⚠ MEDIA ONLY, and the asymmetry is deliberate. An image, a video or an audio file IS the
- * message — the address above it is a machine-readable duplicate of something the reader is
- * already looking at, and on a giphy link it is most of the row. A CARD is a note ABOUT a page:
- * its heading is different text from the URL, the URL is what somebody would copy or read before
- * deciding to click, and a card can legitimately be titled with nothing but the hostname. So a
- * card never takes its link away.
+ * ⚠⚠ INLINE-RENDERED ONLY, and the asymmetry is deliberate. An image IS the message — the
+ * address above it is a machine-readable duplicate of something the reader is already looking
+ * at, and on a giphy link it is most of the row. A CARD is a note ABOUT something: its heading
+ * is different text from the URL, the URL is what somebody would copy or read before deciding
+ * to click, and a card can legitimately be titled with nothing but a filename or a hostname. So
+ * a card never takes its link away.
+ *
+ * ⚠ `rendersInline`, not `isMedia`. Video and audio were on the left of this line while they
+ * were players; as cards they belong on the right, and leaving them behind meant a message
+ * reading "look at this" with a card saying `a1b2c3.mp4` and the address gone from the text.
  *
  * Drawn from `visible` rather than from `urls`, so a URL that failed to resolve, was capped, or
  * is switched off keeps its text. Nothing is ever hidden without something rendered in its place.
  */
 const hiddenUrls = computed(() =>
-  hideableUrls(props.text, new Set(visible.value.filter(isMedia).map((p) => p.url))),
+  hideableUrls(props.text, new Set(visible.value.filter(rendersInline).map((p) => p.url))),
 );
 
 const shownSegments = computed(() => segmentsWithoutUrls(props.segments, hiddenUrls.value));


### PR DESCRIPTION
The proxy exists to stop a card that renders **by itself** from telling a stranger's server who is reading — unintended view stats. It was never meant to be an anonymizing relay for content somebody deliberately plays: hiding an IP at the moment a reader presses play conceals nothing that clicking the link reveals a second later.

So video and audio get no byte URL at all. `toDescriptor` stops minting `src` for those kinds, **and the route refuses their content types** — a token is a pure HMAC of the URL, so a descriptor minted before this still verifies, and changing only the mint would leave the relay unadvertised rather than gone.

## This is not only a privacy argument

The byte cache stores **images only** (`previewCache/index.ts:152`), and range requests are never stored — which is all of video playback. So the one mechanism making previews affordable (store once, then mint a CDN URL) covered only the cheap kind. Video was relayed in full, **per viewer, per view, forever**, with a ceiling 8× higher than images and no aggregate bound anywhere: `mediaPool` bounds slots (24), not bytes.

On 2026-08-10 that exhausted the control plane's kernel socket memory — `TCP: mem 44819` pages ≈ 183 MB against a ~42,600-page `tcp_mem` ceiling — and every socket on the box collapsed to a ~6 KB window. Loopback transfers ran at **7 KB/s**; chat was unusable worldwide for hours. The two files responsible were a 44.8 MB `.mp4` and a 9.4 MB `.mov`, both already sitting on `cdn.lurker.chat`, pulled back through the origin to be handed out again.

## What changes

- `MAX_MEDIA_PROXY_BYTES` (64 MB) is **deleted, not lowered** — there is no size at which video is served now.
- Clients render a file card naming the file and its type, linking to the origin.
- The `#t=0.1` poster hack goes with it. With no ffmpeg to decode a frame, that fragment made the browser range-request real video bytes to paint a poster — the involuntary fetch, wearing a workaround's clothes.

## Notes for review

- **No migration and no `RESOLVER_VERSION` bump.** Planned, then found unnecessary: the record is unchanged and descriptors are minted per request, so cached rows render the new card on the next read. A bump would orphan every row of every kind.
- **iOS needs no change** — verified rather than assumed. It already showed a glyph and handed off on tap, and `MessageAttachmentsView.swift:640` falls back to opening the origin when an item has no `src`.
- **The second commit applies `/code-review high`.** Its sharpest finding was that the Inline media *setting description* still promised users the file "is fetched and served by your Lurker server" for video and audio — false once they stopped being relayed, and it is the sentence people read when deciding to enable it. Now scoped to images.
- Two client regressions the review caught, both fixed with tests that were **confirmed to fail with the fix reverted**: video bypassed `MAX_CARDS_PER_MESSAGE` (20 pasted clips = 20 uncapped full-width cards), and `hiddenUrls` still stripped their address from the message body.

## Deliberately not in scope

A `.mp4` is still gated on the **Inline media** toggle rather than **Link previews**, so someone with inline media off sees nothing for a video link. That is now arguably the wrong toggle for a card that fetches nothing — but changing it changes who sees what, which is a product decision, not this change's to make.

Plan, incident writeup and the phase 2 sketch: `lurker-dev/LINK_PREVIEWS_MEDIA_POLICY.md`.

`npm run check` and `npm test` both exit 0 (3913 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
