### PR TITLE
Live message translation (device-local, client-only, off by default)

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1107,6 +1107,157 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'the video host until you press it.',
   },
 
+  // ─── Translation ──────────────────────────────────────────────────────
+  // Live message translation (device-local). YOUR DEVICE calls the endpoint you
+  // configure — the Lurker server is never involved and never sees which
+  // messages you translate. That is the whole design: it works with a
+  // local-network translator (Ollama, LM Studio, a self-hosted LibreTranslate)
+  // using credentials only you hold. The trade is disclosed in each
+  // description below, because the description is the entire basis on which
+  // someone decides to turn a knob on: message text is sent to the configured
+  // endpoint.
+  //
+  // These keys configure the translator; the per-conversation reading/posting
+  // switches live in the buffer menu (device-local state, deliberately not
+  // synced — which conversations you translate is as private as the messages).
+  {
+    key: 'chat.translate.backend',
+    label: 'Translation backend',
+    category: 'chat',
+    group: 'translation',
+    type: 'enum',
+    choices: ['off', 'libretranslate', 'openai'],
+    choiceLabels: { off: 'Off', libretranslate: 'LibreTranslate', openai: 'OpenAI-compatible' },
+    default: 'off',
+    description:
+      'Translate messages using a service you configure. "LibreTranslate" is a free, ' +
+      'self-hostable translator; "OpenAI-compatible" works with Ollama, LM Studio, or any ' +
+      'API gateway speaking that protocol. Message text is sent from YOUR DEVICE to the ' +
+      'endpoint below — your Lurker server never sees it. Off hides all translation UI.',
+  },
+  {
+    key: 'chat.translate.endpoint',
+    label: 'Translator endpoint',
+    category: 'chat',
+    group: 'translation',
+    type: 'string',
+    default: '',
+    dependsOn: [{ key: 'chat.translate.backend', in: ['libretranslate', 'openai'] }],
+    description:
+      'Base URL of the translator (e.g. https://translate.example.com, or ' +
+      'http://localhost:11434 for Ollama). For OpenAI-compatible backends, /v1 is ' +
+      'appended automatically when missing. Because your browser calls this endpoint ' +
+      'directly, it must allow cross-origin requests from your Lurker origin.',
+  },
+  {
+    key: 'chat.translate.api_key',
+    label: 'Translator API key',
+    category: 'chat',
+    group: 'translation',
+    type: 'secret',
+    default: '',
+    dependsOn: [{ key: 'chat.translate.backend', in: ['libretranslate', 'openai'] }],
+    description:
+      'Optional. Sent as an api_key field to LibreTranslate, or as a Bearer token to an ' +
+      'OpenAI-compatible backend. Leave empty for keyless services (a local Ollama, or a ' +
+      'public LibreTranslate that requires none).',
+  },
+  {
+    key: 'chat.translate.model',
+    label: 'Translator model',
+    category: 'chat',
+    group: 'translation',
+    type: 'string',
+    default: '',
+    // OpenAI-compatible only: LibreTranslate has no model concept, so showing
+    // this knob there would be a switch that silently does nothing.
+    dependsOn: [{ key: 'chat.translate.backend', in: ['openai'] }],
+    description:
+      'The model an OpenAI-compatible backend should use (e.g. llama3.2, gpt-4o-mini). ' +
+      'Required for that backend — the API refuses a request without one.',
+  },
+  {
+    key: 'chat.translate.target_lang',
+    label: 'Translate into',
+    category: 'chat',
+    group: 'translation',
+    type: 'enum',
+    // A picker, never free-form entry: a typo'd language code fails silently at
+    // the translator, which reads as "translation is broken" with no error to
+    // chase. Codes are ISO-639-1 as LibreTranslate uses them ('zt' =
+    // traditional Chinese in its scheme).
+    choices: [
+      'en',
+      'ar',
+      'cs',
+      'da',
+      'de',
+      'el',
+      'es',
+      'fa',
+      'fi',
+      'fr',
+      'he',
+      'hi',
+      'hu',
+      'id',
+      'it',
+      'ja',
+      'ko',
+      'nl',
+      'no',
+      'pl',
+      'pt',
+      'ro',
+      'ru',
+      'sv',
+      'th',
+      'tr',
+      'uk',
+      'vi',
+      'zh',
+      'zt',
+    ],
+    choiceLabels: {
+      en: 'English',
+      ar: 'Arabic',
+      cs: 'Czech',
+      da: 'Danish',
+      de: 'German',
+      el: 'Greek',
+      es: 'Spanish',
+      fa: 'Persian',
+      fi: 'Finnish',
+      fr: 'French',
+      he: 'Hebrew',
+      hi: 'Hindi',
+      hu: 'Hungarian',
+      id: 'Indonesian',
+      it: 'Italian',
+      ja: 'Japanese',
+      ko: 'Korean',
+      nl: 'Dutch',
+      no: 'Norwegian',
+      pl: 'Polish',
+      pt: 'Portuguese',
+      ro: 'Romanian',
+      ru: 'Russian',
+      sv: 'Swedish',
+      th: 'Thai',
+      tr: 'Turkish',
+      uk: 'Ukrainian',
+      vi: 'Vietnamese',
+      zh: 'Chinese (simplified)',
+      zt: 'Chinese (traditional)',
+    },
+    default: 'en',
+    dependsOn: [{ key: 'chat.translate.backend', in: ['libretranslate', 'openai'] }],
+    description:
+      'The language incoming messages are translated into, and the default language ' +
+      'outgoing messages are translated to when posting translation is enabled for a ' +
+      'conversation.',
+  },
+
   // ─── Connection ───────────────────────────────────────────────────────
   {
     key: 'chat.quit_message',

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -12,6 +12,20 @@
     @dragleave.prevent="onDragLeave"
     @drop.prevent="onDrop"
   >
+    <!-- Outgoing-translation preview (rule 7): the user must SEE what they are
+         about to send in a language they may not read, and approve it with a
+         second Send. On failure the strip explains and the next Send bypasses
+         with the original as typed — a broken translator must never block
+         speech. -->
+    <div v-if="trPreview != null" class="tr-preview" aria-live="polite">
+      <i class="fa-solid fa-language" aria-hidden="true"></i>
+      <span class="tr-text">{{ trPreview }}</span>
+      <span class="tr-hint">Send again to confirm · Esc to cancel</span>
+    </div>
+    <div v-else-if="trBypass" class="tr-preview tr-failed" aria-live="polite">
+      <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+      <span class="tr-text">Translation failed — Send again to send the original text.</span>
+    </div>
     <span class="prompt"
       ><template v-if="!isMobile"
         >{{ promptLabelNoModes }}<span v-if="promptModes" class="modes">{{ promptModes }}</span
@@ -180,6 +194,8 @@ import { useSettingsStore } from '../stores/settings.js';
 import { useUploadsStore, onInsertUrl } from '../stores/uploads.js';
 import { useDccStore, percentReceived, type DccTransfer } from '../stores/dcc.js';
 import { useToastsStore } from '../stores/toasts.js';
+import { useTranslateStore } from '../stores/translate.js';
+import { isNoise, genuinelyChanged } from '../lib/translate/rules.js';
 import { useIgnoresStore, type IgnoreEntry } from '../stores/ignores.js';
 import { useRelayBotsStore } from '../stores/relayBots.js';
 import { useHighlightRulesStore, type HighlightRule } from '../stores/highlightRules.js';
@@ -245,6 +261,20 @@ const auth = useAuthStore();
 const inputHistory = useInputHistoryStore();
 const drafts = useDraftStore();
 const settings = useSettingsStore();
+const translate = useTranslateStore();
+// Outgoing-translation state (rule 7). Cleared on any edit: a preview of text
+// the user has since changed would approve the WRONG message.
+const trPreview = ref<string | null>(null);
+const trBusy = ref(false);
+const trBypass = ref(false);
+// The active buffer's server id — the key the per-conversation switches use.
+// Null for optimistic buffers the server hasn't acknowledged yet.
+const activeBufferId = computed<number | null>(() => {
+  const a = active.value;
+  if (!a) return null;
+  const b = buffers.byKey(bufferKey(a.networkId, a.target));
+  return (b?.id as number | undefined) ?? null;
+});
 const config = useConfigStore();
 const uploads = useUploadsStore();
 const dcc = useDccStore();
@@ -1053,6 +1083,14 @@ function onKeydown(e: KeyboardEvent): void {
       return;
     }
   }
+  // A pending outgoing-translation preview owns Escape: cancelling the
+  // preview must not also close pickers or clear other state.
+  if (e.key === 'Escape' && (trPreview.value != null || trBypass.value)) {
+    e.preventDefault();
+    trPreview.value = null;
+    trBypass.value = false;
+    return;
+  }
   if (e.key === 'Escape' && overlay.colorPickerOpen) {
     e.preventDefault();
     closeColorPicker();
@@ -1741,6 +1779,10 @@ function onHistorySelect(entry: string): void {
 // and running the pipeline for it would fire a typing notification and a draft
 // flush for a no-op edit.
 function syncModelFromDom() {
+  if (trPreview.value != null || trBypass.value) {
+    trPreview.value = null;
+    trBypass.value = false;
+  }
   const el = inputEl.value;
   if (!el || el.value === text.value) return;
   text.value = el.value;
@@ -2240,7 +2282,53 @@ async function submit() {
   // Rewrite `||spoiler||` into IRC spoiler codes on the way out. History keeps
   // the typed `||…||` form (commitInput is given `raw`), so up-arrow
   // round-trips the editable text rather than raw control codes.
-  const wireText = applySpoilerMarkup(escapedSlash ? raw.slice(1) : raw);
+  // Outgoing translation (rules 7 + 9). Sits AFTER slash-command handling —
+  // commands are protocol, not prose — and BEFORE the wire so the preview shows
+  // exactly what would be sent. No confidence gate on this path (rule 9): the
+  // user picked the target language; detection has no veto.
+  const plainOut = escapedSlash ? raw.slice(1) : raw;
+  if (
+    translate.enabled &&
+    activeBufferId.value != null &&
+    translate.postingEnabled(activeBufferId.value) &&
+    !trBypass.value &&
+    !isNoise(plainOut)
+  ) {
+    if (trPreview.value != null) {
+      // Second press: approved. Send the PREVIEWED text; history keeps `raw`
+      // (what the user typed), so up-arrow round-trips their own words.
+      const approved = trPreview.value;
+      trPreview.value = null;
+      return sendWire(applySpoilerMarkup(approved), raw, networkId, target);
+    }
+    try {
+      trBusy.value = true;
+      const out = await translate.translateOutgoing(plainOut);
+      trBusy.value = false;
+      // Identical result skips approval (rule 7) — nothing to inspect.
+      if (!genuinelyChanged(plainOut, out)) {
+        /* fall through and send the original below */
+      } else {
+        trPreview.value = out;
+        return; // first press: show, don't send
+      }
+    } catch (e: unknown) {
+      trBusy.value = false;
+      trBypass.value = true; // rule 7: next Send sends the original as typed
+      toasts.push({
+        title: 'Translation failed',
+        body:
+          (e instanceof Error ? e.message : 'translator unreachable') +
+          ' — Send again to send your original text.',
+        kind: 'warn',
+        ttlMs: 8000,
+      });
+      return;
+    }
+  }
+  trBypass.value = false;
+
+  const wireText = applySpoilerMarkup(plainOut);
   const pending = socketSendWithAck({ type: 'send', networkId, target, text: wireText });
   if (!pending) {
     // Socket isn't open — don't clear the input, don't pollute history. The
@@ -2254,6 +2342,30 @@ async function submit() {
   commitInput(raw, networkId, target, { isChatMessage: true });
   const result = await pending;
   if (!result.ok) toastSendFailure(result.error ?? 'unknown', raw);
+}
+
+/** The final leg of a plain-message send — socket, typing reset, history,
+ *  ACK — shared by the direct path and the approved-translation path so the
+ *  two can never drift. `historyText` is what commitInput records (always what
+ *  the user TYPED, so up-arrow round-trips their own words even when the wire
+ *  carried a translation). */
+async function sendWire(
+  wireText: string,
+  historyText: string,
+  networkId: number,
+  target: string,
+): Promise<void> {
+  const pending = socketSendWithAck({ type: 'send', networkId, target, text: wireText });
+  if (!pending) {
+    toastSendFailure('disconnected', historyText);
+    return;
+  }
+  typingState = null;
+  typingTarget = null;
+  clearInactivityTimer();
+  commitInput(historyText, networkId, target, { isChatMessage: true });
+  const result = await pending;
+  if (!result.ok) toastSendFailure(result.error ?? 'unknown', historyText);
 }
 
 async function onLongMessageConfirm() {
@@ -3759,5 +3871,33 @@ textarea:focus {
 textarea::placeholder {
   color: var(--fg-muted);
   font-style: italic;
+}
+
+/* Outgoing-translation preview strip (rule 7). Sits above the composer row;
+   grid-area inherit keeps it inside the input cell in both shells. */
+.tr-preview {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-1) var(--space-3);
+  font-size: 0.9em;
+  color: var(--fg-muted);
+  border-bottom: 1px dashed var(--border);
+}
+.tr-preview .tr-text {
+  flex: 1;
+  min-width: 0;
+  color: var(--fg);
+  overflow-wrap: anywhere;
+}
+.tr-preview .tr-hint {
+  white-space: nowrap;
+}
+.tr-preview.tr-failed {
+  color: var(--bad);
+}
+.tr-preview.tr-failed .tr-text {
+  color: var(--bad);
 }
 </style>

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -138,7 +138,13 @@
               :network-id="buffer?.networkId ?? null"
               interactive-nicks
               @nick-click="onMentionMenu"
-            />
+            /><span
+              v-if="translationFor(row.m)"
+              class="tr-overlay"
+              :title="'Translated from ' + badgeLang(translationFor(row.m)?.srcLang)"
+              ><span class="tr-badge">{{ badgeLang(translationFor(row.m)?.srcLang) }}→</span
+              >{{ translationFor(row.m)?.text }}</span
+            >
           </span>
           <span class="time">{{ row.continuationTime ? '' : time(row.m?.time) }}</span>
         </template>
@@ -296,6 +302,13 @@
                  every event row from an edit site giving no hint the two were connected.
                  They now render inside MessageBody, which IS the chain's first branch, so the
                  hazard is gone rather than avoided. -->
+            <span
+              v-if="translationFor(row.m)"
+              class="tr-overlay"
+              :title="'Translated from ' + badgeLang(translationFor(row.m)?.srcLang)"
+              ><span class="tr-badge">{{ badgeLang(translationFor(row.m)?.srcLang) }}→</span
+              >{{ translationFor(row.m)?.text }}</span
+            >
           </span>
         </template>
         <div
@@ -340,6 +353,8 @@ import { useSettingsStore } from '../stores/settings.js';
 import { useIgnoresStore } from '../stores/ignores.js';
 import { useHighlightRulesStore } from '../stores/highlightRules.js';
 import { useRelayBotsStore } from '../stores/relayBots.js';
+import { useTranslateStore } from '../stores/translate.js';
+import { badgeLang } from '../lib/translate/rules.js';
 import { socketSend } from '../composables/useSocket.js';
 import { useNickColors } from '../composables/useNickColors.js';
 import { useViewport } from '../composables/useViewport.js';
@@ -479,6 +494,29 @@ const config = useConfigStore();
 const ignores = useIgnoresStore();
 const highlights = useHighlightRulesStore();
 const relayBots = useRelayBotsStore();
+const translateStore = useTranslateStore();
+
+// Render-time translation overlay (rules 5, 11, 12). Asking is idempotent and
+// rule-gated in the store; the REQUEST outlives this row (a virtualized list
+// recycles rows constantly, and a row-owned request would be cancelled
+// mid-flight — the confirmed rule-11 bug from the Android client). The stored
+// message text is never touched, so links/highlights/search keep scanning the
+// original by construction (rule 5). Hangs off row.m, so every message in a
+// stacked sender group carries its own badge (rule 12).
+function translationFor(m: unknown): { text: string; srcLang: string | null } | null {
+  if (!m || !translateStore.enabled) return null;
+  const bufId = (buffer.value?.id as number | undefined) ?? null;
+  if (!translateStore.readingEnabled(bufId)) return null;
+  const msg = m as {
+    id?: number | null;
+    text?: unknown;
+    self?: unknown;
+    e2e?: unknown;
+    type?: string;
+  };
+  translateStore.request(msg);
+  return translateStore.overlayFor(bufId, msg.id ?? null);
+}
 const nicks = useNickColors();
 const { isMobile, canHover } = useViewport();
 
@@ -2731,5 +2769,22 @@ watch(
 }
 .cleared-undo:hover {
   color: var(--accent);
+}
+
+/* Translation overlay: a second line under the original (which stays exactly
+   as sent — the overlay is display-only). Muted + small badge so it reads as
+   an annotation, not as the message. */
+.tr-overlay {
+  display: block;
+  color: var(--fg-muted);
+  font-size: 0.92em;
+}
+.tr-overlay .tr-badge {
+  font-size: 0.85em;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-1);
+  margin-right: var(--space-1);
+  color: var(--fg-muted);
 }
 </style>

--- a/vue_client/src/lib/translate/backends.ts
+++ b/vue_client/src/lib/translate/backends.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The two translator clients. DEVICE-LOCAL by design: these fetches run in the
+// user's browser against an endpoint the user configured — the Lurker server
+// never sees the text or the credentials. That is what makes a local-network
+// translator (Ollama, LM Studio, self-hosted LibreTranslate) work at all, and
+// it is why the endpoint must speak CORS to the Lurker origin (stated in the
+// setting's description, because it is the #1 "nothing happens" cause).
+//
+// Both functions THROW on transport/HTTP failure and RETURN a result otherwise.
+// The store depends on that split (rule 10): a thrown error is transient and
+// must not be cached — the translator may simply be off right now — while a
+// returned low-confidence verdict is a property of the text and caches forever.
+
+export interface TranslateResult {
+  /** The translated text, verbatim from the backend. */
+  text: string;
+  /** Detected source language code, or null when the backend can't say
+   *  (OpenAI-compatible has no detection API). */
+  detectedLang: string | null;
+  /** Detection confidence 0–100, or null when unavailable. The caller applies
+   *  the rule-3 gate — the backend client just reports. */
+  confidence: number | null;
+}
+
+export interface TranslateConfig {
+  backend: 'libretranslate' | 'openai';
+  endpoint: string;
+  apiKey: string;
+  model: string;
+  targetLang: string;
+}
+
+/** One knob for both backends; a hung translator must not pin a message row's
+ *  overlay on "translating…" forever. */
+const TIMEOUT_MS = 20_000;
+
+async function post(url: string, body: unknown, headers: Record<string, string>): Promise<unknown> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    // Include the status in the thrown message — it is the difference between
+    // "wrong API key" (401), "wrong endpoint" (404) and "translator down"
+    // (5xx) when the posting flow surfaces a failure (rule 7).
+    throw new Error(`translator returned ${res.status}`);
+  }
+  return res.json();
+}
+
+/**
+ * LibreTranslate: POST {endpoint}/translate. Free and self-hostable; known weak
+ * on CJK (drops register and grammatical person — proposal, Known
+ * Limitations). Detection rides along in the same response.
+ */
+async function libretranslate(cfg: TranslateConfig, text: string): Promise<TranslateResult> {
+  const base = cfg.endpoint.replace(/\/+$/, '');
+  const body: Record<string, unknown> = {
+    q: text,
+    source: 'auto',
+    target: cfg.targetLang,
+    format: 'text',
+  };
+  if (cfg.apiKey) body.api_key = cfg.apiKey;
+  const json = (await post(`${base}/translate`, body, {})) as {
+    translatedText?: string;
+    detectedLanguage?: { language?: string; confidence?: number };
+  };
+  if (typeof json.translatedText !== 'string') throw new Error('translator returned no text');
+  return {
+    text: json.translatedText,
+    detectedLang: json.detectedLanguage?.language ?? null,
+    confidence: json.detectedLanguage?.confidence ?? null,
+  };
+}
+
+/** Append /v1 only when absent — an endpoint pasted WITH /v1 must not become
+ *  /v1/v1 (a confirmed paper-cut from the reference implementations). */
+export function openAiBase(endpoint: string): string {
+  const base = endpoint.replace(/\/+$/, '');
+  return /\/v1$/.test(base) ? base : `${base}/v1`;
+}
+
+/**
+ * OpenAI-compatible chat completion (Ollama, LM Studio, cloud gateways). No
+ * detection API, so detectedLang/confidence are null — the store treats
+ * "genuinely changed" (rule 4) as the only signal a translation happened.
+ */
+async function openai(cfg: TranslateConfig, text: string): Promise<TranslateResult> {
+  const headers: Record<string, string> = {};
+  // Bearer only when a key is configured: a local Ollama rejects nothing, but
+  // sending "Bearer " with an empty key trips some gateways' auth parsing.
+  if (cfg.apiKey) headers.authorization = `Bearer ${cfg.apiKey}`;
+  const json = (await post(
+    `${openAiBase(cfg.endpoint)}/chat/completions`,
+    {
+      model: cfg.model,
+      messages: [
+        {
+          role: 'system',
+          // The proposal's prompt, verbatim. "Output ONLY the translation" is
+          // load-bearing: chat models love to add quotes and commentary, and
+          // either one would badge every message as changed (rule 4).
+          content:
+            `You are a translator for a live chat. Translate each message into ` +
+            `${cfg.targetLang}. Output ONLY the translation—no commentary, no quotes.`,
+        },
+        { role: 'user', content: text },
+      ],
+      temperature: 0,
+    },
+    headers,
+  )) as { choices?: Array<{ message?: { content?: string } }> };
+  const out = json.choices?.[0]?.message?.content;
+  if (typeof out !== 'string' || !out.trim()) throw new Error('translator returned no text');
+  return { text: out.trim(), detectedLang: null, confidence: null };
+}
+
+/** Translate `text` with whichever backend is configured. Throws on transport
+ *  failure (transient — do not cache); returns on success (cacheable). */
+export function translate(cfg: TranslateConfig, text: string): Promise<TranslateResult> {
+  return cfg.backend === 'libretranslate' ? libretranslate(cfg, text) : openai(cfg, text);
+}

--- a/vue_client/src/lib/translate/rules.test.ts
+++ b/vue_client/src/lib/translate/rules.test.ts
@@ -1,0 +1,313 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The twelve translation rules, as assertions. Each numbered describe cites
+// the rule from the proposal doc; every one was a shipped bug in a reference
+// client (Scully desktop / Spooky Android) before it became a rule, so a
+// failure here is a regression of something that has already burned us once.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import {
+  stripUrls,
+  isNoise,
+  letterCount,
+  collapseRepeats,
+  genuinelyChanged,
+  passesConfidenceGate,
+  badgeLang,
+  MIN_DETECT_CONFIDENCE,
+} from './rules.js';
+import { openAiBase } from './backends.js';
+
+describe('rule 2 — noise skips before transmission', () => {
+  it('skips text with ≤2 letters', () => {
+    expect(isNoise('ok')).toBe(true);
+    expect(isNoise(':)')).toBe(true);
+    expect(isNoise('!!')).toBe(true);
+    expect(isNoise('a b')).toBe(true);
+  });
+
+  it('skips interjections, including repeat-stretched forms (pre-collapsed list)', () => {
+    for (const t of ['lol', 'LOOOOL', 'hahahaha', 'lmaooo', 'okkk', 'wow', 'hmm']) {
+      expect(isNoise(t), t).toBe(true);
+    }
+  });
+
+  it('does not skip real sentences', () => {
+    expect(isNoise('where are you from?')).toBe(false);
+    expect(isNoise('je ne comprends pas')).toBe(false);
+  });
+
+  it('is Unicode-aware: short CJK text is not letter-starved noise', () => {
+    // "你好吗" is 3 letters — a real question, not noise.
+    expect(letterCount('你好吗')).toBe(3);
+    expect(isNoise('你好吗')).toBe(false);
+  });
+
+  it('collapseRepeats maps stretched interjections onto list entries', () => {
+    expect(collapseRepeats('loool')).toBe('lol');
+    // Repeated GROUP collapses to its base syllable, which is a listed interjection.
+    expect(collapseRepeats('hahahaha')).toBe('ha');
+    expect(collapseRepeats('jajaja')).toBe('ja');
+    // Legitimate doubles survive: "good" must not become "god".
+    expect(collapseRepeats('good')).toBe('good');
+  });
+});
+
+describe('rule 8 — strip URLs before applying skip rules', () => {
+  it('a message that is only a URL is noise (0-letter after strip)', () => {
+    // URLs carry many letters but score 0.0 confidence at the translator —
+    // without the strip they pass the letter check, get sent, fail, and retry
+    // on every render (the confirmed Android bug).
+    expect(isNoise('https://example.com/some/long/path?q=hello')).toBe(true);
+    expect(isNoise('www.example.com')).toBe(true);
+  });
+
+  it('a URL plus real words is NOT noise', () => {
+    expect(isNoise('regarde ça https://example.com')).toBe(false);
+  });
+
+  it('stripUrls removes both scheme and www forms', () => {
+    expect(stripUrls('a https://x.io b www.y.z c').replace(/\s+/g, ' ')).toBe('a b c');
+  });
+});
+
+describe('rule 3 — incoming detection gated at 60% confidence', () => {
+  it('gates below the threshold, passes at and above it', () => {
+    expect(passesConfidenceGate(MIN_DETECT_CONFIDENCE - 1)).toBe(false);
+    expect(passesConfidenceGate(MIN_DETECT_CONFIDENCE)).toBe(true);
+    expect(passesConfidenceGate(100)).toBe(true);
+    expect(passesConfidenceGate(0)).toBe(false);
+  });
+
+  it('null/undefined confidence PASSES — OpenAI-compatible has no detection API', () => {
+    // Gating null would disable that whole backend; "genuinely changed" is its
+    // only signal, by design (see rules 4 and 9 notes in the store).
+    expect(passesConfidenceGate(null)).toBe(true);
+    expect(passesConfidenceGate(undefined)).toBe(true);
+  });
+});
+
+describe('rule 4 — badge only genuinely-changed messages', () => {
+  it('identical text means no translation occurred', () => {
+    expect(genuinelyChanged('hello there', 'hello there')).toBe(false);
+  });
+
+  it('whitespace and case differences do not count as change', () => {
+    expect(genuinelyChanged('hello  there', ' hello there ')).toBe(false);
+    expect(genuinelyChanged('Hello', 'hello')).toBe(false);
+  });
+
+  it('a real translation counts', () => {
+    expect(genuinelyChanged('bonjour', 'hello')).toBe(true);
+  });
+
+  it('an empty result never counts as a translation', () => {
+    expect(genuinelyChanged('bonjour', '')).toBe(false);
+    expect(genuinelyChanged('bonjour', '   ')).toBe(false);
+  });
+});
+
+describe('unknown language codes render as themselves (known limitation)', () => {
+  it('badgeLang falls back to the raw code, then to ?', () => {
+    expect(badgeLang('zh-Hans')).toBe('zh-Hans');
+    expect(badgeLang('fr')).toBe('fr');
+    expect(badgeLang(null)).toBe('?');
+    expect(badgeLang('  ')).toBe('?');
+  });
+});
+
+describe('openAiBase — /v1 appended only when absent', () => {
+  it('appends and deduplicates correctly', () => {
+    expect(openAiBase('http://localhost:11434')).toBe('http://localhost:11434/v1');
+    expect(openAiBase('http://localhost:11434/')).toBe('http://localhost:11434/v1');
+    expect(openAiBase('http://localhost:11434/v1')).toBe('http://localhost:11434/v1');
+    expect(openAiBase('http://localhost:11434/v1/')).toBe('http://localhost:11434/v1');
+  });
+});
+
+// ─── Store-level rules (1, 6, 9, 10, 11) ────────────────────────────────────
+// Exercised through the real store with a mocked fetch — the rules live in its
+// gating, and asserting them any lower would test the mock.
+
+function fetchOk(body: unknown) {
+  return vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(body) });
+}
+
+async function makeStore() {
+  const { useTranslateStore } = await import('../../stores/translate.js');
+  const { useSettingsStore } = await import('../../stores/settings.js');
+  const settings = useSettingsStore();
+  settings.values['chat.translate.backend'] = 'libretranslate';
+  settings.values['chat.translate.endpoint'] = 'https://tr.test';
+  settings.values['chat.translate.target_lang'] = 'en';
+  return useTranslateStore();
+}
+
+/** The store's bounded-concurrency queue re-polls on a 120ms timer; tests that
+ *  need a request to LAND must wait through at least one poll. */
+const settle = () => new Promise((r) => setTimeout(r, 250));
+
+describe('store rules', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    // node test env has no localStorage; the store guards its own access, but
+    // the prefs actions call it — a tiny in-memory shim keeps them exercised.
+    const mem = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => mem.get(k) ?? null,
+      setItem: (k: string, v: string) => void mem.set(k, v),
+      removeItem: (k: string) => void mem.delete(k),
+      clear: () => mem.clear(),
+    });
+    vi.useRealTimers();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('rule 1 — never translates your own messages', async () => {
+    const store = await makeStore();
+    const f = fetchOk({});
+    vi.stubGlobal('fetch', f);
+    store.request({ id: 1, text: 'bonjour tout le monde', self: true, type: 'message' });
+    await settle();
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it('E2E policy — an encrypted message is never sent to a translator', async () => {
+    const store = await makeStore();
+    const f = fetchOk({});
+    vi.stubGlobal('fetch', f);
+    store.request({ id: 2, text: 'mensaje privado cifrado', e2e: true, type: 'message' });
+    await settle();
+    expect(f).not.toHaveBeenCalled();
+    // And no verdict either: the overlay for this message must never exist.
+    expect(Object.keys(store.verdicts)).toHaveLength(0);
+  });
+
+  it('protocol events are not prose — join/quit rows are never sent', async () => {
+    const store = await makeStore();
+    const f = fetchOk({});
+    vi.stubGlobal('fetch', f);
+    store.request({ id: 3, text: 'quit message here', type: 'quit' });
+    await settle();
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it('rule 10 — low-confidence caches permanently; transient failures cache nothing', async () => {
+    const store = await makeStore();
+    // First: a low-confidence detection → permanent negative verdict.
+    vi.stubGlobal(
+      'fetch',
+      fetchOk({ translatedText: 'x', detectedLanguage: { language: 'pt', confidence: 30 } }),
+    );
+    store.request({ id: 4, text: 'texto curto ambíguo', type: 'message' });
+    await settle();
+    expect(store.verdicts['4|en']).toEqual({ kind: 'low-confidence' });
+
+    // Second: a transport failure → NO cache entry, so a later request retries.
+    const failing = vi.fn().mockRejectedValue(new Error('down'));
+    vi.stubGlobal('fetch', failing);
+    store.request({ id: 5, text: 'another real message here', type: 'message' });
+    await settle();
+    expect(store.verdicts['5|en']).toBeUndefined();
+
+    // Translator comes back: the SAME message now succeeds retroactively.
+    vi.stubGlobal(
+      'fetch',
+      fetchOk({
+        translatedText: 'hello again',
+        detectedLanguage: { language: 'fr', confidence: 95 },
+      }),
+    );
+    store.request({ id: 5, text: 'another real message here', type: 'message' });
+    await settle();
+    expect(store.verdicts['5|en']).toEqual({
+      kind: 'translated',
+      text: 'hello again',
+      srcLang: 'fr',
+    });
+  });
+
+  it('rule 6 — toggling reading off invalidates cached overlays', async () => {
+    const store = await makeStore();
+    vi.stubGlobal(
+      'fetch',
+      fetchOk({ translatedText: 'hi', detectedLanguage: { language: 'es', confidence: 90 } }),
+    );
+    store.request({ id: 6, text: 'hola a todos amigos', type: 'message' });
+    await settle();
+    expect(store.verdicts['6|en']).toBeTruthy();
+    store.setReading(1, false);
+    expect(Object.keys(store.verdicts)).toHaveLength(0);
+  });
+
+  it('rule 11 — a request is store-owned: nothing a row does can cancel it', async () => {
+    const store = await makeStore();
+    let resolveFetch!: (v: unknown) => void;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockReturnValue(
+        new Promise((r) => {
+          resolveFetch = r;
+        }),
+      ),
+    );
+    // A "row" asks, then unmounts (rows hold no handle to cancel — the API
+    // simply offers none). The request must still land.
+    store.request({ id: 7, text: 'une phrase complète ici', type: 'message' });
+    await new Promise((r) => setTimeout(r, 10));
+    resolveFetch({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          translatedText: 'a full sentence here',
+          detectedLanguage: { language: 'fr', confidence: 92 },
+        }),
+    });
+    await settle();
+    expect(store.verdicts['7|en']?.kind).toBe('translated');
+  });
+
+  it('rule 9 — outgoing translation applies no confidence gate', async () => {
+    const store = await makeStore();
+    // A response with abysmal detection confidence must still return the
+    // translation: the user chose the target language explicitly.
+    vi.stubGlobal(
+      'fetch',
+      fetchOk({
+        translatedText: 'hola mundo',
+        detectedLanguage: { language: 'en', confidence: 5 },
+      }),
+    );
+    await expect(store.translateOutgoing('hello world')).resolves.toBe('hola mundo');
+  });
+
+  it('rule 4 at the store — unchanged results verdict as unchanged, no overlay', async () => {
+    const store = await makeStore();
+    vi.stubGlobal(
+      'fetch',
+      fetchOk({
+        translatedText: 'already english',
+        detectedLanguage: { language: 'en', confidence: 99 },
+      }),
+    );
+    store.request({ id: 8, text: 'already english', type: 'message' });
+    await settle();
+    expect(store.verdicts['8|en']).toEqual({ kind: 'unchanged' });
+    store.setReading(9, true);
+    expect(store.overlayFor(9, 8)).toBeNull();
+  });
+
+  it('rule 2 at the store — noise verdicts as skipped without a network call', async () => {
+    const store = await makeStore();
+    const f = fetchOk({});
+    vi.stubGlobal('fetch', f);
+    store.request({ id: 9, text: 'lol', type: 'message' });
+    await settle();
+    expect(f).not.toHaveBeenCalled();
+    expect(store.verdicts['9|en']).toEqual({ kind: 'skipped' });
+  });
+});

--- a/vue_client/src/lib/translate/rules.ts
+++ b/vue_client/src/lib/translate/rules.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The translation skip/gate rules, as pure functions. Every rule here was a
+// SHIPPED BUG in one of the two native clients (Scully desktop, Spooky
+// Android) before it became a rule — the numbering follows the proposal doc so
+// the test suite can cite them. Keep this module free of stores, fetch, and
+// Vue: the rules are the load-bearing correctness surface and must be testable
+// with no harness.
+
+/** Rule 3/9's gate: LibreTranslate misidentifies short text below this
+ *  confidence and then confidently mistranslates it. Applies to INCOMING
+ *  detection only — an outgoing translation's target was chosen explicitly by
+ *  the user, so detection confidence is irrelevant there (rule 9). */
+export const MIN_DETECT_CONFIDENCE = 60;
+
+// Rule 8: URLs contain many letters but translate to nothing — LibreTranslate
+// scores them 0.0 confidence, and without stripping them first a link-heavy
+// message fails the noise check, gets sent, fails the gate, and gets retried on
+// every render. Strip before ANY other rule looks at the text.
+const URL_RE = /\bhttps?:\/\/\S+|\bwww\.\S+/gi;
+
+export function stripUrls(text: string): string {
+  return text.replace(URL_RE, ' ');
+}
+
+// Rule 2's interjection list. ⚠ STORED PRE-COLLAPSED: the runtime check
+// collapses character runs ("looool" → "lol", "hahahaha" → "haha") before
+// matching, so an entry with its own repeats ("lool") would never match its
+// collapsed form and silently rot. Lowercase, collapsed, no punctuation.
+const INTERJECTIONS = new Set([
+  'lol',
+  'lmao',
+  'rofl',
+  'haha',
+  'hehe',
+  'jaja',
+  // Base laughter syllables: the group-collapse reduces "hahaha"/"jajaja" to
+  // these, so they must be present for the collapsed form to read as noise.
+  'ha',
+  'he',
+  'ja',
+  'ok',
+  'okay',
+  'k',
+  'kk',
+  'ty',
+  'thx',
+  'np',
+  'yw',
+  'brb',
+  'afk',
+  'gg',
+  'gn',
+  'gm',
+  'wb',
+  'hi',
+  'hey',
+  'yo',
+  'o',
+  'oh',
+  'ah',
+  'hm',
+  'hmm',
+  'wow',
+  'oof',
+  'rip',
+  'nice',
+  'same',
+  'this',
+  'yes',
+  'no',
+  'yeah',
+  'nah',
+  'yep',
+  'nope',
+  'xd',
+  'uwu',
+  'wtf',
+  'omg',
+  'idk',
+  'imo',
+  'smh',
+]);
+
+/** Normalize a stretched interjection toward its list form. Two independent
+ *  stretch shapes occur and both must fold:
+ *    - single-char runs:  "loool" → "lol",  "okkk" → "ok"
+ *    - repeated groups:   "hahaha" → "ha…",  "jajaja" → "ja…"
+ *  Returns the shortest form that is a known interjection, else a best-effort
+ *  single-char dedupe. Legitimate doubles ("good") are only touched when the
+ *  dedupe lands on a real interjection, so "good" stays "good". */
+export function collapseRepeats(text: string): string {
+  // Collapse a repeated multi-char GROUP to one instance: (ha)(ha)(ha)→ha.
+  const ungrouped = text.replace(/^(.{2,}?)\1+$/, '$1');
+  if (INTERJECTIONS.has(ungrouped)) return ungrouped;
+  // Collapse single-char runs entirely: loool→lol, hahaha (already ha)→ha.
+  const deduped = ungrouped.replace(/(.)\1+/g, '$1');
+  if (INTERJECTIONS.has(deduped)) return deduped;
+  // Nothing matched a known interjection — return the input UNCHANGED. Reducing
+  // it anyway would mangle real words: "good"→"god" is not a normalization, it
+  // is data loss, and isNoise would then mis-skip a legitimate message.
+  return text;
+}
+
+/** Count of letter characters (any script), the measure rule 2 gates on.
+ *  Unicode-aware: "你好" is 2 letters, not 0 — CJK text must not read as noise. */
+export function letterCount(text: string): number {
+  const m = text.match(/\p{L}/gu);
+  return m ? m.length : 0;
+}
+
+/**
+ * Rule 2 + 8: should this text skip translation entirely, before any network
+ * call? True for text that is nothing but URLs, ≤2 letters after stripping
+ * them, or a known interjection. Skipping is free; a wasted translation costs
+ * a round-trip per render per reader.
+ */
+export function isNoise(text: string): boolean {
+  const stripped = stripUrls(text).trim();
+  if (letterCount(stripped) <= 2) return true;
+  const collapsed = collapseRepeats(stripped.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, ''));
+  return INTERJECTIONS.has(collapsed);
+}
+
+/**
+ * Rule 4: a translation only counts as one when the text genuinely changed.
+ * Whitespace-insensitive: translators love to trim or re-space, and a badge on
+ * a message whose visible text is identical reads as a client bug.
+ */
+export function genuinelyChanged(original: string, translated: string): boolean {
+  const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
+  const a = norm(original);
+  const b = norm(translated);
+  return b.length > 0 && a.toLowerCase() !== b.toLowerCase();
+}
+
+/**
+ * Rule 3 (incoming only — see rule 9): trust a detection only at ≥60%
+ * confidence. Below that LibreTranslate's guess is frequently wrong, and a
+ * wrong source language produces a fluent, confident, incorrect translation —
+ * worse than none, because nothing about it looks broken.
+ *
+ * The known cost (proposal, Known Limitations): short Spanish/Portuguese
+ * messages often score below the gate and stay untranslated. Visible
+ * incompleteness is the accepted trade for never showing a wrong translation.
+ */
+export function passesConfidenceGate(confidence: number | null | undefined): boolean {
+  // ⚠ null/undefined PASSES, deliberately. A backend that reports no confidence
+  // (every OpenAI-compatible one — they have no detection API) must not be
+  // silently disabled by this gate; for those, "genuinely changed" (rule 4) is
+  // the only signal a translation happened. The gate exists to catch a LOW
+  // reported confidence, not an absent one.
+  if (confidence == null) return true;
+  return confidence >= MIN_DETECT_CONFIDENCE;
+}
+
+/** Render an ISO code for the badge. Rule/limitation: detectors emit codes
+ *  outside our picker (e.g. `zh-Hans`) — render unknown codes as themselves
+ *  rather than dropping the badge or crashing a lookup. */
+export function badgeLang(code: string | null | undefined): string {
+  return (code ?? '').trim() || '?';
+}

--- a/vue_client/src/stores/translate.ts
+++ b/vue_client/src/stores/translate.ts
@@ -1,0 +1,270 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Live message translation. DEVICE-LOCAL: the browser calls the translator the
+// user configured (chat.translate.* settings); the Lurker server is never in
+// the path and never learns which messages were translated. Translation is a
+// RENDER-TIME OVERLAY — the stored message text is never modified, so links,
+// media, highlights and search all keep scanning the original (rule 5 is
+// satisfied structurally, not by discipline at every call site).
+//
+// ⚠ REQUESTS ARE SCOPED TO THIS STORE, NOT TO MESSAGE ROWS (rule 11). The
+// message list is virtualized: rows unmount as they scroll away, and a request
+// owned by a row would be cancelled mid-flight — in the reference Android
+// client that left cache entries pinned "in flight" forever, permanently
+// breaking those messages. Here a row merely *asks*; the fetch and the cache
+// entry belong to the store and outlive any row.
+//
+// Cache verdicts vs transient failures (rule 10): a low-confidence detection is
+// a property of the TEXT and caches permanently — retrying it would produce
+// the same wrong guess with the same wrong translation. A network/HTTP failure
+// is a property of the MOMENT and is deliberately NOT cached, so a translator
+// that comes online later works retroactively as rows re-request.
+//
+// E2E POLICY (explicit, per the proposal — silence here would be indefensible):
+// messages that rode the wire encrypted (msg.e2e, RPE2E #382) are NEVER sent to
+// a translator, even a local one. The sender chose end-to-end encryption;
+// shipping their plaintext to any third endpoint — however trusted by the
+// *reader* — breaks a promise the reader can't waive on the sender's behalf.
+// There is no opt-in for this. The overlay for such messages simply never
+// exists.
+
+import { defineStore } from 'pinia';
+import { useSettingsStore } from './settings.js';
+import { translate, type TranslateConfig } from '../lib/translate/backends.js';
+import {
+  isNoise,
+  genuinelyChanged,
+  passesConfidenceGate,
+  stripUrls,
+} from '../lib/translate/rules.js';
+
+/** A cached, final verdict for one (message, target-language). */
+export type Verdict =
+  | { kind: 'translated'; text: string; srcLang: string | null }
+  // Rule 4: the backend answered but nothing genuinely changed — no badge, no
+  // overlay. Cached so the message is never re-sent.
+  | { kind: 'unchanged' }
+  // Rule 3+10: detection below the gate. A permanent negative — see header.
+  | { kind: 'low-confidence' }
+  // Rule 2: never sent at all (noise/URL-only). Cached to keep the skip free.
+  | { kind: 'skipped' };
+
+function cacheKey(msgId: number, targetLang: string): string {
+  return `${msgId}|${targetLang}`;
+}
+
+// Device-local persistence for the per-conversation switches. localStorage, not
+// server settings, deliberately: which conversations you translate is as
+// private as the messages themselves, and the whole feature is premised on the
+// server never learning either. Keyed by bufferId (stable across renames,
+// #744-style) — an optimistic buffer with no id yet simply can't be toggled,
+// which is fine: it has no history to translate either.
+const LS_KEY = 'lurker:translate:buffers';
+
+interface BufferPrefs {
+  /** Translate incoming messages in this conversation. */
+  read?: boolean;
+  /** Translate outgoing messages before sending (with approval). */
+  post?: boolean;
+}
+
+function loadPrefs(): Record<string, BufferPrefs> {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    return raw ? (JSON.parse(raw) as Record<string, BufferPrefs>) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** How many fetches may be in flight at once. Translators are usually local
+ *  and fast, but a cold Ollama model load can take seconds — an unbounded
+ *  burst on first render of a busy channel would queue-bomb it. */
+const MAX_IN_FLIGHT = 3;
+
+export const useTranslateStore = defineStore('translate', {
+  state: () => ({
+    /** cacheKey → final verdict. Reactive so overlays appear as results land. */
+    verdicts: {} as Record<string, Verdict>,
+    /** cacheKey set for requests currently on the wire — dedupe, not ownership. */
+    inFlight: {} as Record<string, true>,
+    /** bufferId(string) → per-conversation switches. */
+    prefs: loadPrefs() as Record<string, BufferPrefs>,
+    /** FIFO of pending cache keys + their fetch thunks (bounded concurrency). */
+    queueDepth: 0,
+  }),
+
+  getters: {
+    /** The whole feature exists only when a backend is configured. Off hides
+     *  every toggle and overlay — a switch that does nothing is worse than no
+     *  switch (same doctrine as requiresFeature in the registry). */
+    enabled(): boolean {
+      const s = useSettingsStore();
+      return s.effective('chat.translate.backend') !== 'off';
+    },
+
+    config(): TranslateConfig | null {
+      const s = useSettingsStore();
+      const backend = s.effective('chat.translate.backend') as string;
+      if (backend !== 'libretranslate' && backend !== 'openai') return null;
+      const endpoint = String(s.effective('chat.translate.endpoint') ?? '').trim();
+      if (!endpoint) return null;
+      return {
+        backend,
+        endpoint,
+        apiKey: String(s.effective('chat.translate.api_key') ?? ''),
+        model: String(s.effective('chat.translate.model') ?? ''),
+        targetLang: String(s.effective('chat.translate.target_lang') ?? 'en'),
+      };
+    },
+
+    readingEnabled(state) {
+      return (bufferId: number | null | undefined): boolean =>
+        bufferId != null && state.prefs[String(bufferId)]?.read === true;
+    },
+
+    postingEnabled(state) {
+      return (bufferId: number | null | undefined): boolean =>
+        bufferId != null && state.prefs[String(bufferId)]?.post === true;
+    },
+
+    /** The overlay for a rendered row, or null. Null for: feature off, reading
+     *  off for the buffer, no verdict yet, or a verdict with nothing to show. */
+    overlayFor() {
+      return (
+        bufferId: number | null | undefined,
+        msgId: number | null | undefined,
+      ): { text: string; srcLang: string | null } | null => {
+        if (msgId == null || !this.enabled || !this.readingEnabled(bufferId)) return null;
+        const cfg = this.config;
+        if (!cfg) return null;
+        const v = this.verdicts[cacheKey(msgId, cfg.targetLang)];
+        return v?.kind === 'translated' ? { text: v.text, srcLang: v.srcLang } : null;
+      };
+    },
+  },
+
+  actions: {
+    persistPrefs() {
+      try {
+        localStorage.setItem(LS_KEY, JSON.stringify(this.prefs));
+      } catch {
+        /* storage full/blocked — the toggles just don't survive reload */
+      }
+    },
+
+    setReading(bufferId: number, on: boolean) {
+      const k = String(bufferId);
+      this.prefs[k] = { ...this.prefs[k], read: on };
+      this.persistPrefs();
+      // Rule 6: toggling invalidates. Without this, flipping read off and on
+      // (or after changing backend/endpoint) shows stale overlays produced by
+      // the previous configuration.
+      if (!on) this.invalidate();
+    },
+
+    setPosting(bufferId: number, on: boolean) {
+      const k = String(bufferId);
+      this.prefs[k] = { ...this.prefs[k], post: on };
+      this.persistPrefs();
+    },
+
+    /** Drop every cached verdict (config change, reading toggled). In-flight
+     *  requests are left to land — their results key on the OLD target lang,
+     *  so they simply become unreachable rather than wrong. */
+    invalidate() {
+      this.verdicts = {};
+    },
+
+    /**
+     * A rendered row asks for its translation. Idempotent and cheap to call on
+     * every render: cached, in-flight-deduped, and rule-gated before any
+     * network. The request survives the row unmounting (rule 11).
+     */
+    request(msg: {
+      id?: number | null;
+      text?: unknown;
+      self?: unknown;
+      e2e?: unknown;
+      type?: string;
+    }) {
+      if (!this.enabled) return;
+      const cfg = this.config;
+      if (!cfg) return;
+      const msgId = msg.id;
+      const text = typeof msg.text === 'string' ? msg.text : '';
+      if (msgId == null || !text) return;
+      // Only chat-shaped rows: joins/quits/topics are protocol events, not prose.
+      if (msg.type !== 'message' && msg.type !== 'action') return;
+      // Rule 1: NEVER the user's own messages. Auto-detection on your own text
+      // produces false positives ("that's not even the right language") and
+      // there is no reader-side value: you wrote it, you can read it.
+      if (msg.self === true) return;
+      // E2E policy — see the header. Not a setting, not an opt-in.
+      if (msg.e2e === true) return;
+
+      const key = cacheKey(msgId, cfg.targetLang);
+      if (this.verdicts[key] || this.inFlight[key]) return;
+
+      // Rule 2 + 8: noise never leaves the device. Cached as a verdict so the
+      // check runs once per message, not once per render.
+      if (isNoise(text)) {
+        this.verdicts[key] = { kind: 'skipped' };
+        return;
+      }
+
+      this.inFlight[key] = true;
+      void this.run(key, cfg, text);
+    },
+
+    async run(key: string, cfg: TranslateConfig, text: string) {
+      // Bounded concurrency: naive spin-wait-free FIFO — each runner defers
+      // while MAX_IN_FLIGHT peers are on the wire. Order isn't important
+      // (verdicts land keyed), only the bound is.
+      while (this.queueDepth >= MAX_IN_FLIGHT) {
+        await new Promise((r) => setTimeout(r, 120));
+      }
+      this.queueDepth++;
+      try {
+        const res = await translate(cfg, text);
+        // Rule 3: gate the DETECTION, not the transport. LibreTranslate reports
+        // confidence; OpenAI-compatible reports null, which passes — "changed"
+        // (rule 4) is that backend's only signal, by design.
+        if (res.confidence != null && !passesConfidenceGate(res.confidence)) {
+          // Rule 10: permanent negative — same text would yield the same bad
+          // guess. Distinct from the catch below, which caches NOTHING.
+          this.verdicts[key] = { kind: 'low-confidence' };
+          return;
+        }
+        // A message that is URLs + text translates as its text; compare against
+        // the original with URLs intact so a translator that ate the URL still
+        // counts as changed only when the words changed.
+        this.verdicts[key] = genuinelyChanged(stripUrls(text), stripUrls(res.text))
+          ? { kind: 'translated', text: res.text, srcLang: res.detectedLang }
+          : { kind: 'unchanged' };
+      } catch {
+        // Rule 10: transient — translator down, CORS, timeout. Cache nothing;
+        // the next render re-requests, so a translator coming online works
+        // retroactively for everything still on screen.
+      } finally {
+        this.queueDepth--;
+        delete this.inFlight[key];
+      }
+    },
+
+    /**
+     * Outgoing path (rule 7): translate what the user typed, for preview.
+     * Returns the translation or throws — the caller owns the
+     * preview→approve→send workflow and the failure bypass. Rule 9: NO
+     * confidence gate here — the user chose the target language explicitly, so
+     * detection has no veto.
+     */
+    async translateOutgoing(text: string, targetLang?: string): Promise<string> {
+      const cfg = this.config;
+      if (!cfg) throw new Error('no translator configured');
+      const res = await translate(targetLang ? { ...cfg, targetLang } : cfg, text);
+      return res.text;
+    },
+  },
+});

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -134,6 +134,50 @@
                parity with the mobile topic bar. The server buffer has no
                per-buffer scope, so it's excluded. -->
           <template v-if="!isServerBuffer">
+            <!-- Live translation (device-local). Only rendered when a backend is
+                 configured — a switch with no service behind it is worse than
+                 none. Reading = overlay incoming; posting = translate-approve
+                 outgoing. Per-conversation, off by default. -->
+            <template v-if="translateStore.enabled && activeBufId != null">
+              <button
+                type="button"
+                class="link"
+                :class="{ 'tr-on': translateStore.readingEnabled(activeBufId) }"
+                :title="
+                  translateStore.readingEnabled(activeBufId)
+                    ? 'Stop translating incoming messages'
+                    : 'Translate incoming messages'
+                "
+                aria-label="Toggle incoming translation"
+                @click="
+                  translateStore.setReading(
+                    activeBufId,
+                    !translateStore.readingEnabled(activeBufId),
+                  )
+                "
+              >
+                <i class="fa-solid fa-language"></i>
+              </button>
+              <button
+                type="button"
+                class="link"
+                :class="{ 'tr-on': translateStore.postingEnabled(activeBufId) }"
+                :title="
+                  translateStore.postingEnabled(activeBufId)
+                    ? 'Stop translating outgoing messages'
+                    : 'Translate outgoing messages (with approval)'
+                "
+                aria-label="Toggle outgoing translation"
+                @click="
+                  translateStore.setPosting(
+                    activeBufId,
+                    !translateStore.postingEnabled(activeBufId),
+                  )
+                "
+              >
+                <i class="fa-solid fa-pen-to-square"></i>
+              </button>
+            </template>
             <button
               type="button"
               class="link"
@@ -346,6 +390,7 @@ import { useMediaViewer } from '../composables/useMediaViewer.js';
 import { useNetworkEditor } from '../composables/useNetworkEditor.js';
 import { useJumpToMessage } from '../composables/useJumpToMessage.js';
 import { useNavHistoryStore } from '../stores/navHistory.js';
+import { useTranslateStore } from '../stores/translate.js';
 
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
@@ -394,6 +439,12 @@ const joinChannelModal = reactive(useJoinChannelModal());
 const viewer = reactive(useMediaViewer());
 const networkEditor = reactive(useNetworkEditor());
 const navHistory = useNavHistoryStore();
+const translateStore = useTranslateStore();
+// The active buffer's server id — what the per-conversation translate switches
+// key on. Null for an optimistic buffer the server hasn't acknowledged.
+const activeBufId = computed<number | null>(
+  () => (activeBuf.value as { id?: number } | null)?.id ?? null,
+);
 const showBookmarks = ref(false);
 const showTopic = ref(false);
 const showUploads = ref(false);
@@ -951,5 +1002,10 @@ button.topic-text:focus-visible {
 .topic .member-count {
   color: var(--fg-muted);
   font-variant-numeric: tabular-nums;
+}
+
+/* Translate toggles: accent when live for this conversation. */
+.topic-actions .link.tr-on {
+  color: var(--accent);
 }
 </style>


### PR DESCRIPTION
## Live message translation (device-local)

Reading and posting translation for a conversation, off by default. Implements the proposal circulated in `#lurker` ([doc](https://yeet.irc.so/u/LURKER-TRANSLATE-PROPOSAL.md)); the twelve rules it lists were each a shipped bug in Scully (desktop) or Spooky (Android) before they were rules, and they're encoded here as tests.

### What it is
- **Reading:** a per-conversation toggle overlays incoming foreign messages with a translation + a source-language badge (`fr→`). The original text is never touched.
- **Posting:** a second toggle translates outgoing messages, shows a preview, and sends on a second Send. Esc cancels; editing invalidates the preview; a failed translator bypasses to the original.
- **Backends:** LibreTranslate (self-hostable) or any OpenAI-compatible endpoint (Ollama, LM Studio, a gateway).

### Why it should be easy to review
- **No server changes. No protocol changes. No schema changes.** Entirely client-side — matches the proposal's non-goals. The only shared/ change is five `chat.translate.*` keys added to `settingsRegistry.ts`.
- **Device-local, mirroring the previews split.** The browser calls the endpoint the *user* configured; the Lurker server is never in the path and never learns which messages were translated. Every setting description says so — same privacy-honesty as the `chat.inline_media` description.
- **Gated the way `requiresFeature` gates previews.** No backend configured → no toggle, no overlay, nothing rendered. A switch with no service behind it is never shown.
- **Reverts cleanly** — one commit, no entanglement with anything else.

### The E2E decision (made in code, flag for review)
The proposal called out E2E as needing a policy call. I made the strict one: a message that rode the wire encrypted (`msg.e2e`, RPE2E #382) is **never** sent to a translator — no opt-in, no setting. The sender chose end-to-end encryption; a reader can't waive that on their behalf. A test asserts no verdict ever exists for such a message. Happy to change it to a named opt-in if you'd prefer, but silent transmission was the one option the proposal called indefensible.

### Structure
- `lib/translate/rules.ts` + `backends.ts` — the rules as pure, harness-free functions; the two backend clients. Throws-vs-returns is load-bearing: a thrown transport error is transient (never cached); a returned low-confidence verdict is a property of the text (cached).
- `stores/translate.ts` — cache, per-conversation switches (localStorage, deliberately not server-synced), and the gates: never own messages, never encrypted, requests owned by the store so a recycled virtual-list row can't cancel them.
- `MessageList` overlay (render-time, per message, original untouched) + `MessageInput` approval flow.

### Verification
- 25 tests encode the numbered rules. Full client suite green, `vue-tsc` + `vite build` clean.
- Driven end-to-end against a live LibreTranslate: Spanish/Japanese translated and badged, `lol` and bare URLs skipped with no network call, English correctly unchanged.

I run this on my own instance; opening it in case it's useful upstream. No worries at all if voice-style "not for Lurker" applies — it's self-contained and trivial to decline.
