### PR TITLE
Let the ignore GUI express a NOHIGHLIGHT-only rule (#775)

### DIFF
--- a/vue_client/src/components/settings-panes/IgnoresPane.test.ts
+++ b/vue_client/src/components/settings-panes/IgnoresPane.test.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+// #775 lives entirely in the chip handlers and the edit round-trip: which levels
+// a click leaves selected, and what `startEdit` reads back out of a saved rule.
+// None of that is reachable from outside the SFC — the handlers aren't exported —
+// and the bug was precisely that the two disagreed, so a test of either half
+// alone would have gone on passing. Mount it and click.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+vi.mock('../../composables/useSocket.js', () => ({
+  socketSend: vi.fn<(payload: Record<string, unknown>) => void>(),
+}));
+
+import { socketSend } from '../../composables/useSocket.js';
+import { useIgnoresStore, type IgnoreEntry } from '../../stores/ignores.js';
+import IgnoresPane from './IgnoresPane.vue';
+
+function chip(wrapper: VueWrapper, label: string) {
+  const found = wrapper.findAll('.chip').find((c) => c.text() === label);
+  if (!found) throw new Error(`no chip labelled ${label}`);
+  return found;
+}
+
+// The NOHIGHLIGHT modifier is the only checkbox in the "Event types" field.
+function noHighlightBox(wrapper: VueWrapper) {
+  return wrapper.find('.field .ck input[type="checkbox"]');
+}
+
+function submit(wrapper: VueWrapper) {
+  const btn = wrapper
+    .findAll('.actions button')
+    .find((b) => b.text() === 'add ignore' || b.text() === 'save');
+  if (!btn) throw new Error('no submit button');
+  return btn.trigger('click');
+}
+
+// The mask field is the first text input in the form.
+function setMask(wrapper: VueWrapper, mask: string) {
+  return wrapper.findAll('.rule-form input[type="text"]')[0].setValue(mask);
+}
+
+// What actually went to the server, or null if the submit was refused.
+function sentRule(): Record<string, unknown> | null {
+  const call = vi
+    .mocked(socketSend)
+    .mock.calls.map(([payload]) => payload)
+    .findLast((p) => p.type === 'add-ignore');
+  return (call?.rule as Record<string, unknown>) ?? null;
+}
+
+function seedEntry(entry: Partial<IgnoreEntry> & { levels: string[] }) {
+  const store = useIgnoresStore();
+  store.global = [
+    {
+      id: 7,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      mask: 'bob!*@*',
+      channels: null,
+      pattern: null,
+      patternKind: 'substr',
+      isExcept: false,
+      expiresAt: null,
+      ...entry,
+    } as IgnoreEntry,
+  ];
+}
+
+describe('IgnoresPane — the ALL chip and the NOHIGHLIGHT-only rule (#775)', () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.mocked(socketSend).mockClear();
+    wrapper = mount(IgnoresPane);
+  });
+
+  it('starts on ALL, which is what an unqualified /ignore means', async () => {
+    await setMask(wrapper, 'bob');
+    await submit(wrapper);
+    expect(sentRule()?.levels).toEqual(['ALL']);
+  });
+
+  // ⚠⚠ The heart of it. ALL was switch-on-only, and the granular chips snapped
+  // back to it whenever the last one was cleared — so "no hide levels" was a
+  // state the form could not be in, and a NOHIGHLIGHT-only rule could not be
+  // built. It is the rule that suppresses a nick's highlights without hiding
+  // anything, and /ignore bob NOHIGHLIGHT makes one happily.
+  it('builds a NOHIGHLIGHT-only rule when ALL is switched off', async () => {
+    await setMask(wrapper, 'bob');
+    await noHighlightBox(wrapper).setValue(true);
+    await chip(wrapper, 'ALL').trigger('click');
+    await submit(wrapper);
+    expect(sentRule()?.levels).toEqual(['NOHIGHLIGHT']);
+  });
+
+  it('refuses a rule with nothing selected at all, instead of quietly meaning ALL', async () => {
+    // buildLevels used to fall back to ['ALL'], which turned "hide nothing" into
+    // "hide everything" on the way out — silently, and in the one case where an
+    // empty selection is what the user meant.
+    await setMask(wrapper, 'bob');
+    await chip(wrapper, 'ALL').trigger('click');
+    await submit(wrapper);
+    expect(sentRule()).toBeNull();
+    expect(wrapper.find('p.error.inline').text()).toContain('Suppress highlights only');
+  });
+
+  it('keeps a granular selection selectable and clearable', async () => {
+    await setMask(wrapper, 'bob');
+    await chip(wrapper, 'JOINS').trigger('click');
+    await chip(wrapper, 'PARTS').trigger('click');
+    expect(chip(wrapper, 'ALL').attributes('aria-pressed')).toBe('false');
+    await chip(wrapper, 'PARTS').trigger('click');
+    await submit(wrapper);
+    expect(sentRule()?.levels).toEqual(['JOINS']);
+  });
+
+  it('combines hide levels with the modifier — the pairing the fix must not lose', async () => {
+    await setMask(wrapper, 'bob');
+    await chip(wrapper, 'JOINS').trigger('click');
+    await noHighlightBox(wrapper).setValue(true);
+    await submit(wrapper);
+    expect(sentRule()?.levels).toEqual(['JOINS', 'NOHIGHLIGHT']);
+  });
+
+  // ⚠⚠ The other half, and the destructive one: `lv.every(l => l === 'NOHIGHLIGHT')`
+  // is true for ['NOHIGHLIGHT'], so opening one of these rules lit ALL — and
+  // saving wrote back ['ALL','NOHIGHLIGHT'], turning "don't highlight me for bob"
+  // into "hide bob entirely". Rules made with /ignore were rewritten by the act of
+  // looking at them in the GUI.
+  it('round-trips a NOHIGHLIGHT-only rule through edit without adding ALL', async () => {
+    seedEntry({ levels: ['NOHIGHLIGHT'] });
+    await wrapper.vm.$nextTick();
+    await wrapper.find('.row-actions button').trigger('click');
+    expect(chip(wrapper, 'ALL').attributes('aria-pressed')).toBe('false');
+    await submit(wrapper);
+    expect(sentRule()?.levels).toEqual(['NOHIGHLIGHT']);
+  });
+
+  it('round-trips a mixed rule through edit', async () => {
+    seedEntry({ levels: ['JOINS', 'NOHIGHLIGHT'] });
+    await wrapper.vm.$nextTick();
+    await wrapper.find('.row-actions button').trigger('click');
+    expect(chip(wrapper, 'ALL').attributes('aria-pressed')).toBe('false');
+    expect(chip(wrapper, 'JOINS').attributes('aria-pressed')).toBe('true');
+    await submit(wrapper);
+    expect(sentRule()?.levels).toEqual(['JOINS', 'NOHIGHLIGHT']);
+  });
+
+  it('round-trips an ALL rule through edit', async () => {
+    seedEntry({ levels: ['ALL'] });
+    await wrapper.vm.$nextTick();
+    await wrapper.find('.row-actions button').trigger('click');
+    expect(chip(wrapper, 'ALL').attributes('aria-pressed')).toBe('true');
+    await submit(wrapper);
+    expect(sentRule()?.levels).toEqual(['ALL']);
+  });
+});

--- a/vue_client/src/components/settings-panes/IgnoresPane.test.ts
+++ b/vue_client/src/components/settings-panes/IgnoresPane.test.ts
@@ -120,6 +120,31 @@ describe('IgnoresPane — the ALL chip and the NOHIGHLIGHT-only rule (#775)', ()
     expect(sentRule()?.levels).toEqual(['JOINS']);
   });
 
+  // ⚠⚠ toggleLevel used to snap back to ALL when the last granular chip was cleared, which is
+  // half of why the empty state was unreachable. The "selectable and clearable" case above never
+  // clears the LAST chip, so it goes on passing with the snap-back re-added — this is the one
+  // that pins its removal.
+  it('does not snap back to ALL when the last granular chip is cleared', async () => {
+    await setMask(wrapper, 'bob');
+    await chip(wrapper, 'JOINS').trigger('click');
+    await chip(wrapper, 'JOINS').trigger('click');
+    expect(chip(wrapper, 'ALL').attributes('aria-pressed')).toBe('false');
+    await submit(wrapper);
+    expect(sentRule()).toBeNull();
+  });
+
+  // ⚠⚠ The footgun this change newly made reachable. A modifier-only rule with no who/where/what
+  // matches everyone and, being non-hiding, is unbounded — it kills every highlight on every
+  // network while the list shows it as nothing but `*  NOHIGHLIGHT`. The pane already refuses
+  // the ALL-shaped version of the same mistake.
+  it('refuses an unscoped highlight-suppression rule', async () => {
+    await noHighlightBox(wrapper).setValue(true);
+    await chip(wrapper, 'ALL').trigger('click');
+    await submit(wrapper);
+    expect(sentRule()).toBeNull();
+    expect(wrapper.find('p.error.inline').text()).toContain('silence every highlight');
+  });
+
   it('combines hide levels with the modifier — the pairing the fix must not lose', async () => {
     await setMask(wrapper, 'bob');
     await chip(wrapper, 'JOINS').trigger('click');

--- a/vue_client/src/components/settings-panes/IgnoresPane.vue
+++ b/vue_client/src/components/settings-panes/IgnoresPane.vue
@@ -16,8 +16,6 @@
       <code>/ignore</code> command.
     </p>
 
-    <p v-if="formError" class="error inline">{{ formError }}</p>
-
     <p v-if="!ignoreGroups.length" class="muted small">
       No ignores yet. Add one below, right-click a nick in the member list, or type
       <code>/ignore &lt;nick&gt;</code> in any buffer.
@@ -176,6 +174,14 @@
           enter a new duration to reset it.
         </p>
       </div>
+
+      <!-- ⚠ Next to the button, not at the top of the pane. It used to render above the section
+           description and above the whole rule list, so for anyone with a few ignores the
+           explanation for a refused submit was off-screen and the click read as doing nothing.
+           Every one of these errors comes from buildRule, so the form is where they belong —
+           and the empty-levels one below is far likelier to be hit than the regex/duration
+           ones this markup was written for. -->
+      <p v-if="formError" class="error inline">{{ formError }}</p>
 
       <div class="actions">
         <button v-if="editing" class="link" @click="cancelEdit">cancel</button>
@@ -383,6 +389,21 @@ function buildRule(): IgnoreRule | null {
     formError.value = 'that would hide everything — add a mask, channel, or text pattern.';
     return null;
   }
+  // ⚠⚠ The same footgun, in the shape this change newly made reachable. A modifier-only rule
+  // with no who/where/what compiles to matchesNick = () => true with hides:false, and
+  // evaluateIgnores' no-applies branch is unbounded for a non-hiding rule — so it silently kills
+  // every highlight on every network, and the list shows it as nothing but `*  NOHIGHLIGHT`.
+  // Two clicks away from the default form, which is exactly why it needs saying out loud.
+  if (unscoped && !useAll.value && form.levels.length === 0) {
+    formError.value = 'that would silence every highlight — add a mask, channel, or text pattern.';
+    return null;
+  }
+  // ⚠⚠ The same footgun, in the shape this change newly made reachable. A modifier-only rule
+  // with no who/where/what compiles to matchesNick = () => true with hides:false, and
+  // evaluateIgnores' no-applies branch is unbounded for a non-hiding rule — so it silently kills
+  // every highlight on every network, and the list shows it as nothing but `*  NOHIGHLIGHT`.
+  // Two clicks away from the default form, which is exactly why it needs saying out loud.
+
   let expiresAt: string | null = null;
   const dur = form.expiry.trim();
   if (dur) {

--- a/vue_client/src/components/settings-panes/IgnoresPane.vue
+++ b/vue_client/src/components/settings-panes/IgnoresPane.vue
@@ -398,12 +398,6 @@ function buildRule(): IgnoreRule | null {
     formError.value = 'that would silence every highlight — add a mask, channel, or text pattern.';
     return null;
   }
-  // ⚠⚠ The same footgun, in the shape this change newly made reachable. A modifier-only rule
-  // with no who/where/what compiles to matchesNick = () => true with hides:false, and
-  // evaluateIgnores' no-applies branch is unbounded for a non-hiding rule — so it silently kills
-  // every highlight on every network, and the list shows it as nothing but `*  NOHIGHLIGHT`.
-  // Two clicks away from the default form, which is exactly why it needs saying out loud.
-
   let expiresAt: string | null = null;
   const dur = form.expiry.trim();
   if (dur) {

--- a/vue_client/src/components/settings-panes/IgnoresPane.vue
+++ b/vue_client/src/components/settings-panes/IgnoresPane.vue
@@ -132,7 +132,7 @@
             class="chip"
             :class="{ active: useAll }"
             :aria-pressed="useAll"
-            @click="selectAllLevels"
+            @click="toggleAllLevels"
           >
             ALL
           </button>
@@ -298,9 +298,19 @@ function selectNetworkScope() {
   if (!scopeNetworkId.value) scopeNetworkId.value = networkOptions.value[0].id;
 }
 
-function selectAllLevels() {
-  useAll.value = true;
-  form.levels = [];
+// ⚠⚠ A toggle, not a select. ALL used to be switch-on-only, and with the granular
+// chips snapping back to it whenever the last one was cleared, "no hide levels"
+// was a state the GUI could not express at all — which is exactly a NOHIGHLIGHT-only
+// rule, the one that suppresses a nick's highlights without hiding anything. They
+// could be written with `/ignore bob NOHIGHLIGHT` and then not edited here, because
+// opening one re-selected ALL and saving changed what the rule meant (#775).
+//
+// An empty selection is now a legitimate state to be IN. Whether it is a legitimate
+// state to SUBMIT is buildRule's question, and it answers with an error rather than
+// by quietly reinstating ALL.
+function toggleAllLevels() {
+  useAll.value = !useAll.value;
+  if (useAll.value) form.levels = [];
 }
 
 function toggleLevel(lvl: string) {
@@ -308,9 +318,6 @@ function toggleLevel(lvl: string) {
   const i = form.levels.indexOf(lvl);
   if (i >= 0) form.levels.splice(i, 1);
   else form.levels.push(lvl);
-  // Never leave the rule with no hide levels (unless NOHIGHLIGHT-only) — fall
-  // back to ALL so an empty selection isn't an inert rule.
-  if (form.levels.length === 0 && !form.noHighlight) useAll.value = true;
 }
 
 function parseChannels(s: string): string[] | null {
@@ -321,10 +328,14 @@ function parseChannels(s: string): string[] | null {
   return list.length ? list : null;
 }
 
+// ⚠ No `|| ['ALL']` fallback. It was what turned an empty selection back into
+// "hide everything" on the way to the server — silently, and in the one case
+// (NOHIGHLIGHT-only) where empty is what the user meant. buildRule rejects a
+// genuinely empty rule instead, where the user can see it happen.
 function buildLevels(): string[] {
   const out: string[] = useAll.value ? ['ALL'] : [...form.levels];
   if (form.noHighlight) out.push('NOHIGHLIGHT');
-  return out.length ? out : ['ALL'];
+  return out;
 }
 
 function buildRule(): IgnoreRule | null {
@@ -350,6 +361,15 @@ function buildRule(): IgnoreRule | null {
     }
   }
   const levels = buildLevels();
+  // An empty selection is now reachable (ALL is a toggle), so it has to be
+  // answered here — visibly — instead of buildLevels quietly turning it back into
+  // "hide everything". Tick the modifier and it IS a valid rule: hide nothing,
+  // suppress this nick's highlights. That is the rule #775 was about.
+  if (levels.length === 0) {
+    formError.value =
+      'pick at least one event type, or tick “Suppress highlights only” — as written this rule would do nothing.';
+    return null;
+  }
   // Guard the footgun rules a GUI shouldn't make easy. A rule with no who/where/
   // what matches the whole feed: as a hide rule with ALL it hides everything; as
   // an exception it whitelists everyone, neutralizing real ignores. Broad-but-
@@ -400,8 +420,16 @@ function startEdit(entry: IgnoreEntryWithNetwork) {
   form.isExcept = entry.isExcept;
   form.expiry = '';
   const lv = entry.levels || [];
-  useAll.value = lv.includes('ALL') || lv.every((l) => l === 'NOHIGHLIGHT');
-  form.levels = useAll.value ? [] : lv.filter((l) => l !== 'ALL' && l !== 'NOHIGHLIGHT');
+  // ⚠⚠ Read the HIDE levels, and only them. The old test also lit ALL when every
+  // level was NOHIGHLIGHT — `[].every()` and `['NOHIGHLIGHT'].every()` are both
+  // true — so opening a NOHIGHLIGHT-only rule showed ALL selected, and saving
+  // wrote back ['ALL','NOHIGHLIGHT']: the edit turned "don't highlight me for bob"
+  // into "hide bob entirely". That is the "they get the ALL option added by
+  // default" half of #775, and it silently rewrote rules people had already made
+  // with /ignore.
+  const hideLevels = lv.filter((l) => l !== 'NOHIGHLIGHT');
+  useAll.value = hideLevels.includes('ALL');
+  form.levels = useAll.value ? [] : hideLevels;
   form.noHighlight = lv.includes('NOHIGHLIGHT');
   if (entry.networkId == null) {
     scopeMode.value = 'global';


### PR DESCRIPTION
Fixes #775.

## The bug, in two halves

The ALL chip was **switch-on-only**, and the granular chips snapped back to it whenever the last one was cleared. So "no hide levels" was a state the form could not be in — and that state is exactly a NOHIGHLIGHT-only rule: suppress a nick's highlights, hide nothing. `/ignore bob NOHIGHLIGHT` makes one happily; the GUI could not.

Worse, it could not leave one alone either. `startEdit` lit ALL when `lv.every(l => l === 'NOHIGHLIGHT')` — true for exactly the rule in question — so opening one showed ALL selected, and saving wrote back `['ALL','NOHIGHLIGHT']`. **"Don't highlight me for bob" became "hide bob entirely", by the act of looking at the rule in the GUI.**

## The fix

ALL toggles, the granular chips no longer snap back, and `buildLevels` stops appending a `|| ['ALL']` fallback that turned an empty selection into "hide everything" on the way to the server. An empty selection with no modifier is refused **in the form**, where the user can see it happen, rather than being silently reinterpreted — which mirrors the server, whose `ignoreRulesService` rejects an empty level list too. `startEdit` reads the hide levels and only them.

The guard lives in `buildRule`, which matters: `submit()` removes the old rule before adding the new one when editing, so a check that ran later would lose the original.

## Two things review caught

**Making the empty state reachable opened a second unscoped footgun**, two clicks from the default form: a modifier-only rule with no mask, channel, or pattern compiles to `matchesNick = () => true` with `hides: false`, and `evaluateIgnores`' no-applies branch is unbounded for a non-hiding rule — so it silently kills **every highlight on every network**, and the pane lists it as nothing but `*  NOHIGHLIGHT`. The ALL-shaped version of that mistake was already refused; this one now is too.

**The form error rendered at the top of the pane**, above the section description and above the whole rule list, while the button sits at the bottom of the form. For anyone with a few ignores the explanation was off-screen and a refused submit read as doing nothing. Moved next to the button — every one of these errors comes from `buildRule`, so the form is where they belong.

## Testing

Ten cases mounting the pane and clicking the real chips: the handlers aren't exported, and the bug was that the build path and the edit path disagreed, so a test of either half alone would have kept passing.

Five were confirmed to fail against the old code or against a re-added mutation — including the snap-back, which review showed my first test set did *not* pin (the "selectable and clearable" case never clears the *last* granular chip, so re-adding the snap-back left all eight green). The other five cover what must **not** change: ALL as the default, granular selection, and the levels+modifier pairing.

`npm test` (3913 passed) and `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)