### PR TITLE
Ship the link-preview decoder's deployment story

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -262,10 +262,12 @@ VAPID_SUBJECT=mailto:you@example.com
 # user-supplied URL or runs an image/video parser on hostile bytes. Setting
 # LURKER_PREVIEWS_URL is the whole switch: there is no separate on/off flag,
 # because previews cannot function without a decoder and standing one up is
-# itself the deliberate opt-in. Running the decoder is a few lines of compose —
-# see "Link previews & inline media" in docs/SELF_HOSTING.md for the service
-# block, the egress model, and the per-URL user-agent knob (which lives on the
-# DECODER now, not here).
+# itself the deliberate opt-in. Running the decoder is a few lines of compose,
+# and `docker-compose.previews.yml` in this repo is those lines — layer it on
+# the base compose file and it sets this variable for you. See "Link previews &
+# inline media" in docs/SELF_HOSTING.md for the egress model, the hardening
+# script, and the per-URL user-agent knob (which lives on the DECODER now, not
+# here).
 #
 # Off by default because this is the one feature that makes your deployment fetch
 # arbitrary URLs anyone in a channel can paste — your bandwidth, your IP's

--- a/.env.example
+++ b/.env.example
@@ -281,7 +281,7 @@ VAPID_SUBJECT=mailto:you@example.com
 # off, and previews keep working.
 #
 # ---------------------------------------------------------------------------
-# LURKER_PREVIEW_CACHE_MODE=off          # off | local | s3 | dropper
+# LURKER_PREVIEW_CACHE_MODE=off          # off | local | s3
 # LURKER_PREVIEW_CACHE_DIR=              # default: <data dir>/preview-cache
 # LURKER_PREVIEW_CACHE_MAX_BYTES=        # default: 2147483648 (2 GiB), digits only
 #

--- a/.env.example
+++ b/.env.example
@@ -257,9 +257,19 @@ VAPID_SUBJECT=mailto:you@example.com
 # LURKER_PREVIEWS_URL=http://lurker-previews:8030
 
 # ---------------------------------------------------------------------------
-# Caching the preview IMAGE BYTES on disk. OFF by default, and previews work
-# fine without it — this only changes how often the same picture is fetched from
-# the site hosting it.
+# Caching the preview IMAGE BYTES on disk. OFF by default. For links and images
+# this only changes how often the same picture is fetched from the site hosting
+# it — but ⚠⚠ VIDEO POSTERS REQUIRE IT. A video link renders a bare card with no
+# frame while this is off, and nothing logs, because a posterless card is a
+# supported state.
+#
+# The reason is structural. A poster is the one preview image with NO ORIGIN
+# URL: the decoder makes those bytes out of the video itself, so they exist
+# nowhere else and cannot be re-fetched later. With nowhere to put them the
+# server doesn't pretend — it never asks the decoder for a poster, never records
+# one against the link, and its poster route answers 404. Set a mode below and
+# posters appear. ⚠ It does not backfill: a video seen while this was off stays
+# posterless until its row expires (7 days) and someone posts the link again.
 #
 # Without a cache, the metadata for a link is fetched once and remembered, but
 # the BYTES are not: ten people scrolling past the same image is ten fetches
@@ -267,12 +277,14 @@ VAPID_SUBJECT=mailto:you@example.com
 # person per day, not once per view.) With a cache, it is fetched once for
 # everyone, and every byte still goes out through your own authenticated server.
 #
-#   off    stream through, store nothing. The default.
+#   off    stream through, store nothing. The default — and no video posters.
 #   local  a directory beside the database, evicting coldest-first at a ceiling.
+#   s3     a bucket you own, served from its public base URL (see below).
 #
-# ⚠ Only IMAGES are cached. Video and audio are far larger and are read in
-# ranges (a seek is many requests for one object), so caching them would trade
-# the bandwidth this saves for memory it cannot bound.
+# ⚠ Only STILLS are cached — images, and the posters decoded from a video.
+# Video and audio themselves are far larger and are read in ranges (a seek is
+# many requests for one object), so caching them would trade the bandwidth this
+# saves for memory it cannot bound.
 #
 # ⚠ Losing this directory costs nothing but a re-fetch — it is a cache, not
 # data. It is safe to delete while the server is stopped.

--- a/.env.example
+++ b/.env.example
@@ -131,40 +131,6 @@ VAPID_SUBJECT=mailto:you@example.com
 # LURKER_MAX_UPLOAD_MB=100
 
 # ---------------------------------------------------------------------------
-# Node mode (hosted lurker.chat service) — leave ALL of this unset for normal
-# self-hosting. A standalone instance ignores it entirely.
-# ---------------------------------------------------------------------------
-# Deployment edition: 'standalone' (default) or 'node' (a cell managed by an
-# orchestrator / control plane). Unknown values fall back to standalone.
-# LURKER_EDITION=node
-#
-# Shared fleet secret. Authenticates the orchestrator's inbound calls to this
-# cell's /api/node API, and is reused as the bearer when this cell reports out
-# to the orchestrator. Set the same value as FLEET_SECRET on the control plane.
-# LURKER_NODE_SECRET=replace-me-with-a-long-random-string
-#
-# Where the orchestrator lives, and how this cell identifies itself to it.
-# LURKER_ORCHESTRATOR_URL=http://orchestrator:8020
-# LURKER_NODE_NAME=cell-1
-# LURKER_NODE_CONTROL_URL=http://cell-1:8015   # how the orchestrator reaches THIS cell
-# LURKER_NODE_CAPACITY=500                      # soft cap on accounts (fill-then-pin)
-#
-# In-house uploader (node edition only). The cell forces every upload through
-# the operator's R2-backed dropper instead of letting a tenant choose a host;
-# these supply its base URL + API key. Uploads fail (400) until both are set.
-# LURKER_NODE_UPLOAD_URL=https://upload.lurker.chat
-# LURKER_NODE_UPLOAD_API_KEY=replace-me-with-the-dropper-api-key
-#
-# Image-pipeline limits in node edition are operator-controlled (not tenant
-# settings): max raw upload size, longest-edge before JPEG re-encode, and JPEG
-# quality. Each is optional — unset falls back to the built-in default and any
-# value is clamped to the setting's registry bounds. Standalone uses per-user
-# settings instead.
-# LURKER_NODE_UPLOAD_MAX_MB=25     # 1–200, default 25
-# LURKER_NODE_UPLOAD_MAX_DIM=2048  # 256–8192, default 2048
-# LURKER_NODE_UPLOAD_QUALITY=85    # 30–100, default 85
-#
-# ---------------------------------------------------------------------------
 # Built-in identd (RFC 1413). For MULTI-USER deployments connecting many users
 # to a network from one IP, so the network can attribute each user. Off by
 # default (binding :113 is privileged; single-user self-hosts don't need it).
@@ -360,23 +326,7 @@ VAPID_SUBJECT=mailto:you@example.com
 # LURKER_PREVIEW_CACHE_S3_PUBLIC_BASE_URL=https://cdn.example.com
 # LURKER_PREVIEW_CACHE_S3_PREFIX=previews   # optional; sanitized to [A-Za-z0-9._-]/
 # LURKER_PREVIEW_CACHE_S3_REGION=           # default: auto (correct for R2)
-#
-# --- mode=dropper ------------------------------------------------------------
-# The hosted-fleet mode (self-hosters want local or s3). Bytes go to the
-# operator-run dropper service's POST /api/previews — the same service and the
-# same Bearer key uploads use — which writes them under the fleet bucket's
-# previews/ prefix; readers get the public CDN URL. The cell never holds bucket
-# credentials, which is the point (CP #63). Every warning in the s3 section
-# above applies here too: the objects are PUBLIC, the CDN base must be https,
-# retention is the bucket's 30-day lifecycle rule.
-#
-# ⚠ PUBLIC_BASE_URL INCLUDES the prefix the dropper stores under — the server
-# mints <base>/<key> and never hears the dropper's own answer, so the two must
-# agree or every minted URL 404s.
-# ---------------------------------------------------------------------------
-# LURKER_PREVIEW_CACHE_DROPPER_URL=http://<cp-vpc-ip>:8025   # scheme://host[:port] ONLY — /api/previews is appended
-# LURKER_PREVIEW_CACHE_DROPPER_API_KEY=
-# LURKER_PREVIEW_CACHE_DROPPER_PUBLIC_BASE_URL=https://cdn.example.com/previews
+
 
 # ---------------------------------------------------------------------------
 # Built-in IRC bouncer (ZNC- and soju-compatible). OFF by default. When enabled,

--- a/deploy/digitalocean-cloud-init.sh
+++ b/deploy/digitalocean-cloud-init.sh
@@ -63,6 +63,32 @@ ADMIN_EMAIL=""
 # signal to switch.
 ENABLE_IDENTD=""
 
+# ─── Optional: link previews & inline media ─────────────────────────────────
+#
+# Set to "true" to also run `lurker-previews`, the decoder that makes pasted
+# links unfurl into cards, images render inline, and videos show a poster
+# frame. It is a SECOND container by design: it does all the fetching and all
+# the media parsing, so the container holding your database and your users'
+# sessions never dials a URL a stranger chose.
+#
+# Off by default because it makes your droplet fetch third-party URLs that
+# appear in chat — your bandwidth and your IP's reputation, so it should be a
+# decision. Turning it on here only enables it for the INSTANCE; each user
+# still opts in under Settings → Chat, where both switches also default to off.
+#
+# This script gives the decoder the full hosted-fleet treatment rather than the
+# relaxed self-host one: a private bridge of its own, iptables rules that let it
+# reach the public internet and nothing private (not the VPC, not your other
+# containers, not this droplet), a systemd unit that re-applies them on every
+# boot, and the decoder's own boot self-test left ON — so if the containment
+# ever lapses it refuses to serve instead of quietly parsing hostile bytes with
+# a route to your infrastructure.
+#
+# ⚠ Budget RAM for it: the decoder is capped at 512 MB and ffmpeg uses that
+# ceiling when it decodes a poster. On the smallest (1 GB) droplet it will lean
+# on swap; 2 GB is the comfortable size once this is on.
+ENABLE_LINK_PREVIEWS=""
+
 # ─── No edits needed below this line ────────────────────────────────────────
 
 set -euo pipefail
@@ -215,6 +241,18 @@ deploy() {
 
   local compose_files="docker-compose.yml:docker-compose.caddy.yml"
 
+  # The link-preview decoder: its own overlay (a second container on a private
+  # bridge) plus the script that contains its egress. Both are fetched here so
+  # that later `docker compose pull` + `up -d` updates keep the service, and so
+  # the egress script is on disk for the systemd unit to re-run at boot.
+  if [ "$ENABLE_LINK_PREVIEWS" = "true" ]; then
+    log "Link previews enabled — fetching the decoder overlay and egress script."
+    curl -fsSL -o docker-compose.previews.yml "$REPO_RAW/docker-compose.previews.yml"
+    curl -fsSL -o previews-egress.sh "$REPO_RAW/deploy/previews-egress.sh"
+    chmod +x previews-egress.sh
+    compose_files="${compose_files}:docker-compose.previews.yml"
+  fi
+
   # identd overlay, layered AFTER Caddy (which resets the lurker ports), so it
   # re-publishes :113 and turns on the built-in identd while the web port stays
   # internal to Caddy. Generated locally so `pull` + `up -d` updates keep it.
@@ -243,9 +281,37 @@ ADMIN_EMAIL=${ADMIN_EMAIL}
 COMPOSE_FILE=${compose_files}
 EOF
 
+  # ⚠ 0, not unset: the overlay defaults this to 1 (skip the self-test), which
+  # is the right default for a self-host on a plain Docker network but the
+  # wrong one here — this droplet gets real egress rules a few steps below, so
+  # the decoder should check them, and keep checking them on every start.
+  if [ "$ENABLE_LINK_PREVIEWS" = "true" ]; then
+    echo "LURKER_PREVIEWS_ALLOW_PRIVATE=0" >> .env
+  fi
+
   compose pull
   compose up -d
   compose ps
+}
+
+# The decoder's containment: iptables rules scoped to its address so it can
+# reach the public internet and nothing private, plus a systemd unit that
+# re-applies them on boot and whenever Docker restarts. The script verifies its
+# own work by restarting the decoder and reading the verdict its boot self-test
+# logs — so a failure here is a loud one, in the deploy log, rather than a
+# preview service that works while quietly holding a route to this droplet.
+contain_previews() {
+  [ "$ENABLE_LINK_PREVIEWS" = "true" ] || return 0
+  log "Containing the link-preview decoder's egress..."
+  if "$INSTALL_DIR/previews-egress.sh" --install; then
+    log "Link previews are ready — the decoder is contained and serving."
+  else
+    # Not fatal to the deploy: Lurker itself is up and everything else works.
+    # Previews will report themselves unavailable until this is sorted.
+    log "WARNING: the decoder is NOT contained and is refusing to serve, so"
+    log "previews will stay blank. Lurker is otherwise fine. Re-run it with:"
+    log "  ${INSTALL_DIR}/previews-egress.sh --install"
+  fi
 }
 
 # ── Run ─────────────────────────────────────────────────────────────────────
@@ -257,6 +323,11 @@ wait_for_docker
 ensure_swap
 deploy
 configure_firewall
+# ⚠ AFTER configure_firewall, never before: `ufw --force enable` rewrites the
+# filter table wholesale, which would take the decoder's rules with it. The
+# decoder is up by now and refusing to serve (its self-test found this droplet
+# reachable, correctly); the script below fixes that and restarts it.
+contain_previews
 
 PUBLIC_IP=$(curl -fsS --max-time 5 \
   http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address \
@@ -271,4 +342,9 @@ log "admin account, opt in per device from Lurker's settings."
 if [ "$ENABLE_IDENTD" = "true" ]; then
   log "Built-in identd is running on :113 — connect to a network and check that"
   log "your ident shows up verified (no leading ~) via /whois on yourself."
+fi
+if [ "$ENABLE_LINK_PREVIEWS" = "true" ]; then
+  log "Link previews are enabled for the instance, which is only half the gate:"
+  log "each user turns on Link previews and Inline media in Settings → Chat."
+  log "Decoder health: docker logs lurker-previews"
 fi

--- a/deploy/digitalocean-cloud-init.sh
+++ b/deploy/digitalocean-cloud-init.sh
@@ -287,6 +287,14 @@ EOF
   # the decoder should check them, and keep checking them on every start.
   if [ "$ENABLE_LINK_PREVIEWS" = "true" ]; then
     echo "LURKER_PREVIEWS_ALLOW_PRIVATE=0" >> .env
+    # ⚠ The byte cache is not a tuning knob here — VIDEO POSTERS REQUIRE IT.
+    # A poster is the one preview image with no origin URL (the decoder makes
+    # it out of the video), so with nowhere to store it the server doesn't ask
+    # for one and video links render as bare cards. Since this deploy advertises
+    # poster frames, it turns the cache on: a 2 GiB LRU directory inside the
+    # ./data volume, which is a cache and not data — safe to delete with the
+    # server stopped.
+    echo "LURKER_PREVIEW_CACHE_MODE=local" >> .env
     # ⚠ Give the self-test something that is genuinely LISTENING. Its built-in
     # probes are the metadata address and the bridge gateway, and a probe that
     # nothing answers passes whether or not the rules are in force. This

--- a/deploy/digitalocean-cloud-init.sh
+++ b/deploy/digitalocean-cloud-init.sh
@@ -287,6 +287,19 @@ EOF
   # the decoder should check them, and keep checking them on every start.
   if [ "$ENABLE_LINK_PREVIEWS" = "true" ]; then
     echo "LURKER_PREVIEWS_ALLOW_PRIVATE=0" >> .env
+    # ⚠ Give the self-test something that is genuinely LISTENING. Its built-in
+    # probes are the metadata address and the bridge gateway, and a probe that
+    # nothing answers passes whether or not the rules are in force. This
+    # droplet's VPC address has sshd on it, and it is exactly the kind of
+    # neighbour we never want the decoder to reach — so it is the strongest
+    # probe available here. Skipped silently if the droplet has no VPC
+    # interface; the built-in probes still run.
+    local vpc_ip
+    vpc_ip=$(curl -fsS --max-time 5 \
+      http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address 2>/dev/null || true)
+    if [ -n "$vpc_ip" ]; then
+      echo "LURKER_PREVIEWS_SELFTEST_TARGETS=${vpc_ip}:22" >> .env
+    fi
   fi
 
   compose pull

--- a/deploy/digitalocean-cloud-init.sh
+++ b/deploy/digitalocean-cloud-init.sh
@@ -93,7 +93,16 @@ ENABLE_LINK_PREVIEWS=""
 
 set -euo pipefail
 
-REPO_RAW="https://raw.githubusercontent.com/amiantos/lurker/main"
+# The branch or tag every file below is fetched from. `main` is what an operator
+# wants, and what cloud-init gets when this is pasted unedited.
+#
+# ⚠ It is a knob because a change to THIS script cannot otherwise be tested
+# before it is merged: everything comes from raw.githubusercontent, so a file a
+# branch ADDS 404s here until it lands on main, and the deploy dies at the curl.
+# Point this at the branch to test one — `LURKER_REPO_REF=my-branch bash
+# digitalocean-cloud-init.sh` works too, for a re-run on a droplet by hand.
+REPO_REF="${LURKER_REPO_REF:-main}"
+REPO_RAW="https://raw.githubusercontent.com/amiantos/lurker/${REPO_REF}"
 INSTALL_DIR="/opt/lurker"
 DEPLOY_LOG="/var/log/lurker-deploy.log"
 
@@ -104,6 +113,11 @@ exec > >(tee -a "$DEPLOY_LOG") 2>&1
 log() { echo "[lurker-deploy $(date -u +%H:%M:%S)] $*"; }
 
 log "=== Lurker deploy started $(date -u +%FT%TZ) ==="
+# Say it once, up front: a deploy fetching from somewhere other than main is a
+# test of an unmerged change, and the log is the only place that fact survives.
+if [ "$REPO_REF" != "main" ]; then
+  log "⚠ Fetching from ref '${REPO_REF}', NOT main — this is a branch test."
+fi
 
 # Both settings are mandatory. Fail early and loudly — before installing
 # anything — rather than half-deploying; the log is the only place this

--- a/deploy/previews-egress.sh
+++ b/deploy/previews-egress.sh
@@ -1,0 +1,323 @@
+#!/bin/bash
+# Copyright (c) 2026 Brad Root
+# SPDX-License-Identifier: MPL-2.0
+#
+# Lurker — egress containment for the lurker-previews decoder
+# ===========================================================
+#
+#   sudo ./previews-egress.sh              # apply the rules now
+#   sudo ./previews-egress.sh --install    # …and re-apply on every boot
+#
+# The decoder exists so that the box parsing bytes strangers chose is NOT the
+# box holding your database and your users' sessions. That argument only holds
+# if a compromised decoder can reach the public internet and nothing else — not
+# your LAN, not your other containers, not the Docker host itself. An
+# in-process SSRF guard defends against a malicious URL; it does nothing about
+# a malicious process, because a process that owns the parser is already past
+# every check the parser makes. Only the network can say no to that.
+#
+# So this script installs the network half, on a Linux host running Docker:
+#
+#   * DOCKER-USER rules DROPping decoder → RFC1918, link-local (the cloud
+#     metadata service lives at 169.254.169.254) and CGNAT,
+#   * an INPUT rule for the host itself — ⚠ container→host traffic never
+#     touches DOCKER-USER, so forward rules alone leave your own sshd
+#     reachable from the container that runs ffmpeg on hostile input,
+#   * a RETURN rule first, so Lurker ↔ decoder traffic on the shared bridge
+#     survives the DROPs above (the decoder's own subnet is inside 172.16/12).
+#
+# ⚠ DROP, never REJECT. The decoder's boot self-test reads a completed connect
+# as "the policy is not in force"; a REJECT answers RST, which it cannot tell
+# apart from a refusal it should ignore. DROP makes blocked targets time out,
+# which is the unambiguous signal.
+#
+# With the rules in place, remove LURKER_PREVIEWS_ALLOW_PRIVATE (or set it to
+# 0) so the self-test runs for real — from then on the decoder refuses to serve
+# if the rules ever lapse, instead of quietly parsing hostile bytes on your LAN.
+#
+# ⚠ Re-run this after anything that RECREATES the decoder container (an update,
+# `docker compose down && up`): the rules are scoped to the address Docker gave
+# it, and a new container can be given a new one. Re-running is idempotent and
+# takes seconds. You will not have to guess when — a decoder whose rules no
+# longer match it refuses to serve and says so in its log; previews report
+# themselves unavailable and nothing else is affected.
+#
+# This is the self-hosted equivalent of what the hosted fleet does per cell.
+
+set -euo pipefail
+
+CONTAINER="${LURKER_PREVIEWS_CONTAINER:-lurker-previews}"
+UNIT="lurker-previews-egress.service"
+WAIT_SECONDS="${LURKER_PREVIEWS_WAIT:-60}"
+
+# The destinations a preview decoder has no business reaching. Everything else
+# — the public internet — stays open, because fetching from it is the job.
+PRIVATE_V4=(10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 169.254.0.0/16 100.64.0.0/10)
+PRIVATE_V6=(fc00::/7 fe80::/10 ::1/128)
+
+log() { echo "[previews-egress] $*"; }
+die() {
+  echo "[previews-egress] ERROR: $*" >&2
+  exit 1
+}
+
+need_root() { [ "$(id -u)" -eq 0 ] || die "run this as root (sudo)."; }
+
+# ── Rule plumbing ───────────────────────────────────────────────────────────
+
+# ⚠⚠ Every rule this script writes is tagged, and the tag names the RUN that
+# wrote it. Rules go in first and the older generation comes out afterwards, so
+# containment is never briefly absent — during the overlap both generations are
+# in force, which can only be stricter, and a run that dies halfway leaves the
+# decoder over-contained rather than exposed.
+#
+# The cleanup is not tidiness either. These rules name the decoder's ADDRESS, a
+# recreated decoder can be given a different one, and Docker hands freed
+# addresses to whatever asks next: leave the old rules behind and the day
+# Lurker itself lands on that address, Lurker quietly loses the LAN and this
+# host. Replacing the generation makes the rule set a statement about the
+# decoder that exists now.
+# ⚠ No punctuation beyond the dash: iptables prints a comment containing a
+# colon (or a space) QUOTED in `-S` output, and a quoted token cannot be handed
+# straight back to `-D` — the delete then matches nothing, silently, and the
+# generations pile up instead of rolling over.
+TAG_PREFIX="lurker-previews-egress"
+RUN_TAG="${TAG_PREFIX}-$$-$(date +%s)"
+
+add() {
+  local ipt="$1" chain="$2"
+  shift 2
+  # The match goes BEFORE the rule spec: iptables takes its options in any
+  # order, but a `-m` trailing `-j DROP` is the arrangement most likely to be
+  # read as belonging to the target instead of the rule.
+  "$ipt" -I "$chain" -m comment --comment "$RUN_TAG" "$@"
+}
+
+# Delete the rules from every run but this one. Parsing `-S` output is safe
+# here precisely because the tag has no spaces: no quoting to unpick.
+#
+# ⚠ No pipeline: `set -o pipefail` turns a grep that matches nothing — the
+# ordinary case on a first run — into a failed command, and `set -e` then ends
+# the script before it has said anything at all.
+purge_older_generations() {
+  local ipt="$1" chain line rules arg args
+  for chain in DOCKER-USER INPUT; do
+    rules="$("$ipt" -S "$chain" 2>/dev/null || true)"
+    while IFS= read -r line; do
+      case "$line" in
+        *"$RUN_TAG"*) continue ;; # this run's work, leave it
+        *"$TAG_PREFIX"*) ;;       # an older generation, delete it
+        *) continue ;;            # someone else's rule, never touch it
+      esac
+      # shellcheck disable=SC2086 # deliberate: split the rule spec into args
+      set -- $line
+      shift 2 # drop the leading "-A <chain>"
+      # Belt and braces against the quoting above: strip any quotes iptables
+      # decided to print, since they are not part of the value it stored.
+      args=()
+      for arg in "$@"; do
+        arg="${arg#\"}"
+        args+=("${arg%\"}")
+      done
+      "$ipt" -D "$chain" "${args[@]}" || true
+    done <<< "$rules"
+  done
+  return 0
+}
+
+# `iptables -I` prepends, so the LAST thing inserted ends up FIRST in the
+# chain. The RETURN therefore has to be added after the DROPs it protects.
+apply_rules() {
+  local ipt="$1" ip="$2" subnet="$3"
+  shift 3
+  local dest
+  for dest in "$@"; do
+    add "$ipt" DOCKER-USER -s "$ip" -d "$dest" -j DROP
+  done
+  add "$ipt" INPUT -s "$ip" -j DROP
+  # ⚠ Without this, the DROP on the decoder's own private range kills the
+  # replies to Lurker's requests — the bridge subnet is itself RFC1918, and
+  # with br_netfilter loaded, bridge traffic traverses DOCKER-USER too.
+  if [ -n "$subnet" ]; then
+    add "$ipt" DOCKER-USER -s "$ip" -d "$subnet" -j RETURN
+  fi
+}
+
+# ── Discovery ───────────────────────────────────────────────────────────────
+
+# Wait for the container: on boot this runs right after dockerd, which may
+# still be starting the containers Compose asked it to restart.
+wait_for_container() {
+  local i
+  for ((i = 0; i < WAIT_SECONDS; i++)); do
+    if docker inspect "$CONTAINER" >/dev/null 2>&1; then return 0; fi
+    sleep 1
+  done
+  die "no container named '$CONTAINER' after ${WAIT_SECONDS}s. Start the decoder first
+       (docker compose -f docker-compose.yml -f docker-compose.previews.yml up -d),
+       or set LURKER_PREVIEWS_CONTAINER if you named it something else."
+}
+
+# The network's first subnet of the given family ("4" or "6"), or nothing.
+#
+# ⚠ Deliberately no `| head -1`: under `set -o pipefail`, a `head` that exits
+# after the line it wanted makes the whole pipeline return SIGPIPE (141), and
+# `set -e` then kills this script before it has logged a single word. It is a
+# race, so it hides on a fast host and bites on a slow one.
+subnet_of() {
+  local out token
+  out="$(docker network inspect "$1" -f '{{range .IPAM.Config}}{{.Subnet}} {{end}}' 2>/dev/null || true)"
+  for token in $out; do
+    case "$token" in
+      *:*) if [ "$2" = "6" ]; then
+        echo "$token"
+        return 0
+      fi ;;
+      *) if [ "$2" != "6" ]; then
+        echo "$token"
+        return 0
+      fi ;;
+    esac
+  done
+  return 0
+}
+
+# ⚠ Rules are scoped to the decoder's own ADDRESS, not to its bridge subnet.
+# Lurker sits on that same bridge — it has to, to reach the decoder by name —
+# and a subnet-wide rule would cut Lurker off from your LAN and this host too,
+# silently breaking whatever it legitimately reaches there. The cost is that a
+# recreated container needs a re-run; that failure is loud (the decoder refuses
+# to serve), which is the trade this whole subsystem is built to prefer.
+apply_all() {
+  local found=0 net ip ip6 subnet subnet6
+  # ⚠ Pipe-separated, and each address is checked for SHAPE rather than for
+  # emptiness: Docker 29 renders an address a container doesn't have as the
+  # literal string "invalid IP" (Go's netip.Addr zero value), which is neither
+  # empty nor one field.
+  while IFS='|' read -r net ip ip6; do
+    [ -n "$net" ] || continue
+    case "$ip" in *[!0-9.]* | '') ip='' ;; esac
+    case "$ip6" in *[!0-9a-fA-F:]* | '') ip6='' ;; esac
+    subnet="$(subnet_of "$net" 4)"
+    if [ -n "$ip" ]; then
+      log "containing ${CONTAINER} at ${ip} on ${net} (subnet ${subnet:-unknown})"
+      apply_rules iptables "$ip" "$subnet" "${PRIVATE_V4[@]}"
+      found=1
+    fi
+    # IPv6 is off on a default Docker install, so this usually finds nothing —
+    # but where it IS on, forgetting it would leave the whole policy open on
+    # the other address family.
+    if [ -n "$ip6" ]; then
+      command -v ip6tables >/dev/null 2>&1 ||
+        die "$CONTAINER has an IPv6 address ($ip6) but ip6tables is missing — its egress
+       cannot be contained on this host."
+      subnet6="$(subnet_of "$net" 6)"
+      log "containing ${CONTAINER} at ${ip6} on ${net} (IPv6)"
+      apply_rules ip6tables "$ip6" "$subnet6" "${PRIVATE_V6[@]}"
+      found=1
+    fi
+  done < <(docker inspect "$CONTAINER" \
+    -f '{{range $net, $c := .NetworkSettings.Networks}}{{$net}}|{{$c.IPAddress}}|{{$c.GlobalIPv6Address}}{{"\n"}}{{end}}')
+  [ "$found" -eq 1 ] || die "$CONTAINER has no network addresses — is it running?"
+  # Only now that this generation is in force does the previous one go.
+  purge_older_generations iptables
+  if command -v ip6tables >/dev/null 2>&1; then purge_older_generations ip6tables; fi
+}
+
+# ── Verification ────────────────────────────────────────────────────────────
+
+# The rules are only half the point; the decoder confirming them is the other
+# half. Restart it so its boot self-test runs UNDER the rules we just applied
+# — on a reboot the container will usually have started before this script
+# did, and a self-test that ran too early proves nothing.
+verify() {
+  # ⚠ Read only the logs from THIS start. The decoder logs its verdict once, at
+  # boot, and the line from the previous start is still sitting in the log — on
+  # a first run that line says REFUSING TO SERVE, which is exactly the answer
+  # we would otherwise misreport as a failure of the rules we just installed.
+  # ⚠ Epoch seconds, not a formatted timestamp: `docker logs --since` reads a
+  # zoneless RFC3339 string as LOCAL time, so a UTC one silently selects a
+  # window in the future and matches nothing at all.
+  local since
+  since="$(date +%s)"
+  log "restarting $CONTAINER so its boot self-test runs under these rules..."
+  docker restart "$CONTAINER" >/dev/null
+  local i logs
+  for ((i = 0; i < 30; i++)); do
+    sleep 1
+    logs="$(docker logs --since "$since" "$CONTAINER" 2>&1 || true)"
+    case "$logs" in
+      *'ready — egress self-test passed'*)
+        log "self-test PASSED — the decoder can reach the internet and nothing private."
+        return 0
+        ;;
+      *'self-test SKIPPED'*)
+        log "⚠ the decoder still has LURKER_PREVIEWS_ALLOW_PRIVATE=1, so it did not check."
+        log "  The rules are applied; set LURKER_PREVIEWS_ALLOW_PRIVATE=0 and recreate the"
+        log "  container to have it verify them for you on every start."
+        return 0
+        ;;
+      *'REFUSING TO SERVE'*)
+        echo "$logs" >&2
+        die "the decoder can still reach a private address (named above). The rules did not
+       take — check for a firewall that rewrites the filter table (ufw, firewalld,
+       nftables) and apply these AFTER it, then re-run."
+        ;;
+    esac
+  done
+  die "the decoder logged neither success nor refusal within 30s. Check: docker logs $CONTAINER"
+}
+
+# ── Boot persistence ────────────────────────────────────────────────────────
+
+# ⚠ Not iptables-persistent. Docker recreates DOCKER-USER when the daemon
+# starts and container addresses can change on recreate, so a saved snapshot of
+# the table is the wrong shape for this: what has to survive is the DERIVATION,
+# not the rules. A oneshot unit that re-runs this script does that, and
+# PartOf=docker.service means restarting Docker re-applies them too.
+install_unit() {
+  local self
+  self="$(readlink -f "$0")"
+  # The rules are already applied at this point, so a host without systemd
+  # gets a working decoder and an honest warning, not a failed run.
+  if ! command -v systemctl >/dev/null 2>&1; then
+    log "⚠ no systemd here, so the rules were NOT made persistent. Arrange to run"
+    log "  $self after Docker starts, or they lapse on the next boot — at which"
+    log "  point the decoder refuses to serve rather than run uncontained."
+    return 0
+  fi
+  log "installing $UNIT (re-applies these rules on boot and on docker restart)"
+  cat > "/etc/systemd/system/$UNIT" <<EOF
+[Unit]
+Description=Egress containment for the lurker-previews decoder
+Requires=docker.service
+After=docker.service
+PartOf=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=$self
+Environment=LURKER_PREVIEWS_CONTAINER=$CONTAINER
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  systemctl daemon-reload
+  systemctl enable "$UNIT" >/dev/null
+  log "installed. Undo with: systemctl disable --now $UNIT"
+}
+
+# ── Run ─────────────────────────────────────────────────────────────────────
+
+need_root
+command -v docker >/dev/null 2>&1 || die "docker not found."
+command -v iptables >/dev/null 2>&1 || die "iptables not found."
+
+wait_for_container
+apply_all
+verify
+if [ "${1:-}" = "--install" ]; then
+  install_unit
+fi
+log "done."

--- a/deploy/previews-egress.sh
+++ b/deploy/previews-egress.sh
@@ -126,60 +126,71 @@ purge_older_generations() {
 }
 
 # `iptables -I` prepends, so the LAST thing inserted ends up FIRST in the
-# chain. The RETURN therefore has to be added after the DROPs it protects.
+# chain. Everything that must take precedence is therefore added AFTER the
+# DROPs it overrides.
 apply_rules() {
-  local ipt="$1" ip="$2" subnet="$3"
-  shift 3
-  local dest
+  local ipt="$1" ip="$2"
+  shift 2
+  local dest proto
   for dest in "$@"; do
     add "$ipt" DOCKER-USER -s "$ip" -d "$dest" -j DROP
   done
   add "$ipt" INPUT -s "$ip" -j DROP
-  # ⚠ Without this, the DROP on the decoder's own private range kills the
-  # replies to Lurker's requests — the bridge subnet is itself RFC1918, and
-  # with br_netfilter loaded, bridge traffic traverses DOCKER-USER too.
-  if [ -n "$subnet" ]; then
-    add "$ipt" DOCKER-USER -s "$ip" -d "$subnet" -j RETURN
-  fi
+
+  # ⚠⚠ Replies to Lurker, and ONLY replies. Lurker dials the decoder, so every
+  # legitimate packet back to it belongs to a connection something else opened;
+  # a blanket RETURN for the bridge subnet would also let a compromised decoder
+  # OPEN connections to Lurker's own :8015, which is the single most valuable
+  # thing on that bridge and the one this whole design exists to protect.
+  add "$ipt" DOCKER-USER -s "$ip" -m conntrack --ctstate ESTABLISHED,RELATED -j RETURN
+
+  # ⚠⚠ DNS, or the decoder resolves nothing and every preview fails while the
+  # self-test still passes — it probes IP literals, so it cannot see this. The
+  # container queries Docker's embedded resolver at 127.0.0.11 (inside its own
+  # netns, so no rule here touches it), but libnetwork forwards the upstream
+  # query FROM THE CONTAINER'S NAMESPACE — those packets carry the decoder's
+  # address, and on any host whose resolver is a LAN address (a home router at
+  # 192.168.1.1, a Pi-hole, systemd-resolved pointing at either) the DROPs
+  # above swallow them. Verified: ESERVFAIL, and every resolve answers 403.
+  #
+  # Port 53 to any address rather than to an enumerated resolver list: the
+  # upstream can come from the daemon's config, the host's resolv.conf, the
+  # systemd stub, or DHCP changing it next week, and an enumeration that goes
+  # stale fails exactly the same silent way. What it permits a compromised
+  # decoder is talking to DNS servers — not ssh, not an internal API, not the
+  # metadata service (that is :80). To close even that, give the decoder public
+  # resolvers of its own (`dns:` in the compose overlay) and delete these two.
+  for proto in udp tcp; do
+    add "$ipt" DOCKER-USER -s "$ip" -p "$proto" --dport 53 -j RETURN
+    # ⚠ ACCEPT, not RETURN: a RETURN in a BUILT-IN chain stops traversal and
+    # applies the chain POLICY, which on a ufw host is DROP — so a RETURN here
+    # would block the very thing it is written to allow. This matters whenever
+    # the resolver is the Docker host itself, which is the common case.
+    add "$ipt" INPUT -s "$ip" -p "$proto" --dport 53 -j ACCEPT
+  done
 }
 
 # ── Discovery ───────────────────────────────────────────────────────────────
 
-# Wait for the container: on boot this runs right after dockerd, which may
-# still be starting the containers Compose asked it to restart.
+# ⚠ Wait for the container to be RUNNING WITH AN ADDRESS, not merely to exist.
+# A container object survives a reboot, so `docker inspect` succeeds instantly
+# for one that is exited, created, or in restart backoff — and then the rules
+# get written for an empty address and the run dies. That matters most under
+# the systemd unit, where a `Type=oneshot` cannot carry `Restart=`: one unlucky
+# boot leaves the unit failed until a human notices.
 wait_for_container() {
-  local i
+  local i state
   for ((i = 0; i < WAIT_SECONDS; i++)); do
-    if docker inspect "$CONTAINER" >/dev/null 2>&1; then return 0; fi
+    state="$(docker inspect "$CONTAINER" -f '{{.State.Running}}|{{range $n, $c := .NetworkSettings.Networks}}{{$c.IPAddress}} {{end}}' 2>/dev/null || true)"
+    case "$state" in
+      'true|'*[0-9].[0-9]*) return 0 ;;
+    esac
     sleep 1
   done
-  die "no container named '$CONTAINER' after ${WAIT_SECONDS}s. Start the decoder first
-       (docker compose -f docker-compose.yml -f docker-compose.previews.yml up -d),
-       or set LURKER_PREVIEWS_CONTAINER if you named it something else."
-}
-
-# The network's first subnet of the given family ("4" or "6"), or nothing.
-#
-# ⚠ Deliberately no `| head -1`: under `set -o pipefail`, a `head` that exits
-# after the line it wanted makes the whole pipeline return SIGPIPE (141), and
-# `set -e` then kills this script before it has logged a single word. It is a
-# race, so it hides on a fast host and bites on a slow one.
-subnet_of() {
-  local out token
-  out="$(docker network inspect "$1" -f '{{range .IPAM.Config}}{{.Subnet}} {{end}}' 2>/dev/null || true)"
-  for token in $out; do
-    case "$token" in
-      *:*) if [ "$2" = "6" ]; then
-        echo "$token"
-        return 0
-      fi ;;
-      *) if [ "$2" != "6" ]; then
-        echo "$token"
-        return 0
-      fi ;;
-    esac
-  done
-  return 0
+  die "'$CONTAINER' is not running with a network address after ${WAIT_SECONDS}s.
+       Start the decoder first (docker compose -f docker-compose.yml -f
+       docker-compose.previews.yml up -d), raise LURKER_PREVIEWS_WAIT if this
+       host is slow, or set LURKER_PREVIEWS_CONTAINER if you renamed it."
 }
 
 # ⚠ Rules are scoped to the decoder's own ADDRESS, not to its bridge subnet.
@@ -189,7 +200,7 @@ subnet_of() {
 # recreated container needs a re-run; that failure is loud (the decoder refuses
 # to serve), which is the trade this whole subsystem is built to prefer.
 apply_all() {
-  local found=0 net ip ip6 subnet subnet6
+  local found=0 net ip ip6
   # ⚠ Pipe-separated, and each address is checked for SHAPE rather than for
   # emptiness: Docker 29 renders an address a container doesn't have as the
   # literal string "invalid IP" (Go's netip.Addr zero value), which is neither
@@ -198,10 +209,9 @@ apply_all() {
     [ -n "$net" ] || continue
     case "$ip" in *[!0-9.]* | '') ip='' ;; esac
     case "$ip6" in *[!0-9a-fA-F:]* | '') ip6='' ;; esac
-    subnet="$(subnet_of "$net" 4)"
     if [ -n "$ip" ]; then
-      log "containing ${CONTAINER} at ${ip} on ${net} (subnet ${subnet:-unknown})"
-      apply_rules iptables "$ip" "$subnet" "${PRIVATE_V4[@]}"
+      log "containing ${CONTAINER} at ${ip} on ${net}"
+      apply_rules iptables "$ip" "${PRIVATE_V4[@]}"
       found=1
     fi
     # IPv6 is off on a default Docker install, so this usually finds nothing —
@@ -211,9 +221,8 @@ apply_all() {
       command -v ip6tables >/dev/null 2>&1 ||
         die "$CONTAINER has an IPv6 address ($ip6) but ip6tables is missing — its egress
        cannot be contained on this host."
-      subnet6="$(subnet_of "$net" 6)"
       log "containing ${CONTAINER} at ${ip6} on ${net} (IPv6)"
-      apply_rules ip6tables "$ip6" "$subnet6" "${PRIVATE_V6[@]}"
+      apply_rules ip6tables "$ip6" "${PRIVATE_V6[@]}"
       found=1
     fi
   done < <(docker inspect "$CONTAINER" \
@@ -235,13 +244,16 @@ verify() {
   # boot, and the line from the previous start is still sitting in the log — on
   # a first run that line says REFUSING TO SERVE, which is exactly the answer
   # we would otherwise misreport as a failure of the rules we just installed.
-  # ⚠ Epoch seconds, not a formatted timestamp: `docker logs --since` reads a
-  # zoneless RFC3339 string as LOCAL time, so a UTC one silently selects a
-  # window in the future and matches nothing at all.
-  local since
-  since="$(date +%s)"
   log "restarting $CONTAINER so its boot self-test runs under these rules..."
   docker restart "$CONTAINER" >/dev/null
+  # ⚠ The container's own StartedAt, read AFTER the restart. Epoch seconds off
+  # the wall clock have one-second granularity and `--since` is inclusive, so a
+  # REFUSING line from the previous start emitted in the same second reads back
+  # as this start's verdict — the exact misreport this window exists to stop.
+  # (And never a zoneless timestamp: `docker logs --since` reads one as LOCAL
+  # time, so a UTC string selects a window in the future and matches nothing.)
+  local since
+  since="$(docker inspect "$CONTAINER" -f '{{.State.StartedAt}}')"
   local i logs
   for ((i = 0; i < 30; i++)); do
     sleep 1
@@ -266,6 +278,26 @@ verify() {
     esac
   done
   die "the decoder logged neither success nor refusal within 30s. Check: docker logs $CONTAINER"
+}
+
+# ⚠⚠ The one gap this script cannot close by itself, so it says so out loud.
+# A host firewall that rewrites the filter table takes the INPUT rule with it,
+# and unlike a reboot or a Docker restart there is nothing to hook: the decoder
+# only re-tests its containment when it starts, so it would keep serving with a
+# route to this host's sshd and nothing would look wrong. The DOCKER-USER rules
+# survive (ufw does not manage Docker's chains); it is host protection that
+# lapses.
+warn_about_firewall_reloads() {
+  local fw=''
+  if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q 'Status: active'; then
+    fw='ufw'
+  elif command -v firewall-cmd >/dev/null 2>&1 && firewall-cmd --state >/dev/null 2>&1; then
+    fw='firewalld'
+  fi
+  [ -n "$fw" ] || return 0
+  log "⚠ $fw is active. Re-run this script after any $fw change (a reload rewrites"
+  log "  the filter table and drops the INPUT rule that keeps this host unreachable"
+  log "  from the decoder). Rebooting and restarting Docker are already handled."
 }
 
 # ── Boot persistence ────────────────────────────────────────────────────────
@@ -297,6 +329,11 @@ PartOf=docker.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+# ⚠ Comfortably past this script's own worst case — up to LURKER_PREVIEWS_WAIT
+# seconds waiting for the container plus 30 verifying. systemd's 90s default
+# would SIGTERM a slow boot mid-verify and leave the unit failed even though
+# the rules went in.
+TimeoutStartSec=300
 ExecStart=$self
 Environment=LURKER_PREVIEWS_CONTAINER=$CONTAINER
 
@@ -317,6 +354,7 @@ command -v iptables >/dev/null 2>&1 || die "iptables not found."
 wait_for_container
 apply_all
 verify
+warn_about_firewall_reloads
 if [ "${1:-}" = "--install" ]; then
   install_unit
 fi

--- a/deploy/previews-egress.sh
+++ b/deploy/previews-egress.sh
@@ -55,6 +55,12 @@ WAIT_SECONDS="${LURKER_PREVIEWS_WAIT:-60}"
 PRIVATE_V4=(10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 169.254.0.0/16 100.64.0.0/10)
 PRIVATE_V6=(fc00::/7 fe80::/10 ::1/128)
 
+# Set by apply_all / verify, read by the run section at the bottom. Declared
+# here because `set -u` makes an unset read fatal, and they are the two pieces
+# of state that cross function boundaries.
+APPLIED_ADDRESSES=''
+VERIFY_REASON=''
+
 log() { echo "[previews-egress] $*"; }
 die() {
   echo "[previews-egress] ERROR: $*" >&2
@@ -172,6 +178,29 @@ apply_rules() {
 
 # ── Discovery ───────────────────────────────────────────────────────────────
 
+# One template, two readers, so the two can never disagree about what an
+# address is.
+NETWORKS_TEMPLATE='{{range $net, $c := .NetworkSettings.Networks}}{{$net}}|{{$c.IPAddress}}|{{$c.GlobalIPv6Address}}{{"\n"}}{{end}}'
+
+# ⚠ Shape, not emptiness: Docker 29 renders an address a container does not
+# have as the literal string "invalid IP" (Go's netip.Addr zero value).
+shaped_v4() { case "$1" in *[!0-9.]* | '') echo '' ;; *) echo "$1" ;; esac; }
+shaped_v6() { case "$1" in *[!0-9a-fA-F:]* | '') echo '' ;; *) echo "$1" ;; esac; }
+
+# Every address Docker currently gives the container, in the same format
+# apply_all records — so "did it move?" is a string comparison.
+container_addresses() {
+  local net ip ip6 out=''
+  while IFS='|' read -r net ip ip6; do
+    [ -n "$net" ] || continue
+    ip="$(shaped_v4 "$ip")"
+    ip6="$(shaped_v6 "$ip6")"
+    if [ -n "$ip" ]; then out="${out} ${ip}"; fi
+    if [ -n "$ip6" ]; then out="${out} ${ip6}"; fi
+  done < <(docker inspect "$CONTAINER" -f "$NETWORKS_TEMPLATE" 2>/dev/null || true)
+  echo "$out"
+}
+
 # ⚠ Wait for the container to be RUNNING WITH AN ADDRESS, not merely to exist.
 # A container object survives a reboot, so `docker inspect` succeeds instantly
 # for one that is exited, created, or in restart backoff — and then the rules
@@ -179,12 +208,13 @@ apply_rules() {
 # the systemd unit, where a `Type=oneshot` cannot carry `Restart=`: one unlucky
 # boot leaves the unit failed until a human notices.
 wait_for_container() {
-  local i state
+  local i running
   for ((i = 0; i < WAIT_SECONDS; i++)); do
-    state="$(docker inspect "$CONTAINER" -f '{{.State.Running}}|{{range $n, $c := .NetworkSettings.Networks}}{{$c.IPAddress}} {{end}}' 2>/dev/null || true)"
-    case "$state" in
-      'true|'*[0-9].[0-9]*) return 0 ;;
-    esac
+    running="$(docker inspect "$CONTAINER" -f '{{.State.Running}}' 2>/dev/null || true)"
+    # Any address of either family counts: a host running IPv6-only Docker
+    # networking is unusual but perfectly containable, and testing for a dotted
+    # quad would strand it here.
+    if [ "$running" = 'true' ] && [ -n "$(container_addresses)" ]; then return 0; fi
     sleep 1
   done
   die "'$CONTAINER' is not running with a network address after ${WAIT_SECONDS}s.
@@ -201,17 +231,17 @@ wait_for_container() {
 # to serve), which is the trade this whole subsystem is built to prefer.
 apply_all() {
   local found=0 net ip ip6
-  # ⚠ Pipe-separated, and each address is checked for SHAPE rather than for
-  # emptiness: Docker 29 renders an address a container doesn't have as the
-  # literal string "invalid IP" (Go's netip.Addr zero value), which is neither
-  # empty nor one field.
+  # Recorded so a later verdict can ask whether the decoder is still where
+  # these rules say it is.
+  APPLIED_ADDRESSES=''
   while IFS='|' read -r net ip ip6; do
     [ -n "$net" ] || continue
-    case "$ip" in *[!0-9.]* | '') ip='' ;; esac
-    case "$ip6" in *[!0-9a-fA-F:]* | '') ip6='' ;; esac
+    ip="$(shaped_v4 "$ip")"
+    ip6="$(shaped_v6 "$ip6")"
     if [ -n "$ip" ]; then
       log "containing ${CONTAINER} at ${ip} on ${net}"
       apply_rules iptables "$ip" "${PRIVATE_V4[@]}"
+      APPLIED_ADDRESSES="${APPLIED_ADDRESSES} ${ip}"
       found=1
     fi
     # IPv6 is off on a default Docker install, so this usually finds nothing —
@@ -223,10 +253,10 @@ apply_all() {
        cannot be contained on this host."
       log "containing ${CONTAINER} at ${ip6} on ${net} (IPv6)"
       apply_rules ip6tables "$ip6" "${PRIVATE_V6[@]}"
+      APPLIED_ADDRESSES="${APPLIED_ADDRESSES} ${ip6}"
       found=1
     fi
-  done < <(docker inspect "$CONTAINER" \
-    -f '{{range $net, $c := .NetworkSettings.Networks}}{{$net}}|{{$c.IPAddress}}|{{$c.GlobalIPv6Address}}{{"\n"}}{{end}}')
+  done < <(docker inspect "$CONTAINER" -f "$NETWORKS_TEMPLATE")
   [ "$found" -eq 1 ] || die "$CONTAINER has no network addresses — is it running?"
   # Only now that this generation is in force does the previous one go.
   purge_older_generations iptables
@@ -271,13 +301,16 @@ verify() {
         ;;
       *'REFUSING TO SERVE'*)
         echo "$logs" >&2
-        die "the decoder can still reach a private address (named above). The rules did not
-       take — check for a firewall that rewrites the filter table (ufw, firewalld,
-       nftables) and apply these AFTER it, then re-run."
+        VERIFY_REASON="the decoder can still reach a private address (named above). The rules
+       did not take — check for a firewall that rewrites the filter table (ufw,
+       firewalld, nftables) and apply these AFTER it, then re-run."
+        return 1
         ;;
     esac
   done
-  die "the decoder logged neither success nor refusal within 30s. Check: docker logs $CONTAINER"
+  VERIFY_REASON="the decoder logged neither success nor refusal within 30s.
+       Check: docker logs $CONTAINER"
+  return 1
 }
 
 # ⚠⚠ The one gap this script cannot close by itself, so it says so out loud.
@@ -341,8 +374,15 @@ Environment=LURKER_PREVIEWS_CONTAINER=$CONTAINER
 WantedBy=multi-user.target
 EOF
   systemctl daemon-reload
-  systemctl enable "$UNIT" >/dev/null
-  log "installed. Undo with: systemctl disable --now $UNIT"
+  # ⚠⚠ `enable` alone would leave the unit INACTIVE until the first reboot, and
+  # systemd propagates a `PartOf=` restart as a try-restart — a no-op on an
+  # inactive unit. So the Docker-restart half of the promise (unattended
+  # upgrades bouncing docker.service, say) would quietly not hold for the whole
+  # window between install and next boot, which is exactly when an operator
+  # believes it does. `--now` starts it, which costs one redundant pass over
+  # rules that are already correct.
+  systemctl enable --now "$UNIT" >/dev/null
+  log "installed and active. Undo with: systemctl disable --now $UNIT"
 }
 
 # ── Run ─────────────────────────────────────────────────────────────────────
@@ -352,8 +392,25 @@ command -v docker >/dev/null 2>&1 || die "docker not found."
 command -v iptables >/dev/null 2>&1 || die "iptables not found."
 
 wait_for_container
-apply_all
-verify
+
+# ⚠ Verifying means RESTARTING the decoder, and a restart releases its endpoint
+# — on a busy host Docker can hand the container back a different address, and
+# then the rules we just wrote name a container that no longer exists at that
+# address. The symptom is a REFUSING verdict that looks exactly like a firewall
+# problem, so the script would blame the host for its own race (and under the
+# systemd unit, a `Type=oneshot` has no Restart= to save it). Re-derive and try
+# once more before believing the rules are at fault.
+attempt=1
+while true; do
+  apply_all
+  verify && break
+  if [ "$attempt" -ge 2 ] || [ "$(container_addresses)" = "$APPLIED_ADDRESSES" ]; then
+    die "$VERIFY_REASON"
+  fi
+  log "the decoder came back on a different address — re-applying for where it is now."
+  attempt=$((attempt + 1))
+done
+
 warn_about_firewall_reloads
 if [ "${1:-}" = "--install" ]; then
   install_unit

--- a/docker-compose.previews.yml
+++ b/docker-compose.previews.yml
@@ -41,31 +41,50 @@ services:
       # variable IS the feature gate: drop this overlay and previews are off.
       - LURKER_PREVIEWS_URL=http://lurker-previews:8030
       #
-      # ───── Optional: caching the preview image BYTES ─────────────────────
-      # Previews work without this. It changes only how often the same picture
-      # is re-fetched from the site hosting it: uncached, the metadata for a
-      # link is remembered but the bytes are not, so ten people scrolling past
-      # the same image is ten fetches from its origin (once per person per day
-      # — browsers hold their own copy). Misconfiguration is never fatal: a bad
+      # ───── Caching the preview image BYTES ───────────────────────────────
+      # Optional for links and images; ⚠⚠ REQUIRED FOR VIDEO POSTERS. With the
+      # cache off, a video link renders as a card with no frame on it and
+      # nothing logs, because a posterless card is a supported state. The
+      # reason is structural rather than a policy: a poster is the one preview
+      # image with NO ORIGIN URL — the decoder makes those bytes and they exist
+      # nowhere else — so if nothing can store them there is nothing to serve.
+      # The server acts on that in three places: it doesn't ask the decoder for
+      # a poster, it won't put a poster key on the row, and the poster route
+      # answers 404. Uncomment the mode below and posters work.
+      #
+      # ⚠ Turning it on doesn't backfill. A video someone pasted while the
+      # cache was off is remembered as posterless for OK_TTL (7 days); it grows
+      # a frame when that row expires and the link is seen again.
+      #
+      # For links and images this is only about how often the same picture is
+      # re-fetched from the site hosting it: uncached, the metadata is
+      # remembered but the bytes are not, so ten people scrolling past the same
+      # image is ten fetches from its origin (once per person per day — the
+      # browsers hold their own copies). Misconfiguration is never fatal: a bad
       # value logs one warning, caching turns off, previews keep working.
       #
       # ⚠ These belong on THIS service, not the decoder. Storing bytes needs
       # credentials, and the container that parses hostile input is the last
       # place to keep any — it hands bytes back, Lurker decides where they go.
       #
-      # ⚠ Images only. Video and audio are read in ranges (one seek is many
-      # requests for one object), so caching them would trade the bandwidth
-      # this saves for memory it cannot bound.
+      # ⚠ Cached CONTENT is images only: video and audio are never stored (they
+      # are read in ranges, so one seek is many requests for one object, and
+      # caching them would trade the bandwidth this saves for memory it cannot
+      # bound). A poster is a still, which is why it can be kept at all.
       #
-      #   off     stream through, store nothing. The default.
+      #   off     stream through, store nothing. The default — and no posters.
       #   local   a directory beside the database. The sensible self-host
       #           choice — it needs no extra volume, since it lives inside the
       #           ./data mount the base compose file already has.
-      #   s3      a bucket you own, served from its public base URL.
+      #   s3      a bucket you own, served from its public base URL. Posters
+      #           work under this one too; the gate is "not off", not "local".
       #
-      # - LURKER_PREVIEW_CACHE_MODE=local
-      # - LURKER_PREVIEW_CACHE_DIR=            # default: <data dir>/preview-cache
-      # - LURKER_PREVIEW_CACHE_MAX_BYTES=      # local only; default 2 GiB, digits only
+      # Set these in a .env file beside this compose — they are declared at the
+      # bottom of this list, so a value there reaches the container:
+      #
+      #   LURKER_PREVIEW_CACHE_MODE=local
+      #   LURKER_PREVIEW_CACHE_DIR=          # default: <data dir>/preview-cache
+      #   LURKER_PREVIEW_CACHE_MAX_BYTES=    # local only; default 2 GiB, digits only
       #
       # ───── mode=s3 ───────────────────────────────────────────────────────
       # For an instance already behind a CDN: cached images are served from
@@ -102,20 +121,38 @@ services:
       # backend stores things and will not guess a path and delete what is
       # there. Remove the old directory or bucket prefix by hand.
       #
-      # - LURKER_PREVIEW_CACHE_MODE=s3
-      # - LURKER_PREVIEW_CACHE_S3_ENDPOINT=https://<account>.r2.cloudflarestorage.com
-      # - LURKER_PREVIEW_CACHE_S3_BUCKET=
-      # - LURKER_PREVIEW_CACHE_S3_ACCESS_KEY_ID=
-      # - LURKER_PREVIEW_CACHE_S3_SECRET_ACCESS_KEY=
-      # - LURKER_PREVIEW_CACHE_S3_PUBLIC_BASE_URL=https://cdn.example.com
-      # - LURKER_PREVIEW_CACHE_S3_PREFIX=previews   # optional; sanitised to [A-Za-z0-9._-]/
-      # - LURKER_PREVIEW_CACHE_S3_REGION=           # default: auto (correct for R2)
+      # In that same .env file:
+      #
+      #   LURKER_PREVIEW_CACHE_MODE=s3
+      #   LURKER_PREVIEW_CACHE_S3_ENDPOINT=https://<account>.r2.cloudflarestorage.com
+      #   LURKER_PREVIEW_CACHE_S3_BUCKET=
+      #   LURKER_PREVIEW_CACHE_S3_ACCESS_KEY_ID=
+      #   LURKER_PREVIEW_CACHE_S3_SECRET_ACCESS_KEY=
+      #   LURKER_PREVIEW_CACHE_S3_PUBLIC_BASE_URL=https://cdn.example.com
+      #   LURKER_PREVIEW_CACHE_S3_PREFIX=previews  # optional; sanitised to [A-Za-z0-9._-]/
+      #   LURKER_PREVIEW_CACHE_S3_REGION=          # default: auto (correct for R2)
       # ⚠ LURKER_PREVIEW_CACHE_DIR is still used in s3 mode — it is where bytes
       # are staged on their way to the bucket, so it stays inside ./data.
       #
-      # Put the two secrets in a .env file beside this compose rather than
-      # inline, and the full reference — every field, every caveat, and the
-      # reasoning — is in .env.example, worth reading before turning on s3.
+      # The full reference — every field, every caveat, and the reasoning — is
+      # in .env.example, worth reading before turning on s3.
+      #
+      # ⚠ The plumbing for all of the above. Compose passes a variable to the
+      # container only if the service NAMES it, so documenting these as
+      # commented-out lines would have made "put it in .env" quietly do
+      # nothing. Empty is exactly equivalent to unset — the server trims and
+      # falls back for every one of them — so declaring them costs nothing and
+      # the default stays "no cache".
+      - LURKER_PREVIEW_CACHE_MODE=${LURKER_PREVIEW_CACHE_MODE:-}
+      - LURKER_PREVIEW_CACHE_DIR=${LURKER_PREVIEW_CACHE_DIR:-}
+      - LURKER_PREVIEW_CACHE_MAX_BYTES=${LURKER_PREVIEW_CACHE_MAX_BYTES:-}
+      - LURKER_PREVIEW_CACHE_S3_ENDPOINT=${LURKER_PREVIEW_CACHE_S3_ENDPOINT:-}
+      - LURKER_PREVIEW_CACHE_S3_BUCKET=${LURKER_PREVIEW_CACHE_S3_BUCKET:-}
+      - LURKER_PREVIEW_CACHE_S3_ACCESS_KEY_ID=${LURKER_PREVIEW_CACHE_S3_ACCESS_KEY_ID:-}
+      - LURKER_PREVIEW_CACHE_S3_SECRET_ACCESS_KEY=${LURKER_PREVIEW_CACHE_S3_SECRET_ACCESS_KEY:-}
+      - LURKER_PREVIEW_CACHE_S3_PUBLIC_BASE_URL=${LURKER_PREVIEW_CACHE_S3_PUBLIC_BASE_URL:-}
+      - LURKER_PREVIEW_CACHE_S3_PREFIX=${LURKER_PREVIEW_CACHE_S3_PREFIX:-}
+      - LURKER_PREVIEW_CACHE_S3_REGION=${LURKER_PREVIEW_CACHE_S3_REGION:-}
     networks:
       # ⚠ `priority` keeps Lurker's DEFAULT ROUTE on the default network even
       # though it is attached to two. That matters once you harden: the egress

--- a/docker-compose.previews.yml
+++ b/docker-compose.previews.yml
@@ -37,6 +37,83 @@ services:
       # Merges into the base file's environment list. The presence of this
       # variable IS the feature gate: drop this overlay and previews are off.
       - LURKER_PREVIEWS_URL=http://lurker-previews:8030
+      #
+      # ───── Optional: caching the preview image BYTES ─────────────────────
+      # Previews work without this. It changes only how often the same picture
+      # is re-fetched from the site hosting it: uncached, the metadata for a
+      # link is remembered but the bytes are not, so ten people scrolling past
+      # the same image is ten fetches from its origin (once per person per day
+      # — browsers hold their own copy). Misconfiguration is never fatal: a bad
+      # value logs one warning, caching turns off, previews keep working.
+      #
+      # ⚠ These belong on THIS service, not the decoder. Storing bytes needs
+      # credentials, and the container that parses hostile input is the last
+      # place to keep any — it hands bytes back, Lurker decides where they go.
+      #
+      # ⚠ Images only. Video and audio are read in ranges (one seek is many
+      # requests for one object), so caching them would trade the bandwidth
+      # this saves for memory it cannot bound.
+      #
+      #   off     stream through, store nothing. The default.
+      #   local   a directory beside the database. The sensible self-host
+      #           choice — it needs no extra volume, since it lives inside the
+      #           ./data mount the base compose file already has.
+      #   s3      a bucket you own, served from its public base URL.
+      #   dropper the hosted-fleet mode; not for self-hosters.
+      #
+      # - LURKER_PREVIEW_CACHE_MODE=local
+      # - LURKER_PREVIEW_CACHE_DIR=            # default: <data dir>/preview-cache
+      # - LURKER_PREVIEW_CACHE_MAX_BYTES=      # local only; default 2 GiB, digits only
+      #
+      # ───── mode=s3 ───────────────────────────────────────────────────────
+      # For an instance already behind a CDN: cached images are served from
+      # the bucket's public URL, so your server ships zero bytes for an image
+      # it has already fetched. All five of the first fields are REQUIRED —
+      # leave any one unset and caching stays off, naming the field.
+      #
+      # ⚠⚠ THE OBJECTS ARE PUBLIC. Anyone with the URL can read a cached image
+      # for as long as it is kept — the same property Slack's and Discord's
+      # image proxies have. Only allowlisted image types are stored (SVG is
+      # refused) and only your logged-in users can cause an image to be cached
+      # at all, but do not point this at a bucket holding anything else.
+      #
+      # ⚠ PUBLIC_BASE_URL must be https. A browser blocks an http:// image on
+      # an https page as mixed content — an http base URL is a cache that
+      # never renders.
+      #
+      # ⚠ Retention is YOURS. Set a lifecycle rule on the prefix (30 days is
+      # the recommendation — Lurker stops serving an object after 7 and drops
+      # its index row). Nothing here deletes objects for you.
+      #
+      # ⚠ Of the six hardening headers the proxy sends, only three survive on
+      # a stored object (Content-Type, Content-Disposition, Cache-Control).
+      # Add nosniff / CSP / CORP at your CDN edge if you want them here too.
+      #
+      # ⚠⚠ NEEDS AN UP-TO-DATE iOS APP. Cached images are served from the CDN
+      # URL rather than through this server, and Lurker for iOS only learned
+      # to follow an absolute image URL alongside this feature. Older builds
+      # show every cached preview as blank for the rest of the session. The
+      # web client is unaffected.
+      #
+      # ⚠ Switching modes (local <-> s3) leaves the old backend's bytes behind:
+      # the index rows are swept, but the server only knows where the CURRENT
+      # backend stores things and will not guess a path and delete what is
+      # there. Remove the old directory or bucket prefix by hand.
+      #
+      # - LURKER_PREVIEW_CACHE_MODE=s3
+      # - LURKER_PREVIEW_CACHE_S3_ENDPOINT=https://<account>.r2.cloudflarestorage.com
+      # - LURKER_PREVIEW_CACHE_S3_BUCKET=
+      # - LURKER_PREVIEW_CACHE_S3_ACCESS_KEY_ID=
+      # - LURKER_PREVIEW_CACHE_S3_SECRET_ACCESS_KEY=
+      # - LURKER_PREVIEW_CACHE_S3_PUBLIC_BASE_URL=https://cdn.example.com
+      # - LURKER_PREVIEW_CACHE_S3_PREFIX=previews   # optional; sanitised to [A-Za-z0-9._-]/
+      # - LURKER_PREVIEW_CACHE_S3_REGION=           # default: auto (correct for R2)
+      # ⚠ LURKER_PREVIEW_CACHE_DIR is still used in s3 mode — it is where bytes
+      # are staged on their way to the bucket, so it stays inside ./data.
+      #
+      # Put the two secrets in a .env file beside this compose rather than
+      # inline, and the full reference — every field, every caveat, and the
+      # reasoning — is in .env.example, worth reading before turning on s3.
     networks:
       # ⚠ `priority` keeps Lurker's DEFAULT ROUTE on the default network even
       # though it is attached to two. That matters once you harden: the egress

--- a/docker-compose.previews.yml
+++ b/docker-compose.previews.yml
@@ -28,8 +28,11 @@
 # On a Linux host you can have both. Put LURKER_PREVIEWS_ALLOW_PRIVATE=0 in a
 # .env file beside this one and run deploy/previews-egress.sh, which installs
 # the firewall rules that make the self-test pass — and a systemd unit that
-# re-applies them on every boot, so the property can't lapse silently. See
-# "Link previews & inline media" in docs/SELF_HOSTING.md.
+# re-applies them on every boot and whenever Docker restarts. ⚠ One gap it
+# cannot cover: a host firewall that rewrites the filter table later (a `ufw
+# allow …` reload) drops the host-protection rule, and the decoder only
+# re-tests itself when it starts — so re-run the script after changing ufw or
+# firewalld. See "Link previews & inline media" in docs/SELF_HOSTING.md.
 
 services:
   lurker:
@@ -59,7 +62,6 @@ services:
       #           choice — it needs no extra volume, since it lives inside the
       #           ./data mount the base compose file already has.
       #   s3      a bucket you own, served from its public base URL.
-      #   dropper the hosted-fleet mode; not for self-hosters.
       #
       # - LURKER_PREVIEW_CACHE_MODE=local
       # - LURKER_PREVIEW_CACHE_DIR=            # default: <data dir>/preview-cache
@@ -134,6 +136,16 @@ services:
       - previews
     environment:
       - LURKER_PREVIEWS_ALLOW_PRIVATE=${LURKER_PREVIEWS_ALLOW_PRIVATE:-1}
+      - LURKER_PREVIEWS_SELFTEST_TARGETS=${LURKER_PREVIEWS_SELFTEST_TARGETS:-}
+      # ⚠ Only read when ALLOW_PRIVATE=0, and then it matters a lot. The
+      # built-in probes are the cloud metadata address and this host's bridge
+      # gateway on :22/:80 — and a probe that nothing is LISTENING at passes
+      # whether or not your firewall exists. Name something private you know
+      # answers, most simply your Docker host's LAN address with sshd on it,
+      # and the self-test becomes a real test. (Verified: with the rules gone,
+      # a named listening target is what makes the decoder refuse to serve.)
+      # Set it in a .env file beside this compose:
+      #   LURKER_PREVIEWS_SELFTEST_TARGETS=192.168.1.10:22
       # Optional: what the decoder tells sites it is when it fetches a
       # preview. The default names Lurker and the traffic class (a social
       # preview fetch), so a site operator reading their logs can recognise
@@ -141,6 +153,14 @@ services:
       # - LURKER_PREVIEW_USER_AGENT=
       # Optional: a contact URL or mailto: appended to that User-Agent.
       # - USER_AGENT_CONTACT=https://lurker.example.com
+    # ⚠ The decoder only ever resolves names it found on the public internet,
+    # so it can use public resolvers — and if it does, the hardening script has
+    # no reason to allow it DNS to your LAN at all (see the port 53 note in
+    # deploy/previews-egress.sh). Uncomment to close that last gap; leave it
+    # alone to inherit whatever this host uses.
+    # dns:
+    #   - 1.1.1.1
+    #   - 9.9.9.9
     # This process runs memory-unsafe parsers (libvips, ffmpeg) on bytes
     # strangers chose — so it gets no filesystem, no capabilities, no way to
     # gain any, and hard resource ceilings.

--- a/docker-compose.previews.yml
+++ b/docker-compose.previews.yml
@@ -1,0 +1,91 @@
+# Copyright (c) 2026 Brad Root
+# SPDX-License-Identifier: MPL-2.0
+#
+# Link previews & inline media — the `lurker-previews` decoder.
+#
+# Layer it on top of the base compose file:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.previews.yml up -d
+#
+# (Add -f docker-compose.caddy.yml as well if you front Lurker with Caddy —
+# the overlays touch different things and can be combined in any order.)
+#
+# Everything that dials a URL someone pasted in chat, and everything that
+# parses the bytes it gets back, runs in the SECOND container — never in the
+# one holding your database, your uploads and your users' sessions. Pointing
+# Lurker at the decoder is the entire enable switch; there is no separate
+# on/off flag. Each user then opts in for themselves under Settings → Chat
+# (Link previews and Inline media, both off by default).
+#
+# ⚠ EGRESS, and it is the reason this file has a hardening story at all. The
+# decoder is meant to reach the public internet and NOTHING private, and it
+# proves that at boot — on an ordinary Docker network it can reach your host,
+# so it would refuse to serve. This file therefore ships
+# LURKER_PREVIEWS_ALLOW_PRIVATE=1, which skips that self-test. The decoder's
+# in-process SSRF guard is unaffected, so a malicious *link* is refused either
+# way; what you give up is containment of a malicious *process*.
+#
+# On a Linux host you can have both. Put LURKER_PREVIEWS_ALLOW_PRIVATE=0 in a
+# .env file beside this one and run deploy/previews-egress.sh, which installs
+# the firewall rules that make the self-test pass — and a systemd unit that
+# re-applies them on every boot, so the property can't lapse silently. See
+# "Link previews & inline media" in docs/SELF_HOSTING.md.
+
+services:
+  lurker:
+    environment:
+      # Merges into the base file's environment list. The presence of this
+      # variable IS the feature gate: drop this overlay and previews are off.
+      - LURKER_PREVIEWS_URL=http://lurker-previews:8030
+    networks:
+      # ⚠ `priority` keeps Lurker's DEFAULT ROUTE on the default network even
+      # though it is attached to two. That matters once you harden: the egress
+      # rules are scoped to addresses on the previews bridge, and Lurker's own
+      # outbound traffic — IRC, uploads, push — must not leave from there.
+      default:
+        priority: 100
+      previews: {}
+
+  lurker-previews:
+    image: ghcr.io/amiantos/lurker-previews:latest
+    container_name: lurker-previews
+    restart: unless-stopped
+    # Deliberately on its own bridge, and NOT on the default network: the
+    # egress rules key off this subnet, and only Lurker needs to reach it.
+    # No ports are published — nothing on your host or LAN talks to it.
+    networks:
+      - previews
+    environment:
+      - LURKER_PREVIEWS_ALLOW_PRIVATE=${LURKER_PREVIEWS_ALLOW_PRIVATE:-1}
+      # Optional: what the decoder tells sites it is when it fetches a
+      # preview. The default names Lurker and the traffic class (a social
+      # preview fetch), so a site operator reading their logs can recognise
+      # it and block it on purpose.
+      # - LURKER_PREVIEW_USER_AGENT=
+      # Optional: a contact URL or mailto: appended to that User-Agent.
+      # - USER_AGENT_CONTACT=https://lurker.example.com
+    # This process runs memory-unsafe parsers (libvips, ffmpeg) on bytes
+    # strangers chose — so it gets no filesystem, no capabilities, no way to
+    # gain any, and hard resource ceilings.
+    read_only: true
+    # ⚠ ffmpeg's scratch space, and it is RAM: a tmpfs counts against the
+    # memory limit below, which is what bounds it.
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    mem_limit: 512m
+    # ⚠ Counts THREADS, not processes: node's pool plus one capped ffmpeg
+    # decode fits in 128. Meaningfully lower starves thread creation, and the
+    # first symptom is silently posterless cards — a missing poster is a
+    # supported state, so nothing logs.
+    pids_limit: 128
+    logging:
+      options:
+        max-size: 20m
+        max-file: '3'
+
+networks:
+  previews:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,20 @@ services:
       # - LURKER_BOUNCER_ENABLED=true
       # - LURKER_BOUNCER_PORT=6667
       #
+      # ───── Optional: Link previews & inline media ────────────────────────
+      # Off by default. A pasted link can unfurl into a card, an image can
+      # render inline, and a video can show a poster frame — but all of the
+      # fetching and media parsing happens in a SECOND container, so this one
+      # never dials a stranger's URL. Run both with:
+      #
+      #   curl -O https://raw.githubusercontent.com/amiantos/lurker/main/docker-compose.previews.yml
+      #   docker compose -f docker-compose.yml -f docker-compose.previews.yml up -d
+      #
+      # That overlay sets the variable below for you (its presence is the whole
+      # enable switch) and adds the decoder service. See docs/SELF_HOSTING.md
+      # for the egress model and the hardening step.
+      # - LURKER_PREVIEWS_URL=http://lurker-previews:8030
+      #
       # ───── Optional: Secure cookie flag ──────────────────────────────────
       # Off by default so cookies work over plain HTTP (localhost / LAN) and
       # behind TLS-terminating proxies (Cloudflare Tunnel, Caddy, etc.)

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -329,19 +329,51 @@ chmod +x previews-egress.sh
 sudo ./previews-egress.sh --install
 ```
 
-It adds `DOCKER-USER` rules dropping traffic from the decoder's address to
-`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16` and
+Two things to set alongside it:
+
+- **Stop skipping the self-test.** The overlay reads
+  `LURKER_PREVIEWS_ALLOW_PRIVATE` from your `.env`, so `=0` there is enough. If
+  you wrote your own compose file from the block above, that hardcoded
+  `- LURKER_PREVIEWS_ALLOW_PRIVATE=1` wins over any `.env` — delete the line.
+- **Give the self-test a target that answers.** Its built-in probes are the
+  cloud metadata address and the bridge gateway's `:22`/`:80`; on a box with no
+  sshd and nothing on `:80` they all time out whether or not your rules exist,
+  and it passes vacuously. Name something private you know is listening —
+  usually your Docker host's LAN address — via
+  `LURKER_PREVIEWS_SELFTEST_TARGETS=192.168.1.10:22`.
+
+The script adds `DOCKER-USER` rules dropping traffic from the decoder's address
+to `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16` and
 `100.64.0.0/10`, plus an `INPUT` rule for the host itself (⚠ container→host
 traffic never reaches `DOCKER-USER`, so forward rules alone leave your own sshd
-reachable from the container that parses hostile input). `--install` adds a
-systemd unit that re-applies them on boot and whenever Docker restarts. Then it
-restarts the decoder and reads back its verdict, so you know it worked.
+reachable from the container that parses hostile input). Replies to Lurker are
+allowed by connection state rather than by subnet, so the decoder can answer
+Lurker but cannot dial it. `--install` adds a systemd unit that re-applies
+everything on boot and whenever Docker restarts. Then it restarts the decoder
+and reads back its verdict, so you know it worked.
 
-Run it again after anything that recreates the decoder container — the rules are
-scoped to the address Docker gave it, and an update can hand it a new one. That's
-a loud failure, not a silent one: the self-test stops passing, the decoder
-refuses to serve, and previews report themselves unavailable while everything
-else carries on. (This is what the hosted fleet does per-cell, and why.)
+⚠ **DNS is deliberately allowed** — port 53 to any address. Without it, a host
+whose resolver is a LAN address (a home router, a Pi-hole, systemd-resolved
+pointing at either) resolves nothing, every preview fails, and the self-test
+still passes, because it probes IP literals and cannot see DNS at all. What it
+grants a compromised decoder is talking to DNS servers; not ssh, not an internal
+API, not the metadata service. To close even that, give the decoder public
+resolvers of its own with `dns:` in the overlay and delete the two port-53
+rules.
+
+Re-run the script after two things:
+
+- **Anything that recreates the decoder container.** The rules are scoped to the
+  address Docker gave it, and an update can hand it a new one. This failure is
+  loud: the self-test stops passing, the decoder refuses to serve, and previews
+  report themselves unavailable while everything else carries on.
+- **Any change to a host firewall that owns the filter table** (`ufw allow …`,
+  `firewall-cmd`). A reload rewrites `INPUT` and takes the host-protection rule
+  with it. ⚠ This one is _not_ loud — the decoder only re-tests its containment
+  when it starts — so it is the one case where you have to remember. The script
+  warns at the end when it sees ufw or firewalld running.
+
+(This is what the hosted fleet does per-cell, and why.)
 
 #### Caching preview images (optional)
 
@@ -358,7 +390,6 @@ or a bucket for not re-fetching popular images:
   ships zero bytes for an image it has already fetched. This one has real
   operational requirements — the objects are publicly readable, the base URL
   must be https, and **you** own eviction via a lifecycle rule on the bucket.
-- **`dropper`** — the hosted-fleet mode; not for self-hosters.
 
 Misconfiguration is never fatal: a bad cache config logs one warning, caching
 turns off, and previews keep working.

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -48,6 +48,7 @@ Everything Lurker persists lives in `./data/`:
 
 - `lurker.db` (and `-shm`, `-wal` files) — IRC history, settings, users, etc.
 - `session-secret.key` — the secret used to sign session cookies. Backing this up means existing browser sessions survive a restore.
+- `preview-cache/` — only if you enabled [preview image caching](#caching-preview-images-required-for-video-posters), and worth **excluding**: it's up to 2 GiB of re-fetchable bytes that would otherwise land in every backup. Restoring without it costs a re-fetch and nothing else.
 
 A `cp -r data/ data-backup-$(date +%F)/` (with the server stopped, to avoid copying mid-write WAL files) is sufficient. If you need a hot copy, use the SQLite `.backup` command:
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -361,8 +361,13 @@ or a bucket for not re-fetching popular images:
 - **`dropper`** — the hosted-fleet mode; not for self-hosters.
 
 Misconfiguration is never fatal: a bad cache config logs one warning, caching
-turns off, and previews keep working. The full per-mode reference — every
-variable, the s3 caveats, and the reasoning — lives in
+turns off, and previews keep working.
+
+Every variable is carried as a commented block in `docker-compose.previews.yml`,
+on the `lurker` service — storing bytes needs credentials, and the container that
+parses hostile input is the last place to keep any, so the decoder hands bytes
+back and Lurker decides where they go. The full per-mode reference — every field,
+the s3 caveats, and the reasoning — lives in
 [`.env.example`](https://github.com/amiantos/lurker/blob/main/.env.example),
 which is worth reading in full before turning on `s3`.
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -231,6 +231,11 @@ card (title, description, image — the way Slack or Discord do it); a link
 straight to an image renders inline; and a link to a **video or audio file**
 renders a poster frame that plays in place when clicked.
 
+⚠ That last one needs one more setting: **video posters require the byte cache**
+(`LURKER_PREVIEW_CACHE_MODE=local`). See
+[Caching preview images](#caching-preview-images-required-for-video-posters)
+below — without it, video links get a card with no frame on it.
+
 It's off by default because it makes your deployment fetch third-party URLs that
 appear in chat — a behavior an operator should choose, not inherit.
 
@@ -375,13 +380,30 @@ Re-run the script after two things:
 
 (This is what the hosted fleet does per-cell, and why.)
 
-#### Caching preview images (optional)
+#### Caching preview images (required for video posters)
 
-Without a cache this already works — the server just re-fetches an image when
-nobody's browser has it cached. `LURKER_PREVIEW_CACHE_MODE` trades a little disk
-or a bucket for not re-fetching popular images:
+For links and images this is a tuning knob: without a cache everything still
+works, the server just re-fetches an image when nobody's browser has it cached.
+**For video and audio it is the difference between a poster frame and a bare
+card**, so if you want the feature described at the top of this section, turn it
+on.
 
-- **`off`** (default) — fetch through, store nothing.
+Why a video needs it when an image doesn't: a poster is the one preview image
+with **no origin URL**. The decoder produces those bytes from the video itself,
+so they exist nowhere else on the internet — if your instance has nowhere to put
+them, there is nothing to serve later. The server is consistent about that
+rather than half-working: with the cache off it doesn't ask the decoder for a
+poster at all, won't record one against the link, and its poster route answers 404. The card renders without a frame and nothing logs, because a posterless
+card is a supported state.
+
+⚠ **Turning it on doesn't backfill.** A video someone pasted while the cache was
+off is remembered as posterless for a week (the success TTL); it grows a frame
+once that entry expires and someone posts the link again.
+
+`LURKER_PREVIEW_CACHE_MODE` trades a little disk or a bucket for this, and for
+not re-fetching popular images:
+
+- **`off`** (default) — fetch through, store nothing. No video posters.
 - **`local`** — the sensible self-host choice. Cached bytes live in a directory
   next to the database (2 GiB cap by default, least-recently-used eviction).
   It's a cache, not data: safe to delete while the server is stopped.
@@ -390,6 +412,9 @@ or a bucket for not re-fetching popular images:
   ships zero bytes for an image it has already fetched. This one has real
   operational requirements — the objects are publicly readable, the base URL
   must be https, and **you** own eviction via a lifecycle rule on the bucket.
+
+Posters work under `local` or `s3` — the gate is "a cache exists", not `local`
+specifically.
 
 Misconfiguration is never fatal: a bad cache config logs one warning, caching
 turns off, and previews keep working.

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -244,7 +244,21 @@ your database, and it never dials a stranger's URL or runs an image/video decode
 to be thrown away if it's ever compromised.
 
 **Setting `LURKER_PREVIEWS_URL` to point at a running decoder is the entire enable
-switch** — there's no separate on/off flag. Add the service alongside Lurker:
+switch** — there's no separate on/off flag.
+
+If you run the stock `docker-compose.yml`, there's a ready-made overlay that adds
+the decoder and sets that variable for you:
+
+```bash
+curl -O https://raw.githubusercontent.com/amiantos/lurker/main/docker-compose.previews.yml
+docker compose -f docker-compose.yml -f docker-compose.previews.yml up -d
+```
+
+(Add `-f docker-compose.caddy.yml` too if you front Lurker with Caddy.) On a
+DigitalOcean droplet, [`ENABLE_LINK_PREVIEWS="true"`](digitalocean.md) in the
+deploy script does all of this — including the hardening below — unattended.
+
+If you keep your own compose file, the service is this:
 
 ```yaml
 services:
@@ -302,13 +316,32 @@ straight to the origin, the one request the reader deliberately made.
 runs on an ordinary Docker network. The in-process SSRF guard is still active, so
 a malicious _URL_ is refused either way — what you give up is protection against a
 malicious _process_ (an RCE in the decoder reaching your LAN). For a trusted
-group that's a fair trade; to close it, drop the `ALLOW_PRIVATE` line and instead
-firewall the decoder so it can reach the internet but not private ranges. On a
-Linux host that's `DOCKER-USER` rules dropping traffic from the decoder's subnet
-to `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16` and
-`100.64.0.0/10`, plus an `INPUT` rule for the host itself. With those in place the
-self-test passes and the container refuses to serve if they ever lapse. (This is
-exactly what the hosted fleet does per-cell.)
+group that's a fair trade; to close it, firewall the decoder so it can reach the
+internet but not private ranges, and let the self-test run.
+
+On a Linux host, [`deploy/previews-egress.sh`](https://github.com/amiantos/lurker/blob/main/deploy/previews-egress.sh)
+does that for you:
+
+```bash
+# with LURKER_PREVIEWS_ALLOW_PRIVATE=0 in a .env beside your compose file
+curl -O https://raw.githubusercontent.com/amiantos/lurker/main/deploy/previews-egress.sh
+chmod +x previews-egress.sh
+sudo ./previews-egress.sh --install
+```
+
+It adds `DOCKER-USER` rules dropping traffic from the decoder's address to
+`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16` and
+`100.64.0.0/10`, plus an `INPUT` rule for the host itself (⚠ container→host
+traffic never reaches `DOCKER-USER`, so forward rules alone leave your own sshd
+reachable from the container that parses hostile input). `--install` adds a
+systemd unit that re-applies them on boot and whenever Docker restarts. Then it
+restarts the decoder and reads back its verdict, so you know it worked.
+
+Run it again after anything that recreates the decoder container — the rules are
+scoped to the address Docker gave it, and an update can hand it a new one. That's
+a loud failure, not a silent one: the self-test stops passing, the decoder
+refuses to serve, and previews report themselves unavailable while everything
+else carries on. (This is what the hosted fleet does per-cell, and why.)
 
 #### Caching preview images (optional)
 

--- a/docs/digitalocean.md
+++ b/docs/digitalocean.md
@@ -17,6 +17,17 @@ Passkeys and web push notifications are configured automatically — the deploy 
 
 Deploy progress is logged to `/var/log/lurker-deploy.log` on the droplet.
 
+## Optional extras
+
+Two features are off unless you switch them on in the script, next to the two required values:
+
+- **`ENABLE_IDENTD="true"`** — runs Lurker's built-in identd on port 113, so a multi-user instance can give each user a verified ident on IRC instead of a shared `~ident`.
+- **`ENABLE_LINK_PREVIEWS="true"`** — runs [`lurker-previews`](https://github.com/amiantos/lurker-previews), the second container that turns pasted links into preview cards, renders images inline, and gives videos a poster frame.
+
+Link previews are worth a word on what the script does for you, because it is the part that is fiddly by hand. All the fetching and media parsing happens in that second container, never in the one holding your database and sessions — and the script gives it the same treatment the hosted fleet gets: its own private bridge, firewall rules that let it reach the public internet and nothing private (not this droplet, not your VPC, not your other containers), and a systemd unit that re-applies them on every boot. The decoder's own boot self-test is left on, so if that containment ever lapses it refuses to serve rather than quietly parsing hostile bytes with a route to your infrastructure.
+
+Budget the RAM: the decoder is capped at 512 MB and ffmpeg will use it when it makes a poster. On the smallest 1 GB droplet it leans on swap; 2 GB is comfortable. And enabling it here only opens the door — each user still turns on **Link previews** and **Inline media** in **Settings → Chat**, both off by default.
+
 ## Updating
 
 SSH in (or open the DigitalOcean web console) and run:
@@ -27,6 +38,14 @@ docker compose pull && docker compose up -d
 ```
 
 The deploy script records the Caddy overlay in `.env`, so `docker compose` picks it up automatically — no `-f` flags needed. Your `data/` directory is left untouched.
+
+If you enabled link previews, follow that with:
+
+```bash
+sudo /opt/lurker/previews-egress.sh
+```
+
+The firewall rules are scoped to the address Docker gave the decoder, and updating it can hand it a new one. Re-running is idempotent and takes seconds. You will not have to remember: a decoder whose rules no longer fit refuses to serve and says so in `docker logs lurker-previews`, previews go blank, and nothing else is affected.
 
 ## Going further
 

--- a/docs/digitalocean.md
+++ b/docs/digitalocean.md
@@ -26,6 +26,8 @@ Two features are off unless you switch them on in the script, next to the two re
 
 Link previews are worth a word on what the script does for you, because it is the part that is fiddly by hand. All the fetching and media parsing happens in that second container, never in the one holding your database and sessions — and the script gives it the same treatment the hosted fleet gets: its own private bridge, firewall rules that let it reach the public internet and nothing private (not this droplet, not your VPC, not your other containers), and a systemd unit that re-applies them on every boot. The decoder's own boot self-test is left on, so it re-proves that containment every time it starts and refuses to serve rather than quietly parse hostile bytes with a route to your infrastructure — the one lapse it can't catch by itself is a firewall reload while it's running, which is why the note below the update command exists.
 
+The deploy also turns on the preview byte cache (`local`, a 2 GiB least-recently-used directory inside `data/`). That is not a tuning choice: **video posters require a cache**, because a poster is the one preview image with no origin URL — the decoder makes those bytes out of the video itself, so with nowhere to store them the server never asks for one and video links render as bare cards. It's a cache and not data; deleting it while the server is stopped costs nothing but a re-fetch.
+
 Budget the RAM: the decoder is capped at 512 MB and ffmpeg will use it when it makes a poster. On the smallest 1 GB droplet it leans on swap; 2 GB is comfortable. And enabling it here only opens the door — each user still turns on **Link previews** and **Inline media** in **Settings → Chat**, both off by default.
 
 ## Updating

--- a/docs/digitalocean.md
+++ b/docs/digitalocean.md
@@ -24,7 +24,7 @@ Two features are off unless you switch them on in the script, next to the two re
 - **`ENABLE_IDENTD="true"`** — runs Lurker's built-in identd on port 113, so a multi-user instance can give each user a verified ident on IRC instead of a shared `~ident`.
 - **`ENABLE_LINK_PREVIEWS="true"`** — runs [`lurker-previews`](https://github.com/amiantos/lurker-previews), the second container that turns pasted links into preview cards, renders images inline, and gives videos a poster frame.
 
-Link previews are worth a word on what the script does for you, because it is the part that is fiddly by hand. All the fetching and media parsing happens in that second container, never in the one holding your database and sessions — and the script gives it the same treatment the hosted fleet gets: its own private bridge, firewall rules that let it reach the public internet and nothing private (not this droplet, not your VPC, not your other containers), and a systemd unit that re-applies them on every boot. The decoder's own boot self-test is left on, so if that containment ever lapses it refuses to serve rather than quietly parsing hostile bytes with a route to your infrastructure.
+Link previews are worth a word on what the script does for you, because it is the part that is fiddly by hand. All the fetching and media parsing happens in that second container, never in the one holding your database and sessions — and the script gives it the same treatment the hosted fleet gets: its own private bridge, firewall rules that let it reach the public internet and nothing private (not this droplet, not your VPC, not your other containers), and a systemd unit that re-applies them on every boot. The decoder's own boot self-test is left on, so it re-proves that containment every time it starts and refuses to serve rather than quietly parse hostile bytes with a route to your infrastructure — the one lapse it can't catch by itself is a firewall reload while it's running, which is why the note below the update command exists.
 
 Budget the RAM: the decoder is capped at 512 MB and ffmpeg will use it when it makes a poster. On the smallest 1 GB droplet it leans on swap; 2 GB is comfortable. And enabling it here only opens the door — each user still turns on **Link previews** and **Inline media** in **Settings → Chat**, both off by default.
 
@@ -45,7 +45,9 @@ If you enabled link previews, follow that with:
 sudo /opt/lurker/previews-egress.sh
 ```
 
-The firewall rules are scoped to the address Docker gave the decoder, and updating it can hand it a new one. Re-running is idempotent and takes seconds. You will not have to remember: a decoder whose rules no longer fit refuses to serve and says so in `docker logs lurker-previews`, previews go blank, and nothing else is affected.
+The firewall rules are scoped to the address Docker gave the decoder, and updating it can hand it a new one. Re-running is idempotent and takes seconds. You will not have to remember for updates: a decoder whose rules no longer fit refuses to serve and says so in `docker logs lurker-previews`, previews go blank, and nothing else is affected.
+
+⚠ Run it again after changing the firewall too — `ufw allow …` reloads the ruleset and drops the rule that keeps the droplet itself unreachable from the decoder. That one is _not_ self-announcing, because the decoder only re-checks its containment when it starts. Reboots and Docker restarts are already handled by the systemd unit the script installs.
 
 ## Going further
 


### PR DESCRIPTION
Closes #784.

Link previews have needed a second container since 2.1.2, and the only place that said how to run one was prose in `SELF_HOSTING.md`. Prose is the wrong artifact for a service whose security argument is a firewall — the copy-paste has to be the safe thing.

## What's here

| File | |
|---|---|
| `docker-compose.previews.yml` *(new)* | The decoder as an overlay, layered like the Caddy one. Own bridge, `read_only`, `cap_drop ALL`, 512m, `pids_limit 128`, `LURKER_PREVIEWS_URL` set for you — plus the byte-cache options (`local`/`s3`) documented where someone turning previews on will actually look. |
| `deploy/previews-egress.sh` *(new)* | The network half of the argument: `DOCKER-USER` DROPs, the `INPUT` rule forward rules miss, conntrack for the reply path, a systemd unit for persistence, and a verification step that restarts the decoder and reads back its own verdict. |
| `deploy/digitalocean-cloud-init.sh` | `ENABLE_LINK_PREVIEWS="true"` wires all of it up unattended, with the self-test left **on**. |
| docs, `docker-compose.yml`, `.env.example` | Pointers and the operator-facing story. |

Rules are tagged per run and the previous generation is removed only *after* the new one is in force, so containment never dips — a half-finished run leaves the decoder over-contained rather than exposed.

## Testing

Everything was exercised in a `docker:dind` sandbox with real iptables, a real decoder, a stand-in for Lurker, and a listener on the sandbox host — not reasoned about. Final state: DNS ✓, resolve ✓, ffmpeg poster ✓, `Lurker → decoder` ✓; `decoder → Lurker:8015`, `→ host`, `→ metadata` all blocked; repeated runs converge on one generation of rules.

That sandbox is why this PR is worth the diff. It found, among others:

- **The decoder could not resolve a single name** on any host whose resolver is a LAN address. libnetwork forwards the upstream query from *inside the container's namespace*, so those packets carry the decoder's address and the DROPs swallowed them — `ESERVFAIL`, every preview `403`, and the self-test passing throughout, because it probes IP literals and cannot see DNS.
- A **blanket subnet RETURN let a compromised decoder dial Lurker's `:8015`**, which the docs claimed it couldn't. It is connection-state now.
- `systemctl enable` **without `--now`** left the unit inactive until first reboot, and `PartOf=` propagates as a try-restart — a no-op on an inactive unit. So the Docker-restart promise didn't hold in exactly the window where an operator believes it does.

## Known limits, stated rather than papered over

- **A `ufw`/`firewalld` reload drops the `INPUT` rule and nothing notices** — the decoder only re-tests containment when it starts. This is the one lapse the design can't self-heal; the docs now say so and the script warns when it sees either running. A periodic re-apply timer is the obvious follow-up if we want it closed.
- **The systemd path is untested** — no systemd on this machine, and the sandbox is Alpine. The unit file and the `enable --now` reasoning are review-checked only.

Two `/code-review high` passes; both rounds' findings are applied.