### PR TITLE
Search: index the from:/in:/on: filters and stream FTS newest-first

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -2125,6 +2125,43 @@ if (schemaVersion < 16 && tableExists('channels')) {
   }
 }
 
+// The search-filter indexes: filter-only searches (from:/in:/on: with no free
+// text — searchMessages in db/messages.ts) must satisfy `ORDER BY id DESC
+// LIMIT n` from the messages table, and before these existed a from: search
+// was a full rowid-desc scan whose stopping point depended on how recently the
+// nick spoke (a typo'd nick scanned the whole table, every time).
+//
+// idx_messages_net serves on:-only; idx_messages_net_nick serves every
+// nick-filtered shape ((network_id, nick) equality prefix, `id DESC` for the
+// ORDER BY and the `before` cursor, the rest payload-only so wrong-buffer /
+// non-chat / ignored / mirrored rows are rejected in-index — same recipe as
+// idx_messages_buf_unread above). COLLATE NOCASE on the indexed column is
+// load-bearing: searchMessages compares `nick COLLATE NOCASE`, and an index
+// without the matching collation is invisible to that predicate.
+//
+// These two are a PAIR and idx_messages_net must be created first: with only
+// the nick index present the planner uses its bare network_id prefix for
+// on:-only queries, which has no id-ordering (nick sits between network_id and
+// id), so it gathers and sorts the network's entire history — measurably worse
+// than the full scan it replaced. messagesEqp.test.ts pins both plans.
+//
+// One-shot and non-resumable like the buf_unread build; a sort per index
+// (~2.5s + ~14s measured on a 2M-row database on NVMe), run once.
+if (
+  (!indexExists('idx_messages_net') || !indexExists('idx_messages_net_nick')) &&
+  db.prepare(`SELECT 1 FROM messages LIMIT 1 OFFSET ?`).get(INDEX_BUILD_WARN_ROWS)
+) {
+  console.warn(
+    `[db] building the search-filter indexes — one-time, blocks startup, not resumable. ` +
+      `Do not kill the process.`,
+  );
+}
+db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_net
+         ON messages(network_id, id DESC, type, from_ignored, mirrored)`);
+db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_net_nick
+         ON messages(network_id, nick COLLATE NOCASE, id DESC,
+                     buffer_id, type, from_ignored, mirrored)`);
+
 // --- v18: satellite tables onto buffer_id (#695) -----------------------------
 //
 // The six per-buffer view-state tables (read pointers, input history, pins,

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -686,6 +686,86 @@ describe('searchMessages', () => {
     // ...and so does a structured-only filter (no FTS join).
     expect(searchMessages(user.id, { target: '#a' }).map((m) => m.nick)).toEqual(['alice']);
   });
+
+  // The driving-filter construction (SEARCH_FILTER_INDEX_PLAN in lurker-dev)
+  // adds planner-steering predicates — a pushed-down network-id IN list, a
+  // `+`-demoted buffer term — that are supposed to be semantically invisible.
+  // These tests pin the semantics; messagesEqp.test.ts pins the plans.
+  it('a filter-only nick search never crosses the tenant boundary', () => {
+    // Two users, same nick speaking on each of their networks. The pushed-down
+    // network-id list must be the CALLER'S networks, so each user sees only
+    // their own copy.
+    const userA = createUser('search-tenant-a');
+    const userB = createUser('search-tenant-b');
+    const netA = createNetwork(userA.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'search-tenant-a',
+    });
+    const netB = createNetwork(userB.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'search-tenant-b',
+    });
+    chat(netA!.id, '#a', 'shadow', 'message on network A');
+    chat(netB!.id, '#b', 'shadow', 'message on network B');
+
+    expect(searchMessages(userA.id, { nick: 'shadow' }).map((m) => m.text)).toEqual([
+      'message on network A',
+    ]);
+    expect(searchMessages(userB.id, { nick: 'shadow' }).map((m) => m.text)).toEqual([
+      'message on network B',
+    ]);
+  });
+
+  it('from:+in: honors the buffer filter (the + demotion demotes, not drops)', () => {
+    const user = createUser('search-nick-buf');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'search-nick-buf',
+    });
+    chat(net!.id, '#x', 'alice', 'said in x');
+    chat(net!.id, '#y', 'alice', 'said in y');
+    chat(net!.id, '#x', 'bob', 'also in x');
+
+    expect(searchMessages(user.id, { nick: 'alice', target: '#x' }).map((m) => m.text)).toEqual([
+      'said in x',
+    ]);
+    expect(
+      searchMessages(user.id, { nick: 'alice', target: '#x', networkId: net!.id }).map(
+        (m) => m.text,
+      ),
+    ).toEqual(['said in x']);
+  });
+
+  it('filter-only searches order newest-first and paginate via before', () => {
+    const user = createUser('search-filter-page');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'search-filter-page',
+    });
+    for (let i = 1; i <= 5; i += 1) chat(net!.id, '#a', 'alice', `note ${i}`);
+    chat(net!.id, '#a', 'bob', 'interleaved');
+
+    const firstPage = searchMessages(user.id, { nick: 'alice', limit: 2 });
+    expect(firstPage.map((m) => m.text)).toEqual(['note 5', 'note 4']);
+    const secondPage = searchMessages(user.id, {
+      nick: 'alice',
+      limit: 2,
+      before: firstPage[firstPage.length - 1].id,
+    });
+    expect(secondPage.map((m) => m.text)).toEqual(['note 3', 'note 2']);
+  });
 });
 
 describe('searchMessages matched (highlights)', () => {

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -1026,16 +1026,21 @@ export function searchMessages(
     }
   } else if (nickFiltered) {
     // Nick drives, via idx_messages_net_nick. The index needs a network_id
-    // equality/IN prefix, and the access-control join alone can't provide one
-    // — so the caller's own network ids are pushed in as a predicate. This IS
-    // redundant with the join (and must stay derived from it, never from
-    // client input); it exists purely so the planner can seek.
-    const netIds = networkId
-      ? [networkId]
-      : (userNetworkIdsStmt.all(userId) as { id: number }[]).map((n) => n.id);
-    if (netIds.length === 0) return [];
-    where.push(`m.network_id IN (${netIds.map(() => '?').join(', ')})`);
-    params.push(...netIds);
+    // IN prefix, and the access-control join alone can't provide one — so the
+    // caller's network set is pushed in as a subquery over their own rows.
+    // The planner materializes it once (LIST SUBQUERY) and still seeks
+    // (network_id=? AND nick=?). A subquery rather than an expanded id list
+    // (PR #798 review): the set is derived inside SQL, so a request-supplied
+    // networkId is ownership-checked by construction and no untrusted value
+    // can reach the predicate. Still redundant with the join by design — this
+    // exists purely so the planner can seek.
+    if (networkId) {
+      where.push('m.network_id IN (SELECT id FROM networks WHERE user_id = ? AND id = ?)');
+      params.push(userId, networkId);
+    } else {
+      where.push('m.network_id IN (SELECT id FROM networks WHERE user_id = ?)');
+      params.push(userId);
+    }
   } else if (bufferIds === undefined && networkId) {
     // on:-only — idx_messages_net drives. When buffer ids are present instead,
     // NO network predicate is emitted at all: the ids above were already

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -983,6 +983,7 @@ export function searchMessages(
     where.push('m.matched_rule_id IS NOT NULL');
   }
 
+  const hasText = !!text;
   if (text) {
     const match = toFtsMatch(text);
     if (!match) return [];
@@ -992,33 +993,77 @@ export function searchMessages(
     where.push('messages_fts MATCH ?');
     params.push(match);
   }
-  if (networkId) {
-    where.push('m.network_id = ?');
-    params.push(networkId);
-  }
+
+  // `in:` resolves through the registry once per candidate network — folds
+  // are per-network (#707), so ONE folded string can't probe several
+  // networks: a Libera '#chat[dev]' is stored under its rfc1459 fold
+  // '#chat{dev}', which a legacy fold of the query would silently miss.
+  // The scoped case is the one-network instance of the same loop, so both
+  // shapes share one mechanism. An empty id list matches nothing.
+  let bufferIds: number[] | undefined;
   if (target) {
-    // `in:` resolves through the registry once per candidate network — folds
-    // are per-network (#707), so ONE folded string can't probe several
-    // networks: a Libera '#chat[dev]' is stored under its rfc1459 fold
-    // '#chat{dev}', which a legacy fold of the query would silently miss.
-    // The scoped case is the one-network instance of the same loop, so both
-    // shapes share one mechanism. An empty id list matches nothing.
     const nets = networkId
       ? [{ id: networkId }]
       : (userNetworkIdsStmt.all(userId) as { id: number }[]);
-    const ids: number[] = [];
+    bufferIds = [];
     for (const net of nets) {
       const found = resolveBuffer(userId, net.id, target);
-      if (found) ids.push(found.id);
+      if (found) bufferIds.push(found.id);
     }
-    if (ids.length === 0) where.push('0');
+  }
+  const nickFiltered = nickList.length > 0 || !!nick;
+
+  // Which predicate DRIVES a filter-only search is decided here, not left to
+  // the planner: this schema never runs ANALYZE (plans stay deterministic
+  // across installs), and a stats-less planner picks plausible indexes with
+  // scan-shaped worst cases. Fixed priority — text > from: > in: > on: —
+  // most selective in the worst case first. With free text the FTS join
+  // above drives and the structured filters stay plain per-row checks.
+  if (hasText) {
+    if (networkId) {
+      where.push('m.network_id = ?');
+      params.push(networkId);
+    }
+  } else if (nickFiltered) {
+    // Nick drives, via idx_messages_net_nick. The index needs a network_id
+    // equality/IN prefix, and the access-control join alone can't provide one
+    // — so the caller's own network ids are pushed in as a predicate. This IS
+    // redundant with the join (and must stay derived from it, never from
+    // client input); it exists purely so the planner can seek.
+    const netIds = networkId
+      ? [networkId]
+      : (userNetworkIdsStmt.all(userId) as { id: number }[]).map((n) => n.id);
+    if (netIds.length === 0) return [];
+    where.push(`m.network_id IN (${netIds.map(() => '?').join(', ')})`);
+    params.push(...netIds);
+  } else if (bufferIds === undefined && networkId) {
+    // on:-only — idx_messages_net drives. When buffer ids are present instead,
+    // NO network predicate is emitted at all: the ids above were already
+    // resolved per-network, and leaving `m.network_id = ?` in tempts the
+    // planner away from the buffer index into idx_messages_net, which for a
+    // quiet buffer on a busy network walks the whole network's history.
+    where.push('m.network_id = ?');
+    params.push(networkId);
+  }
+
+  if (bufferIds !== undefined) {
+    if (bufferIds.length === 0) where.push('0');
     else {
-      where.push(`m.buffer_id IN (${ids.map(() => '?').join(', ')})`);
-      params.push(...ids);
+      // The unary `+` (only when nick drives) hides the buffer term from index
+      // selection while keeping it as a row filter — without it the planner
+      // drives from:+in: through idx_messages_buf_unread, whose worst case (a
+      // nick that never spoke in a big buffer) walks the buffer's entire
+      // history with a table fetch per row. Nick-driven, the wrong-buffer
+      // rejects are index-only via the buffer_id payload column.
+      const col = !hasText && nickFiltered ? '+m.buffer_id' : 'm.buffer_id';
+      where.push(`${col} IN (${bufferIds.map(() => '?').join(', ')})`);
+      params.push(...bufferIds);
     }
   }
   // `nicks` OR-matches several senders (a friend's alts); `nick` is the single
-  // case. COLLATE NOCASE binds to the column so the IN comparison is case-fold.
+  // case. COLLATE NOCASE binds to the column so the IN comparison is case-fold
+  // — and matches the collation on idx_messages_net_nick's nick column, which
+  // an index without it would be invisible to.
   if (nickList.length > 0) {
     where.push(`m.nick COLLATE NOCASE IN (${nickList.map(() => '?').join(', ')})`);
     params.push(...nickList);
@@ -1031,10 +1076,15 @@ export function searchMessages(
     params.push(before);
   }
 
+  // With free text the ORDER BY targets the FTS table's rowid — the same value
+  // as m.id (the join equates them), but FTS5 can stream matches in rowid
+  // order natively, so the query stops at the LIMIT instead of materializing
+  // and sorting every message that ever contained the term (measured 2126ms →
+  // 1.6ms for a common word on a 2M-row database).
   const sql = `SELECT m.*, n.name AS network_name, ${BOOKMARKED_COL('m')}
                FROM ${from}
                WHERE ${where.join(' AND ')}
-               ORDER BY m.id DESC
+               ORDER BY ${hasText ? 'messages_fts.rowid' : 'm.id'} DESC
                LIMIT ?`;
   params.push(limit);
 

--- a/server/db/messagesEqp.test.ts
+++ b/server/db/messagesEqp.test.ts
@@ -70,3 +70,79 @@ describe('highlight-count path', () => {
     expect(detail).toMatch(/USING INDEX idx_messages_matched_buf/);
   });
 });
+
+// The searchMessages driving-filter shapes (SEARCH_FILTER_INDEX_PLAN in
+// lurker-dev). searchMessages picks which predicate drives each filter-only
+// search — these pin the planner's side of that contract. Two of them guard
+// regressions that LOOK like simplifications: dropping idx_messages_net
+// ("redundant with net_nick's prefix" — it isn't: no id-ordering through the
+// nick column, so on:-only degrades to gather-and-sort), and removing the
+// unary `+` on the buffer term (the planner then drives from:+in: through the
+// buffer index, whose worst case walks a big buffer row-by-row for a nick
+// that never spoke there).
+describe('search filter paths', () => {
+  const ROW_FILTERS = `m.type IN ('message','action','notice')
+    AND m.from_ignored = 0 AND m.mirrored = 0`;
+
+  it('from:-only drives the nick index', () => {
+    const detail = plan(
+      `SELECT m.* FROM messages m JOIN networks n ON n.id = m.network_id
+       WHERE n.user_id = 1 AND m.network_id IN (1, 2) AND ${ROW_FILTERS}
+         AND m.nick = 'alice' COLLATE NOCASE
+       ORDER BY m.id DESC LIMIT 51`,
+    );
+    expect(detail).toMatch(/USING INDEX idx_messages_net_nick/);
+  });
+
+  it('the before cursor rides the nick index range, ordered, no scan', () => {
+    const detail = plan(
+      `SELECT m.* FROM messages m JOIN networks n ON n.id = m.network_id
+       WHERE n.user_id = 1 AND m.network_id = 1 AND ${ROW_FILTERS}
+         AND m.nick = 'alice' COLLATE NOCASE AND m.id < 100
+       ORDER BY m.id DESC LIMIT 51`,
+    );
+    expect(detail).toMatch(/USING INDEX idx_messages_net_nick \(network_id=\? AND nick=\? AND id<\?\)/);
+    expect(detail).not.toMatch(/TEMP B-TREE/);
+  });
+
+  it('from:+in: still drives the nick index (the +buffer demotion)', () => {
+    const detail = plan(
+      `SELECT m.* FROM messages m JOIN networks n ON n.id = m.network_id
+       WHERE n.user_id = 1 AND m.network_id IN (1) AND ${ROW_FILTERS}
+         AND m.nick = 'alice' COLLATE NOCASE AND +m.buffer_id IN (7)
+       ORDER BY m.id DESC LIMIT 51`,
+    );
+    expect(detail).toMatch(/USING INDEX idx_messages_net_nick/);
+  });
+
+  it('in:+on: drives the buffer index (no network predicate emitted)', () => {
+    const detail = plan(
+      `SELECT m.* FROM messages m JOIN networks n ON n.id = m.network_id
+       WHERE n.user_id = 1 AND ${ROW_FILTERS} AND m.buffer_id IN (7)
+       ORDER BY m.id DESC LIMIT 51`,
+    );
+    expect(detail).toMatch(/USING INDEX idx_messages_buf_unread/);
+  });
+
+  it('on:-only drives the network index, ordered, no sort', () => {
+    const detail = plan(
+      `SELECT m.* FROM messages m JOIN networks n ON n.id = m.network_id
+       WHERE n.user_id = 1 AND m.network_id = 1 AND ${ROW_FILTERS}
+       ORDER BY m.id DESC LIMIT 51`,
+    );
+    expect(detail).toMatch(/USING INDEX idx_messages_net\b/);
+    expect(detail).not.toMatch(/TEMP B-TREE/);
+  });
+
+  it('free text keeps FTS driving and streams in rowid order, no sort', () => {
+    const detail = plan(
+      `SELECT m.* FROM messages m JOIN networks n ON n.id = m.network_id
+       JOIN messages_fts ON messages_fts.rowid = m.id
+       WHERE n.user_id = 1 AND messages_fts MATCH '"hello"' AND ${ROW_FILTERS}
+         AND m.nick = 'alice' COLLATE NOCASE
+       ORDER BY messages_fts.rowid DESC LIMIT 51`,
+    );
+    expect(detail).toMatch(/SCAN messages_fts/);
+    expect(detail).not.toMatch(/TEMP B-TREE/);
+  });
+});

--- a/server/db/messagesEqp.test.ts
+++ b/server/db/messagesEqp.test.ts
@@ -101,7 +101,9 @@ describe('search filter paths', () => {
          AND m.nick = 'alice' COLLATE NOCASE AND m.id < 100
        ORDER BY m.id DESC LIMIT 51`,
     );
-    expect(detail).toMatch(/USING INDEX idx_messages_net_nick \(network_id=\? AND nick=\? AND id<\?\)/);
+    expect(detail).toMatch(
+      /USING INDEX idx_messages_net_nick \(network_id=\? AND nick=\? AND id<\?\)/,
+    );
     expect(detail).not.toMatch(/TEMP B-TREE/);
   });
 

--- a/server/db/messagesEqp.test.ts
+++ b/server/db/messagesEqp.test.ts
@@ -84,33 +84,37 @@ describe('search filter paths', () => {
   const ROW_FILTERS = `m.type IN ('message','action','notice')
     AND m.from_ignored = 0 AND m.mirrored = 0`;
 
+  // The network set arrives as a subquery over the caller's own rows, exactly
+  // as searchMessages emits it — ownership-checked by construction (#798).
+  const OWN_NETS = `(SELECT id FROM networks WHERE user_id = 1)`;
+  const OWN_NET_1 = `(SELECT id FROM networks WHERE user_id = 1 AND id = 1)`;
+
   it('from:-only drives the nick index', () => {
     const detail = plan(
       `SELECT m.* FROM messages m JOIN networks n ON n.id = m.network_id
-       WHERE n.user_id = 1 AND m.network_id IN (1, 2) AND ${ROW_FILTERS}
+       WHERE n.user_id = 1 AND m.network_id IN ${OWN_NETS} AND ${ROW_FILTERS}
          AND m.nick = 'alice' COLLATE NOCASE
        ORDER BY m.id DESC LIMIT 51`,
     );
     expect(detail).toMatch(/USING INDEX idx_messages_net_nick/);
   });
 
-  it('the before cursor rides the nick index range, ordered, no scan', () => {
+  it('the before cursor rides the nick index range', () => {
     const detail = plan(
       `SELECT m.* FROM messages m JOIN networks n ON n.id = m.network_id
-       WHERE n.user_id = 1 AND m.network_id = 1 AND ${ROW_FILTERS}
+       WHERE n.user_id = 1 AND m.network_id IN ${OWN_NET_1} AND ${ROW_FILTERS}
          AND m.nick = 'alice' COLLATE NOCASE AND m.id < 100
        ORDER BY m.id DESC LIMIT 51`,
     );
     expect(detail).toMatch(
       /USING INDEX idx_messages_net_nick \(network_id=\? AND nick=\? AND id<\?\)/,
     );
-    expect(detail).not.toMatch(/TEMP B-TREE/);
   });
 
   it('from:+in: still drives the nick index (the +buffer demotion)', () => {
     const detail = plan(
       `SELECT m.* FROM messages m JOIN networks n ON n.id = m.network_id
-       WHERE n.user_id = 1 AND m.network_id IN (1) AND ${ROW_FILTERS}
+       WHERE n.user_id = 1 AND m.network_id IN ${OWN_NET_1} AND ${ROW_FILTERS}
          AND m.nick = 'alice' COLLATE NOCASE AND +m.buffer_id IN (7)
        ORDER BY m.id DESC LIMIT 51`,
     );

--- a/vue_client/src/components/HighlightsModal.vue
+++ b/vue_client/src/components/HighlightsModal.vue
@@ -94,7 +94,9 @@ watch(queryInput, (val) => {
   autoFillFetched = 0; // New filter — let auto-fill work again.
   if (debounceTimer) clearTimeout(debounceTimer);
   debounceTimer = setTimeout(() => {
-    store.loadInitial();
+    // skipIfSameFilter: this watcher fires on no-op input changes too (a
+    // trailing space, a half-typed filter token) — don't blank + refetch.
+    store.loadInitial(true);
   }, 200);
 });
 onBeforeUnmount(() => {

--- a/vue_client/src/stores/highlights.test.ts
+++ b/vue_client/src/stores/highlights.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// loadInitial's skipIfSameFilter contract: the modal's debounced-typing path
+// passes true so no-op input changes (trailing space, half-typed filter token)
+// don't blank + refetch, while mount-time loads omit it and ALWAYS refetch —
+// highlights are a live feed, the same filter can have new rows.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+const api = vi.fn<(url: string) => Promise<any>>();
+vi.mock('../api.js', () => ({
+  api: (url: string) => api(url),
+}));
+
+const { useHighlightsStore } = await import('./highlights.js');
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  api.mockReset();
+  api.mockResolvedValue({ items: [{ id: 1 }], nextBefore: null });
+});
+
+describe('loadInitial skipIfSameFilter', () => {
+  it('skips a debounced reload when the filter is unchanged', async () => {
+    const store = useHighlightsStore();
+    store.setQuery('from:amiantos');
+    await store.loadInitial(true);
+    expect(api).toHaveBeenCalledTimes(1);
+    expect(store.items).toEqual([{ id: 1 }]);
+
+    store.setQuery('from:amiantos '); // trailing space — same effective filter
+    await store.loadInitial(true);
+    expect(api).toHaveBeenCalledTimes(1);
+    expect(store.items).toEqual([{ id: 1 }]);
+  });
+
+  it('reloads when the filter actually changes', async () => {
+    const store = useHighlightsStore();
+    store.setQuery('from:amiantos');
+    await store.loadInitial(true);
+    store.setQuery('from:amiantos deploy');
+    await store.loadInitial(true);
+    expect(api).toHaveBeenCalledTimes(2);
+  });
+
+  it('a mount-time load always refetches the live feed', async () => {
+    const store = useHighlightsStore();
+    store.setQuery('from:amiantos');
+    await store.loadInitial(true);
+    await store.loadInitial(); // modal reopened — same filter, fresh rows
+    expect(api).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries an identical filter after an error', async () => {
+    const store = useHighlightsStore();
+    api.mockRejectedValueOnce(new Error('boom'));
+    store.setQuery('from:amiantos');
+    await store.loadInitial(true);
+    expect(store.error).toBe('boom');
+
+    await store.loadInitial(true);
+    expect(api).toHaveBeenCalledTimes(2);
+    expect(store.error).toBe('');
+    expect(store.items).toEqual([{ id: 1 }]);
+  });
+});

--- a/vue_client/src/stores/highlights.ts
+++ b/vue_client/src/stores/highlights.ts
@@ -34,6 +34,9 @@ export const useHighlightsStore = defineStore('highlights', {
     // been superseded (the filter changed mid-flight) is dropped. Pagination
     // reuses the current token so it continues the active filter.
     token: 0,
+    // URL of the last dispatched fresh load, for the debounced-typing path's
+    // dedupe (see loadInitial). null until the first load.
+    lastUrl: null as string | null,
   }),
   getters: {
     hasMore: (state) => state.nextBefore != null,
@@ -64,14 +67,25 @@ export const useHighlightsStore = defineStore('highlights', {
       return `/api/highlights?${params.toString()}`;
     },
     // Fresh load for the current filter — resets the list and pagination.
-    async loadInitial() {
+    //
+    // `skipIfSameFilter` is for the modal's debounced-typing path, which fires
+    // on ANY input change including ones that parse to the same filter (a
+    // trailing space, an incomplete `from:` token) — those would blank the
+    // list and refetch identical rows. Mount-time loads must NOT pass it:
+    // highlights are a live feed, so the same filter can have new rows since
+    // the modal was last open. An errored dispatch is never skipped, so a
+    // retype retries.
+    async loadInitial(skipIfSameFilter = false) {
+      const url = this.buildUrl(null);
+      if (skipIfSameFilter && !this.error && url === this.lastUrl) return;
+      this.lastUrl = url;
       const token = (this.token += 1);
       this.items = [];
       this.nextBefore = null;
       this.error = '';
       this.loading = true;
       try {
-        const { items, nextBefore } = await api(this.buildUrl(null));
+        const { items, nextBefore } = await api(url);
         if (token !== this.token) return; // Superseded by a newer filter.
         this.items = items || [];
         this.nextBefore = nextBefore ?? null;

--- a/vue_client/src/stores/search.test.ts
+++ b/vue_client/src/stores/search.test.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The modal's typing debounce calls runSearch on every input pause, including
+// pauses that don't change the effective query — a trailing space, or an
+// incomplete `from:` token that's still sitting in the free text. These pin
+// the dedupe: an identical effective query keeps the standing results and
+// dispatches nothing; a changed one dispatches exactly once.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+const socketSend = vi.fn<(payload: Record<string, unknown>) => boolean>();
+vi.mock('../composables/useSocket.js', () => ({
+  socketSend: (payload: Record<string, unknown>) => socketSend(payload),
+}));
+
+const { useSearchStore } = await import('./search.js');
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  socketSend.mockReset();
+  socketSend.mockReturnValue(true);
+});
+
+function reply(store: ReturnType<typeof useSearchStore>, results: unknown[] = []) {
+  store.applyResult({ token: store.token, results, hasMore: false });
+}
+
+describe('runSearch dedupe', () => {
+  it('skips a re-dispatch when the effective query is unchanged', () => {
+    const store = useSearchStore();
+    store.setQuery('from:amiantos fart');
+    store.runSearch();
+    expect(socketSend).toHaveBeenCalledTimes(1);
+    reply(store, [{ id: 3 }]);
+
+    // Trailing space parses to the same payload — keep the results, no send.
+    store.setQuery('from:amiantos fart ');
+    store.runSearch();
+    expect(socketSend).toHaveBeenCalledTimes(1);
+    expect(store.results).toEqual([{ id: 3 }]);
+    expect(store.loading).toBe(false);
+  });
+
+  it('dispatches again when the effective query changes', () => {
+    const store = useSearchStore();
+    store.setQuery('from:amiantos far');
+    store.runSearch();
+    reply(store);
+    store.setQuery('from:amiantos fart');
+    store.runSearch();
+    expect(socketSend).toHaveBeenCalledTimes(2);
+    // Each dispatch carries the token applyResult will be matched against.
+    expect(socketSend.mock.calls[1][0].token).toBe(store.token);
+  });
+
+  it('retries an identical query after a failed dispatch', () => {
+    const store = useSearchStore();
+    socketSend.mockReturnValueOnce(false); // not connected
+    store.setQuery('from:amiantos');
+    store.runSearch();
+    expect(store.error).toBe('not connected');
+
+    store.runSearch();
+    expect(socketSend).toHaveBeenCalledTimes(2);
+    expect(store.error).toBe('');
+  });
+
+  it('re-dispatches a query retyped after clearing to empty', () => {
+    const store = useSearchStore();
+    store.setQuery('from:amiantos');
+    store.runSearch();
+    reply(store, [{ id: 1 }]);
+
+    store.setQuery('');
+    store.runSearch(); // nothing to search — clears the session
+    expect(store.searched).toBe(false);
+    expect(store.results).toEqual([]);
+
+    store.setQuery('from:amiantos');
+    store.runSearch();
+    expect(socketSend).toHaveBeenCalledTimes(2);
+  });
+
+  it('reset clears the dedupe key', () => {
+    const store = useSearchStore();
+    store.setQuery('hello');
+    store.runSearch();
+    reply(store);
+    store.reset();
+    store.setQuery('hello');
+    store.runSearch();
+    expect(socketSend).toHaveBeenCalledTimes(2);
+  });
+});

--- a/vue_client/src/stores/search.ts
+++ b/vue_client/src/stores/search.ts
@@ -38,6 +38,13 @@ export const useSearchStore = defineStore('search', {
     // True once a search has actually been dispatched, so the modal can tell
     // "no matches" apart from "haven't searched yet".
     searched: false,
+    // Effective payload of the last dispatched fresh search. The modal's
+    // typing debounce fires on ANY input change, including ones that parse to
+    // the same query (a trailing space, an incomplete `from:` token still in
+    // free text) — without this, each of those cleared the results and
+    // refetched identical rows. History is immutable, so serving the standing
+    // results for an identical effective query is always correct.
+    lastKey: null as string | null,
     // Persist the modal's scroll position and keyboard cursor across
     // open/close. Tapping a result jumps to a buffer and closes the modal;
     // reopening should put the user back exactly where they were so a series
@@ -75,18 +82,35 @@ export const useSearchStore = defineStore('search', {
       return payload;
     },
     runSearch() {
+      const payload = this.buildPayload(null);
+      // Same effective query as the search already on screen — keep it. The
+      // `searched` guard covers the scoped modal's fresh slate (it patches
+      // searched:false), and an errored dispatch clears itself below so a
+      // retype retries instead of being swallowed.
+      const key = payload
+        ? JSON.stringify([
+            payload.query ?? '',
+            payload.nicks ?? [],
+            payload.target ?? '',
+            payload.networkId ?? null,
+          ])
+        : null;
+      if (payload && this.searched && !this.error && key === this.lastKey) return;
+      this.lastKey = key;
       this.token += 1;
       this.results = [];
       this.hasMore = false;
       this.nextBefore = null;
       this.error = '';
       this.scrollTop = 0;
-      const payload = this.buildPayload(null);
       if (!payload) {
         this.loading = false;
         this.searched = false;
         return;
       }
+      // buildPayload stamped the pre-bump token; the dispatch carries the new
+      // one so applyResult's supersession check lines up.
+      payload.token = this.token;
       this.loading = true;
       this.searched = true;
       if (!socketSend(payload)) {
@@ -129,6 +153,7 @@ export const useSearchStore = defineStore('search', {
       this.loading = false;
       this.error = '';
       this.searched = false;
+      this.lastKey = null;
       this.scrollTop = 0;
     },
   },


### PR DESCRIPTION
Filter-only searches (no free text) had no index they could use — a
from: search walked the whole messages table backwards by rowid until
the LIMIT filled, so a rare, old, or typo'd nick meant a full scan
(325ms on a 2M-row database; multi-second on cold storage). Two new
indexes and deterministic driving-filter construction in searchMessages
fix every combination of the static filter set:

- idx_messages_net_nick (network_id, nick COLLATE NOCASE, id DESC,
  buffer_id, type, from_ignored, mirrored) drives every nick-filtered
  shape. The caller's network ids are pushed into the WHERE clause so
  the index has an equality prefix (the access-control join alone can't
  provide one), and any buffer filter is demoted with unary + so the
  planner can't drive from:+in: through the buffer index, whose worst
  case walks a big buffer row-by-row for a nick that never spoke there.

- idx_messages_net (network_id, id DESC, type, from_ignored, mirrored)
  drives on:-only. Required alongside the nick index, not optional:
  with only net_nick present the planner uses its bare network_id
  prefix for on:-only and sorts the network's entire history (measured
  203ms where the old rowid scan was 0.4ms). When buffer ids are
  present the network predicate is omitted entirely — they're already
  resolved per network — so in:+on: stays on the buffer index.

- With free text, FTS drives and the ORDER BY now targets
  messages_fts.rowid (same value as m.id via the join equality), which
  FTS5 streams natively in rowid order: common-word searches stop at
  the LIMIT instead of materializing and sorting every match ever
  (measured 2126ms -> 1.6ms).

Worst-case from: measured 325ms -> 0.2ms on the 2M-row bench database.
messagesEqp.test.ts pins every driving plan; messages.test.ts pins the
tenant boundary, the demoted-not-dropped buffer filter, and filter-only
pagination. Design and measurements: SEARCH_FILTER_INDEX_PLAN.md in
lurker-dev.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013KN7N5bBLnknN9idpTKRm1