### PR TITLE
Filter and gate inputs freeze mid-word on Android keyboards (#622)

### DIFF
--- a/vue_client/src/components/ChannelListModal.vue
+++ b/vue_client/src/components/ChannelListModal.vue
@@ -14,7 +14,8 @@
     <div class="controls">
       <input
         ref="filterEl"
-        v-model="filterInput"
+        :value="filterInput"
+        @input="onFilterInput"
         class="filter"
         type="text"
         placeholder="filter (name or topic)"
@@ -75,6 +76,7 @@ import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { socketSend } from '../composables/useSocket.js';
 import { formatRelative } from '../utils/timestamp.js';
+import { useImeSafeInput } from '../composables/useImeSafeInput.js';
 
 const PAGE_LIMIT = 200;
 const FILTER_DEBOUNCE_MS = 200;
@@ -89,6 +91,7 @@ const buffers = useBuffersStore();
 const filterEl = ref<HTMLInputElement | null>(null);
 const listEl = ref<HTMLElement | null>(null);
 const filterInput = ref('');
+const onFilterInput = useImeSafeInput(filterInput);
 let filterTimer: ReturnType<typeof setTimeout> | null = null;
 let prevInProgress = false;
 

--- a/vue_client/src/components/HighlightsModal.vue
+++ b/vue_client/src/components/HighlightsModal.vue
@@ -17,7 +17,8 @@
 
     <div class="search-row">
       <input
-        v-model="queryInput"
+        :value="queryInput"
+        @input="onQueryInput"
         class="filter"
         type="text"
         placeholder="filter highlights — from:nick in:#channel on:network"
@@ -49,6 +50,7 @@ import HistoryMessageRow, { type HistoryMessage } from './HistoryMessageRow.vue'
 import { useSettingsStore } from '../stores/settings.js';
 import { useHighlightsStore } from '../stores/highlights.js';
 import { useIgnoresStore } from '../stores/ignores.js';
+import { useImeSafeInput } from '../composables/useImeSafeInput.js';
 
 const emit = defineEmits<{
   close: [];
@@ -88,6 +90,7 @@ let autoFillFetched = 0;
 // debouncing the text field itself. Seeded from the store so a closed-then-
 // reopened modal keeps the active filter.
 const queryInput = ref(scoped ? `${props.scope} ` : store.query);
+const onQueryInput = useImeSafeInput(queryInput);
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 watch(queryInput, (val) => {
   store.setQuery(val);

--- a/vue_client/src/components/IgnoreModal.vue
+++ b/vue_client/src/components/IgnoreModal.vue
@@ -13,6 +13,7 @@
             ref="inputEl"
             :value="mask"
             @input="onMaskInput"
+            @keydown.enter="blockImeEnter"
             type="text"
             spellcheck="false"
             autocapitalize="off"
@@ -61,7 +62,7 @@
 import { onMounted, ref } from 'vue';
 import AppModal from './AppModal.vue';
 import { useIgnoresStore } from '../stores/ignores.js';
-import { useImeSafeInput } from '../composables/useImeSafeInput.js';
+import { blockImeEnter, useImeSafeInput } from '../composables/useImeSafeInput.js';
 
 const props = withDefaults(
   defineProps<{

--- a/vue_client/src/components/IgnoreModal.vue
+++ b/vue_client/src/components/IgnoreModal.vue
@@ -11,7 +11,8 @@
           <span class="label-text">Mask</span>
           <input
             ref="inputEl"
-            v-model="mask"
+            :value="mask"
+            @input="onMaskInput"
             type="text"
             spellcheck="false"
             autocapitalize="off"
@@ -60,6 +61,7 @@
 import { onMounted, ref } from 'vue';
 import AppModal from './AppModal.vue';
 import { useIgnoresStore } from '../stores/ignores.js';
+import { useImeSafeInput } from '../composables/useImeSafeInput.js';
 
 const props = withDefaults(
   defineProps<{
@@ -88,6 +90,7 @@ const scope = ref<'global' | 'network'>('global');
 // If we don't have an observed user@host yet (member entered before WHO
 // completed and we never saw a join), fall back to nick!*@*.
 const mask = ref(props.user && props.host ? `*!${props.user}@${props.host}` : `${props.nick}!*@*`);
+const onMaskInput = useImeSafeInput(mask);
 
 function confirm() {
   const trimmed = mask.value.trim();

--- a/vue_client/src/components/JoinChannelModal.vue
+++ b/vue_client/src/components/JoinChannelModal.vue
@@ -17,7 +17,8 @@
       <div class="body">
         <input
           ref="inputEl"
-          v-model="channel"
+          :value="channel"
+          @input="onChannelInput"
           class="chan-input"
           type="text"
           placeholder="#channel"
@@ -45,6 +46,7 @@ import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
 import { ensureChannelPrefix } from '../utils/channelTarget.js';
+import { useImeSafeInput } from '../composables/useImeSafeInput.js';
 
 const props = defineProps<{ networkId: number }>();
 const emit = defineEmits<{ close: [] }>();
@@ -55,6 +57,7 @@ const channelListModal = useChannelListModal();
 
 const inputEl = ref<HTMLInputElement | null>(null);
 const channel = ref('');
+const onChannelInput = useImeSafeInput(channel);
 
 const networkLabel = computed(() => {
   const net = networks.networks.find((n) => n.id === props.networkId);

--- a/vue_client/src/components/JoinChannelModal.vue
+++ b/vue_client/src/components/JoinChannelModal.vue
@@ -19,6 +19,7 @@
           ref="inputEl"
           :value="channel"
           @input="onChannelInput"
+          @keydown.enter="blockImeEnter"
           class="chan-input"
           type="text"
           placeholder="#channel"
@@ -46,7 +47,7 @@ import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
 import { ensureChannelPrefix } from '../utils/channelTarget.js';
-import { useImeSafeInput } from '../composables/useImeSafeInput.js';
+import { blockImeEnter, useImeSafeInput } from '../composables/useImeSafeInput.js';
 
 const props = defineProps<{ networkId: number }>();
 const emit = defineEmits<{ close: [] }>();

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -237,6 +237,7 @@ import {
 } from '../composables/useComposerOverlay.js';
 import { useNickColors } from '../composables/useNickColors.js';
 import type { Buffer } from '../stores/buffers.js';
+import { isImeKey } from '../composables/useImeSafeInput.js';
 
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
@@ -1024,16 +1025,16 @@ function onKeydown(e: KeyboardEvent): void {
   // Escape-closes-color-picker — had predictably been missed). While an IME
   // composition is live, every key belongs to the IME: arrows/Tab/Enter drive
   // its candidate window, Escape cancels its preedit — nothing here should
-  // act. keyCode 229 is gated too: Safari fires the Enter that confirms a CJK
-  // composition AFTER compositionend, with isComposing already false but
-  // keyCode still 229 — without this, committing a word would send the message
-  // (the standard ProseMirror/Slate guard).
+  // act. isImeKey also covers keyCode 229, for Safari's confirm-Enter arriving
+  // after compositionend; it is shared with the other fields that had to stop
+  // acting on the IME's keys once their model went live (#622), so the rule is
+  // stated once.
   //
   // Tab still preventDefaults on the way out: the IME has already consumed the
   // key, and letting the default through would walk focus out of the composer
   // onto Send — which on Firefox/Gboard Android, where a composition is open
   // for every word, would be the *only* thing Tab ever did.
-  if (e.isComposing || e.keyCode === 229) {
+  if (isImeKey(e)) {
     if (e.key === 'Tab') e.preventDefault();
     return;
   }

--- a/vue_client/src/components/NetworkPicker.vue
+++ b/vue_client/src/components/NetworkPicker.vue
@@ -14,7 +14,8 @@
   <div class="picker">
     <div class="search-row">
       <input
-        v-model="query"
+        :value="query"
+        @input="onQueryInput"
         class="search"
         type="search"
         placeholder="Search networks…"
@@ -109,6 +110,7 @@ import {
   type NetworkPreset,
 } from '../utils/builtinNetworks.js';
 import { useNetworkPresetsStore } from '../stores/networkPresets.js';
+import { useImeSafeInput } from '../composables/useImeSafeInput.js';
 
 defineEmits<{ select: [net: NetworkPreset]; manual: [] }>();
 
@@ -131,6 +133,7 @@ function hasLurker(net: NetworkPreset): boolean {
 const showTagFilter = computed(() => presets.allowUserDefined && builtinNetworkTags.length > 0);
 
 const query = ref('');
+const onQueryInput = useImeSafeInput(query);
 // Single-select tag filter: clicking a chip selects it (clearing any other);
 // clicking the active chip again clears the filter. The chip tray is collapsed
 // behind the Filter button by default.

--- a/vue_client/src/components/NickNoteModal.vue
+++ b/vue_client/src/components/NickNoteModal.vue
@@ -9,7 +9,8 @@
       <div class="body">
         <textarea
           ref="inputEl"
-          v-model="draft"
+          :value="draft"
+          @input="onDraftInput"
           spellcheck="true"
           autocapitalize="sentences"
           rows="8"
@@ -37,6 +38,7 @@ import { computed, onMounted, ref } from 'vue';
 import AppModal from './AppModal.vue';
 import { useNickNotesStore } from '../stores/nickNotes.js';
 import { formatDateTime } from '../utils/timestamp.js';
+import { useImeSafeInput } from '../composables/useImeSafeInput.js';
 
 const props = defineProps<{
   nick: string;
@@ -50,6 +52,7 @@ const inputEl = ref<HTMLTextAreaElement | null>(null);
 const entry = computed(() => nickNotes.entryFor(props.networkId, props.nick));
 const initial = computed(() => entry.value?.note || '');
 const draft = ref(initial.value);
+const onDraftInput = useImeSafeInput(draft);
 const dirty = computed(() => draft.value !== initial.value);
 const hasExistingNote = computed(() => !!entry.value?.note);
 const formattedUpdatedAt = computed(() => formatDateTime(entry.value?.updatedAt ?? ''));

--- a/vue_client/src/components/QuickSwitcher.ime.test.ts
+++ b/vue_client/src/components/QuickSwitcher.ime.test.ts
@@ -33,9 +33,14 @@ function seedStores() {
     buffers.buffers[`1::${target}`] = { networkId: 1, target, members: [], messages: [] } as never;
   }
   networks.activeKey = '1::#apple';
+  buffersActivated = [];
+  buffers.activate = ((networkId: number, target: string) => {
+    buffersActivated.push(`${networkId}::${target}`);
+  }) as never;
 }
 
 let mounted: VueWrapper[] = [];
+let buffersActivated: string[] = [];
 
 async function mountSwitcher() {
   const wrapper = mount(QuickSwitcher, { attachTo: document.body });
@@ -87,6 +92,23 @@ describe('QuickSwitcher filter under IME composition', () => {
     await composeWord(el, 'zeb');
 
     expect(labels(wrapper)).toEqual(['#zebra']);
+  });
+
+  it('ignores the Enter that confirms an IME candidate', async () => {
+    // The regression a live model opens up: onKeydown's Enter branch picks the
+    // selected row, and with v-model gone this keypress is no longer answered
+    // with a stale-and-harmless query. The IME owns Enter while composing — it
+    // is confirming a candidate, not asking to switch buffers.
+    const { wrapper, el } = await mountSwitcher();
+    await composeWord(el, 'zeb');
+
+    el.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', isComposing: true, bubbles: true }),
+    );
+    await nextFrame();
+
+    expect(wrapper.emitted('close')).toBeUndefined();
+    expect(buffersActivated).toEqual([]);
   });
 
   it('keeps narrowing as the composed word grows', async () => {

--- a/vue_client/src/components/QuickSwitcher.ime.test.ts
+++ b/vue_client/src/components/QuickSwitcher.ime.test.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+// The quick switcher at a real call site, mid-composition.
+//
+// useImeSafeInput.test.ts proves the binding in isolation, with a v-model
+// control to show the assertions can fail. This is the other half: that the
+// switcher's filter is actually wired to it, so the list narrows while an
+// Android keyboard is still composing the word instead of sitting on the
+// unfiltered set until the keyboard is dismissed.
+//
+// The switcher stands in for the other eleven fields (#622) — they all bind the
+// same `:value` + `@input` pair, and the composable's own suite covers what the
+// binding does. Reintroducing v-model here is what this catches.
+
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { useNetworksStore } from '../stores/networks.js';
+import { useBuffersStore } from '../stores/buffers.js';
+import QuickSwitcher from './QuickSwitcher.vue';
+
+const CHANNELS = ['#apple', '#mango', '#zebra'];
+
+function seedStores() {
+  const networks = useNetworksStore();
+  const buffers = useBuffersStore();
+  networks.networks = [{ id: 1, name: 'testnet' }] as never;
+  networks.states = { 1: { nick: 'me' } } as never;
+  for (const target of CHANNELS) {
+    buffers.buffers[`1::${target}`] = { networkId: 1, target, members: [], messages: [] } as never;
+  }
+  networks.activeKey = '1::#apple';
+}
+
+let mounted: VueWrapper[] = [];
+
+async function mountSwitcher() {
+  const wrapper = mount(QuickSwitcher, { attachTo: document.body });
+  mounted.push(wrapper);
+  await nextFrame();
+  const input = wrapper.find('input.filter');
+  expect(input.exists()).toBe(true);
+  return { wrapper, el: input.element as HTMLInputElement };
+}
+
+async function nextFrame() {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+// A soft keyboard delivering one word: the DOM value updates per keystroke
+// inside a composing run that never ends. See composeWord in
+// useImeSafeInput.test.ts.
+async function composeWord(el: HTMLInputElement, word: string) {
+  el.dispatchEvent(new Event('compositionstart', { bubbles: true }));
+  for (let i = 1; i <= word.length; i++) {
+    el.value = word.slice(0, i);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+  await nextFrame();
+}
+
+function labels(wrapper: VueWrapper) {
+  return wrapper.findAll('li.row .target').map((n) => n.text());
+}
+
+describe('QuickSwitcher filter under IME composition', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    seedStores();
+  });
+
+  afterEach(() => {
+    for (const wrapper of mounted) wrapper.unmount();
+    mounted = [];
+  });
+
+  it('narrows the list while the word is still composing', async () => {
+    const { wrapper, el } = await mountSwitcher();
+    // Sanity: with no query this is the alt-tab view, so the active buffer
+    // (#apple) is dropped for a reason unrelated to the filter, and the
+    // network's own server row rides along from flattenBufferOrder.
+    expect(labels(wrapper)).toEqual(['[server]', '#mango', '#zebra']);
+
+    await composeWord(el, 'zeb');
+
+    expect(labels(wrapper)).toEqual(['#zebra']);
+  });
+
+  it('keeps narrowing as the composed word grows', async () => {
+    // The frozen-model failure isn't "no filtering at all" — it's filtering on
+    // whatever the model held when the composition opened. Typing a second
+    // word after a committed first would still narrow, just to the wrong set.
+    const { wrapper, el } = await mountSwitcher();
+
+    await composeWord(el, 'm');
+    expect(labels(wrapper)).toEqual(['#mango']);
+
+    await composeWord(el, 'mangoes');
+    expect(labels(wrapper)).toEqual([]);
+    expect(wrapper.find('p.empty').exists()).toBe(true);
+  });
+});

--- a/vue_client/src/components/QuickSwitcher.vue
+++ b/vue_client/src/components/QuickSwitcher.vue
@@ -9,7 +9,8 @@
       <header class="head">
         <input
           ref="inputEl"
-          v-model="query"
+          :value="query"
+          @input="onQueryInput"
           class="filter"
           type="text"
           placeholder="jump to channel or DM…"
@@ -51,6 +52,7 @@ import { useNickColors } from '../composables/useNickColors.js';
 import { flattenBufferOrder, bufferSortKey } from '../utils/bufferOrder.js';
 import { smartSortRows } from '../utils/switcherSort.js';
 import { isChannelTarget } from '../../../shared/channels.js';
+import { useImeSafeInput } from '../composables/useImeSafeInput.js';
 
 interface Row {
   networkId: string | number;
@@ -79,6 +81,7 @@ const recent = useRecentBuffersStore();
 const nicks = useNickColors();
 
 const query = ref('');
+const onQueryInput = useImeSafeInput(query);
 const selected = ref(0);
 const inputEl = ref<HTMLInputElement | null>(null);
 const listEl = ref<HTMLUListElement | null>(null);

--- a/vue_client/src/components/QuickSwitcher.vue
+++ b/vue_client/src/components/QuickSwitcher.vue
@@ -52,7 +52,7 @@ import { useNickColors } from '../composables/useNickColors.js';
 import { flattenBufferOrder, bufferSortKey } from '../utils/bufferOrder.js';
 import { smartSortRows } from '../utils/switcherSort.js';
 import { isChannelTarget } from '../../../shared/channels.js';
-import { useImeSafeInput } from '../composables/useImeSafeInput.js';
+import { isImeKey, useImeSafeInput } from '../composables/useImeSafeInput.js';
 
 interface Row {
   networkId: string | number;
@@ -187,6 +187,10 @@ function onPointerMove(e: MouseEvent, i: number) {
 }
 
 function onKeydown(e: KeyboardEvent) {
+  // While a composition is live every key belongs to the IME: arrows and Enter
+  // drive its candidate window, Escape cancels its preedit. One gate for the
+  // whole handler, as in the composer (MessageInput's onKeydown).
+  if (isImeKey(e)) return;
   if (e.key === 'ArrowDown') {
     e.preventDefault();
     if (rows.value.length === 0) return;

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -30,7 +30,8 @@
           <i class="fa-solid fa-magnifying-glass search-icon"></i>
           <input
             ref="searchEl"
-            v-model="query"
+            :value="query"
+            @input="onQueryInput"
             type="search"
             class="search-input"
             placeholder="Search filenames…"
@@ -211,6 +212,7 @@ import { formatRelative } from '../utils/timestamp.js';
 import { joinMeta } from '../utils/metaLine.js';
 import { iconForMime } from '../utils/uploaders.js';
 import { mediaKindForUrl } from '../utils/uploadHostMatch.js';
+import { useImeSafeInput } from '../composables/useImeSafeInput.js';
 
 // The server response can include extra metadata fields not tracked in the
 // store's base UploadItem shape (they come from the GET /api/uploads list).
@@ -256,6 +258,7 @@ const starring = ref(new Set<number>());
 // Local, so typing is never gated on a round trip; pushed to the store (and thus the
 // server) on a debounce.
 const query = ref(uploads.query);
+const onQueryInput = useImeSafeInput(query);
 let debounce: ReturnType<typeof setTimeout> | null = null;
 
 const isFiltered = computed(() => Boolean(uploads.query || uploads.kind || uploads.favoritesOnly));

--- a/vue_client/src/components/SearchModal.vue
+++ b/vue_client/src/components/SearchModal.vue
@@ -8,7 +8,8 @@
     <div class="search-row">
       <input
         ref="inputEl"
-        v-model="queryInput"
+        :value="queryInput"
+        @input="onQueryInput"
         class="filter"
         type="text"
         placeholder="search messages — from:nick in:#channel on:network"
@@ -41,6 +42,7 @@ import { useSearchStore } from '../stores/search.js';
 import type { SearchResult } from '../stores/search.js';
 import { useIgnoresStore } from '../stores/ignores.js';
 import type { HistoryMessage } from './HistoryMessageRow.vue';
+import { useImeSafeInput } from '../composables/useImeSafeInput.js';
 
 const emit = defineEmits<{
   close: [];
@@ -73,6 +75,7 @@ const listEl = ref<HTMLUListElement | null>(null);
 // Local mirror of the store's raw query so we can debounce dispatch without
 // debouncing the text field itself. Scoped opens seed the prefilled filter.
 const queryInput = ref(scoped ? `${props.scope} ` : store.query);
+const onQueryInput = useImeSafeInput(queryInput);
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 watch(queryInput, (val) => {
   store.setQuery(val);

--- a/vue_client/src/components/SettingsSidebar.vue
+++ b/vue_client/src/components/SettingsSidebar.vue
@@ -20,7 +20,8 @@
   <nav class="settings-sidebar" aria-label="settings sections">
     <div class="search-wrap">
       <input
-        v-model="searchInput"
+        :value="searchInput"
+        @input="onSearchInput"
         type="search"
         class="search"
         placeholder="Search settings…"
@@ -103,6 +104,7 @@ import { useRouter } from 'vue-router';
 import type { SettingCategory } from '../../../shared/settingsRegistry.js';
 import { REGISTRY, CATEGORIES, optionVisible } from '../utils/settingsRegistry.js';
 import { useConfigStore } from '../stores/config.js';
+import { useImeSafeInput } from '../composables/useImeSafeInput.js';
 
 const props = defineProps<{
   activeCategoryId: string;
@@ -123,6 +125,7 @@ interface SettingsSubsection {
 const router = useRouter();
 const config = useConfigStore();
 const searchInput = ref('');
+const onSearchInput = useImeSafeInput(searchInput);
 const searchEl = ref<HTMLInputElement | null>(null);
 
 const searchActive = computed(() => searchInput.value.trim().length > 0);

--- a/vue_client/src/components/UploaderConfigForm.ime.test.ts
+++ b/vue_client/src/components/UploaderConfigForm.ime.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+// Implicit form submission under an IME (#622).
+//
+// The other half of unfreezing a model, at the call site where it is easiest to
+// reach. This form's save button goes live as soon as the DRIVER fields are
+// complete — which is before you have finished the Name if you type it last —
+// so the Enter that confirms a CJK candidate would implicitly submit the form
+// and create the uploader early, under the driver's default name rather than the
+// one still sitting in the preedit.
+//
+// Worth a call-site test rather than trusting blockImeEnter's own unit coverage:
+// what can go wrong here is the binding, not the handler.
+
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import UploaderConfigForm from './UploaderConfigForm.vue';
+import type { UploaderDriver } from '../utils/uploaders.js';
+
+const DRIVER: UploaderDriver = {
+  driver: 'test',
+  label: 'Test Driver',
+  creatable: true,
+  configSchema: [
+    { key: 'endpoint', label: 'Endpoint', type: 'string', required: true, description: '' },
+  ],
+};
+
+// A form whose required driver field is already filled, so the submit button is
+// enabled and implicit submission is actually reachable.
+function mountReady() {
+  const wrapper = mount(UploaderConfigForm, {
+    props: { driver: DRIVER },
+    attachTo: document.body,
+  });
+  const [nameEl, endpointEl] = wrapper.findAll('input').map((n) => n.element as HTMLInputElement);
+  endpointEl.value = 'https://example.test';
+  endpointEl.dispatchEvent(new Event('input', { bubbles: true }));
+  return { wrapper, nameEl };
+}
+
+function pressEnter(el: HTMLInputElement, init: KeyboardEventInit = {}) {
+  const e = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  el.dispatchEvent(e);
+  return e;
+}
+
+// NB: these assert on defaultPrevented rather than on a 'save' emit, because
+// happy-dom does not implement implicit form submission — a synthetic Enter
+// never submits there, IME or not, so an emit-based assertion would pass
+// whether or not the binding existed. Cancelling the default IS the mechanism
+// that stops the real browser submitting, so this is the observable half; the
+// consequence is a browser behaviour, and belongs to the manual QA recipe.
+describe('UploaderConfigForm under IME composition', () => {
+  it("cancels the Enter that confirms a candidate, so the form can't submit", async () => {
+    const { wrapper, nameEl } = mountReady();
+    await wrapper.vm.$nextTick();
+
+    // Mid-composition the visible name is preedit and `label` is whatever
+    // v-model last let through — neither is what the user means to save, and
+    // onSubmit would fall back to the driver's default name.
+    nameEl.dispatchEvent(new Event('compositionstart', { bubbles: true }));
+    nameEl.value = 'nihao';
+    nameEl.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(pressEnter(nameEl, { isComposing: true }).defaultPrevented).toBe(true);
+    expect(wrapper.emitted('save')).toBeUndefined();
+    wrapper.unmount();
+  });
+
+  it('leaves a real Enter alone, so the form still submits from the keyboard', async () => {
+    // A form you can no longer submit from the keyboard would be a worse bug
+    // than the one being fixed.
+    const { wrapper, nameEl } = mountReady();
+    await wrapper.vm.$nextTick();
+
+    nameEl.value = 'my uploader';
+    nameEl.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(pressEnter(nameEl).defaultPrevented).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('gates the driver fields the same way', () => {
+    const { wrapper } = mountReady();
+    const endpointEl = wrapper.findAll('input')[1].element as HTMLInputElement;
+
+    expect(pressEnter(endpointEl, { isComposing: true }).defaultPrevented).toBe(true);
+    expect(pressEnter(endpointEl).defaultPrevented).toBe(false);
+    wrapper.unmount();
+  });
+});

--- a/vue_client/src/components/UploaderConfigForm.vue
+++ b/vue_client/src/components/UploaderConfigForm.vue
@@ -24,6 +24,7 @@
         maxlength="64"
         :placeholder="driver.label"
         :disabled="busy"
+        @keydown.enter="blockImeEnter"
       />
     </label>
 
@@ -95,8 +96,15 @@ const values = ref<Record<string, string>>(
 
 // One handler for every driver field, since these are a v-for over the driver's
 // schema rather than named refs. Bound off the element because `incomplete`
-// below reads them as you type to gate the save button. The Name field above
-// keeps v-model on purpose: nothing reads it until submit.
+// below reads them as you type to gate the save button.
+//
+// The Name field above keeps v-model on purpose — nothing reads it until submit
+// — but still takes the Enter gate, because those are two separate questions.
+// It is a single-line input in a <form> whose submit button goes live as soon as
+// the DRIVER fields are complete, which is before you have finished the name if
+// you type it last. An IME's confirm-Enter there implicitly submits, and the
+// uploader is created early under the driver's default name (onSubmit falls back
+// to it) rather than the one still sitting in the preedit.
 function onFieldInput(key: string, e: Event) {
   values.value[key] = imeSafeValue(e);
 }

--- a/vue_client/src/components/UploaderConfigForm.vue
+++ b/vue_client/src/components/UploaderConfigForm.vue
@@ -33,7 +33,9 @@
         <em v-if="!field.required" class="optional">optional</em>
       </span>
       <input
-        v-model="values[field.key]"
+        :value="values[field.key]"
+        @input="onFieldInput(field.key, $event)"
+        @keydown.enter="blockImeEnter"
         :type="field.type === 'secret' ? 'password' : 'text'"
         :placeholder="placeholderFor(field)"
         :autocomplete="field.type === 'secret' ? 'new-password' : 'off'"
@@ -62,6 +64,7 @@ import {
   valuesFrom,
   missingRequired,
 } from '../utils/uploaders.js';
+import { blockImeEnter, imeSafeValue } from '../composables/useImeSafeInput.js';
 
 const props = defineProps<{
   driver: UploaderDriver;
@@ -89,6 +92,14 @@ const label = ref(props.existing?.label ?? '');
 const values = ref<Record<string, string>>(
   props.existing ? valuesFrom(props.driver, props.existing.config) : emptyValues(props.driver),
 );
+
+// One handler for every driver field, since these are a v-for over the driver's
+// schema rather than named refs. Bound off the element because `incomplete`
+// below reads them as you type to gate the save button. The Name field above
+// keeps v-model on purpose: nothing reads it until submit.
+function onFieldInput(key: string, e: Event) {
+  values.value[key] = imeSafeValue(e);
+}
 
 const incomplete = computed(() =>
   missingRequired(props.driver, values.value, props.existing?.secretsSet ?? {}),

--- a/vue_client/src/components/settings-panes/ApiTokensPane.vue
+++ b/vue_client/src/components/settings-panes/ApiTokensPane.vue
@@ -24,6 +24,7 @@
         <input
           :value="newName"
           @input="onNameInput"
+          @keydown.enter="blockImeEnter"
           type="text"
           maxlength="64"
           placeholder="e.g. claude-desktop, autonotes"
@@ -80,7 +81,7 @@
 import { ref, onMounted } from 'vue';
 import { api } from '../../api.js';
 import { formatRelative } from '../../utils/timestamp.js';
-import { useImeSafeInput } from '../../composables/useImeSafeInput.js';
+import { blockImeEnter, useImeSafeInput } from '../../composables/useImeSafeInput.js';
 
 interface ApiToken {
   id: string;

--- a/vue_client/src/components/settings-panes/ApiTokensPane.vue
+++ b/vue_client/src/components/settings-panes/ApiTokensPane.vue
@@ -22,7 +22,8 @@
       <label>
         <span>Name</span>
         <input
-          v-model="newName"
+          :value="newName"
+          @input="onNameInput"
           type="text"
           maxlength="64"
           placeholder="e.g. claude-desktop, autonotes"
@@ -79,6 +80,7 @@
 import { ref, onMounted } from 'vue';
 import { api } from '../../api.js';
 import { formatRelative } from '../../utils/timestamp.js';
+import { useImeSafeInput } from '../../composables/useImeSafeInput.js';
 
 interface ApiToken {
   id: string;
@@ -96,6 +98,7 @@ interface RevealedToken {
 
 const tokens = ref<ApiToken[]>([]);
 const newName = ref('');
+const onNameInput = useImeSafeInput(newName);
 const newAllowWrite = ref(false);
 const revealed = ref<RevealedToken | null>(null);
 const copied = ref(false);

--- a/vue_client/src/components/settings-panes/HighlightsPane.vue
+++ b/vue_client/src/components/settings-panes/HighlightsPane.vue
@@ -113,7 +113,8 @@
         >
         <div class="row">
           <input
-            v-model="form.pattern"
+            :value="form.pattern"
+            @input="onPatternInput"
             type="text"
             class="grow"
             placeholder="word or phrase to highlight"
@@ -138,7 +139,8 @@
           >Sender mask <span class="muted small">(who — blank = anyone)</span></span
         >
         <input
-          v-model="form.mask"
+          :value="form.mask"
+          @input="onMaskInput"
           type="text"
           placeholder="nick or nick!user@host — highlights everything they say"
           spellcheck="false"
@@ -153,7 +155,8 @@
           >Channels <span class="muted small">(where — blank = all buffers)</span></span
         >
         <input
-          v-model="form.channels"
+          :value="form.channels"
+          @input="onChannelsInput"
           type="text"
           placeholder="#chan #other (space-separated)"
           spellcheck="false"
@@ -190,6 +193,7 @@ import IconButton from '../IconButton.vue';
 import { parseChannelList } from '../../../../shared/channels.js';
 import { highlightRuleDetailParts } from '../../utils/highlightFormat.js';
 import { joinMeta } from '../../utils/metaLine.js';
+import { imeSafeValue } from '../../composables/useImeSafeInput.js';
 
 type RuleKind = 'substr' | 'full' | 'glob' | 'regex';
 
@@ -274,6 +278,20 @@ const form = reactive({
   caseSensitive: false,
   enabled: true,
 });
+
+// `form` is a reactive object, not three refs, so these take the value off the
+// element directly rather than through useImeSafeInput. Bound this way because
+// canSubmit reads pattern/mask as you type, and because all three are written
+// programmatically — cleared after a save, repopulated when you edit a rule.
+function onPatternInput(e: Event) {
+  form.pattern = imeSafeValue(e);
+}
+function onMaskInput(e: Event) {
+  form.mask = imeSafeValue(e);
+}
+function onChannelsInput(e: Event) {
+  form.channels = imeSafeValue(e);
+}
 
 const canSubmit = computed(() => {
   if (scopeMode.value === 'network' && !scopeNetworkId.value) return false;

--- a/vue_client/src/components/settings-panes/ThemesSection.vue
+++ b/vue_client/src/components/settings-panes/ThemesSection.vue
@@ -59,7 +59,8 @@
 
   <div class="theme-save">
     <input
-      v-model="newName"
+      :value="newName"
+      @input="onNameInput"
       type="text"
       :maxlength="THEME_NAME_MAX"
       :disabled="busy"
@@ -117,6 +118,7 @@ import { useThemesStore } from '../../stores/themes.js';
 import { prefersDark } from '../../utils/prefersDark.js';
 import { THEME_NAME_MAX, themeNameError } from '../../../../shared/themePresets.js';
 import type { ThemePreset } from '../../../../shared/themePresets.js';
+import { useImeSafeInput } from '../../composables/useImeSafeInput.js';
 
 const settings = useSettingsStore();
 const themes = useThemesStore();
@@ -124,6 +126,7 @@ const themes = useThemesStore();
 const error = ref('');
 const busy = ref(false);
 const newName = ref('');
+const onNameInput = useImeSafeInput(newName);
 
 const drifted = computed(() => settings.themeDriftKeys.length > 0);
 const mode = computed(() => String(settings.effective('look.theme.mode') ?? 'single'));

--- a/vue_client/src/components/settings-panes/ThemesSection.vue
+++ b/vue_client/src/components/settings-panes/ThemesSection.vue
@@ -65,7 +65,7 @@
       :maxlength="THEME_NAME_MAX"
       :disabled="busy"
       placeholder="Save current look as…"
-      @keydown.enter.prevent="saveNew"
+      @keydown.enter.prevent="onNameEnter"
     />
     <button class="link" :disabled="busy || !newName.trim()" @click="saveNew">Save theme</button>
   </div>
@@ -118,7 +118,7 @@ import { useThemesStore } from '../../stores/themes.js';
 import { prefersDark } from '../../utils/prefersDark.js';
 import { THEME_NAME_MAX, themeNameError } from '../../../../shared/themePresets.js';
 import type { ThemePreset } from '../../../../shared/themePresets.js';
-import { useImeSafeInput } from '../../composables/useImeSafeInput.js';
+import { isImeKey, useImeSafeInput } from '../../composables/useImeSafeInput.js';
 
 const settings = useSettingsStore();
 const themes = useThemesStore();
@@ -127,6 +127,16 @@ const error = ref('');
 const busy = ref(false);
 const newName = ref('');
 const onNameInput = useImeSafeInput(newName);
+
+// Enter in this field saves the theme — but the Enter that CONFIRMS a CJK
+// candidate is the IME's, not ours, and the model now holds raw preedit while a
+// composition is live. Without the gate that keypress saves a theme named
+// `nihao` and clears the field the user was still typing into. `.prevent` stays
+// on the binding: the key is the IME's either way.
+function onNameEnter(e: KeyboardEvent) {
+  if (isImeKey(e)) return;
+  saveNew();
+}
 
 const drifted = computed(() => settings.themeDriftKeys.length > 0);
 const mode = computed(() => String(settings.effective('look.theme.mode') ?? 'single'));

--- a/vue_client/src/composables/useImeSafeInput.test.ts
+++ b/vue_client/src/composables/useImeSafeInput.test.ts
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+// The composing guard, from both sides.
+//
+// The fix itself is an absence — with v-model gone there is no composing flag
+// left to freeze anything, so a compositionstart-driven test of the fixed
+// binding passes trivially. On its own that proves nothing: a test that cannot
+// fail is not a regression guard.
+//
+// So every case here runs against BOTH bindings. The v-model harness is the
+// positive control: it is a faithful hand-assembly of what the compiler emits
+// for `v-model="model"` on a native input (the vModelText directive, plus the
+// `onUpdate:modelValue` assigner it reads out of the vnode), and it is expected
+// to FAIL the same assertions the real binding passes. That contrast is what
+// gives the passing half its meaning, and it is what fails loudly if someone
+// puts v-model back on one of these fields.
+//
+// What none of this can prove is that a real Android keyboard behaves the way
+// these synthetic events say it does. It doesn't need to: the guard lives
+// entirely in Vue, not the browser. Device QA covers the other half.
+
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { defineComponent, h, nextTick, ref, vModelText, withDirectives, type Ref } from 'vue';
+import { useImeSafeInput } from './useImeSafeInput.js';
+
+// `:value` + an unconditional @input — what all twelve live-derived fields bind.
+function mountImeSafe(model: Ref<string>) {
+  return mount(
+    defineComponent({
+      setup() {
+        const onInput = useImeSafeInput(model);
+        return () => h('input', { value: model.value, onInput });
+      },
+    }),
+    { attachTo: document.body },
+  );
+}
+
+// The control: `v-model="model"` on a native input, as the SFC compiler emits
+// it. vModelText's created hook pulls its assigner off `onUpdate:modelValue`,
+// so the prop is not decoration — without it the directive has nothing to
+// write the model through and the harness would fail for the wrong reason.
+function mountVModel(model: Ref<string>) {
+  return mount(
+    defineComponent({
+      setup() {
+        return () =>
+          withDirectives(
+            h('input', {
+              'onUpdate:modelValue': (v: string) => {
+                model.value = v;
+              },
+            }),
+            [[vModelText, model.value]],
+          );
+      },
+    }),
+    { attachTo: document.body },
+  );
+}
+
+// One composed word, as a soft keyboard delivers it: compositionstart, then an
+// input event per keystroke with the DOM value already updated. No
+// compositionend — that is the point. Everything a user sees mid-word happens
+// in here, and on Android "mid-word" is most of the time they spend typing.
+async function composeWord(el: HTMLInputElement, word: string) {
+  el.dispatchEvent(new Event('compositionstart', { bubbles: true }));
+  for (let i = 1; i <= word.length; i++) {
+    el.value = word.slice(0, i);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+  await nextTick();
+}
+
+describe('useImeSafeInput', () => {
+  describe('the read half — DOM to model', () => {
+    it('tracks the field while a composition is in flight', async () => {
+      const model = ref('');
+      const wrapper = mountImeSafe(model);
+
+      await composeWord(wrapper.find('input').element as HTMLInputElement, 'zebra');
+
+      // A live filter, a submit button's :disabled, a computed preview: all of
+      // them read this, and all of them were a whole word stale.
+      expect(model.value).toBe('zebra');
+      wrapper.unmount();
+    });
+
+    it('control: v-model freezes the model for the whole word', async () => {
+      const model = ref('');
+      const wrapper = mountVModel(model);
+
+      await composeWord(wrapper.find('input').element as HTMLInputElement, 'zebra');
+
+      expect(model.value).toBe('');
+      wrapper.unmount();
+    });
+  });
+
+  describe('the write half — model to DOM', () => {
+    it('lets a programmatic clear reach the field mid-composition', async () => {
+      const model = ref('');
+      const wrapper = mountImeSafe(model);
+      const el = wrapper.find('input').element as HTMLInputElement;
+      await composeWord(el, 'zebra');
+
+      // The uploads browser's clear button and Esc handler, the settings
+      // sidebar's reset, the "" after a token or theme is saved.
+      model.value = '';
+      await nextTick();
+
+      expect(el.value).toBe('');
+      wrapper.unmount();
+    });
+
+    it('control: v-model leaves the cleared text on screen', async () => {
+      const model = ref('');
+      const wrapper = mountVModel(model);
+      const el = wrapper.find('input').element as HTMLInputElement;
+      await composeWord(el, 'zebra');
+
+      // Nothing to clear as far as the model is concerned — the read half
+      // already froze it at '' — so drive the divergence the other way and
+      // give it a value the DOM does not have.
+      model.value = 'mango';
+      await nextTick();
+
+      expect(el.value).toBe('zebra');
+      wrapper.unmount();
+    });
+  });
+
+  it('leaves the caret alone when the model already matches', async () => {
+    // Why `:value` is safe to bind on every keystroke: patchDOMProp skips the
+    // write when el.value already equals the incoming value, so re-rendering
+    // does not reset the selection out from under the user mid-word.
+    const model = ref('');
+    const wrapper = mountImeSafe(model);
+    const el = wrapper.find('input').element as HTMLInputElement;
+
+    await composeWord(el, 'zebra');
+    el.setSelectionRange(2, 2);
+    await nextTick();
+
+    expect(el.selectionStart).toBe(2);
+    wrapper.unmount();
+  });
+});

--- a/vue_client/src/composables/useImeSafeInput.test.ts
+++ b/vue_client/src/composables/useImeSafeInput.test.ts
@@ -25,7 +25,7 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { defineComponent, h, nextTick, ref, vModelText, withDirectives, type Ref } from 'vue';
-import { useImeSafeInput } from './useImeSafeInput.js';
+import { blockImeEnter, isImeKey, useImeSafeInput } from './useImeSafeInput.js';
 
 // `:value` + an unconditional @input — what all twelve live-derived fields bind.
 function mountImeSafe(model: Ref<string>) {
@@ -131,6 +131,40 @@ describe('useImeSafeInput', () => {
 
       expect(el.value).toBe('zebra');
       wrapper.unmount();
+    });
+  });
+
+  // The other half of unfreezing the model. v-model used to answer the Enter
+  // that confirms a CJK candidate with the PRE-composition value — usually ''
+  // — so a submit handler's own `if (!name) return` swallowed it. Now the
+  // model holds live preedit, and that same keypress would run the action for
+  // real.
+  describe("the IME's own Enter", () => {
+    const key = (init: KeyboardEventInit) =>
+      new KeyboardEvent('keydown', { key: 'Enter', ...init });
+
+    it('is recognised while a composition is live', () => {
+      expect(isImeKey(key({ isComposing: true }))).toBe(true);
+    });
+
+    it('is recognised from keyCode 229 after compositionend', () => {
+      // Safari fires the confirming Enter once isComposing is already false.
+      expect(isImeKey(Object.assign(key({}), { keyCode: 229 }))).toBe(true);
+    });
+
+    it('leaves a real Enter alone', () => {
+      expect(isImeKey(key({}))).toBe(false);
+    });
+
+    it('cancels implicit form submission only for the IME', () => {
+      const composing = key({ isComposing: true, cancelable: true });
+      blockImeEnter(composing);
+      expect(composing.defaultPrevented).toBe(true);
+
+      // A real Enter must still submit the form it sits in.
+      const real = key({ cancelable: true });
+      blockImeEnter(real);
+      expect(real.defaultPrevented).toBe(false);
     });
   });
 

--- a/vue_client/src/composables/useImeSafeInput.ts
+++ b/vue_client/src/composables/useImeSafeInput.ts
@@ -42,10 +42,15 @@
 // a theme saved as "nihao" and the field cleared out from under the user.
 //
 // So a field that DOES something on Enter — an explicit @keydown, or implicit
-// form submission from a single-line input — pairs the binding with isImeKey /
-// blockImeEnter below. A filter that only filters needs neither; a <textarea> in
-// a form needs neither either, since Enter there inserts a newline rather than
-// submitting.
+// form submission from a single-line input — needs isImeKey / blockImeEnter
+// below. A filter that only filters needs neither; a <textarea> in a form needs
+// neither either, since Enter there inserts a newline rather than submitting.
+//
+// That gate is a SEPARATE question from the binding, and a field can need one
+// without the other. A single-line input still on v-model needs it too: its
+// stale model doesn't make an early submit harmless, it just changes what gets
+// submitted (UploaderConfigForm's Name field is the worked example — see the
+// note there).
 //
 // ─── Scope ──────────────────────────────────────────────────────────────────
 //

--- a/vue_client/src/composables/useImeSafeInput.ts
+++ b/vue_client/src/composables/useImeSafeInput.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// "Bind a text input to a ref without v-model, so an IME can't freeze it."
+// "Bind a text input to a ref without v-model, so an IME can't freeze it —
+// and don't let the IME's own Enter run your action."
 //
 // v-model on a native <input>/<textarea> compiles to vModelText, which carries a
 // `composing` flag — set between compositionstart and compositionend — and refuses
@@ -31,17 +32,74 @@
 //   const onQueryInput = useImeSafeInput(query);
 //   <input :value="query" @input="onQueryInput" />
 //
+// ─── The catch: preedit is now live, so Enter needs its own gate ─────────────
+//
+// v-model's frozen model was accidentally protecting one thing. A CJK user
+// pressing Enter to CONFIRM a candidate fires a keydown like any other, and a
+// field bound with v-model answered it with the pre-composition value — usually
+// '', so the form's submit handler hit its own `if (!name) return` and no-op'd.
+// Unfreeze the model and that same Enter runs the action against raw preedit:
+// a theme saved as "nihao" and the field cleared out from under the user.
+//
+// So a field that DOES something on Enter — an explicit @keydown, or implicit
+// form submission from a single-line input — pairs the binding with isImeKey /
+// blockImeEnter below. A filter that only filters needs neither; a <textarea> in
+// a form needs neither either, since Enter there inserts a newline rather than
+// submitting.
+//
+// ─── Scope ──────────────────────────────────────────────────────────────────
+//
 // Deliberately the read half only. The composer (MessageInput.vue) needs more —
 // it re-runs on change/compositionend as backstops and re-establishes the write
 // guard in the drafts store, because a missed sync there corrupts a sent message.
 // See the "IME composition" note there. Callers of THIS never splice into the
 // field mid-composition, so `input` alone is the whole premise.
+//
+// Fields NOT bound this way are the ones nothing reads until submit: v-model is
+// fine there, because compositionend lands the value long before the click.
 
 import type { Ref } from 'vue';
 
+/**
+ * The text the user can actually see, read straight off the element rather than
+ * through a binding that may be holding something older.
+ *
+ * For fields that can't hand over a ref — a `reactive()` form object, a row in a
+ * `v-for`. Pair with `:value`, same as useImeSafeInput.
+ */
+export function imeSafeValue(e: Event): string {
+  const el = e.target as HTMLInputElement | HTMLTextAreaElement | null;
+  return el ? el.value : '';
+}
+
+/** Ready-made @input handler for the common case: one ref mirroring one field. */
 export function useImeSafeInput(model: Ref<string>) {
   return (e: Event) => {
-    const el = e.target as HTMLInputElement | HTMLTextAreaElement | null;
-    if (el) model.value = el.value;
+    model.value = imeSafeValue(e);
   };
+}
+
+/**
+ * True when a keydown belongs to the IME rather than to us: it is driving a
+ * candidate window, not asking for an action.
+ *
+ * keyCode 229 is checked alongside `isComposing` because Safari fires the Enter
+ * that CONFIRMS a CJK composition *after* compositionend — isComposing already
+ * false, keyCode still 229 (the standard ProseMirror/Slate guard). This is the
+ * same rule the composer's onKeydown states; see the comment there for why it
+ * gates the whole handler rather than individual branches.
+ */
+export function isImeKey(e: KeyboardEvent): boolean {
+  return e.isComposing || e.keyCode === 229;
+}
+
+/**
+ * Stop an IME's Enter from implicitly submitting the form the field sits in.
+ *
+ * Bind as `@keydown.enter="blockImeEnter"`. Deliberately NOT the `.prevent`
+ * modifier: a real Enter must still submit, so the default is only cancelled for
+ * the key the IME is consuming.
+ */
+export function blockImeEnter(e: KeyboardEvent): void {
+  if (isImeKey(e)) e.preventDefault();
 }

--- a/vue_client/src/composables/useImeSafeInput.ts
+++ b/vue_client/src/composables/useImeSafeInput.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// "Bind a text input to a ref without v-model, so an IME can't freeze it."
+//
+// v-model on a native <input>/<textarea> compiles to vModelText, which carries a
+// `composing` flag — set between compositionstart and compositionend — and refuses
+// to do anything while it is up. Its input listener opens with
+// `if (e.target.composing) return`, and its beforeUpdate hook bails the same way
+// before it would write. On a desktop CJK IME that covers a candidate session; on
+// an Android soft keyboard with suggestions on it covers EVERY WORD, first letter
+// to space. Firefox on Android composes the most aggressively of the mobile
+// engines, which is where this first surfaced (lurker#624).
+//
+// Both halves of that guard hurt anything that reads the model as you type:
+//   - READ  — a live filter list, or a submit button gated on the model, sits a
+//             whole word stale. The tell is "it updates the moment I dismiss the
+//             keyboard": that's compositionend delivering the word in one go. A
+//             single-word field (a channel name, a token name) has no spaces at
+//             all, so the gate can stay wrong for the entire value.
+//   - WRITE — a programmatic `model.value = ''` (a clear button, an Esc, a reset
+//             after save) does not reach the DOM, leaving text on screen the model
+//             no longer holds.
+//
+// A plain `:value` binding has no such flag: patchDOMProp writes el.value whenever
+// the model differs and skips when it doesn't, so normal typing leaves the caret
+// alone while a genuine divergence still repaints. Paired with the unconditional
+// input handler below, model and DOM track each other in both directions no matter
+// what the IME is doing.
+//
+//   const onQueryInput = useImeSafeInput(query);
+//   <input :value="query" @input="onQueryInput" />
+//
+// Deliberately the read half only. The composer (MessageInput.vue) needs more —
+// it re-runs on change/compositionend as backstops and re-establishes the write
+// guard in the drafts store, because a missed sync there corrupts a sent message.
+// See the "IME composition" note there. Callers of THIS never splice into the
+// field mid-composition, so `input` alone is the whole premise.
+
+import type { Ref } from 'vue';
+
+export function useImeSafeInput(model: Ref<string>) {
+  return (e: Event) => {
+    const el = e.target as HTMLInputElement | HTMLTextAreaElement | null;
+    if (el) model.value = el.value;
+  };
+}

--- a/vue_client/src/views/InviteAccept.vue
+++ b/vue_client/src/views/InviteAccept.vue
@@ -28,7 +28,9 @@
           <label>
             <span>Username</span>
             <input
-              v-model="username"
+              :value="username"
+              @input="onUsernameInput"
+              @keydown.enter="blockImeEnter"
               autocomplete="username"
               autofocus
               required
@@ -70,6 +72,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useAuthStore } from '../stores/auth.js';
 import WordBackdrop from '../components/WordBackdrop.vue';
 import { USERNAME_PATTERN, MAX_USERNAME_LENGTH } from '../../../shared/username.js';
+import { blockImeEnter, useImeSafeInput } from '../composables/useImeSafeInput.js';
 
 const route = useRoute();
 const router = useRouter();
@@ -83,6 +86,7 @@ interface InviteStatus {
 const status = ref<InviteStatus | null>(null);
 const checking = ref(true);
 const username = ref('');
+const onUsernameInput = useImeSafeInput(username);
 const password = ref('');
 const working = ref(false);
 


### PR DESCRIPTION
Closes #622.

## The bug

`v-model` on a native input compiles to `vModelText`, which carries a `composing` flag — set between `compositionstart` and `compositionend` — and refuses to do anything while it is up. Its input listener opens with `if (e.target.composing) return`, and its `beforeUpdate` hook bails the same way before it would write.

On a desktop CJK IME that covers a candidate session. On an Android soft keyboard with suggestions on it covers **every word**, first letter to space. So anything reading the model as you type is a whole word stale, and anything writing to it never reaches the screen. The composer fixed this for itself in #624; these are the fields that share the binding.

## What was affected

Fifteen fields, in three symptom families:

**Live filter freezes** — `QuickSwitcher`, `ChannelListModal`, `SearchModal`, `RecentUploadsModal`, `HighlightsModal`, `NetworkPicker`, `SettingsSidebar`. The reported shape: the result list sits on the unfiltered set until the keyboard is dismissed, which commits the composition and delivers the word in one go.

**Submit gate stuck disabled** — `JoinChannelModal`, `IgnoreModal`, `ApiTokensPane`, `ThemesSection`, `NickNoteModal`, `HighlightsPane`, `UploaderConfigForm`, `InviteAccept` gate a button on the model (`!normalized`, `!mask.trim()`, `!dirty`, `canSubmit`, `incomplete`). A channel name or a token name has no spaces in it, so the whole value can sit inside one composition and the button stays disabled for all of it — the tap that blurs the field is the tap that enables it, so the first one does nothing.

**Programmatic writes that never land** — `ChannelListModal` restores a saved filter on open; `RecentUploadsModal` clears on its clear button and on Esc; `SettingsSidebar`, `ApiTokensPane` and `ThemesSection` reset after use; `HighlightsPane` clears after a save and repopulates when you edit a rule. Mid-composition none of those reach the DOM, leaving text on screen the model no longer holds.

## The fix

Drop `v-model` for `:value` + an unconditional `@input`. A plain `:value` prop has no composing flag — `patchDOMProp` writes `el.value` whenever the model differs and skips when it doesn't, so normal typing leaves the caret alone while a real divergence repaints. One shared composable rather than fifteen copies; the inventory on the issue grew twice while it was open, so the next person needs one place that says why.

Deliberately the read half only. The composer additionally re-runs on `change`/`compositionend` and re-establishes the write guard in the drafts store, because a missed sync there corrupts a sent message. Nothing here splices into a field mid-composition, so `input` alone is the whole premise.

### Unfreezing the model means Enter needs its own gate

`v-model`'s frozen model was accidentally protecting one thing. A CJK user pressing Enter to *confirm* a candidate fires a keydown like any other, and a `v-model` field answered it with the pre-composition value — usually `''`, so the handler hit its own `if (!name) return` and no-op'd. With the model live that same Enter runs for real: `ThemesSection`'s `@keydown.enter.prevent="saveNew"` would save a theme literally named `nihao` and then clear the field the user was still typing into.

So fields whose Enter *does* something are gated, with one shared predicate:

- an explicit handler (`QuickSwitcher` picks a row, `ThemesSection` saves) returns early on `isImeKey`
- a single-line input inside a `<form>` takes `blockImeEnter`, which cancels only the implicit submission the IME's Enter would trigger and leaves a real Enter alone

Filters that only filter need neither, and a `<textarea>` in a form doesn't either — Enter inserts a newline there rather than submitting. `isImeKey` covers `keyCode === 229` as well as `isComposing`, for Safari firing the confirming Enter after `compositionend`; `MessageInput` now states the rule through it rather than inline.

## Scope — what is deliberately left on `v-model`

The criterion is **what something reads as you type**. A field nothing looks at until submit is fine on `v-model`, because `compositionend` lands the value long before the click — which is what keeps `NetworkForm`'s twelve fields, `OnboardingFlow`, and the admin panes out of this. `IgnoresPane` looks like the same shape as `HighlightsPane` and is not: its `canSubmit` reads neither field. `Login` isn't either — its checks live inside the submit handlers, not in a gate. Password fields are left alone throughout.

## Testing

⚠️ **This needs device QA, and the tests can't stand in for it.** With `v-model` gone there is no flag left to freeze anything, so a `compositionstart`-driven test of the fixed binding passes trivially. Every case in the composable's suite therefore runs against a hand-assembled `v-model` control that is *expected to fail* it, and the call-site suites were confirmed to fail with `v-model`/the guard put back. That makes them real regression guards, but the guard lives in Vue, not the browser — nothing here proves a real Android keyboard behaves as these synthetic events claim.

Full gate green locally: `npm run check` and `npm test` (3956 tests).

## Manual QA recipe — no Android device needed

The bug is **composition**-specific, not Android-specific: `el.composing` is set by the same Vue code path whichever IME opened the composition. So a desktop CJK IME exercises the identical mechanism, and macOS ships one for free.

That matters more than it sounds, because **the regression this branch had to fix is a desktop-CJK bug, not an Android one** — a theme saved as `nihao` is literally the Pinyin scenario.

**Setup:** System Settings → Keyboard → Input Sources → **+** → Chinese, Simplified → *Pinyin – Simplified* (Japanese → *Romaji* behaves the same). Switch with Ctrl+Space. Typing `nihao` raises a candidate bar — **while that bar is up you are mid-composition and nothing has committed.** That is the whole test condition.

In value order:

1. **The Enter regression.** Settings → Themes → "Save current look as…". Type `nihao`, press Enter to accept the candidate.
   - ✅ 你好 lands in the field and **nothing is saved**; a second Enter saves it.
   - ❌ pre-fix behaviour: a theme named literally `nihao`, and the field wiped out from under you.
   - ⚠️ **Check the flip side too — that Enter still selects the candidate normally.** That binding keeps `.prevent`, so it cancels the default even for the IME's Enter. This rests on the IME having already consumed the key, the same assumption `MessageInput` documents for Tab, and it is the one assumption in this branch not verified against a real IME.

2. **Quick switcher** (Cmd/Ctrl+K). Type pinyin.
   - ✅ the list narrows as the preedit changes.
   - ✅ Enter while the candidate bar is up picks the candidate and does **not** jump to a buffer.
   - ❌ pre-fix: the list sits on the unfiltered set until the composition commits.

3. **Uploads search** — type pinyin, then hit the clear button or Esc **while still composing**.
   - ✅ the field actually empties. This is the write half `v-model` used to swallow.

4. **Join channel** (+ on a network header) — the Join button enables as you type, and Enter mid-composition does not fire the join.

**What this does not cover:** Android's *frequency* — every Latin word composing, first letter to space — and Gboard / Firefox-Android quirks. The Vue-level behaviour is identical, so passing 1–4 means the fix is right; what stays unproven is browser-specific weirdness. Firefox for Android composes the most aggressively of the mobile engines and is where #622 was originally reported, so a user in #lurker with a device is the natural way to close that gap.
