### PR TITLE
Inline media polish: pad image-only messages, drop the 4-tile mosaic cap

### DIFF
--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -716,67 +716,74 @@ describe('MessageAttachments — arrangement', () => {
   it('takes the mosaic shape from the COUNT, never from the pictures', () => {
     // ⚠⚠ The property the whole grid rests on, and the reason it replaced a strip whose height
     // was derived from `thumbWidth`/`thumbHeight`. Two groups of the same size get the same
-    // layout class no matter what shape their images are, so no descriptor — and therefore no
+    // layout no matter what shape their images are, so no descriptor — and therefore no
     // late-arriving answer — can change a message's height. Asserted as the class binding
     // because the geometry itself is CSS and happy-dom applies no stylesheet.
     seed(img(1, 800, 600), img(2, 1200, 500));
     expect(
       mountFor('https://e.test/1.png https://e.test/2.png').find('.mosaic').classes(),
-    ).toContain('n2');
+    ).not.toContain('odd');
 
     resolved.clear();
     seed(img(1, 600, 900), img(2, 500, 1000));
     expect(
       mountFor('https://e.test/1.png https://e.test/2.png').find('.mosaic').classes(),
-    ).toContain('n2');
+    ).not.toContain('odd');
   });
 
-  it('gives three images the hero-and-two shape', () => {
+  it('leads an ODD count with the three-up block, at three and at nine alike', () => {
     // A 2x2 grid holding three items leaves a hole; stretching the third across the bottom makes
     // it the subject of the message. The full-height first cell is what gives an odd count a
-    // shape, and `.n3` is what selects it.
-    seed(img(1, 800, 600), img(2, 800, 600), img(3, 800, 600));
-    const mosaic = mountFor('https://e.test/1.png https://e.test/2.png https://e.test/3.png').find(
-      '.mosaic',
-    );
-    expect(mosaic.classes()).toContain('n3');
-    expect(mosaic.findAll('.tile').length).toBe(3);
-  });
-
-  it('caps the mosaic at four tiles and counts the rest onto the last one', () => {
-    // ⚠ The cap is what keeps `MAX_MEDIA_PER_MESSAGE` (20) affordable. The strip could carry the
-    // twelfth image for free because it scrolled; a grid cannot, so past four it counts instead
-    // of growing. Everything past the cap is still reachable — see the gallery suite.
-    const urls: string[] = [];
-    for (let n = 1; n <= 6; n++) {
-      urls.push(`https://e.test/${n}.png`);
-      seed(img(n, 800, 600));
-    }
-    const wrapper = mountFor(urls.join(' '));
-    expect(wrapper.findAll('.mosaic .tile')).toHaveLength(4);
-    expect(wrapper.find('.more').text()).toBe('+2');
-    // `+2` is not a sentence, so the count is spelled out for a screen reader too.
-    expect(wrapper.find('.sr-only').text()).toBe('2 more images');
-  });
-
-  it('does not render the images it capped away a SECOND time, below the grid', () => {
-    // ⚠⚠ Regression, /code-review high. `stacked` subtracted `mosaic` — the four DRAWN tiles —
-    // so every image from the fifth on fell through and rendered again at full size underneath,
-    // while the `+2` badge above announced those same pictures as not shown. At
-    // MAX_MEDIA_PER_MESSAGE (20) that is a four-cell grid followed by sixteen photographs, which
-    // is the exact screenful the cap exists to prevent.
+    // shape, and `.odd` is what selects it — at any count, because whatever the three-up block
+    // doesn't take is even by construction and pairs up behind it.
     //
-    // ⚠ The test above this one could not catch it: it counts `.mosaic .tile`, which was
-    // correctly 4 the whole time. Counting what you capped is not counting what rendered — so
-    // this asserts the TOTAL number of images in the block.
+    // ⚠ The class used to be `n${count}` with the CSS keyed on `.n3`, which was correct only
+    // because nothing past the fourth image was ever drawn. At five that spelling silently
+    // degrades to a two-column grid with a hole in its last row.
+    for (const n of [3, 5, 9]) {
+      resolved.clear();
+      const urls: string[] = [];
+      for (let i = 1; i <= n; i++) {
+        urls.push(`https://e.test/${i}.png`);
+        seed(img(i, 800, 600));
+      }
+      const mosaic = mountFor(urls.join(' ')).find('.mosaic');
+      expect(mosaic.classes()).toContain('odd');
+      expect(mosaic.findAll('.tile').length).toBe(n);
+    }
+  });
+
+  it('tiles EVERY image, with no four-cell cap and no overflow count', () => {
+    // lurker#773. The grid used to draw four tiles and a `+N` badge over the last one; lurker-ios
+    // shows the lot, and the badge was advertising pictures as hidden from inside a layout whose
+    // whole point is that the message is on screen at once. What bounds the worst case is
+    // `MAX_MEDIA_PER_MESSAGE` (20), applied long before this component sees anything.
     const urls: string[] = [];
     for (let n = 1; n <= 6; n++) {
       urls.push(`https://e.test/${n}.png`);
       seed(img(n, 800, 600));
     }
     const wrapper = mountFor(urls.join(' '));
-    expect(wrapper.findAll('.mosaic .tile')).toHaveLength(4);
-    expect(wrapper.findAll('img.inline-image')).toHaveLength(4);
+    expect(wrapper.findAll('.mosaic .tile')).toHaveLength(6);
+    expect(wrapper.find('.more').exists()).toBe(false);
+  });
+
+  it('renders each image exactly ONCE — in the grid, never again below it', () => {
+    // ⚠⚠ Regression, /code-review high, from when the cap existed: `stacked` subtracted the four
+    // DRAWN tiles, so every image from the fifth on fell through and rendered a SECOND time at
+    // full size underneath, while the `+2` badge above announced those same pictures as hidden.
+    //
+    // ⚠ The test above this one could not catch it: it counts `.mosaic .tile`, which was correct
+    // the whole time. Counting what the grid took is not counting what RENDERED — so this counts
+    // every image in the block, and goes on doing so now that the two sets should agree.
+    const urls: string[] = [];
+    for (let n = 1; n <= 6; n++) {
+      urls.push(`https://e.test/${n}.png`);
+      seed(img(n, 800, 600));
+    }
+    const wrapper = mountFor(urls.join(' '));
+    expect(wrapper.findAll('.mosaic .tile')).toHaveLength(6);
+    expect(wrapper.findAll('img.inline-image')).toHaveLength(6);
   });
 
   it('still stacks a LONE image, which the mosaic never stands in for', () => {
@@ -788,16 +795,9 @@ describe('MessageAttachments — arrangement', () => {
     expect(wrapper.findAll('img.inline-image')).toHaveLength(1);
   });
 
-  it('draws no overflow badge when everything fits', () => {
-    seed(img(1, 800, 600), img(2, 800, 600));
-    expect(mountFor('https://e.test/1.png https://e.test/2.png').find('.more').exists()).toBe(
-      false,
-    );
-  });
-
   it('caps CARDS against the server answer, not against the extension guess', () => {
     // ⚠ `previewableUrls` charges anything that LOOKS like media to the generous media budget
-    // (20), because a mosaic costs the same at 2 as at 12. But an image-looking URL that resolves
+    // (20), because half a grid row is not what a card costs. But an image-looking URL that resolves
     // as a page — an extensionless CDN link, a .png that redirects to an HTML login page —
     // becomes a CARD, and a card costs real vertical space. Applying the tight cap only to the
     // guess meant twenty such links rendered twenty stacked cards and took over the screen.
@@ -982,24 +982,35 @@ describe('MessageBody — atomic reveal', () => {
   });
 
   it('decides the mosaic SHAPE once, from the complete group', async () => {
-    // ⚠ TWO images arrive first, so that without the gate there IS a mosaic mid-flight — an `n2`,
-    // one row tall — which then becomes an `n4` two rows tall when the rest land. An earlier draft
-    // of the strip-era version of this test seeded ONE image and passed with the gate reverted,
-    // because one image is never a group either way; two is the smallest count that can be wrong.
+    // ⚠ TWO images arrive first, so that without the gate there IS a mosaic mid-flight — a single
+    // paired row — which then becomes a three-up block over a pair, three rows tall, when the rest
+    // land. An earlier draft of the strip-era version of this test seeded ONE image and passed
+    // with the gate reverted, because one image is never a group either way; two is the smallest
+    // count that can be wrong.
+    //
+    // ⚠ FIVE in total, not four, so the finished shape differs from the mid-flight one in the
+    // class as well as the tile count: parity is what the layout keys on now, and 2 and 4 are
+    // both even. A count that only changed the number of tiles would still catch this, but only
+    // by the assertion the cap-era version happened to have.
     resolved.set(img(1).url, img(1));
     resolved.set(img(2).url, img(2));
     seedSettings();
-    setInFlight(img(3).url, img(4).url);
+    setInFlight(img(3).url, img(4).url, img(5).url);
     const wrapper = mount(MessageBody, {
-      props: { text: `${TWO} https://e.test/3.png https://e.test/4.png`, segments: [] },
+      props: {
+        text: `${TWO} https://e.test/3.png https://e.test/4.png https://e.test/5.png`,
+        segments: [],
+      },
     });
     expect(wrapper.find('.mosaic').exists()).toBe(false);
 
     answer(img(3));
     answer(img(4));
+    answer(img(5));
     await nextTick();
 
-    expect(wrapper.find('.mosaic').classes()).toContain('n4');
+    expect(wrapper.find('.mosaic').classes()).toContain('odd');
+    expect(wrapper.findAll('.mosaic .tile')).toHaveLength(5);
   });
 
   it('does not stall on a URL no answer is coming for', () => {
@@ -1282,11 +1293,12 @@ describe('MessageAttachments — the lightbox is a gallery over the whole messag
     expect(viewer.current.value?.kind).toBe('video');
   });
 
-  it('reaches the images the mosaic capped away', async () => {
-    // ⚠⚠ What makes the four-tile cap acceptable rather than a silent truncation. The gallery is
-    // built from EVERY image in the message, not from the drawn tiles, so the sixth is one arrow
-    // key from the fourth. Built the other way the `+2` badge would advertise images that could
-    // not be opened by any means.
+  it('arrows through the whole message from whichever tile was clicked', async () => {
+    // ⚠⚠ The gallery is built from EVERY image in the message, positioned on the one clicked. It
+    // used to be the guarantee that made the four-tile cap a crop rather than a truncation — the
+    // sixth image was one arrow key from the fourth even though nothing drew it. The cap is gone
+    // (lurker#773) and the guarantee is not: a TILE is itself a crop, and the arrow set is what
+    // says the middle of a photograph is not all there is of it.
     for (const n of [1, 2, 3, 4, 5, 6]) resolved.set(img(n).url, img(n));
     seedSettings();
     const wrapper = mount(MessageBody, {
@@ -1295,7 +1307,7 @@ describe('MessageAttachments — the lightbox is a gallery over the whole messag
         segments: [],
       },
     });
-    expect(wrapper.findAll('.mosaic .tile')).toHaveLength(4);
+    expect(wrapper.findAll('.mosaic .tile')).toHaveLength(6);
 
     await wrapper.findAll('.mosaic img')[3].trigger('click');
     const viewer = useMediaViewer();

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -312,8 +312,8 @@ const props = defineProps<{
 // unless the reader is at the tail, so a scrolled-up reader is never moved by a late decode.
 // `activate` rather than opening the viewer here: what a click MEANS depends on the
 // arrangement, and the arrangement is the parent's business. A tap on one tile of a mosaic
-// should open the whole message's images as a gallery — including the ones the mosaic capped
-// away — and only the parent knows what those are.
+// should open the whole message's images as a gallery, positioned on the one that was tapped,
+// and only the parent knows what the rest of the set is.
 const emit = defineEmits<{ measured: []; activate: [] }>();
 
 const settings = useSettingsStore();

--- a/vue_client/src/components/MessageAttachments.vue
+++ b/vue_client/src/components/MessageAttachments.vue
@@ -183,10 +183,12 @@ function openAt(item: LinkPreview): void {
    ⚠⚠ It does NOT follow that the gap goes to zero, and for two commits it did (lurker#773): an
    image-only message sat flush against the top edge of its row, so a hovered, alt-striped or
    highlighted row painted its background right up to the picture while every text row kept a
-   sliver of it. Text never looks flush because a 1.55 line-height puts ~4px of half-leading
-   above the first glyph; an image has no leading, so it is given the same 4px explicitly. It
-   REPLACES the separation margin rather than adding to it — the text-then-image case already has
-   its gap and would otherwise get 8px.
+   sliver of it. What it gets instead is `--space-4` — the SAME value as the bottom margin below,
+   because with no text in the row the picture is the whole of it and an even inset top and bottom
+   is what makes it sit inside the row rather than at the top of it. Half-leading (`--space-2`,
+   what a 1.55 line-height puts above a text row's first glyph) was tried first and reads as too
+   little against 8px underneath. It REPLACES the separation margin rather than adding to it — the
+   text-then-image case already has its gap and would otherwise get 12px.
 
    ⚠ Spelled as padding because a margin here has nothing below it to collapse against and would
    collapse straight out of `.body`, taking the nick/body separator (`.body::before`) 4px down
@@ -197,7 +199,7 @@ function openAt(item: LinkPreview): void {
    never propagates onto `.attachments`. The rule was written there first and did nothing at all. */
 .attachments.body-only {
   margin-top: 0;
-  padding-top: var(--space-2);
+  padding-top: var(--space-4);
 }
 /* A card wants the width it's given — its text has to wrap against something — but not the
    full width of a wide window, where it stops reading as part of the message and starts

--- a/vue_client/src/components/MessageAttachments.vue
+++ b/vue_client/src/components/MessageAttachments.vue
@@ -5,8 +5,8 @@
 
 <template>
   <div class="attachments">
-    <!-- Two or more images become one MOSAIC: a grid whose cells are chosen by the COUNT, each
-         image cropped to fill its cell.
+    <!-- Two or more images become one MOSAIC: a two-column grid of fixed-size cells, each image
+         cropped to fill its cell.
 
          ⚠⚠ This replaced a horizontally-scrolling filmstrip, and the reason is the interaction
          rather than the look. A sideways scroller inside a vertically-scrolling list is a
@@ -16,24 +16,26 @@
          once, needs no scroll container, no ResizeObserver and no fade.
 
          It keeps the property the strip was built for: the group's height is a function of the
-         IMAGE COUNT alone, so a message has one of two possible attachment heights instead of
-         one per picture. That is what makes it byte-independent AND descriptor-independent —
-         nothing here reads a dimension. Cropping is what buys it, and cropping is recoverable
-         because any cell opens the whole set in the viewer. -->
-    <div v-if="mosaic.length > 1" class="mosaic" :class="`n${mosaic.length}`">
-      <div v-for="(item, i) in mosaic" :key="item.url" class="tile">
+         IMAGE COUNT alone — ceil(n / 2) rows of a fixed height — so no descriptor and no
+         late-arriving byte can change it. Nothing here reads a dimension. Cropping is what buys
+         that, and cropping is recoverable because any cell opens the whole set in the viewer.
+
+         The shape rule, for any count: EVEN → all pairs; ODD → the three-up block (one
+         full-height picture beside two stacked) first, then pairs. So 3 is hero-and-two, 4 is
+         2x2, 5 is the three-up plus a pair, 7 the three-up plus two pairs. One rule, no holes at
+         any count, and the odd block LEADS — a trailing full-width tile crops a landscape photo
+         hard and makes the last picture the subject of the message. It is one CSS declaration:
+         the first tile spans two rows when the count is odd, and auto-placement flows everything
+         after it into pairs around the tall cell. Ported from lurker-ios, whose
+         MessageAttachmentsView draws the same rule with stack views. -->
+    <div v-if="mosaic.length" class="mosaic" :class="{ odd: mosaic.length % 2 === 1 }">
+      <div v-for="item in mosaic" :key="item.url" class="tile">
         <MessageAttachment
           :preview="item"
           tiled
           @measured="$emit('measured')"
           @activate="openAt(item)"
         />
-        <!-- The overflow indicator. It sits on the LAST visible tile rather than adding a cell,
-             so the grid stays 2x2 whether a message carries four images or forty. -->
-        <template v-if="i === mosaic.length - 1 && overflow > 0">
-          <span class="more" aria-hidden="true">+{{ overflow }}</span>
-          <span class="sr-only">{{ overflow }} more image{{ overflow === 1 ? '' : 's' }}</span>
-        </template>
       </div>
     </div>
     <MessageAttachment
@@ -69,15 +71,6 @@ defineEmits<{ measured: [] }>();
 const viewer = useMediaViewer();
 
 /**
- * How many tiles the mosaic draws before it starts counting instead.
- *
- * Four is two full rows. A fifth would either add a row — and a message's height stops being a
- * small known set — or shrink every cell to fit, which is worse the more images there are.
- * Everything past the fourth is reachable through the viewer, which has always been a gallery.
- */
-const MOSAIC_CELLS = 4;
-
-/**
  * Every image in the message, in order.
  *
  * ⚠ IMAGES only, and video is the deliberate omission — but no longer for the reason this
@@ -93,40 +86,48 @@ const MOSAIC_CELLS = 4;
  */
 const images = computed(() => props.previews.filter((p) => p.kind === 'image'));
 
-/** The tiles actually drawn. A lone image is not a one-cell mosaic — see `stacked`. */
-const mosaic = computed(() => (images.value.length > 1 ? images.value.slice(0, MOSAIC_CELLS) : []));
-
-/** How many images the mosaic is standing in for. Zero unless the message is genuinely long. */
-const overflow = computed(() => Math.max(0, images.value.length - mosaic.value.length));
+/**
+ * The tiles, which are now EVERY image in the message. A lone image is not a one-cell mosaic —
+ * see `stacked`.
+ *
+ * ⚠⚠ There used to be a four-cell cap with a `+N` count on the last tile, and dropping it is
+ * lurker#773. The cap's stated reason was that a fifth image "either adds a row, and a message's
+ * height stops being a small known set, or shrinks every cell". Only the first half was ever
+ * true, and it was never the property that mattered: what keeps the block byte-independent is
+ * that its height is a function of the COUNT — ceil(n / 2) fixed rows — not that the count of
+ * possible heights is small. The real bound on a message taking over the screen is
+ * `MAX_MEDIA_PER_MESSAGE` (20), which is enforced before any of this. A badge was also a worse
+ * bargain than it looked: it advertises pictures as hidden while the whole point of the grid is
+ * that everything in the message is on screen at once.
+ */
+const mosaic = computed(() => (images.value.length > 1 ? images.value : []));
 
 /**
  * Everything the mosaic didn't take: cards, video, audio — and a lone image, which renders on its
  * own at its own size. That last case is the common one, and a one-cell mosaic would only crop it
  * for no reason.
  *
- * ⚠⚠ Excludes every image the mosaic STANDS IN FOR, not merely the four it draws. Subtracting
- * `mosaic` was the obvious spelling and it re-rendered the overflow: with six images the grid
- * showed four tiles and a `+2` badge, and then images five and six rendered AGAIN underneath at
- * full size — the badge announcing as hidden the very pictures sitting below it. At
- * `MAX_MEDIA_PER_MESSAGE` (20) that is a four-cell grid followed by sixteen stacked photographs,
- * which is precisely the screenful the cap exists to prevent.
+ * ⚠ Subtract the mosaic's own set, and let it be empty when there is no mosaic — otherwise a
+ * single image is spoken for by a grid that was never drawn and the message renders no picture
+ * at all. When the cap existed this had to subtract every image the mosaic STOOD IN FOR rather
+ * than the tiles it drew, or the overflow rendered a second time underneath at full size; with
+ * no cap the two sets are the same and the trap is gone with it.
  *
- * ⚠ The tests could not see it: they counted `.mosaic .tile`, which was correct at 4, and never
- * the total number of images in the block. Counting what you capped is not the same as counting
- * what rendered.
+ * ⚠ The tests could not see that one: they counted `.mosaic .tile`, which was correct the whole
+ * time, and never the total number of images in the block. Counting what you capped is not the
+ * same as counting what rendered — so the suite still asserts the total.
  */
 const stacked = computed(() => {
-  // Empty when there is no mosaic, so a lone image still stacks — that is the common case.
-  const spokenFor = new Set<LinkPreview>(mosaic.value.length ? images.value : []);
-  return props.previews.filter((p) => !spokenFor.has(p));
+  const inMosaic = new Set<LinkPreview>(mosaic.value);
+  return props.previews.filter((p) => !inMosaic.has(p));
 });
 
 /**
  * Open the viewer over EVERY image in the message, positioned on the one that was clicked.
  *
- * ⚠ The gallery is `images`, not `mosaic`, and that is what makes both the cap and the crop
- * safe: the fifth image of a message is not drawn, and the reader still reaches it by arrowing.
- * A lone image is a gallery of one, which the viewer has always handled.
+ * ⚠ The gallery is `images` — every picture in the message, mosaic or not — and that is what
+ * makes the crop safe: a tile shows the middle of a photograph, and clicking it shows the
+ * photograph. A lone image is a gallery of one, which the viewer has always handled.
  *
  * ⚠ The viewer gets `src` — OUR proxy path — never the origin URL. Handing it `preview.url` broke
  * the promise the setting makes in so many words ("the file is fetched and served by your Lurker
@@ -178,11 +179,25 @@ function openAt(item: LinkPreview): void {
 /* The top margin separates an attachment from the text above it. On a body whose every URL was
    hidden there is no text above it — MessageBody sets this class, and MessageList's `:has()`
    companion top-aligns the row's nick for the same reason.
-   ⚠ It lives HERE rather than beside that companion because a scoped rule in MessageList cannot
-   reach this element: MessageBody is a multi-root fragment, so MessageList's scope id never
-   propagates onto `.attachments`. The rule was written there first and did nothing at all. */
+
+   ⚠⚠ It does NOT follow that the gap goes to zero, and for two commits it did (lurker#773): an
+   image-only message sat flush against the top edge of its row, so a hovered, alt-striped or
+   highlighted row painted its background right up to the picture while every text row kept a
+   sliver of it. Text never looks flush because a 1.55 line-height puts ~4px of half-leading
+   above the first glyph; an image has no leading, so it is given the same 4px explicitly. It
+   REPLACES the separation margin rather than adding to it — the text-then-image case already has
+   its gap and would otherwise get 8px.
+
+   ⚠ Spelled as padding because a margin here has nothing below it to collapse against and would
+   collapse straight out of `.body`, taking the nick/body separator (`.body::before`) 4px down
+   with it — a visible notch in a rule that is continuous on every other row.
+
+   ⚠ It lives HERE rather than beside that `:has()` companion because a scoped rule in MessageList
+   cannot reach this element: MessageBody is a multi-root fragment, so MessageList's scope id
+   never propagates onto `.attachments`. The rule was written there first and did nothing at all. */
 .attachments.body-only {
   margin-top: 0;
+  padding-top: var(--space-2);
 }
 /* A card wants the width it's given — its text has to wrap against something — but not the
    full width of a wide window, where it stops reading as part of the message and starts
@@ -203,9 +218,10 @@ function openAt(item: LinkPreview): void {
    whole grid is laid out correctly before a single byte of any picture arrives — the same
    byte-independence a lone image gets from its reserved box, reached without needing one.
 
-   ⚠ One row height, and every layout is a whole number of rows: 1 row for two images, 2 rows
-   for three or more. So a mosaic is 160px or 324px tall (2 × 160 plus the 4px gap) and never
-   anything else, which is the property the filmstrip's fixed height existed to provide. */
+   ⚠ One row height, and every layout is a whole number of rows: ceil(n / 2) of them, so a mosaic
+   is 160px, 324px, 488px … and never a value that depends on a picture. That — not the number of
+   distinct heights, which the four-cell cap kept at two — is the property the filmstrip's fixed
+   height existed to provide, and it survives an uncapped grid unchanged. */
 .mosaic {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -220,50 +236,32 @@ function openAt(item: LinkPreview): void {
      two independent dials, so anything claiming they agree is wrong. */
   max-width: 480px;
 }
-/* Three images: a full-height picture beside two stacked ones. Discord's arrangement, and it is
-   the one that gives an odd count a shape rather than a gap — a 2x2 grid with three items leaves
-   a hole, and stretching the third across the bottom makes it the subject of the message. */
-.mosaic.n3 > .tile:first-child {
+/* An odd count LEADS with the three-up block: a full-height picture beside two stacked ones.
+   Discord's arrangement for three, and it is the one that gives an odd count a shape rather than
+   a gap — a 2x2 grid with three items leaves a hole, and stretching the third across the bottom
+   makes it the subject of the message.
+
+   ⚠⚠ This one declaration is the whole of the "5, 7, 19 images" layout, and that is why the count
+   cap could go. Auto-placement does the rest: the tall cell occupies column 1 of the first two
+   rows, images 2 and 3 fill column 2 beside it, and every image after that finds the first free
+   row and pairs up. Whatever the three-up block doesn't take is even by construction, so no
+   count leaves a hole — which is exactly the rule lurker-ios draws with nested stack views.
+
+   ⚠ It keys off ODD, not off `n3`. The class used to be `n${count}` and the selector `.n3`, which
+   was correct only because nothing past four was ever drawn; at 5 that spelling silently
+   degrades to a 2x2 grid with a hole in it. */
+.mosaic.odd > .tile:first-child {
   grid-row: span 2;
 }
 
 /* The grid item. The image inside is a `display: contents` wrapper's child (see
    MessageAttachment), so it becomes this element's own child for layout — which is why the
-   clipping, the rounding and the overlay all live here rather than on the picture. */
+   clipping and the rounding live here rather than on the picture. */
 .tile {
-  position: relative;
   overflow: hidden;
   border-radius: var(--radius-md);
   /* A grid item's automatic minimum is its content, so a wide image would otherwise refuse to
      shrink and push the second column off the row. */
   min-width: 0;
-}
-
-/* The overflow count, drawn over the last tile.
-   ⚠ `inset: 0` rather than a corner badge: the whole cell is the target, and the cell is already
-   a button (the image carries the role). A small badge would read as a separate control sitting
-   on top of one, with no way to tell which a tap would hit. */
-.more {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: color-mix(in srgb, var(--bg) 60%, transparent);
-  color: var(--fg);
-  font-weight: 600;
-  /* The image beneath owns the click; this is a label, not a control. */
-  pointer-events: none;
-}
-
-/* The count again, for a screen reader, because `+6` is not a sentence. Clipped rather than
-   `display: none`, which would take it out of the accessibility tree along with the layout. */
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip-path: inset(50%);
-  white-space: nowrap;
 }
 </style>

--- a/vue_client/src/components/MessageAttachments.vue
+++ b/vue_client/src/components/MessageAttachments.vue
@@ -186,20 +186,15 @@ function openAt(item: LinkPreview): void {
    sliver of it. What it gets instead is `--space-4` — the SAME value as the bottom margin below,
    because with no text in the row the picture is the whole of it and an even inset top and bottom
    is what makes it sit inside the row rather than at the top of it. Half-leading (`--space-2`,
-   what a 1.55 line-height puts above a text row's first glyph) was tried first and reads as too
-   little against 8px underneath. It REPLACES the separation margin rather than adding to it — the
-   text-then-image case already has its gap and would otherwise get 12px.
-
-   ⚠ Spelled as padding because a margin here has nothing below it to collapse against and would
-   collapse straight out of `.body`, taking the nick/body separator (`.body::before`) 4px down
-   with it — a visible notch in a rule that is continuous on every other row.
+   what a 1.55 line-height puts above a text row's first glyph) was tried first, on screen, and
+   reads as too little against 8px underneath. It REPLACES the separation margin rather than
+   adding to it — the text-then-image case already has its gap and would otherwise get 12px.
 
    ⚠ It lives HERE rather than beside that `:has()` companion because a scoped rule in MessageList
    cannot reach this element: MessageBody is a multi-root fragment, so MessageList's scope id
    never propagates onto `.attachments`. The rule was written there first and did nothing at all. */
 .attachments.body-only {
-  margin-top: 0;
-  padding-top: var(--space-4);
+  margin-top: var(--space-4);
 }
 /* A card wants the width it's given — its text has to wrap against something — but not the
    full width of a wide window, where it stops reading as part of the message and starts

--- a/vue_client/src/utils/previewUrls.ts
+++ b/vue_client/src/utils/previewUrls.ts
@@ -27,10 +27,16 @@ export const MAX_CARDS_PER_MESSAGE = 3;
  * picture's worth of screen. And clicking any cell opens the lightbox as a GALLERY over every
  * image in the message.
  *
- * ⚠ This is now the ONLY bound on how tall one message's media can get. The mosaic used to cap
- * itself at four cells and count the rest (`+N`), and lurker#773 dropped that to match
- * lurker-ios; at this limit the worst case is ten rows of grid, which is a long message and not a
- * runaway one. Lowering the number is the lever if that ever stops being true.
+ * ⚠ This is now most of the bound on how tall one message's media can get, and lowering it is the
+ * lever if a message ever reads as runaway. The mosaic used to cap ITSELF at four cells and count
+ * the rest (`+N`); lurker#773 dropped that to match lurker-ios, so the ceiling here is what stands
+ * between a paste and a screenful.
+ *
+ * ⚠⚠ It is not the whole ceiling, and reading it as one undercounts. An extensionless host is
+ * charged to the CARD budget below (see `mediaKindForUrl`, which cannot judge it) and can still
+ * come back `kind: 'image'` — imgur and twimg, the common case on IRC — at which point MessageBody
+ * renders it as a tile and never applies the card cap to it. So the real bound on TILES is
+ * `MAX_MEDIA_PER_MESSAGE + MAX_CARDS_PER_MESSAGE`: 23 pictures, twelve grid rows.
  *
  * A limit still exists, because a message carrying fifty image URLs is spam and each one is
  * an outbound fetch on the server's behalf. It's set high enough not to bind on anything a

--- a/vue_client/src/utils/previewUrls.ts
+++ b/vue_client/src/utils/previewUrls.ts
@@ -23,10 +23,14 @@ export const MAX_CARDS_PER_MESSAGE = 3;
  * Cap on MEDIA per message — deliberately generous.
  *
  * Media doesn't cost vertical space the way a card does: two or more images render as a mosaic
- * of at most four cells (`MOSAIC_CELLS`), so the tenth image costs exactly as much screen as the
- * fourth — it becomes part of a `+N` count rather than a row. And clicking any cell opens the
- * lightbox as a GALLERY over every image in the message, capped or not, so nothing is
- * unreachable.
+ * of fixed-size cells, two per row, so a tenth image costs half a row rather than a full-width
+ * picture's worth of screen. And clicking any cell opens the lightbox as a GALLERY over every
+ * image in the message.
+ *
+ * ⚠ This is now the ONLY bound on how tall one message's media can get. The mosaic used to cap
+ * itself at four cells and count the rest (`+N`), and lurker#773 dropped that to match
+ * lurker-ios; at this limit the worst case is ten rows of grid, which is a long message and not a
+ * runaway one. Lowering the number is the lever if that ever stops being true.
  *
  * A limit still exists, because a message carrying fifty image URLs is spam and each one is
  * an outbound fetch on the server's behalf. It's set high enough not to bind on anything a


### PR DESCRIPTION
Closes #773. Web client only.

## a) An image-only message sat flush against its row background

`.attachments.body-only` zeroed its top margin, on the reasoning that with every URL hidden there is no text above it to separate from. True, and it does not follow that the gap goes to zero: a hovered, alt-striped or highlighted row painted its background right up to the picture, while every text row keeps a sliver of it.

It gets `--space-4` now — the same value as the bottom margin, because with no text in the row the picture is the whole of it and an even inset is what puts it *inside* the row rather than at the top of it. Half-leading (`--space-2`, what a 1.55 line-height puts above a text row's first glyph) was tried first on screen and read as too little against 8px underneath.

## b) The four-cell cap is gone; every image is tiled

`MOSAIC_CELLS`, the `+N` badge and its screen-reader companion are deleted. The layout answer for 5+ came from lurker-ios, which already solved it: **even → all pairs; odd → the three-up block first, then pairs.** In CSS that is the existing `.n3 > .tile:first-child { grid-row: span 2 }` generalized to `.odd` — the tall cell takes column 1 of the first two rows, images 2 and 3 fill column 2 beside it, and everything after pairs up. No count leaves a hole. The class binding moved from `n${count}` to `{ odd }` to match; `n3` was only ever correct because nothing past the fourth image was drawn, and at five that spelling silently degrades to a grid with a gap in it.

What the cap was credited with keeping is untouched: a mosaic's height is still a function of the COUNT alone — `ceil(n / 2)` fixed 160px rows — so nothing reads a dimension and no late-arriving byte moves a row.

## The bound that replaces it

`MAX_MEDIA_PER_MESSAGE` (20) is where the worst case is now argued, and it says so at its declaration — including the part that is easy to get wrong: it is **not** the whole ceiling. An extensionless host is charged to the CARD budget because `mediaKindForUrl` cannot judge it, and can still resolve as an image (imgur, twimg — the common case on IRC), at which point `MessageBody` renders it as a tile without applying the card cap. So the real bound on tiles is `MAX_MEDIA_PER_MESSAGE + MAX_CARDS_PER_MESSAGE`: 23 pictures, twelve rows.

## Verification

- Full suite green: 268 files / 3764 tests. `npm run check` clean.
- Tests updated where the cap was the subject: parity is asserted at 3, 5 and 9; the atomic-reveal shape test now goes to five images, because 2 and 4 are both even and a parity-keyed layout would not have noticed the old four.
- The gallery test kept its assertion under a new name — it used to be what made the cap a crop rather than a truncation, and it still matters, because a *tile* is itself a crop.
- Both changes are CSS, which happy-dom does not apply, so the suite asserts class bindings only. Brad QA'd the 8px inset and the uncapped grid on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)