### PR TITLE
Bump Lurker version to 2.1.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -279,6 +279,12 @@ VAPID_SUBJECT=mailto:you@example.com
 # decoder even refuses to start if it can reach private addresses, unless you
 # tell it not to check. docs/SELF_HOSTING.md covers both the simple setup and the
 # hardening.
+#
+# ⚠ UPGRADING FROM 2.1.1 OR EARLIER: `LURKER_LINK_PREVIEWS` was the switch then and
+# is read by NOTHING now, so previews go off on upgrade until you set the URL below
+# and run the decoder. `LURKER_PREVIEW_USER_AGENT` also moved — set it on the
+# lurker-previews container, not here. The server warns at startup if it finds
+# either one still set.
 # ---------------------------------------------------------------------------
 # LURKER_PREVIEWS_URL=http://lurker-previews:8030
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/server/server.ts
+++ b/server/server.ts
@@ -26,6 +26,7 @@ import { backfillEncryptColumns } from './db/secretBackfill.js';
 import { assertPushCredentials } from './services/push/credentials.js';
 import { resolveSessionSecret } from './utils/sessionSecret.js';
 import { getEdition, isNodeMode } from './utils/edition.js';
+import { warnRetiredPreviewEnv } from './utils/previews.js';
 import { startOrchestratorClient, stopOrchestratorClient } from './services/orchestratorClient.js';
 import { startModerationReporter, stopModerationReporter } from './services/moderationReport.js';
 import {
@@ -110,6 +111,8 @@ if (isNodeMode() && !isIdentdEnabled() && !isOidentdFileEnabled()) {
     '[lurker] node edition is active but neither LURKER_IDENTD_ENABLED nor LURKER_OIDENTD_FILE is set — IRC networks cannot attribute individual users; they will appear with an unverified ~ident behind the cell IP',
   );
 }
+// Not gated on edition: a self-hoster upgrading from 2.1.1 is exactly who this is for.
+warnRetiredPreviewEnv();
 
 const app = buildApp(SESSION_SECRET);
 const server = http.createServer(app);

--- a/server/utils/previews.test.ts
+++ b/server/utils/previews.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect } from 'vitest';
-import { previewsEnabled } from './previews.js';
+import { previewsEnabled, warnRetiredPreviewEnv } from './previews.js';
 
 describe('previewsEnabled', () => {
   const withUrl = (value: string | undefined, run: () => void) => {
@@ -31,5 +31,105 @@ describe('previewsEnabled', () => {
   it('is enabled by a configured decoder URL — the presence IS the gate', () => {
     withUrl('http://lurker-previews:8030', () => expect(previewsEnabled()).toBe(true));
     withUrl('http://127.0.0.1:8030', () => expect(previewsEnabled()).toBe(true));
+  });
+});
+
+// ⚠ The reason this exists: `LURKER_LINK_PREVIEWS=on` SHIPPED in 2.1.0 and 2.1.1 (it is in
+// .env.example on both tags), so upgraders have it set and working. After the decoder split
+// nothing reads it — previews just stop, with nothing in the log to explain why, and the fix
+// is not a rename they could guess but a second container. The warning is the only signal
+// that reaches an operator who didn't read the release notes.
+describe('warnRetiredPreviewEnv', () => {
+  const withEnv = (env: Record<string, string | undefined>, run: (lines: string[]) => void) => {
+    const saved: Record<string, string | undefined> = {};
+    for (const [k, v] of Object.entries(env)) {
+      saved[k] = process.env[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    const lines: string[] = [];
+    try {
+      warnRetiredPreviewEnv((m) => lines.push(m));
+      run(lines);
+    } finally {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
+  };
+
+  it('says nothing when no retired variable is set', () => {
+    withEnv(
+      {
+        LURKER_LINK_PREVIEWS: undefined,
+        LURKER_PREVIEW_USER_AGENT: undefined,
+        LURKER_PREVIEWS_URL: undefined,
+      },
+      (lines) => expect(lines).toEqual([]),
+    );
+  });
+
+  // The case the whole thing is for: they asked for previews, previews are off, and without
+  // this the only symptom is "it stopped working".
+  it('names the replacement when the old flag is set and previews are OFF', () => {
+    withEnv(
+      {
+        LURKER_LINK_PREVIEWS: 'on',
+        LURKER_PREVIEW_USER_AGENT: undefined,
+        LURKER_PREVIEWS_URL: undefined,
+      },
+      (lines) => {
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toContain('LURKER_LINK_PREVIEWS');
+        expect(lines[0]).toContain('LURKER_PREVIEWS_URL');
+        expect(lines[0]).toContain('no longer read');
+      },
+    );
+  });
+
+  it('points LURKER_PREVIEW_USER_AGENT at the decoder, not at the new URL', () => {
+    withEnv(
+      {
+        LURKER_LINK_PREVIEWS: undefined,
+        LURKER_PREVIEW_USER_AGENT: 'MyBot/1.0',
+        LURKER_PREVIEWS_URL: undefined,
+      },
+      (lines) => {
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toContain('LURKER_PREVIEW_USER_AGENT');
+        expect(lines[0]).toContain('decoder');
+      },
+    );
+  });
+
+  // Already migrated but left the old line in their env file. Nothing is broken, so this is a
+  // tidy-up note rather than a per-variable alarm about a feature that is plainly working.
+  it('downgrades to one leftover-litter line once previews are ON', () => {
+    withEnv(
+      {
+        LURKER_LINK_PREVIEWS: 'on',
+        LURKER_PREVIEW_USER_AGENT: 'MyBot/1.0',
+        LURKER_PREVIEWS_URL: 'http://lurker-previews:8030',
+      },
+      (lines) => {
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toContain('can be removed');
+        expect(lines[0]).toContain('LURKER_LINK_PREVIEWS');
+        expect(lines[0]).toContain('LURKER_PREVIEW_USER_AGENT');
+      },
+    );
+  });
+
+  // Present-but-empty is how a compose file spells "unset"; it must not trip an alarm.
+  it('treats an empty value as unset', () => {
+    withEnv(
+      {
+        LURKER_LINK_PREVIEWS: '   ',
+        LURKER_PREVIEW_USER_AGENT: undefined,
+        LURKER_PREVIEWS_URL: undefined,
+      },
+      (lines) => expect(lines).toEqual([]),
+    );
   });
 });

--- a/server/utils/previews.ts
+++ b/server/utils/previews.ts
@@ -31,3 +31,49 @@
 export function previewsEnabled(): boolean {
   return !!process.env.LURKER_PREVIEWS_URL?.trim();
 }
+
+// Variables that configured previews before the decoder split (2.1.2) and are now read by
+// NOTHING on this server. Each maps to what replaced it.
+const RETIRED_PREVIEW_ENV: Array<{ name: string; advice: string }> = [
+  {
+    name: 'LURKER_LINK_PREVIEWS',
+    advice:
+      'previews are enabled by pointing LURKER_PREVIEWS_URL at a lurker-previews decoder container',
+  },
+  {
+    name: 'LURKER_PREVIEW_USER_AGENT',
+    advice: 'this moved to the decoder — set it on the lurker-previews container instead',
+  },
+];
+
+/**
+ * Warn at startup about preview settings that used to do something and no longer do.
+ *
+ * ⚠ This exists because the 2.1.2 upgrade is otherwise SILENT for the operators it affects most.
+ * `LURKER_LINK_PREVIEWS=on` shipped in 2.1.0 and 2.1.1, and anyone who set it had working
+ * previews; after the decoder split nothing reads it, so previews simply stop and the log says
+ * nothing. Worse, the fix is not a rename they could guess — it is standing up a second
+ * container. Release notes only reach the people who read them; the server can tell the rest.
+ *
+ * Two distinct cases, because the severity genuinely differs: a retired variable set while
+ * previews are OFF means the feature they asked for is not running, and a retired variable set
+ * while previews are ON is just litter in their env file.
+ */
+export function warnRetiredPreviewEnv(warn: (message: string) => void = console.warn): void {
+  const stale = RETIRED_PREVIEW_ENV.filter(({ name }) => !!process.env[name]?.trim());
+  if (stale.length === 0) return;
+
+  if (previewsEnabled()) {
+    warn(
+      `[lurker] ignoring retired preview setting(s): ${stale.map((e) => e.name).join(', ')} — ` +
+        'these are no longer read and can be removed from your environment',
+    );
+    return;
+  }
+  for (const { name, advice } of stale) {
+    warn(
+      `[lurker] ${name} is set but is no longer read, and link previews are OFF — ${advice}. ` +
+        'See "Link previews & inline media" in docs/SELF_HOSTING.md',
+    );
+  }
+}

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "2.1.1",
+  "version": "2.1.2",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
The four package files, plus a startup warning for the retired preview env vars (see below)
and a note in `.env.example`.

⚠ **This release has a breaking change for anyone who turned link previews on in 2.1.0 or 2.1.1** — see the migration section. `LURKER_LINK_PREVIEWS` is now silently ignored, so previews go dark on upgrade with nothing in the log to say why.

---

# Draft release notes

## Lurker 2.1.2

Link previews grow up: the fetching moves out of your main server into a separate decoder you run alongside it. Plus starred uploads, so the reaction gif you post every week is one tap from the composer.

### ⚠ Upgrading with link previews on

If you set `LURKER_LINK_PREVIEWS=on` in 2.1.0 or 2.1.1, **previews stop working when you upgrade** until you do the following. The old variable is no longer read at all.

Previews are now resolved by **lurker-previews**, a second container that does all the fetching and media parsing, so your main server never dials a user-supplied URL or runs a media parser over hostile bytes. Because previews cannot work without it, pointing at a decoder *is* the on switch — there is no separate flag any more.

Two variables change:

| 2.1.1 | 2.1.2 |
| --- | --- |
| `LURKER_LINK_PREVIEWS=on` | `LURKER_PREVIEWS_URL=http://lurker-previews:8030` |
| `LURKER_PREVIEW_USER_AGENT=…` | same name, but set it **on the decoder** |

Add the service to your compose file and point the main server at it:

```yaml
services:
  lurker-previews:
    image: ghcr.io/amiantos/lurker-previews:latest
    restart: unless-stopped

  lurker:
    environment:
      - LURKER_PREVIEWS_URL=http://lurker-previews:8030
```

Both per-user settings ("show link previews" and "show inline media") remain **off by default**, so nothing appears for anyone until each person opts in. Full setup, the egress model, and hardening: **Link previews & inline media** in `docs/SELF_HOSTING.md`.

**The server warns you about this at startup** if it finds either variable still set, so an
upgrade that silently turns previews off now says so in the log.

Not running previews? Nothing to do — they stay off, and the endpoints aren't even mounted.

### Link previews & inline media

- **The decoder split.** All fetching and parsing moves to lurker-previews. Your main server never contacts a pasted URL and never parses untrusted media.
- **Video and audio are no longer relayed** through your server. They are media previews now, served with a stored poster frame rather than proxied byte-for-byte — much less bandwidth for a link nobody clicks.
- **One knob instead of two.** The old flag allowed a broken state (feature on, no decoder → every preview fails forever). That is now unexpressable.
- **Your log tells you when the decoder is unreachable**, once, rather than silently returning nothing.
- **Retired settings are called out at startup** rather than ignored in silence.
- Layout fixes for image-only messages: correct bottom margin, and every image tiles.

### Starred uploads

- **Star any upload** from the uploads browser to keep it at hand. Server-side, so the same set is on every device.
- **The paperclip is now an attach menu**: your starred files, plus upload-a-file and (on phones) camera capture. It leads with starred once you have some and shows recent uploads before that.
- **Add to message** on any tile in the uploads browser, so a file you found by browsing doesn't have to be copied and pasted back by hand.
- Starred uploads survive an account export/import.

### Notes for client authors

`GET /api/uploads` takes `?favorites=1` and every item carries `favorite`. `PUT`/`DELETE /api/uploads/:id/favorite` toggle it. The starred view is ordered by *when you starred*, not by upload id, and therefore ignores the `before` cursor — ask for as much of it as you want with `limit` in one request. See `docs/CLIENT_PROTOCOL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
