### PR TITLE
Measure a URL's span past its sentence punctuation (#774)

### DIFF
--- a/vue_client/src/utils/previewUrls.test.ts
+++ b/vue_client/src/utils/previewUrls.test.ts
@@ -319,9 +319,30 @@ describe('hideableUrls — when the address stops being worth showing', () => {
   it('is not blocked by punctuation the address trim discarded', () => {
     expect([...hideableUrls(`look at this ${A}.`, all(A))]).toEqual([A]);
     expect([...hideableUrls(`look at this ${A}!`, all(A))]).toEqual([A]);
-    expect([...hideableUrls(`look at this (${A})`, all(A))]).toEqual([A]);
+    expect([...hideableUrls(`look at this ${A}?`, all(A))]).toEqual([A]);
+    expect([...hideableUrls(`look at this ${A}...`, all(A))]).toEqual([A]);
     // ...and prose still wins over punctuation, which is the rule the fix must not soften.
     expect([...hideableUrls(`I read ${A}. this morning`, all(A))]).toEqual([]);
+  });
+
+  // ⚠⚠ A closing delimiter has a PARTNER sitting before the address, so it is not the URL's to
+  // take. The first cut of #774 absorbed everything trimTrailingPunctuation discarded, which
+  // made these hideable — and rendered `look at this (…)` as a line holding a lone `(` above the
+  // picture, the same orphan the fix exists to remove, moved to the other end. Not hiding them
+  // is the conservative answer: the address stays on screen next to its preview, which is
+  // merely redundant rather than broken.
+  it('will not absorb a delimiter whose partner is in the prose', () => {
+    expect([...hideableUrls(`look at this (${A})`, all(A))]).toEqual([]);
+    expect([...hideableUrls(`look at this [${A}]`, all(A))]).toEqual([]);
+    expect([...hideableUrls(`he said "check ${A}"`, all(A))]).toEqual([]);
+  });
+
+  // ⚠ Measured on the VISIBLE text, not on the regex match, which stops at a run boundary. Bold
+  // or colour wrapped around just the address is a common bot output shape, and it used to
+  // decide the verdict: the identical plain-text message hid.
+  it('sees punctuation across a formatting boundary', () => {
+    expect([...hideableUrls(`look at this \u0002${A}\u0002.`, all(A))]).toEqual([A]);
+    expect([...hideableUrls(`look at this \u001f${A}\u000f.`, all(A))]).toEqual([A]);
   });
 
   it('hides nothing when there are no candidates', () => {
@@ -370,16 +391,30 @@ describe('segmentsWithoutUrls — closing the gap', () => {
     expect(segmentsWithoutUrls(segs, new Set([A]))).toEqual([]);
   });
 
-  it('takes an unbalanced closing bracket, and keeps a balanced one', () => {
-    // ⚠ Asked of trimTrailingPunctuation rather than a character class, because its bracket rule
-    // is balance-sensitive: the `)` closing `(see …)` is punctuation, the one closing `Foo_(bar)`
-    // is part of the address and was never split off in the first place.
+  it('leaves a closing delimiter alone, because its partner is not the URL to take', () => {
+    // ⚠⚠ The deletion must remove exactly what the SPAN counted, no more. It counted no `)`
+    // (hideableUrls won't hide a wrapped URL at all now), so neither does this — and the
+    // assertion is here rather than only on the verdict because the first cut of the fix did
+    // strip it, leaving `(` alone on a line above the picture. If a caller ever hides one
+    // anyway, the bracket survives rather than being half-deleted.
     const wrapped = [{ text: '(' }, { text: A, url: A }, { text: ')' }];
-    expect(segmentsWithoutUrls(wrapped, new Set([A]))).toEqual([{ text: '(' }]);
+    expect(segmentsWithoutUrls(wrapped, new Set([A]))).toEqual([{ text: '(' }, { text: ')' }]);
+  });
 
-    const BAL = 'https://e.test/Foo_(bar)';
-    const balanced = [{ text: BAL, url: BAL }, { text: ' tail' }];
-    expect(segmentsWithoutUrls(balanced, new Set([BAL]))).toEqual([{ text: 'tail' }]);
+  it('follows a punctuation run across a formatting boundary', () => {
+    // The span crosses runs, so the deletion has to as well or it leaves the tail behind.
+    const segs = [{ text: A, url: A }, { text: '.', bold: true }, { text: '.' }];
+    expect(segmentsWithoutUrls(segs, new Set([A]))).toEqual([]);
+  });
+
+  it('stops absorbing once a segment survives', () => {
+    // ⚠ A positive control for the rule above: carrying on past a segment that kept text would
+    // eat punctuation belonging to whatever came after.
+    const segs = [{ text: A, url: A }, { text: '. done' }, { text: '. and more' }];
+    expect(segmentsWithoutUrls(segs, new Set([A]))).toEqual([
+      { text: 'done' },
+      { text: '. and more' },
+    ]);
   });
 
   it('does not eat text that merely follows a hidden URL', () => {

--- a/vue_client/src/utils/previewUrls.test.ts
+++ b/vue_client/src/utils/previewUrls.test.ts
@@ -310,6 +310,20 @@ describe('hideableUrls — when the address stops being worth showing', () => {
     expect([...hideableUrls(buried, all(A))]).toEqual([]);
   });
 
+  // ⚠⚠ #774. The span's end was measured to the end of the TRIMMED address, so the `.` the
+  // trimmer had just discarded sat between the span and the end of the message and failed the
+  // "nothing but whitespace after it" test. The same URL at the FRONT hid regardless, because
+  // the leading check is vacuously true at offset zero — so identical punctuation produced
+  // opposite verdicts decided by nothing but which end the URL sat at. Ported from
+  // PreviewHidingTests.trimmedPunctuationDoesNotBlockThePeel in lurker-ios.
+  it('is not blocked by punctuation the address trim discarded', () => {
+    expect([...hideableUrls(`look at this ${A}.`, all(A))]).toEqual([A]);
+    expect([...hideableUrls(`look at this ${A}!`, all(A))]).toEqual([A]);
+    expect([...hideableUrls(`look at this (${A})`, all(A))]).toEqual([A]);
+    // ...and prose still wins over punctuation, which is the rule the fix must not soften.
+    expect([...hideableUrls(`I read ${A}. this morning`, all(A))]).toEqual([]);
+  });
+
   it('hides nothing when there are no candidates', () => {
     expect([...hideableUrls(`${A} ${B}`, new Set())]).toEqual([]);
     expect([...hideableUrls(null, all(A))]).toEqual([]);
@@ -337,6 +351,54 @@ describe('segmentsWithoutUrls — closing the gap', () => {
 
   it('leaves nothing at all for a message that was only a link', () => {
     expect(segmentsWithoutUrls([{ text: A, url: A }], new Set([A]))).toEqual([]);
+  });
+
+  // ⚠⚠ The other half of #774, and the half that decides whether the span fix is a fix or just
+  // a relocation of the damage. The hiding rule counts trailing punctuation as part of the
+  // address, so the deletion has to as well — the linkifier trims it off into a text segment of
+  // its own, and the end-trim below strips whitespace only.
+  it('takes the punctuation the address trim split off with it', () => {
+    const segs = [{ text: 'look at this ' }, { text: A, url: A }, { text: '.' }];
+    expect(segmentsWithoutUrls(segs, new Set([A]))).toEqual([{ text: 'look at this' }]);
+  });
+
+  it('leaves nothing for a message that was only a link and a full stop', () => {
+    // The worst version of it: the body was a single `.`, which is not empty — so the
+    // attachments-only collapse never fired and a line holding one full stop was painted
+    // above the picture.
+    const segs = [{ text: A, url: A }, { text: '.' }];
+    expect(segmentsWithoutUrls(segs, new Set([A]))).toEqual([]);
+  });
+
+  it('takes an unbalanced closing bracket, and keeps a balanced one', () => {
+    // ⚠ Asked of trimTrailingPunctuation rather than a character class, because its bracket rule
+    // is balance-sensitive: the `)` closing `(see …)` is punctuation, the one closing `Foo_(bar)`
+    // is part of the address and was never split off in the first place.
+    const wrapped = [{ text: '(' }, { text: A, url: A }, { text: ')' }];
+    expect(segmentsWithoutUrls(wrapped, new Set([A]))).toEqual([{ text: '(' }]);
+
+    const BAL = 'https://e.test/Foo_(bar)';
+    const balanced = [{ text: BAL, url: BAL }, { text: ' tail' }];
+    expect(segmentsWithoutUrls(balanced, new Set([BAL]))).toEqual([{ text: 'tail' }]);
+  });
+
+  it('does not eat text that merely follows a hidden URL', () => {
+    // The stripping is bounded by what the trimmer would have taken — the run stops at the
+    // first character it would have kept.
+    const segs = [{ text: A, url: A }, { text: ', which I liked' }];
+    expect(segmentsWithoutUrls(segs, new Set([A]))).toEqual([{ text: 'which I liked' }]);
+    const spaced = [{ text: A, url: A }, { text: ' see also' }];
+    expect(segmentsWithoutUrls(spaced, new Set([A]))).toEqual([{ text: 'see also' }]);
+  });
+
+  it('leaves punctuation that is painted ink alone', () => {
+    // Same rule as the whitespace trim: a mIRC background run is a drawing, so a `.` sitting on
+    // one is not stray punctuation to be tidied away.
+    const segs = [
+      { text: A, url: A },
+      { text: '.', bg: 4 },
+    ];
+    expect(segmentsWithoutUrls(segs, new Set([A]))).toEqual([{ text: '.', bg: 4 }]);
   });
 
   it('trims the front too, so a leading link does not leave an indent', () => {

--- a/vue_client/src/utils/previewUrls.ts
+++ b/vue_client/src/utils/previewUrls.ts
@@ -143,21 +143,41 @@ interface UrlSpan {
   /** Offset of the match in the VISIBLE body — formatting codes removed, spoiler text kept. */
   start: number;
   /**
-   * Offset of the END OF THE MATCH — **not** of `url`.
+   * Offset of the end of the address PLUS any sentence punctuation that reads as belonging to it.
    *
-   * ⚠⚠ Untrimmed deliberately. Measuring to the end of the trimmed address leaves the
+   * ⚠⚠ Not simply `start + url.length`. Measuring to the end of the trimmed address leaves the
    * punctuation `trimTrailingPunctuation` just discarded sitting between the span and the end of
    * the message, so `look at this https://e.test/a.png.` failed the "nothing but whitespace after
    * it" test and kept its address — while the same URL at the FRONT hid, the leading check being
    * vacuously true at offset zero. Identical punctuation, opposite verdicts, decided by nothing
-   * but which end the URL sat at. (#774, fixed first on iOS as `PreviewText.UrlSpan.end`.)
+   * but which end the URL sat at. (#774.)
    *
-   * ⚠⚠ Whatever DELETES the URL has to agree with this or the fix just moves the damage: the
-   * rule counted the punctuation as part of the address, so leaving it behind orphans it. See
-   * `segmentsWithoutUrls`.
+   * ⚠⚠ And not the whole untrimmed match either, which is where the first version of this fix
+   * went wrong. The trimmer also discards a CLOSING DELIMITER whose partner sits before the URL,
+   * so absorbing everything it dropped made `look at this (https://e.test/a.png)` hideable and
+   * rendered it as a line holding a lone `(` above the picture — the same orphan this fix exists
+   * to remove, moved to the other end. Sentence punctuation has no partner; a bracket or a quote
+   * does. So the span crosses `.,;:!?` and stops at anything paired, which leaves a wrapped URL
+   * simply not hideable rather than half-deleted.
+   *
+   * ⚠⚠ Whatever DELETES the URL has to agree with this or the fix just moves the damage again:
+   * the rule counts this punctuation as part of the address, so leaving it behind orphans it.
+   * See `segmentsWithoutUrls`.
    */
   end: number;
 }
+
+/**
+ * The punctuation a URL may absorb — see `UrlSpan.end` and `withoutAbsorbedPunctuation`.
+ *
+ * ⚠⚠ Narrower than `trimTrailingPunctuation`'s class, deliberately, and the two characters left
+ * out are the whole point: `'` and `"` are paired, as are the brackets it handles by balance. A
+ * closing delimiter has a partner sitting BEFORE the address, so absorbing it deletes half of a
+ * pair and strands the other half — `he said "check <url>"` became `he said "check`. Sentence
+ * punctuation has no partner, so taking it with the address is safe and reads correctly: a
+ * message ending `…shot.png.` reads as ending with the picture.
+ */
+const ABSORBABLE_PUNCTUATION = '.,;:!?';
 
 /**
  * Every resolvable URL in `text`, with where it sits in what the reader actually sees.
@@ -180,8 +200,20 @@ function urlSpans(text: string): { visible: string; spans: UrlSpan[] } {
       if (isBracketedUrl(run.text, match.index, raw)) continue;
       const url = trimTrailingPunctuation(raw);
       if (!url) continue;
-      spans.push({ url, start: base + match.index, end: base + match.index + raw.length });
+      spans.push({ url, start: base + match.index, end: base + match.index + url.length });
     }
+  }
+  // Extend each span across the sentence punctuation that follows it — see UrlSpan.end.
+  //
+  // ⚠ Measured on `visible` rather than on the match, and that is what makes it survive a
+  // formatting code between the address and its full stop. `raw` stops at the run boundary, so
+  // `look at this \x02https://e.test/a.png\x02.` (a common bot output shape) put the `.` in a
+  // different run entirely and the address stayed on screen while the identical plain text hid.
+  // Adjacency in `visible` is adjacency ON SCREEN, which is the domain the rule is about.
+  for (const span of spans) {
+    let end = span.end;
+    while (end < visible.length && ABSORBABLE_PUNCTUATION.includes(visible[end])) end++;
+    span.end = end;
   }
   return { visible, spans };
 }
@@ -253,31 +285,29 @@ function isTrimmableText(seg: RenderSegment): boolean {
 }
 
 /**
- * `seg` with the punctuation that belonged to the URL just dropped taken off its front.
+ * `seg` with the punctuation the URL just dropped had absorbed taken off its front.
  *
- * ⚠⚠ The punctuation goes WITH the address, and this is the half of #774 that makes the span fix
- * a fix rather than a relocation of the damage. `UrlSpan.end` measures the UNTRIMMED match, so the
- * hiding rule counted a trailing `.` or an unbalanced `)` as part of the URL when it decided the
- * URL sat against an edge — while the linkifier, which trims, left exactly those characters at the
- * head of the following text segment. Dropping only the anchor orphans them: `look at this
- * https://e.test/a.png.` rendered as `look at this .`, and a message that was ONLY
+ * ⚠⚠ This is the half of #774 that makes the span fix a fix rather than a relocation of the
+ * damage. `UrlSpan.end` counts trailing sentence punctuation as part of the address when it
+ * decides the URL sits against an edge — while the linkifier, which trims, leaves exactly those
+ * characters at the head of the following text segment. Dropping only the anchor orphans them:
+ * `look at this https://e.test/a.png.` rendered as `look at this .`, and a message that was ONLY
  * `https://e.test/shot.png.` collapsed to a body of one full stop — which is not empty, so the
  * end-trim (whitespace only) left it and a line holding a lone `.` was painted above the picture.
  *
- * How much to take is asked of `trimTrailingPunctuation` itself rather than re-derived from a
- * character class: it is the function that decided where the address ended, and its bracket rule
- * is balance-sensitive (`…/Foo_(bar)` keeps its `)`, `(see …com)` does not), so a hand-rolled
- * class would disagree with it on exactly the inputs that matter.
+ * ⚠ Exactly `ABSORBABLE_PUNCTUATION`, no more. It is tempting to ask `trimTrailingPunctuation`
+ * how much it discarded, since that is the function that decided where the address ended — but it
+ * discards paired delimiters too, and this side must delete precisely what the span counted or
+ * the two disagree and orphan something again. (It is also O(n²) on brackets, and asking it once
+ * per candidate character made a line of a hundred `)` cost ~0.5ms per render.)
  *
  * ⚠ A decorated segment is left alone. Punctuation on a mIRC background run is painted ink, and
  * the same reasoning that stops the whitespace trim from eating a colour block applies here.
  */
-function withoutOrphanedPunctuation(seg: RenderSegment, url: string): RenderSegment {
+function withoutAbsorbedPunctuation(seg: RenderSegment): RenderSegment {
   if (!isTrimmableText(seg)) return seg;
   let n = 0;
-  while (n < seg.text.length && trimTrailingPunctuation(url + seg.text.slice(0, n + 1)) === url) {
-    n++;
-  }
+  while (n < seg.text.length && ABSORBABLE_PUNCTUATION.includes(seg.text[n])) n++;
   return n === 0 ? seg : { ...seg, text: seg.text.slice(n) };
 }
 
@@ -299,17 +329,21 @@ export function segmentsWithoutUrls(
   if (!hidden.size) return segments;
   const kept: RenderSegment[] = [];
   let dropped = 0;
-  // The URL just dropped, whose trailing punctuation the NEXT segment holds — see
-  // withoutOrphanedPunctuation.
-  let orphaned: string | null = null;
+  // Whether the segment we are about to keep holds punctuation the URL just dropped had absorbed
+  // — see withoutAbsorbedPunctuation.
+  let absorbing: boolean = false;
   for (const seg of segments) {
     if (seg.url && hidden.has(seg.url)) {
       dropped++;
-      orphaned = seg.url;
+      absorbing = true;
       continue;
     }
-    kept.push(orphaned ? withoutOrphanedPunctuation(seg, orphaned) : seg);
-    orphaned = null;
+    const stripped: RenderSegment = absorbing ? withoutAbsorbedPunctuation(seg) : seg;
+    kept.push(stripped);
+    // ⚠ Keep absorbing while a segment is consumed WHOLE. The span is measured on the visible
+    // text and crosses formatting boundaries, so a run of punctuation can be split across two
+    // segments (`\x02.\x02.`); stopping at the first would leave the tail behind.
+    absorbing = absorbing && stripped.text === '';
   }
   if (!dropped) return segments;
 

--- a/vue_client/src/utils/previewUrls.ts
+++ b/vue_client/src/utils/previewUrls.ts
@@ -138,9 +138,24 @@ export function previewableUrls(
 }
 
 interface UrlSpan {
+  /** The address, trailing punctuation trimmed — what actually gets resolved. */
   url: string;
-  /** Offsets into the VISIBLE body — formatting codes removed, spoiler text kept. */
+  /** Offset of the match in the VISIBLE body — formatting codes removed, spoiler text kept. */
   start: number;
+  /**
+   * Offset of the END OF THE MATCH — **not** of `url`.
+   *
+   * ⚠⚠ Untrimmed deliberately. Measuring to the end of the trimmed address leaves the
+   * punctuation `trimTrailingPunctuation` just discarded sitting between the span and the end of
+   * the message, so `look at this https://e.test/a.png.` failed the "nothing but whitespace after
+   * it" test and kept its address — while the same URL at the FRONT hid, the leading check being
+   * vacuously true at offset zero. Identical punctuation, opposite verdicts, decided by nothing
+   * but which end the URL sat at. (#774, fixed first on iOS as `PreviewText.UrlSpan.end`.)
+   *
+   * ⚠⚠ Whatever DELETES the URL has to agree with this or the fix just moves the damage: the
+   * rule counted the punctuation as part of the address, so leaving it behind orphans it. See
+   * `segmentsWithoutUrls`.
+   */
   end: number;
 }
 
@@ -165,7 +180,7 @@ function urlSpans(text: string): { visible: string; spans: UrlSpan[] } {
       if (isBracketedUrl(run.text, match.index, raw)) continue;
       const url = trimTrailingPunctuation(raw);
       if (!url) continue;
-      spans.push({ url, start: base + match.index, end: base + match.index + url.length });
+      spans.push({ url, start: base + match.index, end: base + match.index + raw.length });
     }
   }
   return { visible, spans };
@@ -238,6 +253,35 @@ function isTrimmableText(seg: RenderSegment): boolean {
 }
 
 /**
+ * `seg` with the punctuation that belonged to the URL just dropped taken off its front.
+ *
+ * ⚠⚠ The punctuation goes WITH the address, and this is the half of #774 that makes the span fix
+ * a fix rather than a relocation of the damage. `UrlSpan.end` measures the UNTRIMMED match, so the
+ * hiding rule counted a trailing `.` or an unbalanced `)` as part of the URL when it decided the
+ * URL sat against an edge — while the linkifier, which trims, left exactly those characters at the
+ * head of the following text segment. Dropping only the anchor orphans them: `look at this
+ * https://e.test/a.png.` rendered as `look at this .`, and a message that was ONLY
+ * `https://e.test/shot.png.` collapsed to a body of one full stop — which is not empty, so the
+ * end-trim (whitespace only) left it and a line holding a lone `.` was painted above the picture.
+ *
+ * How much to take is asked of `trimTrailingPunctuation` itself rather than re-derived from a
+ * character class: it is the function that decided where the address ended, and its bracket rule
+ * is balance-sensitive (`…/Foo_(bar)` keeps its `)`, `(see …com)` does not), so a hand-rolled
+ * class would disagree with it on exactly the inputs that matter.
+ *
+ * ⚠ A decorated segment is left alone. Punctuation on a mIRC background run is painted ink, and
+ * the same reasoning that stops the whitespace trim from eating a colour block applies here.
+ */
+function withoutOrphanedPunctuation(seg: RenderSegment, url: string): RenderSegment {
+  if (!isTrimmableText(seg)) return seg;
+  let n = 0;
+  while (n < seg.text.length && trimTrailingPunctuation(url + seg.text.slice(0, n + 1)) === url) {
+    n++;
+  }
+  return n === 0 ? seg : { ...seg, text: seg.text.slice(n) };
+}
+
+/**
  * The message body with `hidden`'s URL segments taken out, and the gap they leave closed up.
  *
  * Returns the ORIGINAL array when nothing is dropped, so the overwhelmingly common case costs one
@@ -253,8 +297,21 @@ export function segmentsWithoutUrls(
   hidden: ReadonlySet<string>,
 ): RenderSegment[] {
   if (!hidden.size) return segments;
-  const kept = segments.filter((seg) => !(seg.url && hidden.has(seg.url)));
-  if (kept.length === segments.length) return segments;
+  const kept: RenderSegment[] = [];
+  let dropped = 0;
+  // The URL just dropped, whose trailing punctuation the NEXT segment holds — see
+  // withoutOrphanedPunctuation.
+  let orphaned: string | null = null;
+  for (const seg of segments) {
+    if (seg.url && hidden.has(seg.url)) {
+      dropped++;
+      orphaned = seg.url;
+      continue;
+    }
+    kept.push(orphaned ? withoutOrphanedPunctuation(seg, orphaned) : seg);
+    orphaned = null;
+  }
+  if (!dropped) return segments;
 
   let lo = 0;
   let hi = kept.length;


### PR DESCRIPTION
Fixes #774.

## The bug

`urlSpans` set `end` from the **trimmed** address, so any punctuation `trimTrailingPunctuation` had just dropped sat *outside* the span — and `hideableUrls` read it as content between the URL and the end of the message. The peel then gave opposite verdicts for the same message shape, decided by nothing but which end the URL sat at:

```
look at this https://e.test/a.png.   → NOT hidden  (the leftover `.` breaks the trailing peel)
https://e.test/a.png. tail           → hidden      (the leading check is vacuously true at 0)
```

The second is the worse one: the address was dropped and the orphaned `.` survived, so a message that was *only* `https://e.test/shot.png.` collapsed to a body of a single full stop — not empty, so the attachments-only path never fired and a line holding one `.` was painted above the picture.

## The fix, and where the first cut of it went wrong

The span now extends across the sentence punctuation that follows the address, and the deletion removes exactly what the span counted — otherwise the fix just relocates the damage.

**It does not absorb the whole untrimmed match**, which is what I wrote first and what review caught. `trimTrailingPunctuation` also discards a *closing delimiter* whose partner sits before the URL, so absorbing everything it dropped made `look at this (https://e.test/a.png)` hideable and rendered it as a line holding a lone `(` above the image — the very orphan this fix exists to remove, moved to the other end. `[…]` did the same, and `he said "check …"` became `he said "check`. And those were *newly* broken: pre-fix a wrapped URL was never hideable at all, so untrimming the span end is what admitted them.

Sentence punctuation has no partner; a bracket or a quote does. So the span crosses `.,;:!?` and stops at anything paired, which leaves a wrapped URL simply not hideable — its address stays on screen beside the preview, redundant rather than broken.

Measuring the run on the **visible** text rather than on the regex match closes a further case: `raw` stops at a formatting-run boundary, so `look at this \x02https://e.test/a.png\x02.` (a common bot output shape) kept its address while the identical plain text hid it. Adjacency in the visible body is adjacency on screen, which is the domain the rule is about.

That also made the deletion a character-class scan rather than a probe calling `trimTrailingPunctuation` once per candidate character — review measured a line of a hundred `)` at ~0.5ms **per render**, 400 at ~24ms, because that function is itself quadratic on brackets.

## Verified end to end

Through the real pipeline (`splitTextByTokens` → `previewableUrls` → `hideableUrls` → `segmentsWithoutUrls`):

| message | hidden | rendered body |
|---|---|---|
| `look at this …/a.png.` | 1 | `look at this` |
| `…/shot.png.` | 1 | *(empty)* |
| `look at this (…/a.png)` | 0 | unchanged |
| `look at this […/a.png]` | 0 | unchanged |
| `he said "check …/a.png"` | 0 | unchanged |
| `have you seen …/a.png?` | 1 | `have you seen` |
| `I read …/a.png. this morning` | 0 | unchanged |
| `…/a.png. tail` | 1 | `tail` |
| `look at this \x02…/a.png\x02.` | 1 | `look at this` |

`npm test` (3912 passed) and `npm run check` clean.

## ⚠ Note for lurker-ios

iOS fixed the span half first (`PreviewText.UrlSpan.end`) and deletes `match.raw`, which starts at the scheme — so `PreviewHidingTests.trimmedPunctuationDoesNotBlockThePeel` asserts `look at this (URL)` hides, and the renderer will leave the `(` behind exactly as the first cut here did. Worth a follow-up issue there; this PR deliberately diverges rather than porting the defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)