### PR TITLE
Link previews: warn when the decoder is unreachable, and document the shared-network requirement

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -273,6 +273,15 @@ services:
     # shared Docker network.
 ```
 
+⚠ **Both containers must be on the same Docker network.** Declaring
+`lurker-previews` as a service in the _same_ compose file does this for you — that
+is the whole reason the block above is one file. If you instead start the decoder
+on its own (a separate `docker run`, or a different compose project), the Lurker
+container can't resolve the name `lurker-previews`, every preview silently fails
+to resolve, and nothing renders even though the settings are on. The cell logs one
+throttled `link-preview decoder unreachable` line when this happens — check for it
+if previews stay blank.
+
 **Enabling the instance doesn't show anyone a preview yet.** The feature is
 double-gated: each user also has two toggles in **Settings → Chat** — **Link
 previews** and **Inline media** — both defaulting to off. Those toggles only

--- a/server/services/previewClient.test.ts
+++ b/server/services/previewClient.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The one thing the client does beyond translating status codes: warn — once,
+// throttled — when the decoder is UNREACHABLE, because that failure is otherwise
+// silent (it degrades to transient-unavailable) and cost a self-hoster a debugging
+// session. The distinctions under test are the whole point: a decoder that ANSWERS
+// (even a 503) is not unreachable, and a recovery re-arms the warning.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { decoderResolve } from './previewClient.js';
+
+let stub: http.Server;
+let stubUrl: string;
+/** What the stub answers /resolve with; a test flips it. */
+let stubStatus = 200;
+
+const SAVED = process.env.LURKER_PREVIEWS_URL;
+/** A port nothing listens on → connect refused with a syscall `code`, which is "unreachable". */
+const DEAD_URL = 'http://127.0.0.1:1';
+
+beforeAll(async () => {
+  stub = http.createServer((_req, res) => {
+    if (stubStatus === 503) {
+      res.writeHead(503, { 'retry-after': '30' }).end();
+      return;
+    }
+    res
+      .writeHead(200, { 'content-type': 'application/json' })
+      .end(JSON.stringify({ kind: 'page', title: 'x' }));
+  });
+  await new Promise<void>((r) => stub.listen(0, '127.0.0.1', r));
+  stubUrl = `http://127.0.0.1:${(stub.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  if (SAVED === undefined) delete process.env.LURKER_PREVIEWS_URL;
+  else process.env.LURKER_PREVIEWS_URL = SAVED;
+  await new Promise<void>((r) => stub.close(() => r()));
+});
+
+/** Every test starts from a clean warn latch — one reachable success zeroes it (that IS the
+ *  reset-on-recovery path), so tests don't depend on each other's leftover throttle state. */
+beforeEach(async () => {
+  stubStatus = 200;
+  process.env.LURKER_PREVIEWS_URL = stubUrl;
+  await decoderResolve('https://example.com/reset', false);
+});
+
+describe('decoderResolve — unreachable-decoder warning', () => {
+  it('warns once when the decoder cannot be reached, and throttles the rest', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      process.env.LURKER_PREVIEWS_URL = DEAD_URL;
+      const a = await decoderResolve('https://example.com/1', false);
+      const b = await decoderResolve('https://example.com/2', false);
+      expect(a.status).toBe('down');
+      expect(b.status).toBe('down');
+      // Two failures, ONE line — a link-heavy backlog must not become a wall of logs.
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = warn.mock.calls[0][0] as string;
+      expect(msg).toContain('unreachable');
+      expect(msg).toContain(DEAD_URL);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does NOT warn when the decoder answers, even with a 503 back-off', async () => {
+    // A 503 is the decoder REACHABLE and speaking — "back off", not "you can't find me". Warning
+    // here would cry wolf every time an origin rate-limited a preview.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      stubStatus = 503;
+      const out = await decoderResolve('https://example.com/limited', false);
+      expect(out.status).toBe('backoff');
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('warns again after the decoder recovers and breaks a second time', async () => {
+    // The latch resets on any contact, so a later outage isn't swallowed by the first one's
+    // throttle window. (beforeEach already did one reachable call; this proves the cycle.)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      process.env.LURKER_PREVIEWS_URL = DEAD_URL;
+      await decoderResolve('https://example.com/down-1', false);
+      expect(warn).toHaveBeenCalledTimes(1);
+
+      // Recover: a reachable success clears the latch...
+      process.env.LURKER_PREVIEWS_URL = stubUrl;
+      await decoderResolve('https://example.com/up', false);
+
+      // ...so the next outage warns afresh rather than staying quiet for the interval.
+      process.env.LURKER_PREVIEWS_URL = DEAD_URL;
+      await decoderResolve('https://example.com/down-2', false);
+      expect(warn).toHaveBeenCalledTimes(2);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/server/services/previewClient.ts
+++ b/server/services/previewClient.ts
@@ -175,6 +175,38 @@ function post(
 }
 
 /**
+ * An unreachable decoder degrades to transient-unavailable and self-heals, so it must neither
+ * throw nor spam — but a SILENT seam is undiagnosable, and that cost a self-hoster a debugging
+ * session: settings on, container up, and nothing rendering with nothing in any log to say the
+ * cell simply couldn't find the decoder. One throttled line names the cause and the usual fix
+ * (the two containers not sharing a Docker network is almost always it).
+ *
+ * ⚠ Only SYSCALL-level failures count — a `code` like ENOTFOUND/ECONNREFUSED/ETIMEDOUT means
+ * the seam itself is broken. A 502/503 is the decoder ANSWERING (reachable, just busy or
+ * refusing), and our own deadline/abort errors carry no `code`; none of those are "unreachable".
+ */
+let lastUnreachableWarnMs = 0;
+const UNREACHABLE_WARN_INTERVAL_MS = 60_000;
+function noteDecoderUnreachable(err: unknown): void {
+  const code = (err as NodeJS.ErrnoException)?.code;
+  if (typeof code !== 'string') return;
+  const now = Date.now();
+  if (now - lastUnreachableWarnMs < UNREACHABLE_WARN_INTERVAL_MS) return;
+  lastUnreachableWarnMs = now;
+  console.warn(
+    `[lurker] link-preview decoder unreachable at ${process.env.LURKER_PREVIEWS_URL} (${code}) — ` +
+      'previews will stay blank until the cell can reach it. The lurker and lurker-previews ' +
+      'containers must share a Docker network.',
+  );
+}
+
+/** Any contact with the decoder clears the warn latch, so a later outage warns afresh rather
+ *  than staying quiet for the interval after one recovery. */
+function noteDecoderReached(): void {
+  lastUnreachableWarnMs = 0;
+}
+
+/**
  * Ask the decoder to resolve one URL. NEVER throws — every local failure is `down`.
  */
 export async function decoderResolve(url: string, wantPoster: boolean): Promise<DecoderResolve> {
@@ -185,6 +217,7 @@ export async function decoderResolve(url: string, wantPoster: boolean): Promise<
   if (!base) return { status: 'down' };
   try {
     const res = await post(base, '/resolve', { url, wantPoster }, RESOLVE_TIMEOUT_MS);
+    noteDecoderReached();
     switch (res.status) {
       case 200: {
         let parsed: unknown;
@@ -223,7 +256,8 @@ export async function decoderResolve(url: string, wantPoster: boolean): Promise<
       default:
         return { status: 'down' };
     }
-  } catch {
+  } catch (err) {
+    noteDecoderUnreachable(err);
     return { status: 'down' };
   }
 }
@@ -268,6 +302,7 @@ export function decoderFetch(
       (res) => {
         settled = true;
         clearTimeout(deadline);
+        noteDecoderReached();
         resolve({ status: res.statusCode || 0, headers: res.headers, stream: res });
       },
     );
@@ -287,7 +322,9 @@ export function decoderFetch(
       signal.removeEventListener('abort', onAbort);
     });
     req.on('error', (err) => {
-      if (!settled) reject(err);
+      if (settled) return;
+      noteDecoderUnreachable(err);
+      reject(err);
     });
     req.end(payload);
   });


### PR DESCRIPTION
Follow-up to the decoder split (#779), from a real self-host debugging session: settings on, decoder container up, and **nothing rendering — not even images — with nothing in any log** to explain it. The cause was the cell and the decoder not sharing a Docker network, so `lurker-previews` didn't resolve; every resolve failed and silently degraded to `unavailable`.

## Changes

- **`previewClient.ts`** — one throttled warning (60s, reset on any successful contact) when the decoder is unreachable, on both the resolve and fetch paths. Fires only on **syscall-level** failures (`ENOTFOUND`/`ECONNREFUSED`/`ETIMEDOUT`); a 502/503 is the decoder *answering* (reachable, just busy/refusing), and our own deadline/abort errors carry no `code`, so neither warns. The message names the URL and the usual fix.
- **`SELF_HOSTING.md`** — an explicit ⚠ that both containers must be on the same Docker network, calling out the exact footgun (a separate `docker run` instead of a compose service) that produced the silent blank.
- **`previewClient.test.ts`** (new) — warns once + throttles a batch; does **not** warn on a 503 back-off; re-arms after recovery.

Full check + test green (3766 + 3 new).

## Not in this PR (already shipped elsewhere)
The deploy-side of the same lesson — `update-cell.sh` re-attaching the decoder network, and `cell-cloud-init.sh` provisioning the decoder on new droplets — landed in the control-plane repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)