### PR TITLE
Surface a failed channel command in the channel it was run in (#434)

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -22,6 +22,7 @@ import {
   joinRejectionMessage,
   joinRejectionMessageByTag,
   resolveChannelContext,
+  channelCommandTargets,
   commandResultError,
   isCommandResultErrorTag,
   sendRejectionTargetKind,
@@ -727,6 +728,57 @@ describe('command-result error classification (#434)', () => {
   });
 });
 
+// ERR_NOSUCHNICK names no channel, so the only thing that can place it is the
+// command we sent — which the server, unlike the client, gets to read on the
+// way out (#434).
+describe('channel-command target extraction (#434)', () => {
+  it('reads KICK, whose channel comes first', () => {
+    expect(channelCommandTargets('KICK #anime fartboy')).toEqual([
+      { nick: 'fartboy', channel: '#anime' },
+    ]);
+  });
+
+  it('reads INVITE, whose operands are the other way round', () => {
+    expect(channelCommandTargets('INVITE fartboy #anime')).toEqual([
+      { nick: 'fartboy', channel: '#anime' },
+    ]);
+  });
+
+  it("doesn't mistake a word in a kick reason for a target", () => {
+    expect(channelCommandTargets('KICK #anime fartboy :go away bob')).toEqual([
+      { nick: 'fartboy', channel: '#anime' },
+    ]);
+  });
+
+  it('expands the comma lists KICK is allowed to carry', () => {
+    expect(channelCommandTargets('KICK #a,#b x,y')).toHaveLength(4);
+  });
+
+  it('takes MODE arguments without deciding which are nicks', () => {
+    // Whether an arg is a nick depends on the mode string read against
+    // CHANMODES; recording a mask or a limit anyway is inert, because it can
+    // only match a 401 naming that exact string and a 401 names a bare nick.
+    expect(channelCommandTargets('MODE #anime +o ghost')).toEqual([
+      { nick: 'ghost', channel: '#anime' },
+    ]);
+    expect(channelCommandTargets('MODE #anime +b *!*@host')).toEqual([
+      { nick: '*!*@host', channel: '#anime' },
+    ]);
+  });
+
+  it('claims nothing from commands that aren\u2019t channel-scoped', () => {
+    expect(channelCommandTargets('WHOIS fartboy')).toEqual([]);
+    expect(channelCommandTargets('PRIVMSG fartboy :hi')).toEqual([]);
+    expect(channelCommandTargets('MODE #anime')).toEqual([]);
+    expect(channelCommandTargets('')).toEqual([]);
+  });
+
+  it('rejects operands the wrong way round rather than guessing', () => {
+    // A channel where the nick should be is not an invite we can attribute.
+    expect(channelCommandTargets('INVITE #anime #other')).toEqual([]);
+  });
+});
+
 // End-to-end check that the real irc-framework event handlers route refused
 // outgoing messages to the right buffer (#283). publish/publishEphemeral are
 // stubbed so we can assert the routing decision without a DB or a live socket.
@@ -878,6 +930,59 @@ describe('refused-message handler routing (#283)', () => {
     expect(publish).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'error', target: '#news[dev]' }),
     );
+  });
+
+  it('places a 401 in the channel the command that caused it was aimed at', () => {
+    // The case a user actually hits: /kick someone who has left the network.
+    // 401 carries no channel, so this is attributed from the outgoing line.
+    const conn = makeConn();
+    conn.upsertChannel('#anime');
+    conn.client.raw = vi.fn<(line: string) => void>(); // don't touch a real socket
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.raw('KICK #anime fartboy');
+    conn.client.emit('irc error', {
+      error: 'no_such_nick',
+      nick: 'fartboy',
+      reason: 'No such nick/channel',
+    });
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        target: '#anime',
+        text: "fartboy isn't on this network.",
+      }),
+    );
+  });
+
+  it('leaves an unprompted 401 alone', () => {
+    // No command of ours named this nick, so there is nothing to attribute it
+    // to and it keeps its existing server-buffer routing.
+    const conn = makeConn();
+    conn.upsertChannel('#anime');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'stranger' });
+
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: '#anime' }));
+  });
+
+  it("doesn't drag an unrelated /whois miss into the channel", () => {
+    // Attribution is keyed on the NICK, not on "a command went out recently",
+    // so a 401 for a different nick inside the same window stays put.
+    const conn = makeConn();
+    conn.upsertChannel('#anime');
+    conn.client.raw = vi.fn<(line: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.raw('KICK #anime fartboy');
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'someoneelse' });
+
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: '#anime' }));
   });
 
   it('leaves a command aimed at a channel we are not in in the server buffer', () => {

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -987,6 +987,25 @@ describe('refused-message handler routing (#283)', () => {
     expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: '#anime' }));
   });
 
+  it('forgets an intent across a reconnect', () => {
+    // The intent describes a command that went out on a socket that is now
+    // gone; the reply to it died with it. Left in place, a kick nobody ever saw
+    // the outcome of could place an unrelated 401 on the new connection —
+    // resetSendState clears the sibling send-attribution maps for exactly this
+    // reason (#283) and this one is the same class of state.
+    const conn = makeConn();
+    conn.upsertChannel('#anime');
+    conn.client.raw = vi.fn<(line: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.raw('KICK #anime fartboy');
+    conn.resetSendState();
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'fartboy' });
+
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: '#anime' }));
+  });
+
   it('attributes one command to one bounce, not to every 401 in the window', () => {
     // Pins the consume half specifically: the supersede rule only fires when
     // the user does something else with the nick, and a repeated numeric (a

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -22,6 +22,8 @@ import {
   joinRejectionMessage,
   joinRejectionMessageByTag,
   resolveChannelContext,
+  commandResultError,
+  isCommandResultErrorTag,
   sendRejectionTargetKind,
   sendRejectionText,
   outgoingAddr,
@@ -642,6 +644,75 @@ describe('formatSocketCloseErrorMessage', () => {
 });
 
 // End-to-end check that the real irc-framework event handlers route refused
+
+// A channel command that fails (kick / invite / mode / topic) used to report
+// only in the server buffer, far from the channel the user ran it in (#434).
+describe('command-result error classification (#434)', () => {
+  it('reads the channel out of ERR_CHANOPRIVSNEEDED (482)', () => {
+    expect(commandResultError('482', ['me', '#chan', "You're not channel operator"])).toEqual({
+      channel: '#chan',
+      text: "You're not a channel operator.",
+    });
+  });
+
+  it('takes ERR_USERNOTINCHANNEL (441) from the wire, not the framework', () => {
+    // The whole reason this reads raw params. irc-framework's generic map for
+    // 441 is off by one against its own 443: it reports OUR nick as `nick` and
+    // the target NICK as `channel`, so an event-driven version of this would
+    // publish into a buffer called "baduser".
+    expect(
+      commandResultError('441', ['me', 'baduser', '#chan', "They aren't on that channel"]),
+    ).toEqual({ channel: '#chan', text: "baduser isn't on this channel." });
+  });
+
+  it('names the subject for ERR_USERONCHANNEL (443), which sends a fragment', () => {
+    // The server's own trailing text is "is already on channel" — a sentence
+    // with its subject missing, which is why these messages are ours.
+    expect(commandResultError('443', ['me', 'bob', '#chan', 'is already on channel'])).toEqual({
+      channel: '#chan',
+      text: 'bob is already on this channel.',
+    });
+  });
+
+  it('covers the mode failures irc-framework never models at all', () => {
+    expect(commandResultError('467', ['me', '#chan', 'Channel key already set'])?.channel).toBe(
+      '#chan',
+    );
+    expect(commandResultError('478', ['me', '#chan', 'b', 'Channel list is full'])?.channel).toBe(
+      '#chan',
+    );
+  });
+
+  it('accepts every channel prefix, not just #', () => {
+    expect(commandResultError('482', ['me', '&local', 'nope'])?.channel).toBe('&local');
+  });
+
+  it('declines a numeric it does not own', () => {
+    expect(commandResultError('401', ['me', 'ghost', 'No such nick'])).toBeNull();
+    expect(commandResultError('482', [])).toBeNull();
+  });
+
+  it('declines when the channel param is not a channel', () => {
+    // A server shipping these params in another order must not be routed on.
+    expect(commandResultError('482', ['me', 'notachannel', 'nope'])).toBeNull();
+    expect(commandResultError('441', ['me', '#chan', 'baduser', 'nope'])).toBeNull();
+  });
+
+  it('declines when the subject param is missing', () => {
+    expect(commandResultError('443', ['me', '', '#chan'])).toBeNull();
+  });
+
+  it('claims exactly the tags whose server-buffer line is now a duplicate', () => {
+    expect(isCommandResultErrorTag('chanop_privs_needed')).toBe(true);
+    expect(isCommandResultErrorTag('user_not_in_channel')).toBe(true);
+    expect(isCommandResultErrorTag('user_on_channel')).toBe(true);
+    // Owned by other buckets — must keep their existing routing.
+    expect(isCommandResultErrorTag('cannot_send_to_channel')).toBe(false);
+    expect(isCommandResultErrorTag('banned_from_channel')).toBe(false);
+    expect(isCommandResultErrorTag('no_such_nick')).toBe(false);
+  });
+});
+
 // outgoing messages to the right buffer (#283). publish/publishEphemeral are
 // stubbed so we can assert the routing decision without a DB or a live socket.
 describe('refused-message handler routing (#283)', () => {
@@ -709,6 +780,95 @@ describe('refused-message handler routing (#283)', () => {
     expect(publish).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'error', target: 'sleepynick' }),
     );
+  });
+
+  // #434 — the third routing bucket. Driven through the 'raw' handler because
+  // that is where it lives: it is the only place with the numeric's params
+  // intact (see COMMAND_RESULT_ERRORS on why the parsed event won't do).
+  function emitRaw(conn: IrcConnection, line: string) {
+    conn.client.emit('raw', { from_server: true, line });
+  }
+
+  it('routes ERR_CHANOPRIVSNEEDED (482) inline to the channel the command ran in', () => {
+    const conn = makeConn();
+    conn.upsertChannel('#anime');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    emitRaw(conn, ":irc.example.test 482 nick #anime :You're not channel operator");
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        target: '#anime',
+        text: "You're not a channel operator.",
+      }),
+    );
+  });
+
+  it('still logs the server\u2019s own line to the server buffer', () => {
+    // Additive, like a join rejection: the friendly line goes to the channel,
+    // the authentic record stays in the server buffer (#342).
+    const conn = makeConn();
+    conn.upsertChannel('#anime');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    emitRaw(conn, ":irc.example.test 482 nick #anime :You're not channel operator");
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'motd',
+        target: ':server:1',
+        text: "#anime You're not channel operator",
+      }),
+    );
+  });
+
+  it('routes 441 to the channel, never to the nick the framework calls a channel', () => {
+    const conn = makeConn();
+    conn.upsertChannel('#anime');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    emitRaw(conn, ":irc.example.test 441 nick baduser #anime :They aren't on that channel");
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', target: '#anime' }),
+    );
+    expect(publish).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', target: 'baduser' }),
+    );
+  });
+
+  it('leaves a command aimed at a channel we are not in in the server buffer', () => {
+    // No buffer to land in, and fabricating one would be worse than the status
+    // quo. The raw line still reports it.
+    const conn = makeConn();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    emitRaw(conn, ":irc.example.test 482 nick #elsewhere :You're not channel operator");
+
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: '#elsewhere' }));
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ target: ':server:1' }));
+  });
+
+  it('drops the duplicate tag line the server buffer used to get as well', () => {
+    // 482 reached the server buffer twice: the raw line, plus a
+    // "chanop_privs_needed #anime — …" line from the 'irc error' catch-all.
+    const conn = makeConn();
+    conn.upsertChannel('#anime');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('irc error', {
+      error: 'chanop_privs_needed',
+      channel: '#anime',
+      reason: "You're not channel operator",
+    });
+
+    expect(publish).not.toHaveBeenCalled();
   });
 
   it('surfaces 477 inline as a speak rejection when we are already in the channel', () => {

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -22,7 +22,7 @@ import {
   joinRejectionMessage,
   joinRejectionMessageByTag,
   resolveChannelContext,
-  channelCommandTargets,
+  outgoingNickIntents,
   commandResultError,
   isCommandResultErrorTag,
   sendRejectionTargetKind,
@@ -731,51 +731,58 @@ describe('command-result error classification (#434)', () => {
 // ERR_NOSUCHNICK names no channel, so the only thing that can place it is the
 // command we sent — which the server, unlike the client, gets to read on the
 // way out (#434).
-describe('channel-command target extraction (#434)', () => {
+describe('outgoing nick intent extraction (#434)', () => {
   it('reads KICK, whose channel comes first', () => {
-    expect(channelCommandTargets('KICK #anime fartboy')).toEqual([
+    expect(outgoingNickIntents('KICK #anime fartboy')).toEqual([
       { nick: 'fartboy', channel: '#anime' },
     ]);
   });
 
   it('reads INVITE, whose operands are the other way round', () => {
-    expect(channelCommandTargets('INVITE fartboy #anime')).toEqual([
+    expect(outgoingNickIntents('INVITE fartboy #anime')).toEqual([
       { nick: 'fartboy', channel: '#anime' },
     ]);
   });
 
   it("doesn't mistake a word in a kick reason for a target", () => {
-    expect(channelCommandTargets('KICK #anime fartboy :go away bob')).toEqual([
+    expect(outgoingNickIntents('KICK #anime fartboy :go away bob')).toEqual([
       { nick: 'fartboy', channel: '#anime' },
     ]);
   });
 
   it('expands the comma lists KICK is allowed to carry', () => {
-    expect(channelCommandTargets('KICK #a,#b x,y')).toHaveLength(4);
+    expect(outgoingNickIntents('KICK #a,#b x,y')).toHaveLength(4);
   });
 
   it('takes MODE arguments without deciding which are nicks', () => {
     // Whether an arg is a nick depends on the mode string read against
     // CHANMODES; recording a mask or a limit anyway is inert, because it can
     // only match a 401 naming that exact string and a 401 names a bare nick.
-    expect(channelCommandTargets('MODE #anime +o ghost')).toEqual([
+    expect(outgoingNickIntents('MODE #anime +o ghost')).toEqual([
       { nick: 'ghost', channel: '#anime' },
     ]);
-    expect(channelCommandTargets('MODE #anime +b *!*@host')).toEqual([
+    expect(outgoingNickIntents('MODE #anime +b *!*@host')).toEqual([
       { nick: '*!*@host', channel: '#anime' },
     ]);
   });
 
-  it('claims nothing from commands that aren\u2019t channel-scoped', () => {
-    expect(channelCommandTargets('WHOIS fartboy')).toEqual([]);
-    expect(channelCommandTargets('PRIVMSG fartboy :hi')).toEqual([]);
-    expect(channelCommandTargets('MODE #anime')).toEqual([]);
-    expect(channelCommandTargets('')).toEqual([]);
+  it('records a channel-less intent for commands that name a nick alone', () => {
+    // Not "nothing to record": a positive statement that the user's last move
+    // on this nick was direct, which has to overwrite a pending kick.
+    expect(outgoingNickIntents('WHOIS fartboy')).toEqual([{ nick: 'fartboy', channel: null }]);
+    expect(outgoingNickIntents('PRIVMSG fartboy :hi')).toEqual([
+      { nick: 'fartboy', channel: null },
+    ]);
+  });
+
+  it('claims nothing from a channel-directed message or a bare MODE query', () => {
+    expect(outgoingNickIntents('PRIVMSG #anime :hi')).toEqual([]);
+    expect(outgoingNickIntents('MODE #anime')).toEqual([]);
+    expect(outgoingNickIntents('')).toEqual([]);
   });
 
   it('rejects operands the wrong way round rather than guessing', () => {
-    // A channel where the nick should be is not an invite we can attribute.
-    expect(channelCommandTargets('INVITE #anime #other')).toEqual([]);
+    expect(outgoingNickIntents('INVITE #anime #other')).toEqual([]);
   });
 });
 
@@ -955,6 +962,81 @@ describe('refused-message handler routing (#283)', () => {
         text: "fartboy isn't on this network.",
       }),
     );
+  });
+
+  it('doesn\u2019t let a spent kick claim the query\u2019s 401 afterwards', () => {
+    // The reported bug. Kick fartboy in #anime, then open a query with them and
+    // send a message: both bounce 401, and the second belongs in the DM. The
+    // attribution is consumed by the first, so it isn't lying in wait for the
+    // second.
+    const conn = makeConn();
+    conn.upsertChannel('#anime');
+    conn.client.raw = vi.fn<(line: string) => void>();
+    conn.client.say = vi.fn<(target: string, message: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.raw('KICK #anime fartboy');
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'fartboy' });
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ target: '#anime' }));
+
+    publish.mockClear();
+    conn.say('fartboy', 'hi');
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'fartboy' });
+
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: '#anime' }));
+  });
+
+  it('attributes one command to one bounce, not to every 401 in the window', () => {
+    // Pins the consume half specifically: the supersede rule only fires when
+    // the user does something else with the nick, and a repeated numeric (a
+    // bouncer replaying, a server sending it twice) isn't that.
+    const conn = makeConn();
+    conn.upsertChannel('#anime');
+    conn.client.raw = vi.fn<(line: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.raw('KICK #anime fartboy');
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'fartboy' });
+    publish.mockClear();
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'fartboy' });
+
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: '#anime' }));
+  });
+
+  it('lets a direct send supersede a kick that never bounced', () => {
+    // Same hazard without the first 401 to consume the entry: the kick may have
+    // succeeded, or failed some other way. Messaging the nick says the user has
+    // moved on, so the 401 that follows answers the message.
+    const conn = makeConn();
+    conn.upsertChannel('#anime');
+    conn.client.raw = vi.fn<(line: string) => void>();
+    conn.client.say = vi.fn<(target: string, message: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.raw('KICK #anime fartboy');
+    conn.say('fartboy', 'hi');
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'fartboy' });
+
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: '#anime' }));
+  });
+
+  it('lets a whois supersede it too', () => {
+    // Same rule, via raw() rather than say(): "did that kick work? who is
+    // fartboy?" must not put the whois miss back in the channel.
+    const conn = makeConn();
+    conn.upsertChannel('#anime');
+    conn.client.raw = vi.fn<(line: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.raw('KICK #anime fartboy');
+    conn.raw('WHOIS fartboy');
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'fartboy' });
+
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: '#anime' }));
   });
 
   it('leaves an unprompted 401 alone', () => {

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -643,8 +643,6 @@ describe('formatSocketCloseErrorMessage', () => {
   });
 });
 
-// End-to-end check that the real irc-framework event handlers route refused
-
 // A channel command that fails (kick / invite / mode / topic) used to report
 // only in the server buffer, far from the channel the user ran it in (#434).
 describe('command-result error classification (#434)', () => {
@@ -729,6 +727,7 @@ describe('command-result error classification (#434)', () => {
   });
 });
 
+// End-to-end check that the real irc-framework event handlers route refused
 // outgoing messages to the right buffer (#283). publish/publishEphemeral are
 // stubbed so we can assert the routing decision without a DB or a live socket.
 describe('refused-message handler routing (#283)', () => {

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -683,6 +683,22 @@ describe('command-result error classification (#434)', () => {
     );
   });
 
+  it('names the list that actually filled up on ERR_BANLISTFULL (478)', () => {
+    // Not always +b: the invite-exception and quiet limits send the same
+    // numeric, so a hardcoded "ban list" would report the wrong one.
+    expect(commandResultError('478', ['me', '#chan', 'I', 'Channel list is full'])?.text).toBe(
+      "The channel's +I list is full.",
+    );
+  });
+
+  it('stays vague on a 478 that omits the mode char', () => {
+    // Without the guard params[2] is the trailing reason, and the sentence
+    // becomes "The channel's +Channel list is full list is full."
+    expect(commandResultError('478', ['me', '#chan', 'Channel list is full'])?.text).toBe(
+      'That channel list is full.',
+    );
+  });
+
   it('accepts every channel prefix, not just #', () => {
     expect(commandResultError('482', ['me', '&local', 'nope'])?.channel).toBe('&local');
   });
@@ -838,6 +854,30 @@ describe('refused-message handler routing (#283)', () => {
     );
     expect(publish).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'error', target: 'baduser' }),
+    );
+  });
+
+  it('publishes the channel under the name we joined it by, not the wire\u2019s', () => {
+    // Membership and canonicalization used to be two different equivalence
+    // relations here: isChannelJoined folds through the server's CASEMAPPING,
+    // while publish()'s canonicalizer is a plain toLowerCase. They agree on
+    // ASCII case and disagree on rfc1459, where [ \\ ] ^ fold to { | } ~ — so a
+    // 482 naming #news{dev} while we were joined as #news[dev] passed the
+    // membership test and then published a target no buffer is keyed by.
+    // Resolving both through channelState is what fixes it; the fold rule
+    // itself is channelState's and is tested where it lives. This pins the
+    // wiring: that the handler publishes the name channelState hands back
+    // rather than the one off the wire.
+    const conn = makeConn();
+    conn.channelState = ((name: string) =>
+      name === '#news{dev}' ? { name: '#news[dev]' } : undefined) as never;
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    emitRaw(conn, ":irc.example.test 482 nick #news{dev} :You're not channel operator");
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', target: '#news[dev]' }),
     );
   });
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -556,6 +556,8 @@ export class IrcConnection {
   // message (surface it inline) from an automated TAGMSG/typing bounce (stay
   // silent) — the rejection numeric doesn't say which command it refused (#283).
   lastUserSendAt: Map<string, number>;
+  // nick → the channel a command aimed it at, for placing a 401 (#434).
+  commandChannelByNick = new Map<string, { channel: string; at: number }>();
   // Channels we auto-issued a WHO for on join (lowercase). The auto-WHO learns
   // away/ident state and would flood the server buffer if echoed per-member, so
   // the 'wholist' handler consumes these silently. Any wholist NOT in this set
@@ -2699,6 +2701,24 @@ export class IrcConnection {
       if (!banChannel) {
         const banned = classifyServerBan(reason);
         if (banned) this.pendingServerBan = `banned by the server (${banned})`;
+      }
+      // A 401 for a nick we just named in a channel command belongs in that
+      // channel, not the server buffer (#434). Checked before the DM fallback
+      // below because it is the more specific signal: an explicit command,
+      // aimed at a named channel, seconds ago — against "we have DM history
+      // with this nick at some point in the past".
+      if (tag === 'no_such_nick' && eventNick) {
+        const commandChannel = this.recentCommandChannel(eventNick);
+        const joined = commandChannel ? this.channelState(commandChannel) : undefined;
+        if (joined) {
+          this.publish({
+            type: 'error',
+            target: joined.name,
+            text: `${eventNick} isn't on this network.`,
+            raw: event,
+          });
+          return;
+        }
       }
       const isDmMiss = tag === 'no_such_nick' && eventNick && isDmTargetName(eventNick);
       // For ERR_NOSUCHNICK against a nick the user has any DM history with,
@@ -4960,6 +4980,29 @@ export class IrcConnection {
     return at != null && Date.now() - at <= SEND_REJECTION_ATTRIBUTION_MS;
   }
 
+  // Remember which channel an outgoing command aimed a nick at, so a 401 naming
+  // that nick can be placed (#434). Same shape as noteUserSend, including the
+  // prune-before-insert: entries past the window can never match again, and a
+  // long-lived connection kicking at a lot of one-off nicks would otherwise grow
+  // the map without bound.
+  noteChannelCommand(line: string): void {
+    const targets = channelCommandTargets(line);
+    if (!targets.length) return;
+    const now = Date.now();
+    for (const [key, seen] of this.commandChannelByNick) {
+      if (now - seen.at > SEND_REJECTION_ATTRIBUTION_MS) this.commandChannelByNick.delete(key);
+    }
+    for (const t of targets) {
+      this.commandChannelByNick.set(t.nick.toLowerCase(), { channel: t.channel, at: now });
+    }
+  }
+
+  recentCommandChannel(nick: string): string | null {
+    const seen = this.commandChannelByNick.get(nick.toLowerCase());
+    if (!seen || Date.now() - seen.at > SEND_REJECTION_ATTRIBUTION_MS) return null;
+    return seen.channel;
+  }
+
   // The server refused an outgoing message to `target` (ERR_CANNOTSENDTOCHAN
   // 404 / ERR_CANNOTSENDTOUSER 531 / ERR_NEEDREGGEDNICK 477 while joined).
   // Remember the target is unsendable so we stop firing typing TAGMSGs that
@@ -4991,7 +5034,12 @@ export class IrcConnection {
     // alike — rather than scrubbing each interpolated string at its source.
     // Matching control chars is the whole point, so the lint rule is moot here.
     // eslint-disable-next-line no-control-regex
-    this.client.raw(line.replace(/[\u000d\u000a\u0000]/g, ''));
+    const clean = line.replace(/[\u000d\u000a\u0000]/g, '');
+    // Read it before it goes out, so a 401 bouncing back off it can be placed
+    // in the channel it was aimed at (#434). Cheap and total: this is the one
+    // path every slash command and member-menu action takes.
+    this.noteChannelCommand(clean);
+    this.client.raw(clean);
   }
   // Whether the network negotiated IRCv3 message-tags. Client-only tags
   // (+typing, +draft/react, …) and TAGMSG only mean anything to a server that
@@ -5692,6 +5740,47 @@ export function commandResultError(
   if (typeof channel !== 'string' || !isChannelTarget(channel)) return null;
   const text = spec.message(params);
   return text ? { channel, text } : null;
+}
+
+// ERR_NOSUCHNICK (401) is the failure you actually hit first — you kick or
+// invite a nick that has since left the network, or you fat-finger it — and it
+// is the one numeric in this family that names NO channel, so commandResultError
+// can't place it. The only thing that knows which buffer it belongs to is the
+// command we just sent, and we sent it: every slash command and member-menu
+// action goes out through IrcConnection.raw(), so unlike the client the server
+// can read the outgoing line and remember what it aimed at.
+//
+// Returns the (nick, channel) pairs a line claims, or [] for anything that
+// isn't a channel command. Attribution is keyed on the NICK rather than on
+// "a command went out recently", so an unrelated /whois for another missing
+// user can't be dragged into the channel by timing alone.
+export function channelCommandTargets(line: string): Array<{ nick: string; channel: string }> {
+  const parts = line.trim().split(/ +/);
+  const verb = (parts[0] || '').toUpperCase();
+  const out: Array<{ nick: string; channel: string }> = [];
+  const add = (nick: string | undefined, channel: string | undefined) => {
+    if (!nick || !channel) return;
+    if (!isChannelTarget(channel) || isChannelTarget(nick)) return;
+    out.push({ nick, channel });
+  };
+  if (verb === 'KICK') {
+    // KICK <channel>[,<channel>] <user>[,<user>] [:reason] — the reason is
+    // never read, so a word in it that happens to be a nick is not a target.
+    for (const channel of (parts[1] || '').split(',')) {
+      for (const nick of (parts[2] || '').split(',')) add(nick, channel);
+    }
+  } else if (verb === 'INVITE') {
+    // INVITE <nick> <channel> — the operand order is the other way round.
+    add(parts[1], parts[2]);
+  } else if (verb === 'MODE') {
+    // MODE <channel> <modes> [args…]. Which args are nicks depends on the mode
+    // string read against CHANMODES/PREFIX, and we deliberately don't work that
+    // out: recording a ban mask or a limit as though it were a nick is inert,
+    // because it can only ever match a 401 that names that exact string, and a
+    // 401 names a bare nick.
+    for (const arg of parts.slice(3)) add(arg, parts[1]);
+  }
+  return out;
 }
 
 // True for numerics commandResultError owns, keyed by the tag irc-framework

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1005,14 +1005,21 @@ export class IrcConnection {
       // the user to find them in the server buffer (#434). Read off the raw
       // params rather than the parsed 'irc error' event, which mis-maps some of
       // these — see COMMAND_RESULT_ERRORS. Additive: the raw line still goes to
-      // the server buffer below, the same way a join rejection does. Only for
-      // channels we're actually in, so a command aimed elsewhere can't conjure
-      // a buffer; publish() canonicalizes the channel case.
+      // the server buffer below, the same way a join rejection does.
+      //
+      // channelState answers both questions at once — are we in it, and what do
+      // we call it — through ONE equivalence relation. Asking isChannelJoined
+      // and then letting publish() canonicalize would use two: membership folds
+      // through the server's CASEMAPPING, publish()'s canonicalizer is a plain
+      // toLowerCase. On an rfc1459 network (where [ \ ] ^ fold to { | } ~) a 482
+      // naming #news{dev} while we're joined as #news[dev] would pass the
+      // membership test and then publish a target no buffer is keyed by.
       const cmdError = commandResultError(rawCommand, msg?.params ?? []);
-      if (cmdError && this.isChannelJoined(cmdError.channel)) {
+      const cmdErrorChannel = cmdError ? this.channelState(cmdError.channel) : undefined;
+      if (cmdError && cmdErrorChannel) {
         this.publish({
           type: 'error',
-          target: cmdError.channel,
+          target: cmdErrorChannel.name,
           text: cmdError.text,
           raw: { command: rawCommand, params: msg?.params ?? [] },
         });
@@ -5627,23 +5634,44 @@ export function sendRejectionTargetKind(tag: string): 'channel' | 'nick' | null 
 // The message is ours rather than the server's trailing text, for the same
 // reason JOIN_REJECTION_MESSAGES exists: several of these numerics send a
 // sentence FRAGMENT meant to be prefixed by a param ("is already on channel"),
-// which reads as nonsense on its own. `subject` names the param to put in front
-// of it. The server's own line is still logged verbatim to the server buffer by
-// the 'raw' handler, so nothing is lost by not quoting it here.
+// which reads as nonsense on its own. Each entry reads whatever else it needs
+// out of the params itself and returns null to decline, since what those params
+// mean differs per numeric. The server's own line is still logged verbatim to
+// the server buffer by the 'raw' handler, so nothing is lost by not quoting it.
+type WireParams = readonly (string | undefined)[];
+const nonEmpty = (v: string | undefined): v is string => typeof v === 'string' && v.length > 0;
+// A single letter, so a server that omits the list-mode param and leaves the
+// trailing reason in its place can't be interpolated into the sentence.
+const isModeChar = (v: string | undefined): v is string =>
+  typeof v === 'string' && /^[a-zA-Z]$/.test(v);
+
 const COMMAND_RESULT_ERRORS: Record<
   string,
-  { channel: number; subject?: number; message: (subject: string) => string }
+  { channel: number; message: (params: WireParams) => string | null }
 > = {
   // ERR_CHANOPRIVSNEEDED — <client> <channel> :You're not channel operator
   '482': { channel: 1, message: () => "You're not a channel operator." },
   // ERR_USERNOTINCHANNEL — <client> <nick> <channel> :They aren't on that channel
-  '441': { channel: 2, subject: 1, message: (who) => `${who} isn't on this channel.` },
+  '441': {
+    channel: 2,
+    message: (p) => (nonEmpty(p[1]) ? `${p[1]} isn't on this channel.` : null),
+  },
   // ERR_USERONCHANNEL — <client> <nick> <channel> :is already on channel
-  '443': { channel: 2, subject: 1, message: (who) => `${who} is already on this channel.` },
+  '443': {
+    channel: 2,
+    message: (p) => (nonEmpty(p[1]) ? `${p[1]} is already on this channel.` : null),
+  },
   // ERR_KEYSET — <client> <channel> :Channel key already set
   '467': { channel: 1, message: () => 'The channel key is already set.' },
-  // ERR_BANLISTFULL — <client> <channel> <char> :Channel list is full
-  '478': { channel: 1, message: () => "The channel's ban/exception list is full." },
+  // ERR_BANLISTFULL — <client> <channel> <char> :Channel list is full. The char
+  // is the list that filled up, and it is not always +b: hitting the
+  // invite-exception (+I) or quiet (+q) limit gets the same numeric, so naming
+  // bans unconditionally would tell the user about the wrong list.
+  '478': {
+    channel: 1,
+    message: (p) =>
+      isModeChar(p[2]) ? `The channel's +${p[2]} list is full.` : 'That channel list is full.',
+  },
 };
 
 // Resolve a raw numeric into the channel it concerns and the line to show
@@ -5653,7 +5681,7 @@ const COMMAND_RESULT_ERRORS: Record<
 // fabricating one would be worse than the server buffer.
 export function commandResultError(
   numeric: string,
-  params: readonly (string | undefined)[],
+  params: WireParams,
 ): { channel: string; text: string } | null {
   const spec = COMMAND_RESULT_ERRORS[numeric];
   if (!spec) return null;
@@ -5662,9 +5690,8 @@ export function commandResultError(
   // ever ships these params in a different order, a non-channel value here
   // fails the test and the line stays in the server buffer.
   if (typeof channel !== 'string' || !isChannelTarget(channel)) return null;
-  const subject = spec.subject === undefined ? '' : params[spec.subject];
-  if (spec.subject !== undefined && (typeof subject !== 'string' || !subject)) return null;
-  return { channel, text: spec.message(subject as string) };
+  const text = spec.message(params);
+  return text ? { channel, text } : null;
 }
 
 // True for numerics commandResultError owns, keyed by the tag irc-framework

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -3161,6 +3161,14 @@ export class IrcConnection {
         this.lastUserSendAt.set(newLower, lastSend);
       }
       if (this.autoWhoTargets.delete(oldLower)) this.autoWhoTargets.add(newLower);
+      // lastNickIntent is deliberately NOT re-keyed, though it looks like it
+      // belongs here. The maps above are keyed by the TARGET, which follows the
+      // buffer through a rename; that one is keyed by the nick as we addressed
+      // it on the wire, because that is the nick a 401 will name back at us.
+      // Moving it to the new nick would break the lookup rather than fix it,
+      // and the stale entry it leaves can only ever suppress a channel
+      // attribution, which is the safe direction. It expires on its own window
+      // and is cleared wholesale by resetSendState.
       const ctcpQueue = this.ctcpOutstanding.get(oldLower);
       if (ctcpQueue) {
         this.ctcpOutstanding.delete(oldLower);
@@ -5039,6 +5047,10 @@ export class IrcConnection {
   resetSendState(): void {
     this.unsendableTargets.clear();
     this.lastUserSendAt.clear();
+    // Same reasoning for the 401 attribution (#434): an intent recorded on the
+    // old socket describes a command that died with it, and letting it survive
+    // would let a kick nobody ever saw place an unrelated 401 on the new one.
+    this.lastNickIntent.clear();
   }
   raw(line: string): void {
     // Strip CR/LF/NUL before the line hits the socket. irc-framework's

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -556,8 +556,9 @@ export class IrcConnection {
   // message (surface it inline) from an automated TAGMSG/typing bounce (stay
   // silent) — the rejection numeric doesn't say which command it refused (#283).
   lastUserSendAt: Map<string, number>;
-  // nick → the channel a command aimed it at, for placing a 401 (#434).
-  commandChannelByNick = new Map<string, { channel: string; at: number }>();
+  // nick → the user's last move on them, for placing a 401 (#434). A null
+  // channel means the move was a direct one (a query, a whois).
+  lastNickIntent = new Map<string, { channel: string | null; at: number }>();
   // Channels we auto-issued a WHO for on join (lowercase). The auto-WHO learns
   // away/ident state and would flood the server buffer if echoed per-member, so
   // the 'wholist' handler consumes these silently. Any wholist NOT in this set
@@ -2708,7 +2709,7 @@ export class IrcConnection {
       // aimed at a named channel, seconds ago — against "we have DM history
       // with this nick at some point in the past".
       if (tag === 'no_such_nick' && eventNick) {
-        const commandChannel = this.recentCommandChannel(eventNick);
+        const commandChannel = this.takeCommandChannel(eventNick);
         const joined = commandChannel ? this.channelState(commandChannel) : undefined;
         if (joined) {
           this.publish({
@@ -4973,6 +4974,11 @@ export class IrcConnection {
       if (now - at > SEND_REJECTION_ATTRIBUTION_MS) this.lastUserSendAt.delete(key);
     }
     this.lastUserSendAt.set(target.toLowerCase(), now);
+    // A direct message is a channel-less intent (#434): messaging someone you
+    // just tried to kick means the next 401 answers the message, not the kick.
+    // say/action/notice all funnel through here, and none of them pass through
+    // raw() where noteOutgoingCommand would otherwise see them.
+    if (!isChannelTarget(target)) this.noteNickIntent(target, null);
   }
 
   recentUserSend(target: string): boolean {
@@ -4980,26 +4986,35 @@ export class IrcConnection {
     return at != null && Date.now() - at <= SEND_REJECTION_ATTRIBUTION_MS;
   }
 
-  // Remember which channel an outgoing command aimed a nick at, so a 401 naming
-  // that nick can be placed (#434). Same shape as noteUserSend, including the
+  // Record the user's last move on each nick an outgoing line names, so a 401
+  // naming one can be placed (#434). Same shape as noteUserSend, including the
   // prune-before-insert: entries past the window can never match again, and a
-  // long-lived connection kicking at a lot of one-off nicks would otherwise grow
+  // long-lived connection touching a lot of one-off nicks would otherwise grow
   // the map without bound.
-  noteChannelCommand(line: string): void {
-    const targets = channelCommandTargets(line);
-    if (!targets.length) return;
+  noteNickIntent(nick: string, channel: string | null): void {
     const now = Date.now();
-    for (const [key, seen] of this.commandChannelByNick) {
-      if (now - seen.at > SEND_REJECTION_ATTRIBUTION_MS) this.commandChannelByNick.delete(key);
+    for (const [key, seen] of this.lastNickIntent) {
+      if (now - seen.at > SEND_REJECTION_ATTRIBUTION_MS) this.lastNickIntent.delete(key);
     }
-    for (const t of targets) {
-      this.commandChannelByNick.set(t.nick.toLowerCase(), { channel: t.channel, at: now });
+    this.lastNickIntent.set(nick.toLowerCase(), { channel, at: now });
+  }
+
+  noteOutgoingCommand(line: string): void {
+    for (const intent of outgoingNickIntents(line)) {
+      this.noteNickIntent(intent.nick, intent.channel);
     }
   }
 
-  recentCommandChannel(nick: string): string | null {
-    const seen = this.commandChannelByNick.get(nick.toLowerCase());
-    if (!seen || Date.now() - seen.at > SEND_REJECTION_ATTRIBUTION_MS) return null;
+  // The channel a 401 for `nick` belongs in, if the user's last move on them was
+  // a channel command. CONSUMES the intent: one command produces one bounce, and
+  // a spent entry left lying around is exactly what put a query's 401 into the
+  // channel the nick was last kicked from.
+  takeCommandChannel(nick: string): string | null {
+    const key = nick.toLowerCase();
+    const seen = this.lastNickIntent.get(key);
+    if (!seen) return null;
+    this.lastNickIntent.delete(key);
+    if (Date.now() - seen.at > SEND_REJECTION_ATTRIBUTION_MS) return null;
     return seen.channel;
   }
 
@@ -5038,7 +5053,7 @@ export class IrcConnection {
     // Read it before it goes out, so a 401 bouncing back off it can be placed
     // in the channel it was aimed at (#434). Cheap and total: this is the one
     // path every slash command and member-menu action takes.
-    this.noteChannelCommand(clean);
+    this.noteOutgoingCommand(clean);
     this.client.raw(clean);
   }
   // Whether the network negotiated IRCv3 message-tags. Client-only tags
@@ -5750,17 +5765,26 @@ export function commandResultError(
 // action goes out through IrcConnection.raw(), so unlike the client the server
 // can read the outgoing line and remember what it aimed at.
 //
-// Returns the (nick, channel) pairs a line claims, or [] for anything that
-// isn't a channel command. Attribution is keyed on the NICK rather than on
-// "a command went out recently", so an unrelated /whois for another missing
-// user can't be dragged into the channel by timing alone.
-export function channelCommandTargets(line: string): Array<{ nick: string; channel: string }> {
+// What gets remembered is INTENT, not just "a channel command happened": the
+// last thing we did that names this nick, and whether it had a channel. That
+// distinction is the whole design, because a nick's 401 is ambiguous the moment
+// you do two different things with it. Kick fartboy in #chan, then open a query
+// and message them: both bounce 401, and only the first belongs in the channel.
+// Recording the query send as a channel-less intent — and consuming an intent
+// when it is used — is what keeps the second one out of #chan.
+//
+// A `null` channel therefore is not "nothing to record". It is a positive
+// statement that the user's last move on this nick was a direct one, and it has
+// to overwrite whatever a channel command left behind.
+const NICK_ONLY_COMMANDS = new Set(['WHOIS', 'WHOWAS', 'PRIVMSG', 'NOTICE']);
+
+export function outgoingNickIntents(line: string): Array<{ nick: string; channel: string | null }> {
   const parts = line.trim().split(/ +/);
   const verb = (parts[0] || '').toUpperCase();
-  const out: Array<{ nick: string; channel: string }> = [];
-  const add = (nick: string | undefined, channel: string | undefined) => {
-    if (!nick || !channel) return;
-    if (!isChannelTarget(channel) || isChannelTarget(nick)) return;
+  const out: Array<{ nick: string; channel: string | null }> = [];
+  const add = (nick: string | undefined, channel: string | null) => {
+    if (!nick || isChannelTarget(nick)) return;
+    if (channel !== null && !isChannelTarget(channel)) return;
     out.push({ nick, channel });
   };
   if (verb === 'KICK') {
@@ -5771,14 +5795,17 @@ export function channelCommandTargets(line: string): Array<{ nick: string; chann
     }
   } else if (verb === 'INVITE') {
     // INVITE <nick> <channel> — the operand order is the other way round.
-    add(parts[1], parts[2]);
+    add(parts[1], parts[2] ?? null);
   } else if (verb === 'MODE') {
     // MODE <channel> <modes> [args…]. Which args are nicks depends on the mode
     // string read against CHANMODES/PREFIX, and we deliberately don't work that
     // out: recording a ban mask or a limit as though it were a nick is inert,
     // because it can only ever match a 401 that names that exact string, and a
     // 401 names a bare nick.
-    for (const arg of parts.slice(3)) add(arg, parts[1]);
+    for (const arg of parts.slice(3)) add(arg, parts[1] ?? null);
+  } else if (NICK_ONLY_COMMANDS.has(verb)) {
+    // Named the nick with no channel in sight — the superseding case above.
+    for (const nick of (parts[1] || '').split(',')) add(nick, null);
   }
   return out;
 }

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1000,6 +1000,23 @@ export class IrcConnection {
       ) {
         this.registrationLines.push(burstLine);
       }
+      // Command-result errors (a failed kick / invite / mode / topic) name the
+      // channel they concern, so surface them in that buffer instead of leaving
+      // the user to find them in the server buffer (#434). Read off the raw
+      // params rather than the parsed 'irc error' event, which mis-maps some of
+      // these — see COMMAND_RESULT_ERRORS. Additive: the raw line still goes to
+      // the server buffer below, the same way a join rejection does. Only for
+      // channels we're actually in, so a command aimed elsewhere can't conjure
+      // a buffer; publish() canonicalizes the channel case.
+      const cmdError = commandResultError(rawCommand, msg?.params ?? []);
+      if (cmdError && this.isChannelJoined(cmdError.channel)) {
+        this.publish({
+          type: 'error',
+          target: cmdError.channel,
+          text: cmdError.text,
+          raw: { command: rawCommand, params: msg?.params ?? [] },
+        });
+      }
       if (isServerBufferDeniedNumeric(rawCommand)) return;
       // formatUnknownNumeric only renders 3-digit numerics (it strips the
       // leading recipient-nick param), so PRIVMSG/JOIN/NOTICE/etc. naturally
@@ -2732,6 +2749,11 @@ export class IrcConnection {
         this.handleSendRejection(sendRejectTarget, reason, event);
         return;
       }
+      // Command-result errors are routed to their channel off the raw line (see
+      // the 'raw' handler). The generic line below would be a second copy in the
+      // server buffer of what the raw handler already logged verbatim there, so
+      // it goes — whether or not the routing found a buffer to use (#434).
+      if (isCommandResultErrorTag(tag)) return;
       // ERR_UNKNOWNCOMMAND (421) carries the rejected command name in
       // event.command (irc-framework parses it from the numeric's params).
       // Include it so the buffer line names the offending command —
@@ -5579,6 +5601,86 @@ const SEND_REJECTION_TAGS: Record<string, 'channel' | 'nick'> = {
 
 export function sendRejectionTargetKind(tag: string): 'channel' | 'nick' | null {
   return SEND_REJECTION_TAGS[tag] || null;
+}
+
+// Command-result errors: a numeric that reports why a channel COMMAND failed —
+// a kick, an invite, a mode change, a topic set. A third bucket alongside the
+// two already here, and the one that had nowhere to go: join rejections (#260)
+// belong on a channel with no buffer yet, send rejections (#283) belong where
+// the refused message was typed, and these belong in the channel the command
+// was run in. Until now they fell through to the generic server-buffer line, so
+// the user sat in #channel, ran /kick, saw nothing happen, and the reason was
+// buried somewhere they weren't looking (#434).
+//
+// Indexes are into the RAW wire params, params[0] being our own nick. We read
+// the line ourselves rather than take irc-framework's parsed 'irc error' event
+// because its generic map is not reliable here, verified against 4.x:
+//   - ERR_USERNOTINCHANNEL (441) is off by one against its own 443 mapping. It
+//     reports OUR nick as `nick` and the target NICK as `channel`, so routing on
+//     event.channel would publish into a buffer named after a user.
+//   - ERR_USERONCHANNEL (443) carries no `reason` at all.
+//   - ERR_KEYSET (467) and ERR_BANLISTFULL (478) it doesn't model, so they never
+//     reach an 'irc error' event in the first place.
+// The 'raw' handler sees every line with its params intact, which makes one
+// table cover all of them.
+//
+// The message is ours rather than the server's trailing text, for the same
+// reason JOIN_REJECTION_MESSAGES exists: several of these numerics send a
+// sentence FRAGMENT meant to be prefixed by a param ("is already on channel"),
+// which reads as nonsense on its own. `subject` names the param to put in front
+// of it. The server's own line is still logged verbatim to the server buffer by
+// the 'raw' handler, so nothing is lost by not quoting it here.
+const COMMAND_RESULT_ERRORS: Record<
+  string,
+  { channel: number; subject?: number; message: (subject: string) => string }
+> = {
+  // ERR_CHANOPRIVSNEEDED — <client> <channel> :You're not channel operator
+  '482': { channel: 1, message: () => "You're not a channel operator." },
+  // ERR_USERNOTINCHANNEL — <client> <nick> <channel> :They aren't on that channel
+  '441': { channel: 2, subject: 1, message: (who) => `${who} isn't on this channel.` },
+  // ERR_USERONCHANNEL — <client> <nick> <channel> :is already on channel
+  '443': { channel: 2, subject: 1, message: (who) => `${who} is already on this channel.` },
+  // ERR_KEYSET — <client> <channel> :Channel key already set
+  '467': { channel: 1, message: () => 'The channel key is already set.' },
+  // ERR_BANLISTFULL — <client> <channel> <char> :Channel list is full
+  '478': { channel: 1, message: () => "The channel's ban/exception list is full." },
+};
+
+// Resolve a raw numeric into the channel it concerns and the line to show
+// there, or null if it isn't one of these / the params don't hold up. Callers
+// still have to check we're actually JOINED to the channel before publishing:
+// a command aimed at a channel you're not in has no buffer to land in, and
+// fabricating one would be worse than the server buffer.
+export function commandResultError(
+  numeric: string,
+  params: readonly (string | undefined)[],
+): { channel: string; text: string } | null {
+  const spec = COMMAND_RESULT_ERRORS[numeric];
+  if (!spec) return null;
+  const channel = params[spec.channel];
+  // Guards the 441-shaped case above from the other direction too: if a server
+  // ever ships these params in a different order, a non-channel value here
+  // fails the test and the line stays in the server buffer.
+  if (typeof channel !== 'string' || !isChannelTarget(channel)) return null;
+  const subject = spec.subject === undefined ? '' : params[spec.subject];
+  if (spec.subject !== undefined && (typeof subject !== 'string' || !subject)) return null;
+  return { channel, text: spec.message(subject as string) };
+}
+
+// True for numerics commandResultError owns, keyed by the tag irc-framework
+// reports on its 'irc error' event. The routing itself happens on the raw line;
+// this exists so the same error doesn't ALSO get written to the server buffer as
+// a tag line. That line was always a duplicate of the raw one the 'raw' handler
+// logs — routed or not — so suppressing it is not conditional on the routing
+// having found a buffer.
+const COMMAND_RESULT_ERROR_TAGS = new Set<string>([
+  'chanop_privs_needed', // 482
+  'user_not_in_channel', // 441
+  'user_on_channel', // 443
+]);
+
+export function isCommandResultErrorTag(tag: string): boolean {
+  return COMMAND_RESULT_ERROR_TAGS.has(tag);
 }
 
 // ERR_NEEDREGGEDNICK (477) is overloaded: a server sends it both to refuse a


### PR DESCRIPTION
Closes #434.

## The problem

You sit in `#channel`, run `/kick`, and nothing visible happens. The server's refusal lands in the **server buffer**, which is not where you are looking — and for `/invite` it's worse, because "nothing happened" looks identical to success.

Two adjacent routing buckets already exist in the `'irc error'` path and neither covers this:

- **channel-JOIN rejections** (405/471/473/474/475/476/477) → an ephemeral toast on the channel you tried to join (#260)
- **SEND rejections** (404/531, and 477 while joined) → an inline line in the buffer you were messaging (#283)

A failed kick/invite/mode/topic is neither, so it hit the catch-all.

## The fix

A third bucket: numerics that name the channel they concern get an inline error line in that channel.

**Inline rather than a toast**, following #283 — unlike a join rejection the buffer is right there and the user is looking at it, and a toast is exactly the thing that gets missed. Only for channels we're actually joined to; a command aimed elsewhere has no buffer to land in, and fabricating one would be worse than the status quo.

**No client change.** `error` events already render inline in whatever buffer they target.

### Why it reads raw wire params instead of the parsed event

The issue proposed routing on `event.channel`. That would have shipped a bug. irc-framework's generic map can't be trusted for this set — verified against 4.14.0 rather than assumed:

| numeric | what the library does |
|---|---|
| `441 ERR_USERNOTINCHANNEL` | **off by one** against its own 443 mapping — reports *our* nick as `nick` and the target **nick** as `channel` |
| `443 ERR_USERONCHANNEL` | carries no `reason` at all |
| `467 ERR_KEYSET`, `478 ERR_BANLISTFULL` | not modelled, so they never reach an `'irc error'` event to be routed from |

Routing 441 on `event.channel` would have published into a buffer named after a user. The `'raw'` handler sees every line with its params intact, so one table covers all five — and the joined-channel test means a server that ships params in another order degrades to the old behaviour instead of misrouting.

### Why the messages are ours

Same reason `JOIN_REJECTION_MESSAGES` already exists: several of these numerics send a sentence **fragment** meant to be prefixed by a param (`"is already on channel"`), which reads as nonsense alone. Each entry reads whatever else it needs out of the params itself.

478 is the interesting one — it names the list that filled up in `params[2]`, and it is **not** always `+b`: the invite-exception (`+I`) and quiet (`+q`) limits send the same numeric. That param is also not always present, and a server omitting it leaves the trailing reason in its place, so it's guarded on being a single letter — otherwise the line becomes *"The channel's +Channel list is full list is full."*

The server's own words are still logged verbatim to the server buffer by the `'raw'` handler, so the authentic record is untouched. This is additive, exactly like a join rejection.

## Also: one fold relation, not two

Membership and canonicalization disagreed. `isChannelJoined` folds through the server's declared CASEMAPPING; `publish()`'s canonicalizer is a plain `toLowerCase`. They agree on ASCII case and part company on rfc1459, where `[ \ ] ^` fold to `{ | } ~` — so a 482 naming `#news{dev}` while joined as `#news[dev]` would pass the membership test and then publish a target no buffer is keyed by. `channelState` answers both questions through one relation.

## Also: one fewer duplicate in the server buffer

482 arrived there **twice** — once as the raw line, once as a `chanop_privs_needed #chan — …` line from the catch-all. That second copy was always redundant, routed or not, so it's dropped.

## `ERR_NOSUCHNICK` (401), attributed from the outgoing command

This was going to be deferred, and QA caught that immediately — **401 is the failure you actually hit first.** `/kick` or `/invite` a nick that has left the network, or mistype one, and the server answers 401; the 441 above only fires for a user who exists but isn't in *this* channel. Deferring it would have shipped a fix that misses the common case.

The reason for deferring was that 401 names no channel and correlating it with the command needs labeled-response. The first half is true; the second was wrong. Correlation needs labeled-response from the **client's** position — that is what #816 is about. The server isn't in that position: every slash command and member-menu action leaves through `IrcConnection.raw()`, so it can read the outgoing line and remember what it aimed at.

It already does exactly this for refused sends — `noteUserSend`/`recentUserSend`, same 15s window, same prune-before-insert — so this is that pattern a second time rather than a new mechanism.

Two deliberate choices:

- **Keyed on the nick, not on "a command went out recently".** A `/whois` for some other missing user inside the same window names a different nick and stays where it is. Only a 401 naming a nick we just tried to kick, invite or op moves.
- **MODE arguments are recorded without deciding which are nicks.** Working that out means reading the mode string against CHANMODES/PREFIX, and it buys nothing: recording a ban mask or a channel limit as though it were a nick is inert, since it can only ever match a 401 naming that exact string, and a 401 names a bare nick.

Checked before the existing DM-history fallback, which is the weaker signal — an explicit command aimed at a named channel seconds ago beats "we have DM history with this nick at some point." An unattributable 401 keeps its current routing entirely.

## Testing

Server-only. 14 tests across the classifier and the routing, all probe-validated: each fix was reverted in turn to confirm the relevant test fails rather than passing vacuously.

Full gate green: `npm run check` and `npm test` (3961 tests).
