### PR TITLE
Uploads: name the text dialects, and state the charset (#788)

### DIFF
--- a/server/db/uploadHistory.test.ts
+++ b/server/db/uploadHistory.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mimeMatchesKind } from '../../shared/uploadKinds.js';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -86,6 +87,10 @@ describe('listUploads — search + kind filter (#547)', () => {
     ['vacation.png', 'image/webp'],
     ['screenshot-march.png', 'image/webp'],
     ['notes.txt', 'text/plain'],
+    // The text dialects (#788). `application/json` is the interesting one: IANA files
+    // JSON outside `text/`, so a bare prefix match drops it out of every filter.
+    ['README.md', 'text/markdown'],
+    ['data.json', 'application/json'],
     ['clip.mp4', 'video/mp4'],
     ['song.mp3', 'audio/mpeg'],
     ['SCREAMING-SHOT.PNG', 'image/webp'],
@@ -142,11 +147,38 @@ describe('listUploads — search + kind filter (#547)', () => {
     ['image', 5],
     ['video', 1],
     ['audio', 1],
-    ['text', 1],
+    // .txt + .md + .json — the JSON only arrives here because the clause names it.
+    ['text', 3],
   ] as const)('filters to kind=%s', (kind, count) => {
     const rows = mod.listUploads(carol.id, { kind });
     expect(rows.length).toBe(count);
-    expect(rows.every((r) => (r.mime || '').startsWith(`${kind}/`))).toBe(true);
+    expect(rows.every((r) => mimeMatchesKind(r.mime, kind))).toBe(true);
+  });
+
+  // ⚠ #788. The filter was a bare `mime LIKE 'text/%'`, so an uploaded `.json` was
+  // invisible under every filter the browser offers — including the one it obviously
+  // belongs to. Asserted by NAME, not by count, so widening the seed can't mask it.
+  it('finds a .json under text, whose mime sits outside the text/ prefix', () => {
+    expect(names(mod.listUploads(carol.id, { kind: 'text' }))).toEqual([
+      'data.json',
+      'README.md',
+      'notes.txt',
+    ]);
+  });
+
+  // The OR'd clause must not leak past its own kind: `application/json` belongs to
+  // text and nothing else.
+  it('does not leak an extra-mime row into a neighbouring kind', () => {
+    for (const kind of ['image', 'video', 'audio'] as const) {
+      expect(names(mod.listUploads(carol.id, { kind }))).not.toContain('data.json');
+    }
+  });
+
+  // The extras are OR'd with the prefix but must stay AND'd with everything else — an
+  // extra-mime row is not a way past the search term or the ownership scope.
+  it('still ANDs the search term against an extra-mime row', () => {
+    expect(names(mod.listUploads(carol.id, { q: 'data', kind: 'text' }))).toEqual(['data.json']);
+    expect(mod.listUploads(carol.id, { q: 'data', kind: 'audio' })).toEqual([]);
   });
 
   it('ANDs the search term with the kind', () => {

--- a/server/db/uploadHistory.ts
+++ b/server/db/uploadHistory.ts
@@ -1,6 +1,12 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+import {
+  UPLOAD_KINDS,
+  extraMimesForKind,
+  isUploadKind,
+  type UploadKind,
+} from '../../shared/uploadKinds.js';
 import db from './index.js';
 
 /** A row from the `upload_history` table. */
@@ -98,16 +104,10 @@ export function insertUpload(userId: number, row: InsertUploadFields): number {
   return Number(info.lastInsertRowid);
 }
 
-// The kinds the uploads browser filters by (#547), and the mime prefix each one
-// means. Derived from `mime` rather than stored: the mime is already the magic-byte
-// truth (contentClass.ts sniffs it), so a separate column would be a second source
-// of it that could disagree.
-export const UPLOAD_KINDS = ['image', 'video', 'audio', 'text'] as const;
-export type UploadKind = (typeof UPLOAD_KINDS)[number];
-
-export function isUploadKind(value: unknown): value is UploadKind {
-  return typeof value === 'string' && (UPLOAD_KINDS as readonly string[]).includes(value);
-}
+// Re-exported so callers that already speak to this module don't need to know the
+// definition moved to shared/ (it is shared with the client, which builds the same
+// filter for its optimistic inserts).
+export { UPLOAD_KINDS, isUploadKind, type UploadKind };
 
 /**
  * Escape a user's search term for a SQL LIKE pattern.
@@ -172,10 +172,15 @@ export function listUploads(
     params.push(likeTerm(q));
   }
   if (kind) {
-    where.push('mime LIKE ?');
-    // No ESCAPE needed: `kind` is validated against UPLOAD_KINDS, so it can't carry
-    // a wildcard. The trailing % is ours and deliberate.
-    params.push(`${kind}/%`);
+    // A prefix match on `<kind>/`, OR'd with the exact mimes that kind covers from
+    // outside its prefix — today that is `application/json` under text (#788). No
+    // ESCAPE needed: `kind` is validated against UPLOAD_KINDS, so it can't carry a
+    // wildcard, and the extras are literals from our own table. The trailing % is
+    // ours and deliberate.
+    const extras = extraMimesForKind(kind);
+    const clauses = ['mime LIKE ?', ...extras.map(() => 'mime = ?')];
+    where.push(`(${clauses.join(' OR ')})`);
+    params.push(`${kind}/%`, ...extras);
   }
 
   // Recency of the STAR, not of the upload — starring a two-year-old gif today

--- a/server/routes/localUploads.ts
+++ b/server/routes/localUploads.ts
@@ -120,6 +120,15 @@ router.get('/:key', async (req: Request, res: Response) => {
     mime = ft.mime;
     inline = false;
   } else if (isUtf8(trimPartialUtf8(head))) {
+    // ⚠ A `.md` or `.json` (#788) is served as text/plain here, not as its own
+    // dialect, and that is deliberate. Markdown has no signature — nothing in these
+    // bytes says "markdown" — so the only way to reach that label is the extension in
+    // the key, and "never trust a stored or claimed content-type" is the first rule
+    // this handler exists to enforce. The key is ours, so it would be *safe*; it
+    // would also be the first crack in a one-line invariant, in exchange for nothing.
+    // The link still ends in `.md`, which is what any editor or downloader reads, and
+    // text/plain is the type browsers most reliably render inline. The charset — the
+    // half of #788 that was an actual bug — is stated either way.
     mime = 'text/plain; charset=utf-8';
     inline = true;
   } else {

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -167,6 +167,48 @@ describe('POST /api/uploads', () => {
     expect(row.thumbnail_url).toBeUndefined();
   });
 
+  // #788, end to end. These bytes always went through — a `.md` is signature-less
+  // UTF-8, exactly what the text branch takes — but came back as `.txt`, and the
+  // recorded mime lost the one thing telling an editor how to read the file.
+  it('keeps a markdown or JSON upload under its own name and mime', async () => {
+    const cases: [string, string, string, string][] = [
+      ['README.md', 'text/markdown', 'md', 'text/markdown'],
+      ['data.json', 'application/json', 'json', 'application/json'],
+      // The Windows gap: no registered mime for `.md`, so the claim arrives as plain
+      // text and the filename is the only signal left.
+      ['notes.md', 'text/plain', 'md', 'text/markdown'],
+    ];
+    for (const [filename, contentType, ext, mime] of cases) {
+      const res = await agent
+        .post('/api/uploads')
+        .attach('image', Buffer.from('# notes — ünïcodé\n'), { filename, contentType });
+      expect({ filename, status: res.status }).toEqual({ filename, status: 200 });
+      expect(res.body.url).toMatch(new RegExp(`\\.${ext}$`));
+
+      const list = await agent.get('/api/uploads');
+      const row = list.body.items.find((r: { id: number }) => r.id === res.body.id);
+      expect({ filename, mime: row.mime }).toEqual({ filename, mime });
+      // …and it is findable under the filter it belongs to, which for JSON only works
+      // because the kind clause names the mime explicitly (shared/uploadKinds.ts).
+      const filtered = await agent.get('/api/uploads?kind=text');
+      expect(filtered.body.items.map((r: { id: number }) => r.id)).toContain(res.body.id);
+    }
+  });
+
+  // The relaxation is bounded by the dialect table, not by the caller. An `.html` that
+  // decodes as UTF-8 is still text, and must never name the key we serve.
+  it('will not let an unlisted extension become the served one', async () => {
+    const res = await agent
+      .post('/api/uploads')
+      .attach('image', Buffer.from('<b>not markup to us</b>'), {
+        filename: 'evil.html',
+        contentType: 'text/html',
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.url).toMatch(/\.txt$/);
+    expect(res.body.url).not.toContain('html');
+  });
+
   it('preserves an animated GIF (no re-encode)', async () => {
     // sharp().gif() above produces a single-frame GIF, which the pipeline
     // re-encodes as JPEG. The 'animated bypass' branch is exercised when

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -271,7 +271,10 @@ router.post('/', uploadToDisk, async (req: Request, res: Response, next: NextFun
     // the EXIF scrub lives. See services/contentClass.ts.
     let classified: Classification;
     try {
-      classified = await classifyUpload(req.file.path, req.file.mimetype);
+      // The filename rides along only so a `.md`/`.json` keeps its name on platforms
+      // that register no MIME for it (#788). It cannot widen the accepted set, and it
+      // is not where the served extension comes from — see contentClass.ts.
+      classified = await classifyUpload(req.file.path, req.file.mimetype, req.file.originalname);
     } catch (err) {
       if (err instanceof UnsupportedTypeError) {
         res.status(415).json({ error: err.message });

--- a/server/services/contentClass.test.ts
+++ b/server/services/contentClass.test.ts
@@ -6,7 +6,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import sharp from 'sharp';
-import { classifyUpload, UnsupportedTypeError } from './contentClass.js';
+import { classifyUpload, storedContentType, UnsupportedTypeError } from './contentClass.js';
 
 let dir: string;
 
@@ -237,6 +237,89 @@ describe('classifyUpload — text and refusals', () => {
       'text/plain',
     );
     expect(c.contentClass).toBe('text');
+  });
+
+  // #788. These bytes were ALWAYS accepted — signature-less UTF-8 is what the text
+  // branch takes — so this is about the label, not the gate. A README came back as
+  // `README.txt`, and a `.json` lost the one thing telling an editor how to read it.
+  it('names the text dialects from the claimed mime', async () => {
+    const cases: [string, string, string][] = [
+      ['text/plain', 'text/plain', 'txt'],
+      ['text/markdown', 'text/markdown', 'md'],
+      ['application/json', 'application/json', 'json'],
+    ];
+    for (const [claim, mime, ext] of cases) {
+      const c = await classifyUpload(write(`d-${ext}`, Buffer.from('# notes — ünïcodé\n')), claim);
+      expect({ claim, ...c }).toEqual({ claim, contentClass: 'text', mime, ext });
+    }
+  });
+
+  // ⚠ The portability gap the filename fallback exists for: macOS and Linux register
+  // a mime for `.md`, Windows registers none — so the same file arrives claiming
+  // `text/plain` or `application/octet-stream` and would flatten back to `.txt`. The
+  // feature would simply not work there, silently.
+  it('falls back to the filename extension when the platform sends no mime', async () => {
+    const bytes = Buffer.from('# heading\n');
+    for (const claim of ['text/plain', 'application/octet-stream', '']) {
+      const c = await classifyUpload(write('notes.md', bytes), claim, 'notes.md');
+      expect({ claim, ext: c.ext, mime: c.mime }).toEqual({
+        claim,
+        ext: 'md',
+        mime: 'text/markdown',
+      });
+    }
+    const j = await classifyUpload(write('d.json', Buffer.from('{"a":1}')), '', 'data.JSON');
+    expect(j.ext).toBe('json');
+  });
+
+  // The rule the dialect map is a bounded exception to: the served extension can only
+  // ever be one of the three, whatever the caller says it is. An `.html` that decodes
+  // as UTF-8 is still text, and still lands as `.txt`.
+  it('never lets an unlisted extension become the served one', async () => {
+    for (const name of ['evil.html', 'evil.svg', 'x.tar.gz', 'no-extension', '.bashrc']) {
+      const c = await classifyUpload(write('claim.txt', Buffer.from('plain words')), '', name);
+      expect({ name, ext: c.ext, mime: c.mime }).toEqual({
+        name,
+        ext: 'txt',
+        mime: 'text/plain',
+      });
+    }
+  });
+
+  // The claim, not the filename, decides whether the SVG probe runs — so a name can
+  // never suppress it for bytes that really are SVG.
+  it("keeps the SVG probe on the claim, out of the filename's reach", async () => {
+    const svg = Buffer.from('<?xml version="1.0"?>\n<svg xmlns="http://www.w3.org/2000/svg"/>');
+    const hijack = await classifyUpload(write('a.svg', svg), 'image/svg+xml', 'notes.txt');
+    expect(hijack).toEqual({ contentClass: 'image', mime: 'image/svg+xml', ext: 'svg' });
+
+    // …and the exemption widened with the map: a file the user explicitly named `.md`
+    // stays markdown rather than being called an image. Served as text/markdown it is
+    // every bit as inert, and "your README is an SVG" is the more surprising answer.
+    const md = await classifyUpload(write('b.svg', svg), 'text/markdown', 'notes.md');
+    expect(md).toEqual({ contentClass: 'text', mime: 'text/markdown', ext: 'md' });
+  });
+
+  // The bytes still rule the CLASS. A dialect claim is not a way past the UTF-8 gate.
+  it('will not let a dialect claim smuggle binary through', async () => {
+    const junk = Buffer.from([0x00, 0x01, 0xff, 0xfe, 0x00, 0x99]);
+    for (const claim of ['text/markdown', 'application/json']) {
+      await expect(classifyUpload(write('junk.md', junk), claim, 'junk.md')).rejects.toBeInstanceOf(
+        UnsupportedTypeError,
+      );
+    }
+  });
+
+  // #788's actual bug: bytes fine, label incomplete. A browser handed bare
+  // `text/plain` decodes it with a legacy fallback encoding (Latin-1 on Safari), so
+  // every `—` in a UTF-8 paste renders as `â€"`.
+  it('states the charset on stored text, but not on JSON', () => {
+    expect(storedContentType('text/plain')).toBe('text/plain; charset=utf-8');
+    expect(storedContentType('text/markdown')).toBe('text/markdown; charset=utf-8');
+    // RFC 8259 defines no charset parameter for application/json and mandates UTF-8.
+    expect(storedContentType('application/json')).toBe('application/json');
+    // Untouched for everything else — it is a header helper, not a mime rewriter.
+    expect(storedContentType('image/png')).toBe('image/png');
   });
 
   it('refuses recognized types outside the accepted set, naming what is allowed', async () => {

--- a/server/services/contentClass.ts
+++ b/server/services/contentClass.ts
@@ -3,10 +3,12 @@
 
 // What IS this file? Decided from its magic bytes, on the server, every time.
 //
-// THE RULE: the bytes have absolute authority over the class. The client's claimed
-// MIME is consulted for exactly one thing — telling text apart from SVG among
-// signature-less UTF-8 content — where it cannot cause a bypass, because a real
-// image would have been caught by the sniff regardless of what it was called.
+// THE RULE: the bytes have absolute authority over the CLASS. The client's claim is
+// consulted only where it cannot cause a bypass, because a real image would have been
+// caught by the sniff regardless of what it was called:
+//   • telling text apart from SVG among signature-less UTF-8 content
+//   • naming which text dialect that content is — .txt, .md or .json (#788)
+// Both answer "what do we call these bytes", never "do we take them".
 //
 // Why it has to be this way: the route used to take the client's word for it
 // (`req.file.mimetype === 'text/plain'`). That was survivable while the only two
@@ -124,6 +126,93 @@ export const ACCEPTED_SUMMARY = 'images, text, and audio/video (mp4, mov, m4v, m
  */
 const TEXTISH_SNIFF = new Set(['application/xml', 'text/xml']);
 
+/**
+ * The text dialects: signature-less UTF-8 we are willing to NAME, rather than
+ * flattening to `.txt` (#788).
+ *
+ * These bytes have always been accepted — a `.md` is UTF-8 with no signature, which
+ * is exactly what the text branch below takes — so this widens nothing about what
+ * may be uploaded. All it changes is the label: a README came back as `README.txt`,
+ * and a `.json` lost the one thing that told an editor how to read it.
+ *
+ * ⚠ This is the ONE deliberate relaxation of "the ext is NEVER the client's claim".
+ * That rule exists so a user's `.html` cannot become the served extension, and it is
+ * preserved by the shape of this map, not by the source of the answer: the extension
+ * can only ever be one of these three values, whatever the caller says. Adding an
+ * entry here is therefore a real security decision — the type must be inert when
+ * served from an uploads domain, which is the same bar SVG fails (see below).
+ *
+ * Neither markdown nor JSON renders as anything active in a browser: they display or
+ * download, and the pinned Content-Type never comes from the caller.
+ */
+interface TextDialect {
+  mime: string;
+  ext: string;
+}
+
+const PLAIN_TEXT: TextDialect = { mime: 'text/plain', ext: 'txt' };
+
+const TEXT_DIALECT_BY_MIME = new Map<string, TextDialect>([
+  ['text/plain', PLAIN_TEXT],
+  ['text/markdown', { mime: 'text/markdown', ext: 'md' }],
+  ['application/json', { mime: 'application/json', ext: 'json' }],
+]);
+
+/**
+ * The same three, keyed by filename extension — a SECOND signal, needed because the
+ * first is not portable.
+ *
+ * macOS and Linux register a MIME for `.md` and browsers send `text/markdown`.
+ * Windows registers none, so the same file arrives as `text/plain` or
+ * `application/octet-stream` and would flatten back to `.txt` — the feature would
+ * simply not work there, silently, on the platform least likely to be tested.
+ *
+ * ⚠ It is consulted BEFORE the claim, not as a last resort — see the note at the
+ * call site.
+ *
+ * ⚠ But only to pick a label among the dialects, and only AFTER the SVG decision has
+ * been made from the claimed MIME alone. Letting a filename reach that decision would
+ * mean an `x.txt` name could suppress the SVG check for bytes that really are SVG.
+ */
+const TEXT_DIALECT_BY_EXT = new Map<string, TextDialect>([
+  ['txt', PLAIN_TEXT],
+  ['md', { mime: 'text/markdown', ext: 'md' }],
+  ['markdown', { mime: 'text/markdown', ext: 'md' }],
+  ['json', { mime: 'application/json', ext: 'json' }],
+]);
+
+function dialectFromFilename(filename: string): TextDialect | undefined {
+  const dot = filename.lastIndexOf('.');
+  if (dot < 0) return undefined;
+  return TEXT_DIALECT_BY_EXT.get(filename.slice(dot + 1).toLowerCase());
+}
+
+/**
+ * The Content-Type to STORE for an upload, which is not always its classified mime.
+ *
+ * A text file served with a bare `text/plain` and no charset is decoded by whatever
+ * legacy encoding the browser falls back to — Latin-1 on Safari — so a UTF-8 paste
+ * comes back as `â€"` for every `—`. That is #788: the bytes are fine, the label is
+ * incomplete. `routes/localUploads.ts` has always sent the parameter when serving
+ * from disk; this is for the drivers that hand a stored header to someone else.
+ *
+ * ⚠⚠ NOT for the `dropper` driver, and not something to apply to `Classification.mime`
+ * globally. Dropper matches the claim against an exact allowlist of BARE types, so a
+ * `text/plain; charset=utf-8` claim 415s every text upload on the hosted service. The
+ * bare mime is the identity; the charset belongs only on a header we are writing.
+ *
+ * JSON gets none: RFC 8259 defines no charset parameter for `application/json` and
+ * mandates UTF-8 outright.
+ */
+const STORED_CONTENT_TYPE = new Map<string, string>([
+  ['text/plain', 'text/plain; charset=utf-8'],
+  ['text/markdown', 'text/markdown; charset=utf-8'],
+]);
+
+export function storedContentType(mime: string): string {
+  return STORED_CONTENT_TYPE.get(mime) ?? mime;
+}
+
 /** file-type THROWS (End-Of-Stream) on a file too short to finish parsing a
  *  signature it started to recognize — it doesn't just return undefined. A
  *  truncated upload must not become a 500; "couldn't identify it" is the same
@@ -158,10 +247,20 @@ async function looksLikeSvg(path: string): Promise<boolean> {
  * Classify an uploaded file. Throws UnsupportedTypeError (→ 415) for anything
  * outside the accepted set.
  *
- * `claimedMime` is the client's multipart Content-Type. It is untrusted, and it is
- * used for exactly one decision — see looksLikeSvg's caller below.
+ * `claimedMime` is the client's multipart Content-Type. It is untrusted, and it
+ * decides exactly two things, both of them bounded: whether to run the SVG probe
+ * (see looksLikeSvg's caller below), and which of three text dialects to label
+ * signature-less UTF-8 as. It can never widen what is ACCEPTED.
+ *
+ * `filename` is the client's original filename, and is even more tightly bounded —
+ * its extension is a fallback signal for the dialect label and nothing else. It is
+ * never the served extension — see TEXT_DIALECT_BY_MIME.
  */
-export async function classifyUpload(path: string, claimedMime: string): Promise<Classification> {
+export async function classifyUpload(
+  path: string,
+  claimedMime: string,
+  filename = '',
+): Promise<Classification> {
   const sniff = await sniffType(path);
 
   if (sniff) {
@@ -190,16 +289,31 @@ export async function classifyUpload(path: string, claimedMime: string): Promise
   // UTF-8 (not just a window) is what stops "claim text/plain" from smuggling
   // arbitrary bytes through as a .txt.
   if (await isFileUtf8(path)) {
-    // The ONE place the client's claim is consulted. An SVG picked from a file
-    // dialog arrives as image/svg+xml; the long-message → .txt flow ALWAYS claims
-    // text/plain, so this guard keeps it from being hijacked into the image path
-    // when someone pastes raw SVG markup into the composer. Neither direction is a
-    // bypass: a real image would have sniffed above, and a text file misrouted to
-    // sharp simply fails to decode and 415s.
-    if (claimedMime !== 'text/plain' && (await looksLikeSvg(path))) {
+    // An SVG picked from a file dialog arrives as image/svg+xml; a claim that is
+    // already a text dialect exempts it from the probe, which is what keeps the
+    // long-message → .txt flow (ALWAYS text/plain) from being hijacked into the
+    // image path when someone pastes raw SVG markup into the composer. Neither
+    // direction is a bypass: a real image would have sniffed above, and a text file
+    // misrouted to sharp simply fails to decode and 415s.
+    //
+    // ⚠ Decided from the CLAIM alone, before the filename is consulted at all. The
+    // exemption widened from `text/plain` to the dialects together with the map, so
+    // an explicitly-picked `.md` full of SVG markup stays markdown — served as
+    // text/markdown it is just as inert, and calling a file the user named `.md` an
+    // image is the more surprising answer.
+    const claimed = TEXT_DIALECT_BY_MIME.get(claimedMime);
+    if (!claimed && (await looksLikeSvg(path))) {
       return { contentClass: 'image', mime: 'image/svg+xml', ext: 'svg' };
     }
-    return { contentClass: 'text', mime: 'text/plain', ext: 'txt' };
+    // ⚠ FILENAME first, claim second. Backwards from what you'd expect, and the
+    // reverse does not work: on a platform with no registered mime for `.md` the
+    // claim arrives as `text/plain`, which is itself a dialect — so a claim-first
+    // order matches it, returns `.txt`, and the filename fallback never runs in the
+    // one case it exists for. The extension is also the more specific signal: it is
+    // what the user named the file, where the claim is what their OS guessed about
+    // it. Plain text when neither says anything.
+    const dialect = dialectFromFilename(filename) ?? claimed ?? PLAIN_TEXT;
+    return { contentClass: 'text', mime: dialect.mime, ext: dialect.ext };
   }
 
   throw new UnsupportedTypeError(

--- a/server/services/contentClass.ts
+++ b/server/services/contentClass.ts
@@ -25,6 +25,11 @@
 
 import { fileTypeFromFile } from 'file-type';
 import fs from 'node:fs';
+import {
+  PLAIN_TEXT,
+  TEXT_DIALECT_BY_MIME,
+  dialectFromFilename,
+} from '../../shared/textDialects.js';
 import { isFileUtf8 } from '../utils/utf8.js';
 import type { ContentClass } from './uploadProviders/types.js';
 
@@ -127,65 +132,15 @@ export const ACCEPTED_SUMMARY = 'images, text, and audio/video (mp4, mov, m4v, m
 const TEXTISH_SNIFF = new Set(['application/xml', 'text/xml']);
 
 /**
- * The text dialects: signature-less UTF-8 we are willing to NAME, rather than
- * flattening to `.txt` (#788).
+ * The text dialect table moved to shared/ — the CLIENT's paste/drop gate needs the
+ * extension half for the same portability reason this file needs it, and a second
+ * hand-written copy of the rule is how the two drift. The security note about what
+ * may be added to it lives with the table.
  *
- * These bytes have always been accepted — a `.md` is UTF-8 with no signature, which
- * is exactly what the text branch below takes — so this widens nothing about what
- * may be uploaded. All it changes is the label: a README came back as `README.txt`,
- * and a `.json` lost the one thing that told an editor how to read it.
- *
- * ⚠ This is the ONE deliberate relaxation of "the ext is NEVER the client's claim".
- * That rule exists so a user's `.html` cannot become the served extension, and it is
- * preserved by the shape of this map, not by the source of the answer: the extension
- * can only ever be one of these three values, whatever the caller says. Adding an
- * entry here is therefore a real security decision — the type must be inert when
- * served from an uploads domain, which is the same bar SVG fails (see below).
- *
- * Neither markdown nor JSON renders as anything active in a browser: they display or
- * download, and the pinned Content-Type never comes from the caller.
+ * ⚠ Consulted here for exactly two things, and the ORDER matters — see the call site:
+ * the mime table decides whether the SVG probe runs, and the filename table then picks
+ * the label, filename FIRST.
  */
-interface TextDialect {
-  mime: string;
-  ext: string;
-}
-
-const PLAIN_TEXT: TextDialect = { mime: 'text/plain', ext: 'txt' };
-
-const TEXT_DIALECT_BY_MIME = new Map<string, TextDialect>([
-  ['text/plain', PLAIN_TEXT],
-  ['text/markdown', { mime: 'text/markdown', ext: 'md' }],
-  ['application/json', { mime: 'application/json', ext: 'json' }],
-]);
-
-/**
- * The same three, keyed by filename extension — a SECOND signal, needed because the
- * first is not portable.
- *
- * macOS and Linux register a MIME for `.md` and browsers send `text/markdown`.
- * Windows registers none, so the same file arrives as `text/plain` or
- * `application/octet-stream` and would flatten back to `.txt` — the feature would
- * simply not work there, silently, on the platform least likely to be tested.
- *
- * ⚠ It is consulted BEFORE the claim, not as a last resort — see the note at the
- * call site.
- *
- * ⚠ But only to pick a label among the dialects, and only AFTER the SVG decision has
- * been made from the claimed MIME alone. Letting a filename reach that decision would
- * mean an `x.txt` name could suppress the SVG check for bytes that really are SVG.
- */
-const TEXT_DIALECT_BY_EXT = new Map<string, TextDialect>([
-  ['txt', PLAIN_TEXT],
-  ['md', { mime: 'text/markdown', ext: 'md' }],
-  ['markdown', { mime: 'text/markdown', ext: 'md' }],
-  ['json', { mime: 'application/json', ext: 'json' }],
-]);
-
-function dialectFromFilename(filename: string): TextDialect | undefined {
-  const dot = filename.lastIndexOf('.');
-  if (dot < 0) return undefined;
-  return TEXT_DIALECT_BY_EXT.get(filename.slice(dot + 1).toLowerCase());
-}
 
 /**
  * The Content-Type to STORE for an upload, which is not always its classified mime.

--- a/server/services/uploadProviders/s3.ts
+++ b/server/services/uploadProviders/s3.ts
@@ -23,6 +23,7 @@
 
 import { createHash, createHmac, randomBytes } from 'node:crypto';
 import { USER_AGENT } from '../../utils/userAgent.js';
+import { storedContentType } from '../contentClass.js';
 import { putSource, isOk } from './multipart.js';
 import { hashOf, type UploadSource } from './source.js';
 import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
@@ -284,7 +285,12 @@ export async function upload(
     bucket,
     key,
     payloadHash,
-    contentType: mime,
+    // The bucket replays this header verbatim to every viewer, and nothing of ours
+    // sits in front of it to add the charset later — so a bare `text/plain` here is
+    // what a browser decodes as Latin-1, turning a UTF-8 paste into mojibake (#788).
+    // ⚠ Only for a header WE are writing: the dropper driver posts `mime` as its
+    // multipart claim, and dropper matches claims against bare types.
+    contentType: storedContentType(mime),
     region,
     accessKeyId,
     secretAccessKey,

--- a/server/services/uploadProviders/uploadProviders.test.ts
+++ b/server/services/uploadProviders/uploadProviders.test.ts
@@ -314,6 +314,28 @@ describe('dropper provider', () => {
     expect(result.url).toBe('https://cdn.test/aB3kZ.gif');
   });
 
+  // ⚠⚠ The claim posted to dropper must stay the BARE mime, never the stored-header
+  // form the s3 driver sends (#788). Dropper matches a claim against an exact
+  // allowlist of bare types, so a `text/plain; charset=utf-8` claim 415s EVERY text
+  // upload on the hosted service — dropper pins the charset on its own PutObject.
+  // The bare mime is the identity; the parameter belongs only on a header we write.
+  it('posts the bare mime as its claim, with no charset parameter', async () => {
+    for (const mime of ['text/plain', 'text/markdown', 'application/json']) {
+      const cap = capturePost();
+      postResponse = {
+        status: 200,
+        headers: {},
+        text: JSON.stringify({ url: 'https://cdn.test/x.txt' }),
+      };
+      await dropper.upload(
+        src([0x68, 0x69]),
+        { filename: 'note.txt', mime },
+        { url: 'https://upload.example.com', api_key: 'k' },
+      );
+      expect(filePart(cap, 'file').contentType).toBe(mime);
+    }
+  });
+
   it('strips trailing slash from base URL', async () => {
     const cap = capturePost();
     postResponse = {
@@ -717,6 +739,31 @@ describe('s3 provider', () => {
     );
     expect(cap.headers!['content-type']).toBe('image/png');
     expect(cap.headers!.authorization).toContain('AWS4-HMAC-SHA256');
+  });
+
+  // #788, the self-host half. The bucket replays this header verbatim to every viewer
+  // and nothing of ours is in front of it to add the charset later — so a bare
+  // `text/plain` is what a browser decodes as Latin-1, turning a UTF-8 paste into
+  // mojibake. routes/localUploads.ts has always sent the parameter when serving from
+  // disk; a bucket-backed self-host was the path that didn't.
+  it('states the charset on the stored content-type for text', async () => {
+    const cases: [string, string, string][] = [
+      ['n.txt', 'text/plain', 'text/plain; charset=utf-8'],
+      ['r.md', 'text/markdown', 'text/markdown; charset=utf-8'],
+      // RFC 8259 defines no charset parameter for application/json.
+      ['d.json', 'application/json', 'application/json'],
+      // Untouched for everything else.
+      ['x.png', 'image/png', 'image/png'],
+    ];
+    for (const [filename, mime, stored] of cases) {
+      const cap = capturePut();
+      postResponse = { status: 200, headers: {}, text: '' };
+      await s3.upload(src([0x68, 0x69]), { filename, mime }, SECRETS);
+      expect({ mime, sent: cap.headers!['content-type'] }).toEqual({ mime, sent: stored });
+      // ⚠ And it must be the SIGNED value: content-type is in SignedHeaders, so a
+      // header the signature didn't cover is a 403 from the store, not a wrong label.
+      expect(cap.headers!.authorization).toContain('content-type');
+    }
   });
 
   it('rejects with PROVIDER_CONFIG when any required setting is missing', async () => {

--- a/shared/textDialects.ts
+++ b/shared/textDialects.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ * The text dialects: signature-less UTF-8 we are willing to NAME, rather than
+ * flattening to `.txt` (#788).
+ *
+ * These bytes have always been accepted — a `.md` is UTF-8 with no signature, which
+ * is exactly what the server's text branch takes — so this widens nothing about what
+ * may be uploaded. All it changes is the label: a README came back as `README.txt`,
+ * and a `.json` lost the one thing that told an editor how to read it.
+ *
+ * ⚠ This is the ONE deliberate relaxation of "the ext is NEVER the client's claim"
+ * (services/contentClass.ts). That rule exists so a user's `.html` cannot become the
+ * served extension, and it is preserved by the SHAPE of this table, not by the source
+ * of the answer: the extension can only ever be one of these three values, whatever
+ * the caller says. Adding an entry is therefore a real security decision — the type
+ * must be inert when served from an uploads domain, the bar SVG fails. Neither
+ * markdown nor JSON renders as anything active in a browser: they display or
+ * download, and the pinned Content-Type never comes from the caller.
+ *
+ * Shared because the CLIENT needs the extension half too, and for the same portability
+ * reason the server does. Its paste/drop gate sees only `File.type`, which on a
+ * platform with no registered mime for `.md` is `''` or `application/octet-stream` —
+ * so a hand-copied list here would silently ignore the exact files the server's
+ * fallback exists to accept, and would rot the first time a dialect is added.
+ */
+export interface TextDialect {
+  mime: string;
+  ext: string;
+}
+
+export const PLAIN_TEXT: TextDialect = { mime: 'text/plain', ext: 'txt' };
+const MARKDOWN: TextDialect = { mime: 'text/markdown', ext: 'md' };
+const JSON_TEXT: TextDialect = { mime: 'application/json', ext: 'json' };
+
+export const TEXT_DIALECT_BY_MIME = new Map<string, TextDialect>([
+  ['text/plain', PLAIN_TEXT],
+  ['text/markdown', MARKDOWN],
+  ['application/json', JSON_TEXT],
+]);
+
+/**
+ * The same three, keyed by filename extension — a SECOND signal, needed because the
+ * first is not portable.
+ *
+ * macOS and Linux register a mime for `.md` and browsers send `text/markdown`.
+ * Windows registers none, so the same file arrives as `text/plain`,
+ * `application/octet-stream` or nothing at all — and the feature would simply not
+ * work there, silently, on the platform least likely to be tested.
+ */
+const TEXT_DIALECT_BY_EXT = new Map<string, TextDialect>([
+  ['txt', PLAIN_TEXT],
+  ['md', MARKDOWN],
+  ['markdown', MARKDOWN],
+  ['json', JSON_TEXT],
+]);
+
+/** The dialect a filename's extension names, if it names one at all. */
+export function dialectFromFilename(filename: string): TextDialect | undefined {
+  const dot = filename.lastIndexOf('.');
+  if (dot < 0) return undefined;
+  return TEXT_DIALECT_BY_EXT.get(filename.slice(dot + 1).toLowerCase());
+}
+
+/**
+ * Does this filename look like one of the dialects?
+ *
+ * The client's read of the same table: its paste/drop gate has a filename and an
+ * unreliable mime, and needs to decide whether to hand the file to the server at all.
+ * ⚠ A HINT, never a verdict — the server re-derives everything from the bytes, and
+ * this returning true does not mean the upload will be accepted.
+ */
+export function hasTextDialectExtension(filename: string): boolean {
+  return dialectFromFilename(filename) !== undefined;
+}

--- a/shared/uploadKinds.test.ts
+++ b/shared/uploadKinds.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { UPLOAD_KINDS, extraMimesForKind, isUploadKind, mimeMatchesKind } from './uploadKinds.js';
+
+describe('mimeMatchesKind', () => {
+  it('matches on the kind prefix', () => {
+    expect(mimeMatchesKind('image/webp', 'image')).toBe(true);
+    expect(mimeMatchesKind('video/mp4', 'video')).toBe(true);
+    expect(mimeMatchesKind('audio/mpeg', 'audio')).toBe(true);
+    expect(mimeMatchesKind('text/plain', 'text')).toBe(true);
+    expect(mimeMatchesKind('text/markdown', 'text')).toBe(true);
+  });
+
+  // ⚠ The whole reason this module exists (#788). JSON is a text file IANA files under
+  // `application/`, so a prefix match misses it and an uploaded `.json` is invisible
+  // under every filter the uploads browser offers.
+  it('matches JSON under text, which its prefix does not', () => {
+    expect(mimeMatchesKind('application/json', 'text')).toBe(true);
+  });
+
+  it('does not let an extra mime leak into another kind', () => {
+    for (const kind of ['image', 'video', 'audio'] as const) {
+      expect(mimeMatchesKind('application/json', kind)).toBe(false);
+    }
+  });
+
+  it('is not a blanket application/ pass', () => {
+    expect(mimeMatchesKind('application/pdf', 'text')).toBe(false);
+    expect(mimeMatchesKind('application/zip', 'text')).toBe(false);
+  });
+
+  // A prefix match must be on the SEGMENT, so a kind can't match a mime that merely
+  // starts with its letters.
+  it('will not match a mime that only starts with the kind name', () => {
+    expect(mimeMatchesKind('imagefoo/bar', 'image')).toBe(false);
+    expect(mimeMatchesKind('textual/plain', 'text')).toBe(false);
+  });
+
+  it('treats a missing mime as matching nothing', () => {
+    for (const kind of UPLOAD_KINDS) {
+      expect(mimeMatchesKind(null, kind)).toBe(false);
+      expect(mimeMatchesKind('', kind)).toBe(false);
+    }
+  });
+
+  // The server interpolates extras into a SQL clause as bound literals. Any mime with
+  // a LIKE metacharacter in it would be a bug there, so pin the shape at the source.
+  it('exposes extras as plain literal mimes', () => {
+    for (const kind of UPLOAD_KINDS) {
+      for (const mime of extraMimesForKind(kind)) {
+        expect(mime).toMatch(/^[a-z]+\/[a-z0-9.+-]+$/);
+        // An extra that its own prefix already covers is dead weight, and a sign the
+        // table and the kind list have drifted.
+        expect(mime.startsWith(`${kind}/`)).toBe(false);
+      }
+    }
+  });
+});
+
+describe('isUploadKind', () => {
+  it('accepts exactly the declared kinds', () => {
+    for (const kind of UPLOAD_KINDS) expect(isUploadKind(kind)).toBe(true);
+  });
+
+  // It guards a query parameter that becomes part of a SQL clause, so everything else
+  // has to fail — including the near-misses.
+  it('rejects anything else', () => {
+    for (const value of ['', 'texts', 'TEXT', 'application', null, undefined, 7, {}]) {
+      expect(isUploadKind(value)).toBe(false);
+    }
+  });
+});

--- a/shared/uploadKinds.ts
+++ b/shared/uploadKinds.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ * The kinds the uploads browser filters by (#547), and which mimes each one covers.
+ *
+ * Shared because BOTH sides have to answer the same question and must not drift: the
+ * server builds a WHERE clause from it (db/uploadHistory.ts) and the client decides
+ * whether an optimistically-inserted row belongs in the active view
+ * (stores/uploads.ts). Those were two hand-written copies of one rule — the client's
+ * comment said "mirrors the server's WHERE clause", which is a promise a comment
+ * cannot keep.
+ *
+ * The kind is DERIVED from the mime, never stored. The mime is already the
+ * magic-byte truth (services/contentClass.ts sniffs it), so a `kind` column would be
+ * a second source of the same fact, free to disagree with it.
+ */
+export const UPLOAD_KINDS = ['image', 'video', 'audio', 'text'] as const;
+export type UploadKind = (typeof UPLOAD_KINDS)[number];
+
+export function isUploadKind(value: unknown): value is UploadKind {
+  return typeof value === 'string' && (UPLOAD_KINDS as readonly string[]).includes(value);
+}
+
+/**
+ * Mimes a kind covers that its `<kind>/…` prefix does not.
+ *
+ * ⚠ JSON is the whole reason this exists. It is a text file that IANA files under
+ * `application/` (RFC 8259 registers `application/json`, and there is no
+ * `text/json`), so a prefix match on `text/` misses it and an uploaded `.json` is
+ * invisible under every filter the browser offers — including the one it obviously
+ * belongs to (#788). The alternative was inventing a `text/json` we would then be
+ * sending to real object stores, which is worse than one entry in a table.
+ */
+const EXTRA_MIMES: Partial<Record<UploadKind, readonly string[]>> = {
+  text: ['application/json'],
+};
+
+/** The exact mimes a kind covers beyond its prefix. Empty for most kinds. */
+export function extraMimesForKind(kind: UploadKind): readonly string[] {
+  return EXTRA_MIMES[kind] ?? [];
+}
+
+/** Does an upload of this mime belong under this kind? The single definition both
+ *  the SQL filter and the client's optimistic insert are built from. */
+export function mimeMatchesKind(mime: string | null | undefined, kind: UploadKind): boolean {
+  const m = mime || '';
+  return m.startsWith(`${kind}/`) || extraMimesForKind(kind).includes(m);
+}

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -1939,9 +1939,15 @@ function blobFromClipboardItem(item: DataTransferItem): File | null {
   // Same gate as drop, from the same definition — pasting a video file from Finder
   // used to silently do nothing. `kind === 'file'` keeps pasted rich text from being
   // hijacked into an upload; the server has the final say on the type.
-  if (!item || item.kind !== 'file' || !isUploadableType(item.type)) return null;
+  //
+  // ⚠ The file is taken BEFORE the type gate, because the gate needs its name: a
+  // platform with no registered mime for `.md` reports an empty type, and the
+  // extension is then the only thing distinguishing a README from a stray binary
+  // (#788). `kind` is still checked first, so rich text never reaches getAsFile().
+  if (!item || item.kind !== 'file') return null;
   const file = item.getAsFile();
-  return file || null;
+  if (!file || !isUploadableType(file.type, file.name)) return null;
+  return file;
 }
 
 function onPaste(e: ClipboardEvent): void {
@@ -2029,7 +2035,7 @@ function onDrop(e: DragEvent): void {
   dragOver.value = false;
   if (!sendable.value) return;
   const file = e.dataTransfer?.files?.[0];
-  if (!file || !isUploadableType(file.type)) return;
+  if (!file || !isUploadableType(file.type, file.name)) return;
   uploads.upload(file, file.name).catch(() => {});
 }
 

--- a/vue_client/src/stores/uploads.test.ts
+++ b/vue_client/src/stores/uploads.test.ts
@@ -253,6 +253,42 @@ describe('uploads — browser filters', () => {
     expect(uploads.recent.map((u) => u.filename)).toEqual(['shot.png']);
   });
 
+  // ⚠ The optimistic filter and the server's WHERE clause are now ONE definition
+  // (shared/uploadKinds.ts). They used to be two hand-written copies, and the client's
+  // was a mime PREFIX test — so a `.json`, whose mime IANA files under `application/`,
+  // was excluded here while the server's clause returned it (#788). The row would fail
+  // to appear, then arrive on the next reload, which reads as a bug in the uploader.
+  it('inserts a .json under the text filter, matching what a refetch would return', async () => {
+    const uploads = useUploadsStore();
+    await uploads.setFilters({ query: '', kind: 'text' });
+
+    apiMultipart.mockResolvedValue({
+      id: 20,
+      url: 'https://x.test/d.json',
+      mime: 'application/json',
+    });
+    await uploads.upload(new Blob(['{}']), 'data.json');
+    expect(uploads.recent.map((u) => u.filename)).toEqual(['data.json']);
+
+    apiMultipart.mockResolvedValue({ id: 21, url: 'https://x.test/r.md', mime: 'text/markdown' });
+    await uploads.upload(new Blob(['# hi']), 'README.md');
+    expect(uploads.recent.map((u) => u.filename)).toEqual(['README.md', 'data.json']);
+  });
+
+  // The shared rule must not have widened `text` into "anything non-media".
+  it('still excludes a non-text application/ mime from the text filter', async () => {
+    const uploads = useUploadsStore();
+    await uploads.setFilters({ query: '', kind: 'text' });
+
+    apiMultipart.mockResolvedValue({
+      id: 22,
+      url: 'https://x.test/d.pdf',
+      mime: 'application/pdf',
+    });
+    await uploads.upload(new Blob(['x']), 'doc.pdf');
+    expect(uploads.recent).toEqual([]);
+  });
+
   it('respects the search term when optimistically inserting', async () => {
     const uploads = useUploadsStore();
     await uploads.setFilters({ query: 'holiday' });

--- a/vue_client/src/stores/uploads.ts
+++ b/vue_client/src/stores/uploads.ts
@@ -3,6 +3,7 @@
 
 import { ref } from 'vue';
 import { defineStore } from 'pinia';
+import { mimeMatchesKind, type UploadKind } from '../../../shared/uploadKinds.js';
 import { api, apiMultipart } from '../api.js';
 import { makeClientId } from '../utils/clientId.js';
 
@@ -50,9 +51,9 @@ const FAVORITES_LIMIT = 200;
 // either mode: it is a function of the panel, not of what is in it.
 const UPLOAD_MENU_LIMIT = 24;
 
-/** The kinds the uploads browser filters by. Mirrors UPLOAD_KINDS on the server, which
- *  derives each one from the mime prefix. */
-export type UploadKind = 'image' | 'video' | 'audio' | 'text';
+// Re-exported so components keep importing the type from the store they already use.
+// The definition — and the mime→kind rule both sides filter by — lives in shared/.
+export type { UploadKind };
 
 /** Which list the composer's attach menu is showing: the curated starred set, or
  *  the tail of everything uploaded. */
@@ -316,15 +317,18 @@ export const useUploadsStore = defineStore('uploads', {
     },
 
     /**
-     * Would the active filters have returned this row? Mirrors the server's WHERE
-     * clause — substring on filename, mime prefix on kind — so an optimistically
-     * inserted upload appears if and only if a refetch would have shown it.
+     * Would the active filters have returned this row? Shares one definition with the
+     * server's WHERE clause (shared/uploadKinds.ts) — substring on filename,
+     * mimeMatchesKind on kind — so an optimistically inserted upload appears if and
+     * only if a refetch would have shown it. This used to hand-copy the rule as a
+     * mime PREFIX test, which silently disagreed the moment a kind covered a mime
+     * from outside its prefix (`application/json` under text, #788).
      */
     matchesFilters(row: UploadItem): boolean {
       // A fresh upload is never starred, so this also correctly keeps one out of an
       // active starred-only view rather than flashing it in until the next reload.
       if (this.favoritesOnly && !row.favorite) return false;
-      if (this.kind && !(row.mime || '').startsWith(`${this.kind}/`)) return false;
+      if (this.kind && !mimeMatchesKind(row.mime, this.kind)) return false;
       if (!this.query) return true;
       return (row.filename || '').toLowerCase().includes(this.query.toLowerCase());
     },

--- a/vue_client/src/utils/uploadHostMatch.test.ts
+++ b/vue_client/src/utils/uploadHostMatch.test.ts
@@ -61,6 +61,10 @@ describe('mediaKindForUrl', () => {
     ['https://x.test/a.mp3', 'audio'],
     ['https://x.test/a.m4a', 'audio'],
     ['https://x.test/a.txt', 'text'],
+    // The dialects the uploader can now mint (#788) open in the in-app reader too.
+    ['https://x.test/a.md', 'text'],
+    ['https://x.test/a.markdown', 'text'],
+    ['https://x.test/a.json', 'text'],
     // VIDEO, deliberately, even though the ones we serve are audio-only voice memos:
     // 3gp can carry a picture, and <video> on audio-only content still plays where
     // <audio> on a real clip would silently drop the video. See uploadHostMatch.ts.

--- a/vue_client/src/utils/uploadHostMatch.test.ts
+++ b/vue_client/src/utils/uploadHostMatch.test.ts
@@ -61,10 +61,6 @@ describe('mediaKindForUrl', () => {
     ['https://x.test/a.mp3', 'audio'],
     ['https://x.test/a.m4a', 'audio'],
     ['https://x.test/a.txt', 'text'],
-    // The dialects the uploader can now mint (#788) open in the in-app reader too.
-    ['https://x.test/a.md', 'text'],
-    ['https://x.test/a.markdown', 'text'],
-    ['https://x.test/a.json', 'text'],
     // VIDEO, deliberately, even though the ones we serve are audio-only voice memos:
     // 3gp can carry a picture, and <video> on audio-only content still plays where
     // <audio> on a real clip would silently drop the video. See uploadHostMatch.ts.
@@ -98,6 +94,21 @@ describe('mediaKindForUrl', () => {
     'https://x.test/',
     'not-a-url',
   ])('leaves %s unclassified', (url) => {
+    expect(mediaKindForUrl(url)).toBeNull();
+  });
+
+  // ⚠ Regression guard, NOT an oversight. The uploader mints `.md` and `.json`
+  // (#788) and it is tempting to list them here so our own upload opens in-app —
+  // but this table judges arbitrary chat links, and those extensions are
+  // overwhelmingly PAGE urls. Listing them swallows the click on a GitHub blob and
+  // lands the user on "could not read this file" instead of GitHub, and makes
+  // previewUrls count the same link as media so it loses its preview card. See the
+  // note in uploadHostMatch.ts before changing this.
+  it.each([
+    'https://github.com/o/r/blob/main/README.md',
+    'https://x.test/docs/guide.markdown',
+    'https://api.x.test/v1/users.json',
+  ])('leaves %s alone rather than swallowing the click', (url) => {
     expect(mediaKindForUrl(url)).toBeNull();
   });
 

--- a/vue_client/src/utils/uploadHostMatch.ts
+++ b/vue_client/src/utils/uploadHostMatch.ts
@@ -31,7 +31,12 @@ const EXTENSIONS: Record<MediaKind, readonly string[]> = {
   image: ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.avif', '.bmp'],
   video: ['.mp4', '.mov', '.m4v', '.webm', '.3gp', '.3g2'],
   audio: ['.mp3', '.m4a', '.ogg', '.oga', '.wav', '.flac'],
-  text: ['.txt'],
+  // The text dialects the uploader can now produce (#788), so a `.md` or `.json`
+  // opens in the in-app reader instead of ejecting to a new tab. Worth more than it
+  // looks: the viewer fetches the bytes and decodes them with `Response.text()`,
+  // which is UTF-8 by definition — so it reads correctly even from a host that
+  // serves the file with no charset.
+  text: ['.txt', '.md', '.markdown', '.json'],
 };
 
 export function mediaKindForUrl(rawUrl: string): MediaKind | null {

--- a/vue_client/src/utils/uploadHostMatch.ts
+++ b/vue_client/src/utils/uploadHostMatch.ts
@@ -31,12 +31,23 @@ const EXTENSIONS: Record<MediaKind, readonly string[]> = {
   image: ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.avif', '.bmp'],
   video: ['.mp4', '.mov', '.m4v', '.webm', '.3gp', '.3g2'],
   audio: ['.mp3', '.m4a', '.ogg', '.oga', '.wav', '.flac'],
-  // The text dialects the uploader can now produce (#788), so a `.md` or `.json`
-  // opens in the in-app reader instead of ejecting to a new tab. Worth more than it
-  // looks: the viewer fetches the bytes and decodes them with `Response.text()`,
-  // which is UTF-8 by definition — so it reads correctly even from a host that
-  // serves the file with no charset.
-  text: ['.txt', '.md', '.markdown', '.json'],
+  // ⚠ `.md` and `.json` are deliberately ABSENT, though the uploader mints both
+  // (#788). This table judges ARBITRARY chat links by extension, and those two are
+  // overwhelmingly PAGE urls rather than raw files — a GitHub blob, a docs page, an
+  // API endpoint. Listing them costs twice over, on links that have nothing to do
+  // with us: `RenderSegments.isViewableUrl` would swallow the click on
+  // `…/blob/main/README.md` and land the user on the viewer's "could not read this
+  // file" card instead of GitHub, and `previewUrls` would count the same link as
+  // media, so it silently loses its preview card for anyone running link previews
+  // without inline media.
+  //
+  // `.txt` earns its place because a `.txt` url is almost always the file itself.
+  // The failure modes aren't symmetric: a wrong guess here breaks a link the user
+  // did not upload, while the cost of omitting them is only that OUR OWN `.md`
+  // opens in a browser tab. Re-add them keyed on the url being one of the user's
+  // upload hosts — this module's name is aspirational, no such check exists yet —
+  // never on the extension alone.
+  text: ['.txt'],
 };
 
 export function mediaKindForUrl(rawUrl: string): MediaKind | null {

--- a/vue_client/src/utils/uploaders.test.ts
+++ b/vue_client/src/utils/uploaders.test.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect } from 'vitest';
-import { hasUploaderChoice, iconForMime, isUploadableType } from './uploaders.js';
+import {
+  ACCEPTED_FILE_TYPES,
+  hasUploaderChoice,
+  iconForMime,
+  isUploadableType,
+} from './uploaders.js';
 
 describe('hasUploaderChoice', () => {
   // The bug this exists to prevent: on app.lurker.chat there is exactly ONE
@@ -32,6 +37,15 @@ describe('iconForMime', () => {
     expect(iconForMime('image/png')).toBe('fa-file-image');
     expect(iconForMime(null)).toBe('fa-file');
   });
+
+  // #788. JSON is a text file IANA files under `application/`, so a prefix test drops
+  // it onto the generic page glyph this function exists to get away from.
+  it('gives the text glyph to every dialect the uploader can produce', () => {
+    expect(iconForMime('text/markdown')).toBe('fa-file-lines');
+    expect(iconForMime('application/json')).toBe('fa-file-lines');
+    // Not a blanket application/ pass — that would put the glyph on a PDF.
+    expect(iconForMime('application/pdf')).toBe('fa-file');
+  });
 });
 
 describe('isUploadableType', () => {
@@ -43,5 +57,22 @@ describe('isUploadableType', () => {
     expect(isUploadableType('image/png')).toBe(true);
     expect(isUploadableType('text/plain')).toBe(true);
     expect(isUploadableType('application/pdf')).toBe(false);
+  });
+
+  // A dropped `.md` used to be silently ignored here — no upload, no error, nothing
+  // (#788). The picker greying it out was the other half of the same gap.
+  it('accepts the text dialects a file drop can carry', () => {
+    expect(isUploadableType('text/markdown')).toBe(true);
+    expect(isUploadableType('application/json')).toBe(true);
+    // Any text/* — the server takes signature-less UTF-8 whatever it was called.
+    expect(isUploadableType('text/x-python')).toBe(true);
+  });
+
+  it('offers the dialects in the file picker, by mime AND by extension', () => {
+    // Both are needed: macOS greys out anything the attribute doesn't match, with no
+    // "All Files" escape, and platforms disagree about what they call a `.md`.
+    for (const token of ['text/markdown', 'application/json', '.md', '.json']) {
+      expect(ACCEPTED_FILE_TYPES.split(',')).toContain(token);
+    }
   });
 });

--- a/vue_client/src/utils/uploaders.test.ts
+++ b/vue_client/src/utils/uploaders.test.ts
@@ -68,6 +68,36 @@ describe('isUploadableType', () => {
     expect(isUploadableType('text/x-python')).toBe(true);
   });
 
+  // ⚠ The gap Copilot caught on #808. The picker path does NOT share this gate
+  // (onFileSelected uploads directly), so a dragged `.md` on a platform that registers
+  // no mime for it was silently ignored while PICKING the same file worked — and the
+  // server's filename fallback, which exists for exactly that platform, never got to
+  // see the file at all.
+  it('accepts a dialect by extension when the platform reports no mime', () => {
+    for (const mime of ['', 'application/octet-stream']) {
+      expect(isUploadableType(mime, 'README.md')).toBe(true);
+      expect(isUploadableType(mime, 'notes.MARKDOWN')).toBe(true);
+      expect(isUploadableType(mime, 'data.json')).toBe(true);
+      expect(isUploadableType(mime, 'log.txt')).toBe(true);
+    }
+  });
+
+  // Bounded to the dialect extensions, NOT "let every unknown type through": a stray
+  // drag should still do nothing rather than start an upload that 415s.
+  it('still ignores an unknown type that is not a dialect', () => {
+    for (const name of ['installer.dmg', 'archive.tar.gz', 'no-extension', 'x.exe']) {
+      expect(isUploadableType('', name)).toBe(false);
+      expect(isUploadableType('application/octet-stream', name)).toBe(false);
+    }
+  });
+
+  // The extension is consulted ONLY when the mime says nothing. A type we already
+  // refuse is not rescued by naming the file `.md`.
+  it('does not let an extension override a mime we refuse', () => {
+    expect(isUploadableType('application/pdf', 'notes.md')).toBe(false);
+    expect(isUploadableType('application/zip', 'data.json')).toBe(false);
+  });
+
   it('offers the dialects in the file picker, by mime AND by extension', () => {
     // Both are needed: macOS greys out anything the attribute doesn't match, with no
     // "All Files" escape, and platforms disagree about what they call a `.md`.

--- a/vue_client/src/utils/uploaders.ts
+++ b/vue_client/src/utils/uploaders.ts
@@ -119,7 +119,12 @@ export function missingRequired(
 export const ACCEPTED_FILE_TYPES = [
   'image/*',
   'text/plain',
+  'text/markdown',
+  'application/json',
   '.txt',
+  '.md',
+  '.markdown',
+  '.json',
   'video/mp4',
   'video/quicktime',
   'video/x-m4v',
@@ -167,7 +172,12 @@ export function isUploadableType(mime: string): boolean {
     mime.startsWith('image/') ||
     mime.startsWith('audio/') ||
     mime.startsWith('video/') ||
-    mime === 'text/plain'
+    // Any text/* dialect, not just text/plain: the server takes signature-less UTF-8
+    // whatever the browser called it, and this gate's job is only to ignore things
+    // that obviously aren't uploads. `application/json` needs naming because IANA
+    // files JSON outside `text/` (#788).
+    mime.startsWith('text/') ||
+    mime === 'application/json'
   );
 }
 
@@ -179,7 +189,9 @@ export function iconForMime(mime: string | null | undefined): string {
   if (m.startsWith('video/')) return 'fa-file-video';
   if (m.startsWith('audio/')) return 'fa-file-audio';
   if (m.startsWith('image/')) return 'fa-file-image';
-  if (m.startsWith('text/')) return 'fa-file-lines';
+  // JSON is a text file IANA files under `application/` (#788) — without this it
+  // falls to the generic page glyph the rest of this function exists to avoid.
+  if (m.startsWith('text/') || m === 'application/json') return 'fa-file-lines';
   return 'fa-file';
 }
 

--- a/vue_client/src/utils/uploaders.ts
+++ b/vue_client/src/utils/uploaders.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+import { hasTextDialectExtension } from '../../../shared/textDialects.js';
+
 // Shared shapes for the uploader-management UI (#514). The server projects these
 // from each driver's own `configSchema`, so the client renders a form for a
 // driver it has never heard of — adding a driver is a server-only change.
@@ -167,8 +169,8 @@ export const CAMERA_CAPTURE_TYPES = [
 // gate, and its 415 names the problem ("webm files are not accepted — Lurker takes
 // …"), which is far more useful than a drop that silently does nothing — the bug
 // this replaces.
-export function isUploadableType(mime: string): boolean {
-  return (
+export function isUploadableType(mime: string, filename = ''): boolean {
+  if (
     mime.startsWith('image/') ||
     mime.startsWith('audio/') ||
     mime.startsWith('video/') ||
@@ -178,7 +180,22 @@ export function isUploadableType(mime: string): boolean {
     // files JSON outside `text/` (#788).
     mime.startsWith('text/') ||
     mime === 'application/json'
-  );
+  ) {
+    return true;
+  }
+
+  // ⚠ The filename is the ONLY signal left when the platform has no mime for the
+  // extension. Windows registers none for `.md`, so a dragged README arrives as `''`
+  // or `application/octet-stream` — and without this the file is silently ignored
+  // right here, one layer ABOVE the server's filename fallback, which never gets to
+  // see it. The picker path doesn't share this gate, so the bug looked like "drag and
+  // drop is broken on Windows only" while picking the same file worked.
+  //
+  // Bounded to the dialect extensions rather than "let every unknown type through":
+  // a stray `.dmg` drag should still do nothing, not start an upload that 415s. Same
+  // shared table the server labels from, so the two can't drift.
+  if (!mime || mime === 'application/octet-stream') return hasTextDialectExtension(filename);
+  return false;
 }
 
 /** A Font Awesome icon for an upload with no thumbnail, from its MIME. The recent-


### PR DESCRIPTION
Fixes the cell half of #788. The hosted dropper went first (control-plane `a8b7e04`, already on `main`) — per its own ⚠, the cell must not widen its accepted set before dropper is **deployed**, or it streams whole files across the wire before dropper refuses them.

## The "corrupted characters" were never corrupted

The file in the issue is byte-identical to its source. What broke is the label: a text file served with a bare `text/plain` and no charset is decoded by whatever legacy encoding the browser falls back to — Latin-1 on Safari — so that 40 KB UTF-8 paste came back with **164 mojibake characters**, `â€"` for every `—`.

`routes/localUploads.ts` has always sent the parameter when serving from disk. The paths that hand a stored header to someone else did not: the hosted dropper, and the **s3 driver** — every bucket-backed self-host. Same family as the busboy latin-1 bug that put `â¯` in the uploads list.

⚠⚠ The charset goes only on a header *we* write, never on `Classification.mime`. The dropper driver posts that mime as its multipart claim, and dropper matches claims against an exact allowlist of **bare** types — a charset there would 415 every text upload on hosted. Pinned by a test.

## Markdown and JSON

Those bytes always went through — signature-less UTF-8 is exactly what the text branch takes — but flattened to `.txt`, so a README came back as `README.txt`. What is new is the label, not the gate.

This is the one deliberate relaxation of *"the ext is NEVER the client's claim"*. That rule exists so a user's `.html` cannot become the served extension, and it survives by the **shape** of the map rather than the source of the answer: the extension can only ever be one of three values, whatever the caller says. Adding an entry is a real security decision — the type must be inert served from an uploads domain, the bar SVG fails.

⚠ The dialect is read from the **filename first**, claim second, which is backwards from what you'd expect. The reverse does not work: a platform with no registered mime for `.md` sends `text/plain`, which is *itself* a dialect, so a claim-first order matches it and the filename fallback never runs in the one case it exists for. The SVG probe still keys on the claim **alone**, before the filename is consulted, or an `x.txt` name could suppress it for real SVG bytes.

## `shared/uploadKinds.ts`

JSON is a text file IANA files under `application/`, so `mime LIKE 'text/%'` made an uploaded `.json` invisible under every filter the uploads browser offers. The server's WHERE clause and the client's optimistic-insert check were two hand-written copies of one rule — the client's comment said *"mirrors the server's WHERE clause"*, which is a promise a comment cannot keep. One mutation to the shared predicate now fails tests on both sides.

## Review

`/code-review high` found one medium, and it was right: `.md`/`.json` do **not** belong in `uploadHostMatch`'s extension table. It judges arbitrary chat links and feeds two callers beyond the viewer, and those extensions are overwhelmingly *page* urls — clicking `…/blob/main/README.md` would stop opening GitHub and land on "could not read this file", and the same link would lose its preview card for anyone running link previews without inline media. Reverted, with a named regression test. Second finding (local driver serves `.md` as `text/plain`) documented as intentional — that handler's first rule is "never trust a stored or claimed content-type", and the extension is the only route to the label.

## Not in this PR

- **R2 bucket CORS** and edge `nosniff` — dashboard changes. The missing CORS header is why the in-app text reader can never read a hosted upload today, which is worth more than the charset fix: the viewer decodes with `Response.text()`, UTF-8 by definition.
- **Backfill** — existing objects keep the bare `text/plain` until re-PUT.
- **lurker-ios** has its own accepted-types list and needs the same widening.

## Testing

Full suite green: 274 files, 3872 tests. New coverage validated by mutation — reverting the shared predicate to a prefix test fails on both server and client; reverting the dropper's `UNSNIFFABLE` set fails there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
