### PR TITLE
Make Disconnect reachable while a network is reconnecting (#785)

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1020,6 +1020,94 @@ describe('disconnect quit message (#324)', () => {
   });
 });
 
+// #785. Clicking Disconnect during a backoff cancels the retry ladder, and until
+// now nothing said so — the outage's first "Reconnecting in Ns (attempt 1)…" is a
+// PERSISTED row, so the server buffer's last word on the subject was a promise to
+// retry that we then quietly broke.
+describe('cancelled-reconnect notice (#785)', () => {
+  // The notice is PERSISTED, not ephemeral — an ephemeral one would leave the
+  // outage's "Reconnecting in Ns (attempt 1)…" row dangling in history with no
+  // resolution, which is the complaint. So this needs a real network to insert
+  // against.
+  beforeAll(() => {
+    if (!getNetwork(1, 1)) {
+      createNetwork(1, {
+        name: 'n',
+        host: 'irc.example.test',
+        port: 6697,
+        tls: true,
+        nick: 'nick',
+      });
+    }
+  });
+
+  function makeConn(events: unknown[]): IrcConnection {
+    return new IrcConnection({
+      network: {
+        id: 1,
+        user_id: 1,
+        name: 'n',
+        host: 'irc.example.test',
+        port: 6697,
+        tls: 1,
+        trusted_certificates: 1,
+        nick: 'nick',
+        username: null,
+        realname: null,
+        server_password: null,
+        autoconnect: 1,
+        sasl_account: null,
+        sasl_password: null,
+        connect_commands: null,
+        position: 0,
+        casemapping: null,
+        created_at: new Date().toISOString(),
+      },
+      onEvent: (e: unknown) => events.push(e),
+    });
+  }
+
+  function cancelText(events: unknown[]): string[] {
+    return (events as Array<{ type?: string; text?: string }>)
+      .filter((e) => e.type === 'notice' && /Reconnecting cancelled/.test(e.text ?? ''))
+      .map((e) => e.text as string);
+  }
+
+  it('announces the cancellation when a retry was pending', () => {
+    const events: unknown[] = [];
+    const conn = makeConn(events);
+    conn.client.quit = vi.fn<(reason?: string) => void>();
+    conn.setState('reconnecting');
+    conn.disconnect(undefined, { announceCancelledRetry: true });
+    expect(cancelText(events)).toEqual(['Reconnecting cancelled — disconnected.']);
+    expect(conn.state).toBe('disconnected');
+  });
+
+  it('says nothing when there was no retry to cancel', () => {
+    // A normal /quit closes a healthy socket; it was never mid-ladder, and the
+    // 'close' handler is what settles the state.
+    const events: unknown[] = [];
+    const conn = makeConn(events);
+    conn.client.quit = vi.fn<(reason?: string) => void>();
+    conn.setState('connected');
+    conn.disconnect(undefined, { announceCancelledRetry: true });
+    expect(cancelText(events)).toEqual([]);
+  });
+
+  // ⚠⚠ disconnect() is also how a PAUSE and a shutdown tear connections down.
+  // Neither is the user cancelling anything, and announcing by default would
+  // write this row into every network that happened to be reconnecting.
+  it('stays silent on the paths that are not a person asking', () => {
+    const events: unknown[] = [];
+    const conn = makeConn(events);
+    conn.client.quit = vi.fn<(reason?: string) => void>();
+    conn.setState('reconnecting');
+    conn.disconnect('shutting down');
+    expect(cancelText(events)).toEqual([]);
+    expect(conn.state).toBe('disconnected');
+  });
+});
+
 describe('self nick updates the input bar (#362)', () => {
   function makeConn(): IrcConnection {
     return new IrcConnection({

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -5028,7 +5028,7 @@ export class IrcConnection {
     this.publishAwayState();
   }
 
-  disconnect(reason?: string): void {
+  disconnect(reason?: string, opts: { announceCancelledRetry?: boolean } = {}): void {
     // The user/system asked to disconnect — record intent BEFORE quit() so the
     // 'close' handler doesn't fight them by auto-reconnecting, and drop any
     // pending backoff so an earlier drop's retry can't resurrect the connection.
@@ -5043,7 +5043,31 @@ export class IrcConnection {
     // Assert the terminal state directly in that case. When a live socket IS
     // closed, its 'close' handler sets 'disconnected' too — setState is
     // change-guarded, so the double-call is a harmless no-op.
-    if (noLiveSocketToClose) this.setState('disconnected');
+    if (noLiveSocketToClose) {
+      // Say that the retry ladder stopped, because otherwise nothing does. The
+      // outage's first "Reconnecting in Ns (attempt 1)…" is a PERSISTED row, so
+      // without this the server buffer's last word on the subject is a promise to
+      // retry that we then quietly broke — and the user who just clicked
+      // Disconnect has no confirmation it took (#785). Only on the no-live-socket
+      // path: a normal /quit closes a healthy socket and was never mid-retry.
+      //
+      // ⚠ Opt-in rather than automatic, because disconnect() is also how a PAUSE
+      // and a shutdown tear connections down. Neither is the user cancelling
+      // anything, and both would otherwise write this row into every network that
+      // happened to be reconnecting at the time. stopNetwork — whose only two
+      // callers are the disconnect endpoint and the disconnect_network verb — is
+      // the one path that is always a person asking.
+      if (opts.announceCancelledRetry) {
+        this.publish({
+          type: 'notice',
+          target: this.serverTarget(),
+          nick: 'lurker',
+          notable: false, // status line, like the "Reconnecting in Ns" it answers
+          text: 'Reconnecting cancelled — disconnected.',
+        });
+      }
+      this.setState('disconnected');
+    }
   }
 
   // Cancel a pending backoff retry. Idempotent.

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -327,7 +327,10 @@ class IrcManager extends EventEmitter {
       fields: { networkId },
       text: reason ? `Stopping: ${reason}` : 'Stopping',
     });
-    conn.disconnect(reason);
+    // announceCancelledRetry: this is the one disconnect path that is always a
+    // person asking (the REST endpoint and the disconnect_network verb), so it is
+    // the one that should say so when it cancels a pending retry.
+    conn.disconnect(reason, { announceCancelledRetry: true });
     this.connectionsForUser(userId).delete(networkId);
   }
 

--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -652,6 +652,26 @@ describe('MessageInput command dispatch', () => {
     expect(socketSend).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'raw' }));
   });
 
+  it('reports a failed /disconnect in the buffer rather than swallowing it', async () => {
+    // The one branch the happy-path cases can't reach. It matters here more than for most
+    // commands: the whole point of #785 is a user trying to stop a network that won't stop, so
+    // "nothing happened" is precisely the wrong feedback if the call fails.
+    seedStores('#zebra');
+    const networks = useNetworksStore();
+    vi.spyOn(networks, 'disconnect').mockRejectedValue(new Error('network is paused'));
+    const buffers = useBuffersStore();
+    const pushMessage = vi.spyOn(buffers, 'pushMessage');
+    const { el } = await mountComposer();
+
+    await type(el, '/disconnect');
+    await enter(el);
+    await flush();
+
+    expect(pushMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ text: '/disconnect failed: network is paused' }),
+    );
+  });
+
   it('/part <#chan> [reason] retargets the named channel', async () => {
     seedStores('#zebra');
     const { el } = await mountComposer();

--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -627,6 +627,31 @@ describe('MessageInput command dispatch', () => {
     });
   });
 
+  // #785. `/disconnect` is the word people reach for when a network is stuck in a reconnect
+  // loop, and it used to fall through to the raw-line default — so it went out as an unknown
+  // IRC verb, and during a backoff nowhere at all. It shares /quit's branch: both route through
+  // the intentional-disconnect path, which is what sets irc-framework's requested_disconnect
+  // flag so the close doesn't look unexpected and trigger another auto-reconnect.
+  it.each([
+    ['/quit', undefined],
+    ['/disconnect', undefined],
+    ['/disconnect back later', 'back later'],
+  ])('%s stops the network instead of going out as a raw line', async (input, reason) => {
+    seedStores('#zebra');
+    const networks = useNetworksStore();
+    const disconnect = vi
+      .spyOn(networks, 'disconnect')
+      .mockResolvedValue(undefined as unknown as void);
+    const { el } = await mountComposer();
+
+    await type(el, input);
+    await enter(el);
+
+    expect(disconnect).toHaveBeenCalledWith(1, reason);
+    // ⚠ And emphatically not as a raw line — that is the shape of the bug.
+    expect(socketSend).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'raw' }));
+  });
+
   it('/part <#chan> [reason] retargets the named channel', async () => {
     seedStores('#zebra');
     const { el } = await mountComposer();

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -3431,7 +3431,7 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       // an auto-disconnect.
       const reason = argLine || undefined;
       networks.disconnect(networkId, reason).catch((err) => {
-        localInfo(networkId, target, `/${cmd} failed: ${err.message || 'could not disconnect'}`);
+        localInfo(networkId, target, `/${verb} failed: ${err.message || 'could not disconnect'}`);
       });
       return true;
     }

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2369,7 +2369,7 @@ const COMMANDS_LINES = [
   '  /mode <target> <flags> — set modes (target defaults to current channel)',
   '  /topic [text]          — set/clear topic on current channel',
   '  /nick <newnick>        — change your nick',
-  '  /quit [reason]         — disconnect from current network',
+  '  /quit [reason]         — disconnect from current network (alias: /disconnect)',
   '  /reconnect             — reconnect to current network',
   '  /list                  — list channels on current network',
   '  /who [mask]            — find users (also /whowas /userhost /ison /names)',
@@ -3416,6 +3416,11 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       }
       return sendOrToast({ type: 'raw', networkId, line: `MODE ${argLine}` }, line);
     }
+    // `/disconnect` is the word people reach for when a network is stuck in a
+    // reconnect loop, and until #785 it fell through to the raw-line default —
+    // so it went out as an unknown IRC command (and during a backoff, nowhere at
+    // all). It means the same thing as /quit here: stop this network.
+    case 'disconnect':
     case 'quit': {
       // Route through the intentional-disconnect path (POST .../disconnect →
       // ircManager.stopNetwork → client.quit()), which sets irc-framework's
@@ -3426,7 +3431,7 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       // an auto-disconnect.
       const reason = argLine || undefined;
       networks.disconnect(networkId, reason).catch((err) => {
-        localInfo(networkId, target, `/quit failed: ${err.message || 'could not disconnect'}`);
+        localInfo(networkId, target, `/${cmd} failed: ${err.message || 'could not disconnect'}`);
       });
       return true;
     }

--- a/vue_client/src/composables/useNetworkActions.ts
+++ b/vue_client/src/composables/useNetworkActions.ts
@@ -7,7 +7,7 @@ import { useChannelListModal } from './useChannelListModal.js';
 import { useJoinChannelModal } from './useJoinChannelModal.js';
 import { useNetworkEditor } from './useNetworkEditor.js';
 import { useNotifyLadder } from './useNotifyLadder.js';
-import { useNetworksStore, type Network } from '../stores/networks.js';
+import { canDisconnect, useNetworksStore, type Network } from '../stores/networks.js';
 
 // Buffer-list action logic for network rows. Analogous to useBufferActions for
 // channel/DM rows. Builds the network context menu — Join Channel / Channel List,
@@ -23,13 +23,17 @@ export function useNetworkActions() {
 
   function toggleConnection(networkId: number): void {
     const state = networks.states[networkId]?.state;
-    const p =
-      state === 'connected' ? networks.disconnect(networkId) : networks.reconnect(networkId);
+    const p = canDisconnect(state) ? networks.disconnect(networkId) : networks.reconnect(networkId);
     p.catch((err) => console.error('[useNetworkActions] toggle connection failed', err));
   }
 
   function buildItems(net: Network): ContextMenuItem[] {
-    const isConnected = networks.states[net.id]?.state === 'connected';
+    const state = networks.states[net.id]?.state;
+    const isConnected = state === 'connected';
+    // ⚠ Not `isConnected`. Disconnect is what stops a reconnect loop, so it has to be reachable
+    // DURING one — see canDisconnect (#785). Join below stays on isConnected, which is the
+    // different question of whether there's a socket to send JOIN on.
+    const offerDisconnect = canDisconnect(state);
     return [
       // Channel actions first — the common reason to reach for a network's menu.
       // Join needs a live connection; the channel list is still browsable from
@@ -52,8 +56,8 @@ export function useNetworkActions() {
         onClick: () => networkEditor.open(net),
       },
       {
-        label: isConnected ? 'Disconnect' : 'Reconnect',
-        icon: isConnected ? 'fa-solid fa-plug-circle-xmark' : 'fa-solid fa-plug',
+        label: offerDisconnect ? 'Disconnect' : 'Reconnect',
+        icon: offerDisconnect ? 'fa-solid fa-plug-circle-xmark' : 'fa-solid fa-plug',
         onClick: () => toggleConnection(net.id),
       },
       // Network-wide notification ladder (issue #359): Highlights only (default)

--- a/vue_client/src/composables/useNetworkActions.ts
+++ b/vue_client/src/composables/useNetworkActions.ts
@@ -21,9 +21,13 @@ export function useNetworkActions() {
   const notify = useNotifyLadder();
   const networks = useNetworksStore();
 
-  function toggleConnection(networkId: number): void {
-    const state = networks.states[networkId]?.state;
-    const p = canDisconnect(state) ? networks.disconnect(networkId) : networks.reconnect(networkId);
+  // ⚠ Takes the decision rather than re-deriving it. buildItems snapshots the state when the
+  // menu OPENS; re-reading it at click time lets the two disagree while the menu sits there —
+  // and it is reachable: right-click during a backoff (item reads "Disconnect"), the reconnect
+  // gate then refuses (paused account, host dropped from the allowlist) and stopReconnecting
+  // settles the state to 'disconnected', so the click on "Disconnect" would fire a RECONNECT.
+  function toggleConnection(networkId: number, offerDisconnect: boolean): void {
+    const p = offerDisconnect ? networks.disconnect(networkId) : networks.reconnect(networkId);
     p.catch((err) => console.error('[useNetworkActions] toggle connection failed', err));
   }
 
@@ -58,7 +62,7 @@ export function useNetworkActions() {
       {
         label: offerDisconnect ? 'Disconnect' : 'Reconnect',
         icon: offerDisconnect ? 'fa-solid fa-plug-circle-xmark' : 'fa-solid fa-plug',
-        onClick: () => toggleConnection(net.id),
+        onClick: () => toggleConnection(net.id, offerDisconnect),
       },
       // Network-wide notification ladder (issue #359): Highlights only (default)
       // / Nothing / Muted — a -network-scoped NONOTIFY(+NOUNREAD) rule covering

--- a/vue_client/src/stores/networks.test.ts
+++ b/vue_client/src/stores/networks.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+
+import { canDisconnect } from './networks.js';
+
+// The predicate behind every "Disconnect ⟷ Reconnect" control (the network context
+// menu and both chat views' server-buffer headers). It is one function precisely so
+// those three can't drift back apart.
+describe('canDisconnect — which action a network state needs', () => {
+  it('offers Disconnect while a network is on the wire', () => {
+    expect(canDisconnect('connected')).toBe(true);
+  });
+
+  // ⚠⚠ The whole of #785. The retry ladder is unbounded, and it keeps its
+  // IrcConnection for the entire outage — so a network pinned against a dead server
+  // sits in 'reconnecting' indefinitely. Testing for 'connected' left Reconnect as
+  // the only offered action, and Reconnect routes through restartNetwork: it tears
+  // the connection down and starts a FRESH loop. There was no reachable stop.
+  it('offers Disconnect during a reconnect backoff, which is what stops the loop', () => {
+    expect(canDisconnect('reconnecting')).toBe(true);
+  });
+
+  it('offers Disconnect during a connect, which can hang on a handshake', () => {
+    expect(canDisconnect('connecting')).toBe(true);
+  });
+
+  it('offers Reconnect once the network is actually down', () => {
+    expect(canDisconnect('disconnected')).toBe(false);
+  });
+
+  // A network we have never heard a state for reads as "connect it", not "stop it".
+  it('offers Reconnect for an unknown state', () => {
+    expect(canDisconnect(undefined)).toBe(false);
+    expect(canDisconnect(null)).toBe(false);
+    expect(canDisconnect('')).toBe(false);
+  });
+});

--- a/vue_client/src/stores/networks.test.ts
+++ b/vue_client/src/stores/networks.test.ts
@@ -22,8 +22,13 @@ describe('canDisconnect — which action a network state needs', () => {
     expect(canDisconnect('reconnecting')).toBe(true);
   });
 
-  it('offers Disconnect during a connect, which can hang on a handshake', () => {
-    expect(canDisconnect('connecting')).toBe(true);
+  // ⚠⚠ Not 'connecting', though it is equally "Lurker is working on it". setState('connecting')
+  // fires the moment the socket opens — tens of milliseconds after the POST, well inside a
+  // double-click — so a user who clicks Reconnect and impatiently clicks again would hit a
+  // button that had already relabelled itself Disconnect and tear down the connection they just
+  // asked for. Offering Reconnect there re-fires restartNetwork, which is harmless.
+  it('offers Reconnect during a connect, so an impatient double-click is idempotent', () => {
+    expect(canDisconnect('connecting')).toBe(false);
   });
 
   it('offers Reconnect once the network is actually down', () => {

--- a/vue_client/src/stores/networks.ts
+++ b/vue_client/src/stores/networks.ts
@@ -69,13 +69,18 @@ export interface ActiveBuffer {
  * network stuck against a dead server therefore had NO reachable stop, which is #785. Turning
  * off `autoconnect` doesn't stop it either — that flag is about boot, not about retries.
  *
- * `connecting` is included for the same reason: a connect that hangs on a TLS handshake is
- * something the user may well want to call off.
+ * ⚠⚠ `connecting` is deliberately NOT included, though it is equally "Lurker is working on it".
+ * `setState('connecting')` fires the moment irc-framework opens the socket — tens of milliseconds
+ * after the POST, well inside a double-click. So a user who clicks Reconnect on a down network and
+ * impatiently clicks again would hit a button that had already relabelled itself Disconnect, and
+ * tear down the connection they just asked for. Before this predicate existed the second click
+ * re-fired restartNetwork harmlessly, and it still does. A hung TLS handshake is real but
+ * transient and self-resolving; the unbounded retry ladder is the stuck state #785 is about.
  *
  * An absent state means we've never heard about this network, which reads as Connect.
  */
 export function canDisconnect(state: string | null | undefined): boolean {
-  return state === 'connected' || state === 'connecting' || state === 'reconnecting';
+  return state === 'connected' || state === 'reconnecting';
 }
 
 export const useNetworksStore = defineStore('networks', {

--- a/vue_client/src/stores/networks.ts
+++ b/vue_client/src/stores/networks.ts
@@ -57,6 +57,27 @@ export interface ActiveBuffer {
   network: Network | undefined;
 }
 
+/**
+ * Whether Disconnect is the action this network needs, rather than Connect.
+ *
+ * ⚠⚠ The question is "is Lurker holding a connection for this network", NOT "is it on the wire".
+ * Since the auto-reconnect overhaul a dropped network keeps its IrcConnection for the whole
+ * outage while the retry controller backs off, so `reconnecting` is a network Lurker is very
+ * much still working on — and the retry ladder is deliberately unbounded. Testing for
+ * `connected` instead made Reconnect the only offered action during a backoff, and Reconnect
+ * routes through restartNetwork: it tears the connection down and starts a fresh loop. A
+ * network stuck against a dead server therefore had NO reachable stop, which is #785. Turning
+ * off `autoconnect` doesn't stop it either — that flag is about boot, not about retries.
+ *
+ * `connecting` is included for the same reason: a connect that hangs on a TLS handshake is
+ * something the user may well want to call off.
+ *
+ * An absent state means we've never heard about this network, which reads as Connect.
+ */
+export function canDisconnect(state: string | null | undefined): boolean {
+  return state === 'connected' || state === 'connecting' || state === 'reconnecting';
+}
+
 export const useNetworksStore = defineStore('networks', {
   state: () => ({
     networks: [] as Network[],

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -307,7 +307,7 @@ import type { Network } from '../stores/networks.js';
 import { useBuffersStore, type Buffer } from '../stores/buffers.js';
 import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
 import { useSocket } from '../composables/useSocket.js';
-import { useNetworksStore } from '../stores/networks.js';
+import { canDisconnect, useNetworksStore } from '../stores/networks.js';
 import { useChatBootstrap } from '../composables/useChatBootstrap.js';
 import { useActiveBuffer } from '../composables/useActiveBuffer.js';
 import { useBufferSearchScope } from '../composables/useBufferSearchScope.js';
@@ -628,23 +628,20 @@ function editActiveNetwork() {
   if (net) networkEditor.open(net);
 }
 
-// State-aware connect/disconnect for the server buffer header. We label the
-// button "Disconnect" only while we're confidently connected; every other
-// state (idle, connecting, reconnecting, disconnected, unknown) reads as
-// "Reconnect" because the action — fire a fresh connect — is the same in
-// each case, and "Reconnect" is what the user reaches for when something
-// looks stuck.
+// State-aware connect/disconnect for the server buffer header. See canDisconnect:
+// "Disconnect" covers connected AND the in-flight states, because during a
+// reconnect backoff Disconnect is the only thing that STOPS the loop — Reconnect
+// tears the connection down and starts a fresh one (#785).
 const serverConnectionState = computed(() => {
   if (!active.value || !isServerBuffer.value) return null;
   return networks.states[active.value.networkId]?.state ?? null;
 });
+const serverOffersDisconnect = computed(() => canDisconnect(serverConnectionState.value));
 const serverConnectActionLabel = computed(() =>
-  serverConnectionState.value === 'connected' ? 'Disconnect' : 'Reconnect',
+  serverOffersDisconnect.value ? 'Disconnect' : 'Reconnect',
 );
 const serverConnectActionIcon = computed(() =>
-  serverConnectionState.value === 'connected'
-    ? 'fa-solid fa-plug-circle-xmark'
-    : 'fa-solid fa-plug',
+  serverOffersDisconnect.value ? 'fa-solid fa-plug-circle-xmark' : 'fa-solid fa-plug',
 );
 function toggleServerConnection() {
   if (!active.value) return;
@@ -653,8 +650,7 @@ function toggleServerConnection() {
   // success reflects itself. A failed call stays observable via the state
   // (label doesn't flip), so we just log and let the user retry rather
   // than wiring a toast through the topic bar for this case.
-  const p =
-    serverConnectionState.value === 'connected' ? networks.disconnect(id) : networks.reconnect(id);
+  const p = serverOffersDisconnect.value ? networks.disconnect(id) : networks.reconnect(id);
   p.catch((err) => console.error('[DesktopChat] toggle server connection failed', err));
 }
 

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -400,7 +400,15 @@ function openBufferActions() {
       {
         label: serverConnectActionLabel.value,
         icon: serverConnectActionIcon.value,
-        onClick: toggleServerConnection,
+        // ⚠ The decision goes WITH the label. Unlike the desktop header — whose
+        // button binds the computed reactively, so the two are read at the same
+        // instant — this kebab snapshots the label into a static array when the
+        // menu opens, and the menu then sits there. Re-reading state at click
+        // time lets the item say "Disconnect" and fire a reconnect: open it
+        // during a backoff, have the retry gate refuse (paused account, host
+        // dropped from the allowlist) so stopReconnecting settles the state to
+        // 'disconnected', and tap. Same trap as useNetworkActions.buildItems.
+        onClick: () => toggleServerConnection(serverOffersDisconnect.value),
       },
       { label: 'Edit network', icon: 'fa-solid fa-gear', onClick: editActiveNetwork },
     );
@@ -439,14 +447,14 @@ const serverConnectActionLabel = computed(() =>
 const serverConnectActionIcon = computed(() =>
   serverOffersDisconnect.value ? 'fa-solid fa-plug-circle-xmark' : 'fa-solid fa-plug',
 );
-function toggleServerConnection() {
+function toggleServerConnection(offerDisconnect: boolean) {
   if (!active.value) return;
   const id = active.value.networkId;
   // Fire-and-forget — the button's label is driven by networks.states so
   // success reflects itself. A failed call stays observable via the state
   // (label doesn't flip), so we just log and let the user retry rather
   // than wiring a toast through the bar for this case.
-  const p = serverOffersDisconnect.value ? networks.disconnect(id) : networks.reconnect(id);
+  const p = offerDisconnect ? networks.disconnect(id) : networks.reconnect(id);
   p.catch((err) => console.error('[MobileChat] toggle server connection failed', err));
 }
 

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -230,7 +230,7 @@ import { computed, reactive, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import type { Network } from '../stores/networks.js';
 import type { BufferLike } from '../composables/useBufferActions.js';
-import { useNetworksStore } from '../stores/networks.js';
+import { canDisconnect, useNetworksStore } from '../stores/networks.js';
 import { useSocket } from '../composables/useSocket.js';
 import { useChatBootstrap } from '../composables/useChatBootstrap.js';
 import { pushBuffer } from '../composables/useBufferRoute.js';
@@ -425,20 +425,19 @@ function editActiveNetwork() {
 }
 
 // State-aware connect/disconnect for the server buffer header. Mirrors the
-// desktop logic — "Disconnect" only while we're confidently connected;
-// everything else labels as "Reconnect" because a fresh connect is the
-// same action and that's what the user reaches for when things look stuck.
+// desktop logic, via the shared canDisconnect: "Disconnect" covers connected AND
+// the in-flight states, because during a reconnect backoff it is the only thing
+// that stops the loop (#785).
 const serverConnectionState = computed(() => {
   if (!active.value || !isServerBuffer.value) return null;
   return networks.states[active.value.networkId]?.state ?? null;
 });
+const serverOffersDisconnect = computed(() => canDisconnect(serverConnectionState.value));
 const serverConnectActionLabel = computed(() =>
-  serverConnectionState.value === 'connected' ? 'Disconnect' : 'Reconnect',
+  serverOffersDisconnect.value ? 'Disconnect' : 'Reconnect',
 );
 const serverConnectActionIcon = computed(() =>
-  serverConnectionState.value === 'connected'
-    ? 'fa-solid fa-plug-circle-xmark'
-    : 'fa-solid fa-plug',
+  serverOffersDisconnect.value ? 'fa-solid fa-plug-circle-xmark' : 'fa-solid fa-plug',
 );
 function toggleServerConnection() {
   if (!active.value) return;
@@ -447,8 +446,7 @@ function toggleServerConnection() {
   // success reflects itself. A failed call stays observable via the state
   // (label doesn't flip), so we just log and let the user retry rather
   // than wiring a toast through the bar for this case.
-  const p =
-    serverConnectionState.value === 'connected' ? networks.disconnect(id) : networks.reconnect(id);
+  const p = serverOffersDisconnect.value ? networks.disconnect(id) : networks.reconnect(id);
   p.catch((err) => console.error('[MobileChat] toggle server connection failed', err));
 }
 


### PR DESCRIPTION
Fixes #785.

## The cause wasn't the reconnect controller

That part was already correct: `IrcConnection.disconnect()` records intent *before* `quit()`, clears a pending backoff, and asserts `disconnected` when there is no live socket to close. The bug was that **nothing could call it**.

A network pinned against a dead server sits in `reconnecting` indefinitely — the retry ladder is deliberately unbounded, capping at a 300s backoff — and all three "Disconnect ⟷ Reconnect" controls tested `state === 'connected'`. So the only action on offer during a backoff was **Reconnect**, which routes through `restartNetwork`: it disposes the connection and starts a *fresh* loop. Turning off `autoconnect` doesn't help either; that flag is about boot, not about retries.

Three copies of the same comparison had drifted into stating the same wrong rule three times (`useNetworkActions.ts`, and both chat views' server-buffer headers), so the fix is one exported predicate rather than three edits.

`/disconnect` is now an alias for `/quit`. The issue reports that it "does nothing", and it did: no such command existed, so it fell through to the raw-line default and went out as an unknown IRC verb — and mid-backoff, nowhere at all.

`Join Channel…` stays gated on `connected`, which is the different question of whether there is a socket to send JOIN on.

## ⚠ Two deliberate judgement calls, both easy to reverse

**`connecting` is excluded**, though it is equally "Lurker is working on it". `setState('connecting')` fires the moment irc-framework opens the socket — tens of milliseconds after the POST, well inside a double-click. Including it meant a user who clicked Reconnect on a down network and impatiently clicked again would hit a button that had already relabelled itself Disconnect, tearing down the connection they just asked for. Offering Reconnect there re-fires `restartNetwork` harmlessly, as it did before. A hung TLS handshake is a real case, but transient; the unbounded ladder is the stuck state this issue is about.

**This trades away the one-click "reconnect now."** While a network is in backoff every control now offers only Disconnect, so bringing it back early means Disconnect → wait for the state frame → click again, or `/reconnect`, or the network editor's Reconnect button. The context menu is a list rather than a toggle, so it *could* carry both entries during a backoff and keep the fix without the loss — worth doing if the round-trip annoys in practice.

## Added after QA / Copilot

**Disconnect now says it worked.** Cancelling the ladder wrote nothing anywhere, and the outage's first `Reconnecting in Ns (attempt 1)…` is a *persisted* row — so the server buffer's last word on the subject was a promise to retry that we then quietly broke. It now writes `Reconnecting cancelled — disconnected.`, persisted for the same reason (an ephemeral line would leave that promise dangling on the next reload).

Opt-in rather than automatic: `disconnect()` is also how a pause and a shutdown tear connections down, and neither is a person cancelling anything. `stopNetwork` — whose only callers are the disconnect endpoint and the `disconnect_network` verb — is the one path that always is.

**The mobile kebab had the label/action split too.** Same trap review found in `useNetworkActions.buildItems`, in the one place I fixed it and then didn't check for elsewhere: the kebab snapshots the label into a static array when the menu opens, while the callback re-read the state at tap time — so the item could read "Disconnect" and fire a reconnect. Widening the predicate to cover `reconnecting` is what made it reachable, so it belongs here. The desktop header is deliberately untouched: its button binds the computed reactively, so label and action are read at the same instant.

## Testing

`npm test` (3910 passed) and `npm run check` clean. `canDisconnect` is pinned per state, and the `/disconnect` alias is driven through the real command dispatcher — both alias cases were confirmed to fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
