### PR TITLE
Relay bots: follow a chain of marked bridges (#801)

### DIFF
--- a/shared/parseRelay.test.ts
+++ b/shared/parseRelay.test.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect } from 'vitest';
-import { parseRelayMessage, compileRelayTemplate, DEFAULT_RELAY_TEMPLATES } from './parseRelay.js';
+import {
+  parseRelayMessage,
+  parseRelayChain,
+  compileRelayTemplate,
+  DEFAULT_RELAY_TEMPLATES,
+} from './parseRelay.js';
 
 describe('parseRelayMessage — default formats', () => {
   it('parses the bracketed-source form `[source] <nick> message`', () => {
@@ -200,5 +205,91 @@ describe('compileRelayTemplate', () => {
     const parsed = parseRelayMessage('a.*b ivan done', '{source}.*b {nick} {message}');
     expect(parsed).toEqual({ source: 'a', nick: 'ivan', text: 'done' });
     expect(parseRelayMessage('aXXb ivan done', '{source}.*b {nick} {message}')).toBeNull();
+  });
+});
+
+// Marks, as the relay-bot store holds them: nick → custom template ('' means the
+// built-in formats). Anything absent is not a relay bot.
+const marks = (m: Record<string, string>) => (nick: string) => m[nick] ?? null;
+
+describe('parseRelayChain — chained bridges (#801)', () => {
+  // The reported line, verbatim from the corpus: `nR` bridges the IRC-nERDs
+  // network, where a bot nicked `|` is itself bridging Matrix/OFTC.
+  const nested =
+    '\x02[IRC-nERDs]\x02 <~\x0306|\x03> \x0313<yrdsb3222[m]/OFTC> \x0fIs their a discord';
+
+  it('stops at the intermediate bridge when only the outer bot is marked', () => {
+    expect(parseRelayChain(nested, '', marks({}))).toEqual({
+      source: 'IRC-nERDs',
+      nick: '|',
+      text: '\x0313<yrdsb3222[m]/OFTC> \x0fIs their a discord',
+    });
+  });
+
+  it('reaches the real speaker once the intermediate bridge is marked too', () => {
+    expect(parseRelayChain(nested, '', marks({ '|': '' }))).toEqual({
+      source: 'IRC-nERDs',
+      nick: 'yrdsb3222[m]/OFTC',
+      text: '\x0fIs their a discord',
+    });
+  });
+
+  it('leaves a quoted nick alone — quoting looks exactly like an envelope', () => {
+    // Real line: raah, on efnet, quoting ultros. `ultros` carries no mark, so
+    // the line stays raah's. This is the whole reason each hop needs one.
+    const quote = '\x02[efnet]\x02 <+\x0303raah\x03> <\x0310ultros\x03> blasphemer! and a heretic!';
+    expect(parseRelayChain(quote, '', marks({ '|': '' }))?.nick).toBe('raah');
+  });
+
+  it('follows a three-deep chain and prefers the innermost [source] tag', () => {
+    // `DeltaCharlie1888` relays `nR`, which relays rizon. The rizon tag is the
+    // one closest to the speaker, so it wins over the hops outside it.
+    const deep = '<nR> [rizon] <Nsane> Looks like the sequel bombed';
+    expect(parseRelayChain(deep, '', marks({ nR: '' }))).toEqual({
+      source: 'rizon',
+      nick: 'Nsane',
+      text: 'Looks like the sequel bombed',
+    });
+  });
+
+  it('strips a membership prefix on an inner hop too', () => {
+    const line = '<+DOMF> <+Nelluk> many ghosts living and dead abound';
+    expect(parseRelayChain(line, '', marks({ DOMF: '' }))).toEqual({
+      source: null,
+      nick: 'Nelluk',
+      text: 'many ghosts living and dead abound',
+    });
+  });
+
+  it("uses the inner bot's OWN custom template", () => {
+    const line = '[net] <bridge> matrix » alice » hey';
+    expect(parseRelayChain(line, '', marks({ bridge: '{source} » {nick} » {message}' }))).toEqual({
+      source: 'matrix',
+      nick: 'alice',
+      text: 'hey',
+    });
+  });
+
+  it('ends the chain where a marked hop speaks in its own voice', () => {
+    // `bridge` is marked, but this line of its own isn't an envelope — so it
+    // stays attributed to `bridge` rather than falling apart.
+    const line = '[net] <bridge> reconnected to matrix';
+    expect(parseRelayChain(line, '', marks({ bridge: '' }))).toEqual({
+      source: 'net',
+      nick: 'bridge',
+      text: 'reconnected to matrix',
+    });
+  });
+
+  it('terminates on a bot whose envelope names itself', () => {
+    const line = '<loop> <loop> <loop> <loop> <loop> <loop> <loop> done';
+    const parsed = parseRelayChain(line, '', marks({ loop: '' }));
+    // Depth-capped rather than looping: it stops mid-chain, still attributed.
+    expect(parsed?.nick).toBe('loop');
+    expect(parsed?.text).toBe('<loop> <loop> <loop> done');
+  });
+
+  it('returns null when the outer envelope does not parse at all', () => {
+    expect(parseRelayChain('just a line the bot said', '', marks({}))).toBeNull();
   });
 });

--- a/shared/parseRelay.test.ts
+++ b/shared/parseRelay.test.ts
@@ -252,6 +252,17 @@ describe('parseRelayChain — chained bridges (#801)', () => {
     });
   });
 
+  it('prefers the innermost [source] when every hop carries one', () => {
+    // Both tags present, so this is the case that actually pins the direction
+    // of the coalesce — the tests either side of it have a tag on one hop only,
+    // and pass whichever way it's written.
+    expect(parseRelayChain('[A] <bridge> [B] <alice> hi', '', marks({ bridge: '' }))).toEqual({
+      source: 'B',
+      nick: 'alice',
+      text: 'hi',
+    });
+  });
+
   it('strips a membership prefix on an inner hop too', () => {
     const line = '<+DOMF> <+Nelluk> many ghosts living and dead abound';
     expect(parseRelayChain(line, '', marks({ DOMF: '' }))).toEqual({

--- a/shared/parseRelay.ts
+++ b/shared/parseRelay.ts
@@ -148,3 +148,51 @@ export function parseRelayMessage(
   }
   return null;
 }
+
+/**
+ * How many envelopes deep a chain of marked bots is followed. Bridges chain in
+ * the wild — two hops is the deepest real one seen — and the cap is a backstop,
+ * not a limit anyone should hit.
+ */
+const MAX_RELAY_DEPTH = 4;
+
+/**
+ * Parse an envelope, then keep parsing while the speaker it reveals is *itself*
+ * a marked relay bot (#801).
+ *
+ * Bridges chain: a bot bridging network A relays network B's bridge bot, which
+ * is itself bridging Matrix — `[IRC-nERDs] <~|> <alice[m]/OFTC> hi`. Unwrapping
+ * once attributes the line to `|`, an intermediate robot rather than a speaker.
+ *
+ * Each further hop is gated on a mark, and deliberately so: `<nick> ...` inside
+ * a relayed line is *also* how people quote each other on IRC, and the two are
+ * structurally identical — nothing in `[efnet] <+raah> <ultros> heretic!` says
+ * whether `ultros` is a bridge or someone raah is quoting. Only the user knows,
+ * and a mark is them saying so. Auto-unwrapping would put words in the quoted
+ * person's mouth.
+ *
+ * `relayPattern` answers for a revealed nick: null/undefined when it carries no
+ * mark, otherwise its custom template (`''` for the built-in formats) — i.e.
+ * exactly what the relay-bot store already holds. The innermost speaker wins,
+ * as does the innermost `[source]` tag actually present, so a chain that names
+ * the platform only on an outer hop keeps that name.
+ */
+export function parseRelayChain(
+  body: string | null | undefined,
+  pattern: string | null | undefined,
+  relayPattern: (nick: string) => string | null | undefined,
+): RelayParse | null {
+  let parsed = parseRelayMessage(body, pattern);
+  if (!parsed) return null;
+  for (let depth = 1; depth < MAX_RELAY_DEPTH; depth++) {
+    const innerPattern = relayPattern(parsed.nick);
+    if (innerPattern == null) break;
+    // A hop that doesn't parse ends the chain where it stands: the marked bot
+    // said something in its own voice (a join notice, a `/relay`-less line), and
+    // that's still correctly attributed to it.
+    const next = parseRelayMessage(parsed.text, innerPattern);
+    if (!next) break;
+    parsed = { source: next.source ?? parsed.source, nick: next.nick, text: next.text };
+  }
+  return parsed;
+}

--- a/shared/parseRelay.ts
+++ b/shared/parseRelay.ts
@@ -171,6 +171,17 @@ const MAX_RELAY_DEPTH = 4;
  * and a mark is them saying so. Auto-unwrapping would put words in the quoted
  * person's mouth.
  *
+ * ⚠ A hop past the first is keyed on a nick that came out of the *bot's text* —
+ * on most bridges a user-settable Discord/Matrix display name, not a nick any
+ * server enforced. So once a bridge is marked, anyone in the room it carries
+ * can rename themselves to that bridge's name and hand us a second envelope to
+ * unwrap: `<admin> everyone leave now`, attributed to `admin` with no bot
+ * chrome left. The first hop can't be spoofed that way, since the outer nick is
+ * a real IRC nick. Accepted rather than defended against — this is the
+ * trusted-friends threat model, marking a bridge is opting into what it says,
+ * and the defences available (demanding a `[source]` tag on every hop, say)
+ * would break the plain `<nick> message` bridges this exists to read.
+ *
  * `relayPattern` answers for a revealed nick: null/undefined when it carries no
  * mark, otherwise its custom template (`''` for the built-in formats) — i.e.
  * exactly what the relay-bot store already holds. The innermost speaker wins,

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -865,6 +865,7 @@ function openRelayNickMenu(
   y: number,
   triggerEl: Element | null = null,
 ): void {
+  const marked = relayBots.isRelay(networkId, nick);
   const items: ContextMenuItem[] = [
     { label: `Reply to ${nick}`, icon: 'fa-solid fa-reply', onClick: () => addressNick(nick) },
     {
@@ -880,10 +881,18 @@ function openRelayNickMenu(
       // it, so when it turns out to be another bridge there's nowhere else to
       // mark it from — it's in no member list, and its profile is the outer
       // bot's. Marking here makes the next hop unwrap and the real speaker
-      // appear. Same wording as the profile modal's toggle.
-      label: 'Mark relay bot',
+      // appear; unmarking is how a mark landed on a quoted human comes off.
+      //
+      // A toggle, not a "mark" button, and reading live state rather than
+      // assuming: this row CAN belong to an already-marked bot — a marked hop
+      // that says something in its own voice ends the chain on itself. Marking
+      // it again would re-upsert with an empty pattern, which the server takes
+      // as a write and fans out, silently dropping a custom template the user
+      // set with `/relay add <nick> <pattern>`. Same wording and shape as the
+      // profile modal's toggle, which is the other way to reach this.
+      label: marked ? 'Unmark relay bot' : 'Mark relay bot',
       icon: 'fa-solid fa-satellite-dish',
-      onClick: () => relayBots.setRelay(networkId, nick, true),
+      onClick: () => relayBots.setRelay(networkId, nick, !marked),
     },
     {
       label: 'View Profile…',

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -362,7 +362,7 @@ import { consolidateRows } from '../utils/consolidate.js';
 import { historyCountBy } from '../lib/historyPaging.js';
 import type { ConsolidationGroup, NickEntry, RenameEntry } from '../../../shared/consolidate.js';
 import { collapseDisplay } from '../utils/collapseDisplay.js';
-import { parseRelayMessage } from '../../../shared/parseRelay.js';
+import { parseRelayChain } from '../../../shared/parseRelay.js';
 import { asEventMode, eventModeKey, isNoiseType } from '../../../shared/eventFilter.js';
 import NickRef from './NickRef.vue';
 import LinkedText from './LinkedText.vue';
@@ -876,6 +876,16 @@ function openRelayNickMenu(
     },
     { divider: true },
     {
+      // Chained bridges (#801). This name is only *shown* because a bot said
+      // it, so when it turns out to be another bridge there's nowhere else to
+      // mark it from — it's in no member list, and its profile is the outer
+      // bot's. Marking here makes the next hop unwrap and the real speaker
+      // appear. Same wording as the profile modal's toggle.
+      label: 'Mark relay bot',
+      icon: 'fa-solid fa-satellite-dish',
+      onClick: () => relayBots.setRelay(networkId, nick, true),
+    },
+    {
       label: 'View Profile…',
       icon: 'fa-solid fa-id-card',
       onClick: () => whois.openViewer(networkId, bot),
@@ -1194,7 +1204,15 @@ const renderRows = computed((): RenderRow[] => {
       networkId &&
       relayBots.isRelay(networkId, m.nick)
     ) {
-      const parsed = parseRelayMessage(m.text ?? '', relayBots.patternFor(networkId, m.nick));
+      // Chained bridges (#801): keep unwrapping while the speaker a hop reveals
+      // is itself a marked bot, so a relay of a relay lands on the person who
+      // spoke rather than on the bridge in between.
+      const parsed = parseRelayChain(
+        m.text ?? '',
+        relayBots.patternFor(networkId, m.nick),
+        (inner) =>
+          relayBots.isRelay(networkId, inner) ? relayBots.patternFor(networkId, inner) : null,
+      );
       if (parsed) {
         mDisplay = {
           ...m,


### PR DESCRIPTION
Fixes #801.

## The line

```
[IRC-nERDs] <~|> <yrdsb3222[m]/OFTC> Is their a discord
```

`nR` bridges the IRC-nERDs network, where a bot nicked `|` is *itself* bridging Matrix/OFTC. Two envelopes, one unwrap — so the line was attributed to `|`, an intermediate robot, and the real speaker stayed in the body as text. The nick was never the problem: `yrdsb3222[m]/OFTC` parses first try when the parser is given a second pass.

## What changed

`parseRelayChain` keeps unwrapping while the nick a hop reveals is **itself a marked relay bot**. Innermost speaker wins; so does the innermost `[source]` tag actually present, so a chain that names the platform only on an outer hop keeps that name. Depth-capped at 4 (two hops is the deepest chain in a real corpus). `relayBot` stays the outer bot — the only real IRC entity in the chain, and what View Profile needs.

## Why each hop needs a mark

Unwrapping on shape alone was the obvious implementation. Measured against the whole dev corpus (687k rows) it fixes **164 lines and misattributes 4**:

```
[efnet] <@SolidBoss> <sadonion> What games yall be playing now <-- D
[efnet] <+raah> <ultros> blasphemer! and a heretic!
[efnet] <+FAST> <nR> [IRC-nERDs] <acidsun_[d]> Playing Pokémon is like…
```

Quoting someone with `<nick>` is normal IRC habit and is **structurally identical** to a bridge envelope. There's no discriminator — colour codes, membership prefixes and nick shape all appear on both sides; `raah` even pastes with mIRC colours. Only the user knows which is which, and a mark is them saying so. Auto-unwrapping puts words in the quoted person's mouth.

So: the revealed nick is in no member list and its profile is the outer bot's, which left nowhere to mark it from. The relayed-nick menu now carries a **Mark relay bot** toggle — exactly where the wrong name appears.

## Trade-off recorded, not fixed

Past the first hop the nick being looked up came out of the bot's text — on most bridges a user-settable display name, not a nick any server enforced. A marked bridge therefore lets its room fabricate an inner envelope. Accepted under the trusted-friends threat model and written into the docstring; the available defences (demanding a `[source]` tag on every hop) would break the plain `<nick> message` bridges this exists to read.

## Testing

- 9 new tests in `shared/parseRelay.test.ts`, built from real corpus lines — including the raah/ultros quote asserting it must **not** re-attribute
- Full suite 3841 passed, `npm run check` clean
- `/code-review high`: found the menu item hard-coding `marked: true`, which could re-upsert an already-marked bot with an empty pattern and silently drop its custom template. Fixed in c75209d — it reads live state and toggles

iOS port is amiantos/lurker-ios#124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)