### PR TITLE
Refuse sends on a connection that can't reach the wire (#809)

### DIFF
--- a/server/services/bouncer.integration.test.ts
+++ b/server/services/bouncer.integration.test.ts
@@ -259,6 +259,26 @@ describe('live relay', () => {
     expect(acct.upstream.rawSent.some((l) => l.includes('+typing'))).toBe(false);
   });
 
+  // #809. ircManager now refuses a write on a network in reconnect backoff rather
+  // than persisting a message that never reaches IRC. The bouncer ignored the
+  // boolean, so for a BYOC client the line simply evaporated — no error, no echo,
+  // nothing. It has to say so, because unlike the web composer there is no toast.
+  it('tells the client when the upstream is not writable, and sends nothing', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'downstream' });
+    const c = await harness.connect();
+    c.send(`PASS ${acct.user.username}:${acct.password}`);
+    c.send('NICK client');
+    c.send('USER client 0 * :client');
+    await c.waitForCommand('422');
+    acct.upstream.state = 'reconnecting';
+    c.send('PRIVMSG #chan :are you there');
+    const notice = await c.waitFor((l) => l.includes('NOTICE') && l.includes('not sent'));
+    expect(notice).toContain('reconnecting');
+    // ⚠ And nothing left for the network. registerEcho is skipped too, so the
+    // keys don't sit in the pending list waiting to time out.
+    expect(acct.upstream.rawSent.some((l) => l.includes('are you there'))).toBe(false);
+  });
+
   it('never forwards a post-registration AUTHENTICATE to the upstream', async () => {
     const acct = harnessMod.seedAccount({ nick: 'noauth' });
     const c = await harness.connect();

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -1735,6 +1735,14 @@ class BouncerSession {
       this.numeric('412', ':No text to send');
       return;
     }
+    // Upstream in reconnect backoff: ircManager refuses the write rather than
+    // persisting a message that never reaches IRC (#809). Say so here, or the
+    // line vanishes with no feedback at all — and skip registerEcho below, whose
+    // keys would otherwise sit in the pending list until they time out.
+    if (conn.state !== 'connected') {
+      this.notice(`Upstream '${this.network?.name}' is ${conn.state} — message not sent.`);
+      return;
+    }
     for (const target of targets) {
       const isAction = text.startsWith('\u0001ACTION ') || text.startsWith('\u0001ACTION\u0001');
       if (text.startsWith('\u0001') && !isAction) {

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -1739,7 +1739,12 @@ class BouncerSession {
     // persisting a message that never reaches IRC (#809). Say so here, or the
     // line vanishes with no feedback at all — and skip registerEcho below, whose
     // keys would otherwise sit in the pending list until they time out.
-    if (conn.state !== 'connected') {
+    // Asked through ircManager, not by re-testing conn.state here: the whole point
+    // of consolidating the writable test is that a second copy of it can drift
+    // from the one ircManager.send actually applies, and then we either
+    // double-refuse or go back to dropping lines silently. conn.state is read
+    // only to NAME the state in the notice.
+    if (!ircManager.writableConnection(this.userId, this.networkId)) {
       this.notice(`Upstream '${this.network?.name}' is ${conn.state} — message not sent.`);
       return;
     }

--- a/server/services/ctcpWiring.test.ts
+++ b/server/services/ctcpWiring.test.ts
@@ -17,6 +17,7 @@ import { createUser } from '../db/users.js';
 import { createNetwork } from '../db/networks.js';
 import { APP_NAME, APP_VERSION } from '../utils/userAgent.js';
 import settingsService from './settingsService.js';
+import ircManager from './ircManager.js';
 
 // The default ctcp.version template (`${name} ${version}`) expands to this.
 const DEFAULT_VERSION_REPLY = `${APP_NAME} ${APP_VERSION}`;
@@ -422,5 +423,42 @@ describe('inbound CTCP request — msgbuffer routing (ctcp.msgbuffer)', () => {
     expect(ctcpLines()).toHaveLength(0); // no ephemeral ctcp line in system mode
     expect(publishEphemeral).not.toHaveBeenCalled();
     logNet.mockRestore();
+  });
+});
+
+// #809. ircManager.ctcpRequest resolved through getConnection(), which during a
+// reconnect backoff still hands back the IrcConnection the retry controller is
+// holding — so the line went to a socket that discards it while the call reported
+// success. The damage here is worse than a silent drop: sendCtcpRequest ALSO
+// surfaces "→ CTCP PING to bob" into the issuing buffer, so the user watched a
+// request they could see go out wait forever for a reply that could never arrive,
+// while wsHub's "this network isn't connected" warning had no way to fire.
+describe('outbound CTCP needs a writable connection', () => {
+  // The spy lands on the ircManager singleton, which every other describe in this
+  // file shares; nothing restores mocks globally.
+  afterEach(() => vi.restoreAllMocks());
+
+  function stub(state: string) {
+    const sendCtcpRequest =
+      vi.fn<(issuing: string, target: string, t: string, a: string) => void>();
+    vi.spyOn(ircManager, 'getConnection').mockReturnValue({
+      state,
+      sendCtcpRequest,
+    } as unknown as IrcConnection);
+    return sendCtcpRequest;
+  }
+
+  it('refuses, and writes nothing, while the network is reconnecting', () => {
+    const sendCtcpRequest = stub('reconnecting');
+    expect(ircManager.ctcpRequest(1, 1, '#chan', 'bob', 'PING', '')).toBe(false);
+    // ⚠ Both halves. Returning false is what lets wsHub say so; not calling
+    // through is what keeps the "→ CTCP PING to bob" echo off the screen.
+    expect(sendCtcpRequest).not.toHaveBeenCalled();
+  });
+
+  it('still sends on a connected network', () => {
+    const sendCtcpRequest = stub('connected');
+    expect(ircManager.ctcpRequest(1, 1, '#chan', 'bob', 'PING', '')).toBe(true);
+    expect(sendCtcpRequest).toHaveBeenCalledWith('#chan', 'bob', 'PING', '');
   });
 });

--- a/server/services/ircE2eWiring.test.ts
+++ b/server/services/ircE2eWiring.test.ts
@@ -71,6 +71,7 @@ describe('outbound encrypt (ircManager.send)', () => {
       client: { user: { nick: 'alice' } },
       supportsMultiline: () => false,
       echoActive: () => false,
+      state: 'connected', // the writable gate (#809) refuses anything else
       noteSentCiphertext: () => {},
       flushE2eRekeys: () => {},
     } as unknown as IrcConnection;
@@ -110,6 +111,7 @@ describe('outbound encrypt (ircManager.send)', () => {
       client: { user: { nick: 'alice' } },
       supportsMultiline: () => false,
       echoActive: () => false,
+      state: 'connected', // the writable gate (#809) refuses anything else
       noteSentCiphertext: () => {},
       flushE2eRekeys: () => {},
     } as unknown as IrcConnection;
@@ -312,6 +314,7 @@ describe('egress refuses cleartext actions/notices on an E2E channel (#2)', () =
       publish,
       publishEphemeral,
       echoActive: () => false,
+      state: 'connected', // the writable gate (#809) refuses anything else
       client: { user: { nick: 'alice' } },
     } as unknown as IrcConnection;
     return { conn, action, notice, publishEphemeral };

--- a/server/services/ircEchoMessage.test.ts
+++ b/server/services/ircEchoMessage.test.ts
@@ -503,11 +503,17 @@ describe('ircManager optimistic-publish gating', () => {
   // ratchet or burn a queued rekey on a line that never leaves the process.
   it('refuses an E2E send while not writable, without encrypting', () => {
     e2eManager.setChannelConfig(userId, networkId, '#e2eoffline', true, 'normal');
-    const { conn, say, publish } = fakeConn({ state: 'reconnecting' });
+    const flushE2eRekeys = vi.fn<() => void>();
+    const { conn, say, publish } = fakeConn({ state: 'reconnecting', flushE2eRekeys });
     vi.spyOn(ircManager, 'getConnection').mockReturnValue(conn);
     expect(ircManager.send(userId, networkId, '#e2eoffline', 'secret hello')).toBe(false);
     expect(say).not.toHaveBeenCalled();
     expect(publish).not.toHaveBeenCalled();
+    // ⚠⚠ This is the assertion that pins WHERE the gate sits. say/publish alone
+    // would still pass with the gate moved to just after encryptOutgoing() —
+    // which advances the ratchet and DRAINS the pending rekey queue into a dead
+    // socket, losing those rekeys for good. Only flushE2eRekeys catches that.
+    expect(flushE2eRekeys).not.toHaveBeenCalled();
   });
 
   it('the E2E branch keeps its optimistic plaintext publish even with echo active', () => {

--- a/server/services/ircEchoMessage.test.ts
+++ b/server/services/ircEchoMessage.test.ts
@@ -429,6 +429,9 @@ describe('ircManager optimistic-publish gating', () => {
       notice,
       publish,
       client: { user: { nick: 'me' } },
+      // The writable gate (#809) reads this — these cases are about echo
+      // adoption, so they all start from a live socket.
+      state: 'connected',
       supportsMultiline: () => false,
       echoActive: () => true,
       noteSentCiphertext: () => {},
@@ -476,6 +479,35 @@ describe('ircManager optimistic-publish gating', () => {
     ircManager.send(userId, networkId, '#gate', 'a\nb');
     expect(noEcho.publish).toHaveBeenCalledTimes(1);
     expect(noEcho.publish.mock.calls[0][0]).toMatchObject({ text: 'a\nb', self: true });
+  });
+
+  // #809: a network in reconnect backoff keeps its IrcConnection, but every line
+  // written to it is dropped by irc-framework. send/action/notice must refuse
+  // rather than persist a self row and fan it out to every device as sent.
+  it('refuses send/action/notice while the connection is not writable', () => {
+    for (const state of ['reconnecting', 'connecting', 'disconnected']) {
+      const { conn, say, action, notice, publish } = fakeConn({ state, echoActive: () => false });
+      vi.spyOn(ircManager, 'getConnection').mockReturnValue(conn);
+      expect(ircManager.send(userId, networkId, '#gate', 'hi')).toBe(false);
+      expect(ircManager.action(userId, networkId, '#gate', 'waves')).toBe(false);
+      expect(ircManager.notice(userId, networkId, '#gate', 'psst')).toBe(false);
+      expect(say).not.toHaveBeenCalled();
+      expect(action).not.toHaveBeenCalled();
+      expect(notice).not.toHaveBeenCalled();
+      expect(publish).not.toHaveBeenCalled();
+      vi.restoreAllMocks();
+    }
+  });
+
+  // The gate sits AHEAD of the E2E branch, so a doomed send can't advance the
+  // ratchet or burn a queued rekey on a line that never leaves the process.
+  it('refuses an E2E send while not writable, without encrypting', () => {
+    e2eManager.setChannelConfig(userId, networkId, '#e2eoffline', true, 'normal');
+    const { conn, say, publish } = fakeConn({ state: 'reconnecting' });
+    vi.spyOn(ircManager, 'getConnection').mockReturnValue(conn);
+    expect(ircManager.send(userId, networkId, '#e2eoffline', 'secret hello')).toBe(false);
+    expect(say).not.toHaveBeenCalled();
+    expect(publish).not.toHaveBeenCalled();
   });
 
   it('the E2E branch keeps its optimistic plaintext publish even with echo active', () => {

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -152,6 +152,24 @@ class IrcManager extends EventEmitter {
     return this.byUser.get(userId)?.get(networkId) || null;
   }
 
+  // Resolve a connection we may actually WRITE to. `getConnection() !== null` is
+  // a different question: since the auto-reconnect overhaul a dropped network
+  // keeps its IrcConnection in the map for the whole outage while the retry
+  // controller backs off, so the object outlives the socket. irc-framework's
+  // Connection.write() then returns false and DROPS the line, which is invisible
+  // from here — so anything that reports success (or worse, persists a self row)
+  // off a non-null connection is lying about a message that never left the
+  // process (#809).
+  //
+  // Reads of already-materialised state (topic, membership) deliberately do NOT
+  // go through here: last-known state is stale, not a lie, and refusing it
+  // mid-reconnect would be strictly less useful. See verbs/liveConn.ts, which
+  // delegates here so the writable test has one definition.
+  writableConnection(userId: number, networkId: number): IrcConnection | null {
+    const conn = this.getConnection(userId, networkId);
+    return conn && conn.state === 'connected' ? conn : null;
+  }
+
   listConnections(userId: number): IrcConnection[] {
     return Array.from(this.connectionsForUser(userId).values());
   }
@@ -477,7 +495,14 @@ class IrcManager extends EventEmitter {
   // peers saw N. Splitting on our side and publishing per chunk keeps the
   // local view symmetric with what was actually transmitted.
   send(userId: number, networkId: number, target: string, text: string): boolean {
-    const conn = this.getConnection(userId, networkId);
+    // writableConnection, not getConnection: a network in reconnect backoff still
+    // has a connection object, and every line written to it is silently dropped.
+    // Reporting success there persisted a self row and fanned it out to every
+    // device as sent, forever, for a message that never reached IRC (#809).
+    // Returning false gives the composer its existing not-connected affordance —
+    // a toast, with the typed text kept. Gated ahead of the E2E branch below so a
+    // doomed send can't advance the ratchet or burn a rekey either.
+    const conn = this.writableConnection(userId, networkId);
     if (!conn) return false;
 
     // RPE2E: on an encryption-enabled channel, transmit ciphertext chunks on the
@@ -600,7 +625,8 @@ class IrcManager extends EventEmitter {
   }
 
   action(userId: number, networkId: number, target: string, text: string): boolean {
-    const conn = this.getConnection(userId, networkId);
+    // Same phantom-send gate as send() — see the comment there (#809).
+    const conn = this.writableConnection(userId, networkId);
     if (!conn) return false;
     if (this.refuseCleartextOnE2eChannel(conn, userId, networkId, target, 'action')) return true;
     // Same echo-adoption gating as send() — see the comment there.
@@ -628,7 +654,8 @@ class IrcManager extends EventEmitter {
   // send/action. splitSay applies because NOTICE shares PRIVMSG's length
   // budget.
   notice(userId: number, networkId: number, target: string, text: string): boolean {
-    const conn = this.getConnection(userId, networkId);
+    // Same phantom-send gate as send() — see the comment there (#809).
+    const conn = this.writableConnection(userId, networkId);
     if (!conn) return false;
     if (this.refuseCleartextOnE2eChannel(conn, userId, networkId, target, 'notice')) return true;
     const adoptEcho = conn.echoActive();

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -499,9 +499,14 @@ class IrcManager extends EventEmitter {
     // has a connection object, and every line written to it is silently dropped.
     // Reporting success there persisted a self row and fanned it out to every
     // device as sent, forever, for a message that never reached IRC (#809).
-    // Returning false gives the composer its existing not-connected affordance —
-    // a toast, with the typed text kept. Gated ahead of the E2E branch below so a
-    // doomed send can't advance the ratchet or burn a rekey either.
+    // Returning false routes into the composer's existing not-connected
+    // affordance: an error toast carrying the message body. ⚠ It does NOT keep
+    // the text in the input — MessageInput calls commitInput() before awaiting
+    // the ack, so the field and the synced draft are already cleared by the time
+    // the failure lands; the body survives in the toast and in local up-arrow
+    // history. Worth knowing, because this gate makes ok:false the ordinary
+    // outcome of any outage rather than a rarity. Gated ahead of the E2E branch
+    // below so a doomed send can't advance the ratchet or burn a rekey either.
     const conn = this.writableConnection(userId, networkId);
     if (!conn) return false;
 
@@ -705,6 +710,13 @@ class IrcManager extends EventEmitter {
   // Send an outbound CTCP request (/ctcp, /ping). `issuingTarget` is the buffer
   // the command came from so the reply routes back there. Returns false when the
   // network isn't connected (no wire to send on).
+  //
+  // Same phantom-send class as send() (#809), and the docstring above was the
+  // claim that made it one: sendCtcpRequest ALSO surfaces "→ CTCP PING to <nick>"
+  // into the issuing buffer, so on a dead socket the user watched a request they
+  // could see go out wait forever for a reply that could never arrive. wsHub has
+  // a "this network isn't connected" warning on the false branch that had no way
+  // to fire.
   ctcpRequest(
     userId: number,
     networkId: number,
@@ -713,7 +725,7 @@ class IrcManager extends EventEmitter {
     type: string,
     args: string,
   ): boolean {
-    const conn = this.getConnection(userId, networkId);
+    const conn = this.writableConnection(userId, networkId);
     if (!conn) return false;
     conn.sendCtcpRequest(issuingTarget, target, type, args);
     return true;

--- a/server/services/verbs/liveConn.ts
+++ b/server/services/verbs/liveConn.ts
@@ -19,8 +19,9 @@ import type { IrcConnection } from '../ircConnection.js';
 // already-materialised state (get_topic, list_members) deliberately do NOT go
 // through here: they return last-known membership, which is stale but not a
 // lie, and refusing them mid-reconnect would be strictly less useful.
+//
+// The test itself lives on ircManager (the send path needs the same gate and
+// can't import this module without a cycle); this stays the verbs' name for it.
 export function writableConnection(userId: number, networkId: number): IrcConnection | null {
-  const conn = ircManager.getConnection(userId, networkId);
-  if (!conn || conn.state !== 'connected') return null;
-  return conn;
+  return ircManager.writableConnection(userId, networkId);
 }

--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -627,6 +627,62 @@ describe('MessageInput command dispatch', () => {
     });
   });
 
+  // #809 QA. The clear is optimistic — commitInput runs before the ACK — so a send
+  // that comes back not-connected used to leave the composer empty with nothing
+  // but a toast and up-arrow. Fine while a failed send was a rarity; the
+  // writable-connection gate makes it the ordinary outcome of any outage.
+  describe('a failed send comes back to the composer', () => {
+    async function failingSend(input: string) {
+      seedStores('#zebra');
+      vi.mocked(socketSendWithAck).mockReturnValue(
+        Promise.resolve({ ok: false, error: 'not-connected' }) as never,
+      );
+      const drafts = useDraftStore();
+      const { el } = await mountComposer();
+      await type(el, input);
+      await enter(el);
+      await flush();
+      return drafts;
+    }
+
+    it('restores a plain message as the buffer draft', async () => {
+      const drafts = await failingSend('hello there');
+      expect(drafts.forBuffer(1, '#zebra')).toBe('hello there');
+    });
+
+    it('restores the whole typed line for a command, not just its body', async () => {
+      // ⚠ `/me waves` and not `waves` — what comes back has to be re-sendable.
+      const drafts = await failingSend('/me waves');
+      expect(drafts.forBuffer(1, '#zebra')).toBe('/me waves');
+    });
+
+    it('restores a /notice to the buffer it was TYPED IN, not to its target', async () => {
+      const drafts = await failingSend('/notice bob psst');
+      expect(drafts.forBuffer(1, '#zebra')).toBe('/notice bob psst');
+      expect(drafts.forBuffer(1, 'bob')).toBe('');
+    });
+
+    // ⚠⚠ The rule that keeps this from being a regression of its own: the ACK is
+    // late, so the user may already be typing something else. Theirs wins.
+    it('never clobbers text typed while the ACK was in flight', async () => {
+      seedStores('#zebra');
+      let settle: (r: { ok: boolean; error: string }) => void = () => {};
+      vi.mocked(socketSendWithAck).mockReturnValue(
+        new Promise((r) => {
+          settle = r as typeof settle;
+        }) as never,
+      );
+      const drafts = useDraftStore();
+      const { el } = await mountComposer();
+      await type(el, 'first');
+      await enter(el);
+      await type(el, 'second thoughts');
+      settle({ ok: false, error: 'not-connected' });
+      await flush();
+      expect(drafts.forBuffer(1, '#zebra')).toBe('second thoughts');
+    });
+  });
+
   it('/part <#chan> [reason] retargets the named channel', async () => {
     seedStores('#zebra');
     const { el } = await mountComposer();

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -192,7 +192,7 @@ import { ACCEPTED_FILE_TYPES, CAMERA_CAPTURE_TYPES, isUploadableType } from '../
 import { useWhoisStore } from '../stores/whois.js';
 import { useChanlistStore } from '../stores/chanlist.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
-import { socketSend, socketSendWithAck } from '../composables/useSocket.js';
+import { socketSend, socketSendWithAck, type AckResult } from '../composables/useSocket.js';
 import { requestScrollToBottom } from '../composables/useScrollState.js';
 import { setComposingState } from '../composables/useComposing.js';
 import {
@@ -2043,6 +2043,35 @@ defineExpose({
   focus: () => inputEl.value?.focus(),
 });
 
+/**
+ * Put a failed send's text back where the user can act on it.
+ *
+ * ⚠⚠ The clear is OPTIMISTIC — commitInput runs before the ACK resolves, so by the time a send
+ * comes back `not-connected` the composer and the synced draft have already been emptied. That
+ * was survivable while a failed send was a rarity; the writable-connection gate (#809) makes it
+ * the ordinary outcome of any outage, and "your message vanished, there's a toast, press up-arrow"
+ * is not a thing a chat client should ask of you.
+ *
+ * Restoring the DRAFT is what does the work: the composer's `text` is a computed over the draft
+ * for the active buffer, so this refills the input if you're still looking at that buffer, and
+ * leaves it waiting for you (on every device) if you're not.
+ *
+ * ⚠⚠ Addressed to the buffer the send came FROM, never through `text.value` — whose setter
+ * targets whatever buffer is active NOW. `/msg nick text` activates the DM before we get here, so
+ * writing through the setter would strand the text in the wrong composer. Same trap commitInput
+ * documents (#4).
+ *
+ * ⚠ Never clobbers. The user may have started typing something else in the gap; theirs wins, and
+ * the toast (which carries the body) plus up-arrow are the fallback.
+ */
+function restoreFailedSend(networkId: number, target: string, raw: string): void {
+  if (drafts.forBuffer(networkId, target).trim() !== '') return;
+  drafts.setLocal(networkId, target, raw);
+  // Straight to the server rather than on the debounce, so closing the tab or
+  // switching buffers can't lose what we just recovered.
+  drafts.flushBuffer(networkId, target);
+}
+
 function toastSendFailure(error: string, body: string): void {
   // Translate the small set of ack/error strings into something a person can
   // act on. We keep the failed text in the toast body so the user can copy
@@ -2235,9 +2264,17 @@ async function submit() {
     // synchronously if the socket is closed so we don't silently swallow
     // them either.
     const said = chatMessagesSent;
+    // Cleared first so a stale ack from an earlier command can't be mistaken for
+    // this one's.
+    pendingCommandAck = null;
     const handled = await handleCommand(raw, networkId, target);
     if (!handled) return;
     commitInput(raw, networkId, target, { isChatMessage: chatMessagesSent > said });
+    const ack = takeCommandAck();
+    if (ack) {
+      const result = await ack.promise;
+      if (!result.ok) restoreFailedSend(ack.origin.networkId, ack.origin.target, ack.origin.line);
+    }
     return;
   }
 
@@ -2259,7 +2296,10 @@ async function submit() {
   clearInactivityTimer();
   commitInput(raw, networkId, target, { isChatMessage: true });
   const result = await pending;
-  if (!result.ok) toastSendFailure(result.error ?? 'unknown', raw);
+  if (!result.ok) {
+    toastSendFailure(result.error ?? 'unknown', raw);
+    restoreFailedSend(networkId, target, raw);
+  }
 }
 
 async function onLongMessageConfirm() {
@@ -2514,7 +2554,39 @@ function sendOrToast(payload: Record<string, unknown>, body: string): boolean {
 // to sequence wrongly against the read.
 let chatMessagesSent = 0;
 
-function ackedSend(payload: Record<string, unknown>, body: string): boolean {
+// The ACK of the last command that put something on the wire, plus the buffer it
+// was TYPED IN and the line as typed. submit() picks this up AFTER commitInput.
+//
+// ⚠⚠ Handed up rather than restored inside ackedSend, and the ordering is the
+// reason. submit does `await handleCommand(...)` — one microtask — and only then
+// calls commitInput to clear the composer. An ACK that resolves inside that
+// window would be restored and then immediately cleared again. A real socket
+// can't answer that fast, but "correct because the network is slow" is not an
+// invariant worth shipping.
+interface CommandAck {
+  promise: Promise<AckResult>;
+  origin: { networkId: number; target: string; line: string };
+}
+let pendingCommandAck: CommandAck | null = null;
+
+// Read-and-clear. A function rather than a bare read because TypeScript narrows
+// the module-level `let` to `null` at the reset in submit() and doesn't widen it
+// back across the `await handleCommand(...)` that fills it in.
+function takeCommandAck(): CommandAck | null {
+  const ack = pendingCommandAck;
+  pendingCommandAck = null;
+  return ack;
+}
+
+// `origin` is the buffer the command was TYPED IN plus the line as typed, so a
+// failure can hand the whole thing back — `/notice bob hi`, not the bare `hi`
+// that `body` carries. Not the payload's target: `/notice bob …` is addressed to
+// bob but was written in #chan, and #chan is where the text belongs.
+function ackedSend(
+  payload: Record<string, unknown>,
+  body: string,
+  origin?: { networkId: number; target: string; line: string },
+): boolean {
   const pending = socketSendWithAck(payload);
   if (!pending) {
     toastSendFailure('disconnected', body);
@@ -2523,10 +2595,11 @@ function ackedSend(payload: Record<string, unknown>, body: string): boolean {
   // 'notice' is deliberately not counted: it's addressed to someone else and
   // puts nothing in the buffer the command was run from.
   if (payload.type === 'send' || payload.type === 'action') chatMessagesSent += 1;
-  pending.then((result) => {
+  const settled = pending.then((result) => {
     if (!result.ok) toastSendFailure(result.error ?? 'unknown', body);
     return result;
   });
+  if (origin) pendingCommandAck = { promise: settled, origin };
   return true;
 }
 
@@ -3169,7 +3242,11 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       // relay mark is per-(network, nick), so it needs an active network.
       return runRelay(argLine, networkId, target);
     case 'me':
-      return ackedSend({ type: 'action', networkId, target, text: chatBody(argLine) }, argLine);
+      return ackedSend({ type: 'action', networkId, target, text: chatBody(argLine) }, argLine, {
+        networkId,
+        target,
+        line,
+      });
     case 'ctcp': {
       // /ctcp <nick> <type> [args] — send a CTCP query (#263). The cell frames
       // and sends it, echoes locally, and routes the reply back to this buffer.
@@ -3214,7 +3291,13 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       if (!who) return true;
       const body = msgParts.join(' ');
       if (body) {
-        if (!ackedSend({ type: 'send', networkId, target: who, text: chatBody(body) }, body))
+        if (
+          !ackedSend({ type: 'send', networkId, target: who, text: chatBody(body) }, body, {
+            networkId,
+            target,
+            line,
+          })
+        )
           return false;
       }
       buffers.activate(networkId, who);
@@ -3454,7 +3537,11 @@ function handleCommand(line: string, networkId: number | null, target: string): 
         return true;
       }
       const url = `https://meet.jit.si/lurker-${randomRoomId()}`;
-      return ackedSend({ type: 'send', networkId, target, text: url }, url);
+      return ackedSend({ type: 'send', networkId, target, text: url }, url, {
+        networkId,
+        target,
+        line,
+      });
     }
     case 'op':
       return modeShortcut(networkId, target, rest, '+', 'o', 'usage: /op [#chan] <nick…>', line);
@@ -3593,7 +3680,11 @@ function handleCommand(line: string, networkId: number | null, target: string): 
         localInfo(networkId, target, 'usage: /notice <target> <text>');
         return true;
       }
-      return ackedSend({ type: 'notice', networkId, target: who, text: chatBody(body) }, body);
+      return ackedSend({ type: 'notice', networkId, target: who, text: chatBody(body) }, body, {
+        networkId,
+        target,
+        line,
+      });
     }
     case 'slap': {
       // mIRC's classic: a CTCP ACTION with the canonical trout line, so it rides
@@ -3608,7 +3699,11 @@ function handleCommand(line: string, networkId: number | null, target: string): 
         return true;
       }
       const slapText = `slaps ${who} around a bit with a large trout`;
-      return ackedSend({ type: 'action', networkId, target, text: slapText }, slapText);
+      return ackedSend({ type: 'action', networkId, target, text: slapText }, slapText, {
+        networkId,
+        target,
+        line,
+      });
     }
     case 'shrug': {
       // A plain message, not an ACTION: everywhere this convention comes from
@@ -3619,7 +3714,11 @@ function handleCommand(line: string, networkId: number | null, target: string): 
         return true;
       }
       const shrugText = shrugBody(argLine);
-      return ackedSend({ type: 'send', networkId, target, text: chatBody(shrugText) }, shrugText);
+      return ackedSend({ type: 'send', networkId, target, text: chatBody(shrugText) }, shrugText, {
+        networkId,
+        target,
+        line,
+      });
     }
     // Info/query commands. These already function via the raw fallback now that
     // unhandled server numerics surface in the server buffer (#269) — listing


### PR DESCRIPTION
Fixes #809.

## The bug

While a network is in reconnect backoff, `ircManager.send()` reported success, wrote a self-attributed message row, and pushed it to every one of the user's devices — for a line that never left the process. The user saw their message in the buffer, on every device, forever. No error, no toast, no retry.

Three things lined up:

1. Since the auto-reconnect overhaul a dropped network keeps its `IrcConnection` in the manager's map for the whole outage, so `getConnection()` returns a live-looking object.
2. `conn.say()` reaches irc-framework's `Connection.write`, which returns `false` and **discards** the line when `!this.connected`. Nothing propagated that back up.
3. `echoActive()` returns false when the socket is down, so the optimistic publish fired. That branch exists to cover servers without `echo-message` — it can't tell "no cap" from "no socket".

## The fix

Gate `send`/`action`/`notice` on a genuinely writable connection. The affordance already existed end to end: the verbs map `false` → `not-connected`, and the composer raises "Network offline — message not sent".

The writable test moves onto `ircManager` (the send path can't import `verbs/liveConn` without a cycle) and `liveConn` delegates to it, so there is one definition rather than two that can drift.

In `send()` the gate sits **ahead** of the E2E branch: a doomed line must not advance the ratchet or drain the queued rekeys into a dead socket. A test asserts `flushE2eRekeys` wasn't called, which is what pins that placement — asserting only on `say`/`publish` would pass with the gate one block lower.

`ctcpRequest()` turned out to be the same class, and worse: `sendCtcpRequest` surfaces `→ CTCP PING to <nick>` into the issuing buffer, so `/ping bob` rendered as sent and then waited forever. `wsHub` already had a "this network isn't connected" warning that had no way to fire. `e2eCommand`/`probePresence` deliberately stay ungated — `/e2e on|off` is configuration and legitimately works offline, and reads of last-known state are stale rather than a lie.

The bouncer ignored the boolean, so a BYOC client would have lost the line with no feedback at all. It now answers with a NOTICE naming the upstream state, and skips `registerEcho`, whose keys would otherwise have sat in the pending list until they timed out.

## ⚠ One correction to the issue's framing

The issue (and my first pass at the comment) said returning `false` "makes the composer keep the text". **It didn't.** `MessageInput` calls `commitInput()` *before* awaiting the ack, so the field and the server-synced draft were already cleared by the time the failure landed — the body survived only in the toast and in local up-arrow history.

QA hit exactly that, so it's now fixed here rather than deferred: **a failed send gets its text back.** The draft for the originating buffer is restored, which refills the composer if you're still on that buffer and leaves the text waiting on every device if you're not, flushed immediately rather than on the debounce. Commands get it too, with the whole typed line rather than the bare body — `/notice bob hi` comes back as `/notice bob hi` into the channel it was typed in, not as `hi` into bob's DM. It never clobbers text typed while the ack was in flight; the ack is late, so that text wins.

⚠ The ack is handed up to `submit()` rather than restored inside `ackedSend`, because `submit` does `await handleCommand(...)` — one microtask — and only then calls `commitInput` to clear. An ack resolving inside that window was restored and then immediately cleared again. A real socket can't answer that fast, but "correct because the network is slow" isn't an invariant worth shipping; the tests catch it because a mocked ack resolves instantly.

## Testing

`npm test` and `npm run check` clean. Regression tests cover the refusal across `reconnecting`/`connecting`/`disconnected` for all three verbs, the E2E gate placement, the `ctcpRequest` refusal, the bouncer's not-writable NOTICE driven end-to-end through the real listener, and the four composer-restore cases (each confirmed to fail against a mutation).

**QA'd live** against a local ergo behind a killable `socat` proxy, with `LURKER_RECONNECT_BASE_MS` raised to hold the network in `reconnecting`: no row reaches the `messages` table during a backoff, and the composer keeps your text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
