### PR TITLE
Tell the user when a nick isn't there (#817, #818)

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1099,6 +1099,62 @@ describe('refused-message handler routing (#283)', () => {
     expect(publish).toHaveBeenCalledWith(expect.objectContaining({ target: ':server:1' }));
   });
 
+  it('puts the first DM to a nick that does not exist in the query (#817)', () => {
+    // The reported bug. Under echo-message nothing is persisted for a send the
+    // server never echoes, so the has-DM-history gate is false by construction
+    // on a FIRST message — the one case where the user most needs to be told.
+    // The DB here is empty, which is exactly that state.
+    const conn = makeConn();
+    conn.client.say = vi.fn<(target: string, message: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.say('fartboy', 'you stink');
+    conn.client.emit('irc error', {
+      error: 'no_such_nick',
+      nick: 'fartboy',
+      reason: 'No such nick/channel',
+    });
+
+    // In the query, not the server buffer. The publish is what leaves a buffer
+    // behind as well: an 'error' row persists, so the query survives a reload.
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', target: 'fartboy' }),
+    );
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: ':server:1' }));
+  });
+
+  it('still refuses to open a query from a /whois miss', () => {
+    // The guard rail on the widened gate. recentUserSend is set only by
+    // say/action/notice, so looking someone up must not conjure a DM buffer for
+    // a nick the user never messaged — it stays in the server buffer.
+    const conn = makeConn();
+    conn.client.raw = vi.fn<(line: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.raw('WHOIS fartboy');
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'fartboy' });
+
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: 'fartboy' }));
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ target: ':server:1' }));
+  });
+
+  it('forgets the send attribution across a reconnect, so a stale 401 stays put', () => {
+    // Same reasoning resetSendState already applies to the 531 path: a send on
+    // a dead socket must not place the first bounce on the new one.
+    const conn = makeConn();
+    conn.client.say = vi.fn<(target: string, message: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.say('fartboy', 'you stink');
+    conn.resetSendState();
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'fartboy' });
+
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: 'fartboy' }));
+  });
+
   it('drops the duplicate tag line the server buffer used to get as well', () => {
     // 482 reached the server buffer twice: the raw line, plus a
     // "chanop_privs_needed #anime — …" line from the 'irc error' catch-all.

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1140,6 +1140,44 @@ describe('refused-message handler routing (#283)', () => {
     expect(publish).toHaveBeenCalledWith(expect.objectContaining({ target: ':server:1' }));
   });
 
+  it("doesn't open a query from a /ctcp to a nick that isn't there", () => {
+    // A CTCP is a real user-initiated PRIVMSG, so it marks the send — but its
+    // outcome is reported into the buffer it was issued from, and answering the
+    // 401 with a brand-new query would both fabricate a conversation the user
+    // never started and split the exchange across two buffers.
+    const conn = makeConn();
+    conn.upsertChannel('#anime');
+    conn.client.ctcpRequest = vi.fn<(target: string, type: string, payload?: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.sendCtcpRequest('#anime', 'fartboy', 'VERSION', '');
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'fartboy' });
+
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: 'fartboy' }));
+  });
+
+  it('still surfaces a refused CTCP, which is what marks the send in the first place', () => {
+    // The guard above must not go so far as to silence 531 for a CTCP:
+    // handleSendRejection reads recentUserSend to tell a real send from a
+    // typing bounce, and a CTCP is a real send.
+    const conn = makeConn();
+    conn.client.ctcpRequest = vi.fn<(target: string, type: string, payload?: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.sendCtcpRequest(':server:1', 'fartboy', 'VERSION', '');
+    expect(conn.recentUserSend('fartboy')).toBe(true);
+    expect(conn.recentConversationalSend('fartboy')).toBe(false);
+
+    conn.client.emit('irc error', {
+      error: 'cannot_send_to_user',
+      nick: 'fartboy',
+      reason: 'They are blocking messages',
+    });
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ target: 'fartboy' }));
+  });
+
   it('forgets the send attribution across a reconnect, so a stale 401 stays put', () => {
     // Same reasoning resetSendState already applies to the 531 path: a send on
     // a dead socket must not place the first bounce on the new one.

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1116,10 +1116,16 @@ describe('refused-message handler routing (#283)', () => {
       reason: 'No such nick/channel',
     });
 
-    // In the query, not the server buffer. The publish is what leaves a buffer
-    // behind as well: an 'error' row persists, so the query survives a reload.
+    // In the query, not the server buffer, and in the same words the channel
+    // routing and the profile modal use rather than the server's raw
+    // "No such nick/channel". The publish is what leaves a buffer behind as
+    // well: an 'error' row persists, so the query survives a reload.
     expect(publish).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'error', target: 'fartboy' }),
+      expect.objectContaining({
+        type: 'error',
+        target: 'fartboy',
+        text: "fartboy isn't on this network.",
+      }),
     );
     expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: ':server:1' }));
   });

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2722,12 +2722,35 @@ export class IrcConnection {
         }
       }
       const isDmMiss = tag === 'no_such_nick' && eventNick && isDmTargetName(eventNick);
-      // For ERR_NOSUCHNICK against a nick the user has any DM history with,
-      // route the error into that DM buffer so the failure surfaces where
-      // they sent the message instead of getting lost in the server buffer.
-      // Presence is no longer driven from here — MONITOR is the authority
-      // for online/offline state.
-      if (isDmMiss && hasMessageForTarget(this.network.id, eventNick as string)) {
+      // For ERR_NOSUCHNICK against a nick the user just messaged, or has any DM
+      // history with, route the error into that DM buffer so the failure
+      // surfaces where they sent the message instead of getting lost in the
+      // server buffer. Presence is no longer driven from here — MONITOR is the
+      // authority for online/offline state.
+      //
+      // recentUserSend is checked first, and not just because it's a map read
+      // against a DB one. Under echo-message the FIRST message to a nick that
+      // doesn't exist has no history to find, by construction: the optimistic
+      // publish is skipped (ircManager waits for the server to echo) and the
+      // server answers 401 instead of echoing, so no row is ever written. So
+      // history alone is blind to precisely the case that needs this most —
+      // the first thing you ever say to someone (#817). handleSendRejection
+      // already gates the sibling numeric (531) on recentUserSend for the same
+      // reason; this brings the two into line.
+      //
+      // The publish below is what leaves a buffer behind, too: an 'error' row
+      // persists, so the query survives a reload instead of vanishing with the
+      // optimistic one the client opened.
+      //
+      // recentUserSend has to stay narrower than "any recent interest in this
+      // nick" — a /whois miss must never conjure a DM buffer. Only say/action/
+      // notice set it, so it has that property; lastNickIntent deliberately
+      // does not (a whois records there too).
+      if (
+        isDmMiss &&
+        (this.recentUserSend(eventNick as string) ||
+          hasMessageForTarget(this.network.id, eventNick as string))
+      ) {
         const message = reason || 'No such nick — they may be offline.';
         this.publish({
           type: 'error',

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2748,10 +2748,19 @@ export class IrcConnection {
       // optimistic one the client opened.
       //
       // The signal has to stay narrower than "any recent interest in this
-      // nick" — a /whois miss must never conjure a DM buffer, and neither may
-      // a /ctcp, which reports into the buffer it was issued from. So this
-      // reads recentConversationalSend (say/action/notice/multiline) rather
-      // than recentUserSend, and not lastNickIntent, which a whois writes to.
+      // nick": neither a /whois nor a /ctcp may CONJURE a DM buffer — a whois
+      // isn't a message at all, and a ctcp already reports into the buffer it
+      // was issued from. So this reads recentConversationalSend (say / action /
+      // notice / multiline) rather than recentUserSend, and not lastNickIntent,
+      // which a whois writes to.
+      //
+      // ⚠ "Conjure" is the exact scope, and the hasMessageForTarget fallback
+      // below is deliberately untouched: a /ctcp miss against a nick you
+      // ALREADY have a DM with still lands in that DM rather than in the buffer
+      // the ctcp was issued from. That predates this branch, and it's what
+      // handleSendRejection does with a 531 for a CTCP too — so it is at least
+      // consistent. Routing a CTCP failure back to its issuing buffer is a
+      // separate change, and it would have to move both paths together.
       if (
         isDmMiss &&
         (this.recentConversationalSend(eventNick as string) ||

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2757,11 +2757,15 @@ export class IrcConnection {
         (this.recentConversationalSend(eventNick as string) ||
           hasMessageForTarget(this.network.id, eventNick as string))
       ) {
-        const message = reason || 'No such nick — they may be offline.';
+        // Same sentence the channel-routed 401 uses (#815) and the profile
+        // modal now uses (#818). It replaces the server's raw `reason`, which
+        // on almost every ircd is the literal "No such nick/channel" — one
+        // failure the user can meet in three places shouldn't speak ircd in
+        // one of them and English in the other two.
         this.publish({
           type: 'error',
           target: eventNick,
-          text: message,
+          text: `${eventNick} isn't on this network.`,
           raw: event,
         });
         return;

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -555,7 +555,12 @@ export class IrcConnection {
   // key → epoch ms). Lets the send-rejection handler tell an actual failed
   // message (surface it inline) from an automated TAGMSG/typing bounce (stay
   // silent) — the rejection numeric doesn't say which command it refused (#283).
-  lastUserSendAt: Map<string, number>;
+  //
+  // `conversational` separates the sends that ARE a conversation with the
+  // target from a CTCP probe, which is also a real user-initiated PRIVMSG but
+  // reports its outcome back to the buffer it was issued from. Both count for
+  // the rejection handler; only the former may open a DM buffer (#817).
+  lastUserSendAt: Map<string, { at: number; conversational: boolean }>;
   // nick → the user's last move on them, for placing a 401 (#434). A null
   // channel means the move was a direct one (a query, a whois).
   lastNickIntent = new Map<string, { channel: string | null; at: number }>();
@@ -2742,13 +2747,14 @@ export class IrcConnection {
       // persists, so the query survives a reload instead of vanishing with the
       // optimistic one the client opened.
       //
-      // recentUserSend has to stay narrower than "any recent interest in this
-      // nick" — a /whois miss must never conjure a DM buffer. Only say/action/
-      // notice set it, so it has that property; lastNickIntent deliberately
-      // does not (a whois records there too).
+      // The signal has to stay narrower than "any recent interest in this
+      // nick" — a /whois miss must never conjure a DM buffer, and neither may
+      // a /ctcp, which reports into the buffer it was issued from. So this
+      // reads recentConversationalSend (say/action/notice/multiline) rather
+      // than recentUserSend, and not lastNickIntent, which a whois writes to.
       if (
         isDmMiss &&
-        (this.recentUserSend(eventNick as string) ||
+        (this.recentConversationalSend(eventNick as string) ||
           hasMessageForTarget(this.network.id, eventNick as string))
       ) {
         const message = reason || 'No such nick — they may be offline.';
@@ -4300,7 +4306,9 @@ export class IrcConnection {
     const now = Date.now();
     let payload = args.trim();
     if (t === 'PING' && !payload) payload = String(now);
-    this.noteUserSend(target);
+    // Real enough for the rejection handler to surface a 531, but not a
+    // conversation: the outcome belongs in `issuing`, not in a new query.
+    this.noteUserSend(target, false);
     if (payload) this.client.ctcpRequest(target, t, payload);
     else this.client.ctcpRequest(target, t);
     this.pruneCtcpOutstanding(now);
@@ -4994,17 +5002,17 @@ export class IrcConnection {
   // Record that the user just sent a real message to `target`. handleSendRejection
   // reads this to tell an actual failed message from an automated TAGMSG/typing
   // bounce — the rejection numeric alone doesn't say which command it refused.
-  noteUserSend(target: string): void {
+  noteUserSend(target: string, conversational = true): void {
     const now = Date.now();
     // Prune entries past the attribution window before adding. They can never
     // satisfy recentUserSend again, so keeping them would let the map grow
     // unbounded as the user messages more one-off DM targets over a long-lived
     // connection. The live set is tiny — only targets messaged in the last few
     // seconds — so this stays cheap.
-    for (const [key, at] of this.lastUserSendAt) {
-      if (now - at > SEND_REJECTION_ATTRIBUTION_MS) this.lastUserSendAt.delete(key);
+    for (const [key, seen] of this.lastUserSendAt) {
+      if (now - seen.at > SEND_REJECTION_ATTRIBUTION_MS) this.lastUserSendAt.delete(key);
     }
-    this.lastUserSendAt.set(target.toLowerCase(), now);
+    this.lastUserSendAt.set(target.toLowerCase(), { at: now, conversational });
     // A direct message is a channel-less intent (#434): messaging someone you
     // just tried to kick means the next 401 answers the message, not the kick.
     // say/action/notice all funnel through here, and none of them pass through
@@ -5013,8 +5021,20 @@ export class IrcConnection {
   }
 
   recentUserSend(target: string): boolean {
-    const at = this.lastUserSendAt.get(target.toLowerCase());
-    return at != null && Date.now() - at <= SEND_REJECTION_ATTRIBUTION_MS;
+    const seen = this.lastUserSendAt.get(target.toLowerCase());
+    return seen != null && Date.now() - seen.at <= SEND_REJECTION_ATTRIBUTION_MS;
+  }
+
+  // Narrower than recentUserSend: did the user just say something TO this
+  // target, as opposed to probing it? Only this may conjure a DM buffer out of
+  // a 401 (#817) — a CTCP already reports into the buffer it was issued from,
+  // so answering one with a brand-new query would both fabricate a
+  // conversation the user never started and split the exchange in two.
+  recentConversationalSend(target: string): boolean {
+    const seen = this.lastUserSendAt.get(target.toLowerCase());
+    return (
+      seen != null && seen.conversational && Date.now() - seen.at <= SEND_REJECTION_ATTRIBUTION_MS
+    );
   }
 
   // Record the user's last move on each nick an outgoing line names, so a 401

--- a/vue_client/src/components/UserProfileModal.test.ts
+++ b/vue_client/src/components/UserProfileModal.test.ts
@@ -23,6 +23,7 @@ vi.mock('../composables/useSocket.js', () => ({
 }));
 
 import { useWhoisStore } from '../stores/whois.js';
+import { useNetworksStore } from '../stores/networks.js';
 import UserProfileModal from './UserProfileModal.vue';
 
 const NET = 1;
@@ -76,6 +77,25 @@ describe('UserProfileModal — no such user', () => {
 
     const w = open('fartboy');
     expect(w.text()).toContain('Waiting for whois reply');
+    expect(w.text()).not.toContain("isn't on this network");
+  });
+
+  it('stays quiet for a peer MONITOR already knows is offline', () => {
+    // The pre-existing rule, which the in-flight demotion must not trample: if
+    // MONITOR has told us they're offline, the header dot carries it and the
+    // body lets "Your note" stand on its own. A WHOIS is in flight here — it
+    // always is on open — and that alone must not put a spinner on screen.
+    const networks = useNetworksStore();
+    networks.states[NET] = {
+      state: 'connected',
+      peerPresence: {
+        fartboy: { nick: 'fartboy', state: 'offline', stateAt: null, awayMessage: null },
+      },
+    } as never;
+    useWhoisStore().openViewer(NET, 'fartboy');
+
+    const w = open('fartboy');
+    expect(w.text()).not.toContain('Waiting for whois reply');
     expect(w.text()).not.toContain("isn't on this network");
   });
 

--- a/vue_client/src/components/UserProfileModal.test.ts
+++ b/vue_client/src/components/UserProfileModal.test.ts
@@ -19,7 +19,7 @@ import { mount } from '@vue/test-utils';
 import { setActivePinia, createPinia } from 'pinia';
 
 vi.mock('../composables/useSocket.js', () => ({
-  socketSend: vi.fn<(payload: Record<string, unknown>) => boolean>(),
+  socketSend: vi.fn<(payload: Record<string, unknown>) => boolean>(() => true),
 }));
 
 import { useWhoisStore } from '../stores/whois.js';
@@ -63,6 +63,20 @@ describe('UserProfileModal — no such user', () => {
     const dot = open('fartboy').find('.dot');
     expect(dot.classes()).toContain('offline');
     expect(dot.attributes('aria-label')).toBe('Offline');
+  });
+
+  it('goes back to waiting while a fresh lookup is out over a stale miss', () => {
+    // A cached miss is stale the moment a refresh goes out — they may have
+    // connected since. Asserting "isn't on this network" through that
+    // round-trip is a definite claim about a fact we're in the middle of
+    // re-checking, so the in-flight lookup demotes it.
+    const whois = useWhoisStore();
+    whois.applyResult(NET, { nick: 'fartboy', error: 'not_found' });
+    whois.openViewer(NET, 'fartboy');
+
+    const w = open('fartboy');
+    expect(w.text()).toContain('Waiting for whois reply');
+    expect(w.text()).not.toContain("isn't on this network");
   });
 
   it('hides Send DM for a nick that is not there', () => {

--- a/vue_client/src/components/UserProfileModal.test.ts
+++ b/vue_client/src/components/UserProfileModal.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+// The modal's no-such-user state (#818).
+//
+// This file exists because of a bug it would have caught. The failure signal
+// was already arriving — irc-framework synthesizes `error: 'not_found'` on
+// RPL_ENDOFWHOIS when nothing filled the whois cache, and the component
+// already computed `isNotFound` from it — but that computed was only ever
+// folded into `isOffline`, so nothing on screen said the lookup had failed.
+// The modal rendered a name, a note prompt, and nothing else: exactly what a
+// profile we simply have no details for looks like. Only a mounted component
+// can see that difference, so this mounts the real one and reads the DOM.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+
+vi.mock('../composables/useSocket.js', () => ({
+  socketSend: vi.fn<(payload: Record<string, unknown>) => boolean>(),
+}));
+
+import { useWhoisStore } from '../stores/whois.js';
+import UserProfileModal from './UserProfileModal.vue';
+
+const NET = 1;
+
+function open(nick: string) {
+  return mount(UserProfileModal, { props: { nick, networkId: NET } });
+}
+
+describe('UserProfileModal — no such user', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('says so when the whois came back not-found', () => {
+    useWhoisStore().applyResult(NET, { nick: 'fartboy', error: 'not_found' });
+    expect(open('fartboy').text()).toContain("fartboy isn't on this network.");
+  });
+
+  it('shows the waiting state instead while the reply is still out', () => {
+    // Nothing cached at all is the genuinely-in-the-dark case, and it must not
+    // be reported as a miss — the two are what this whole issue is about
+    // telling apart.
+    const w = open('fartboy');
+    expect(w.text()).toContain('Waiting for whois reply');
+    expect(w.text()).not.toContain("isn't on this network");
+  });
+
+  it('says nothing of the sort once an identity lands', () => {
+    useWhoisStore().applyResult(NET, { nick: 'someone', ident: 'u', hostname: 'h.test' });
+    const w = open('someone');
+    expect(w.text()).not.toContain("isn't on this network");
+    expect(w.text()).not.toContain('Waiting for whois reply');
+  });
+
+  it('reads the missing nick as offline, not unknown', () => {
+    // The header dot is the other half. With no MONITOR data a not-found nick
+    // fell through to "Unknown" — the one status we can rule out — which is
+    // why the dot could not be left to carry this on its own.
+    useWhoisStore().applyResult(NET, { nick: 'fartboy', error: 'not_found' });
+    const dot = open('fartboy').find('.dot');
+    expect(dot.classes()).toContain('offline');
+    expect(dot.attributes('aria-label')).toBe('Offline');
+  });
+
+  it('hides Send DM for a nick that is not there', () => {
+    // A DM would bounce. This already worked via isOffline; pinned so the
+    // presence rework above can't quietly undo it.
+    useWhoisStore().applyResult(NET, { nick: 'fartboy', error: 'not_found' });
+    expect(open('fartboy').find('button[title="Send DM"]').exists()).toBe(false);
+  });
+});

--- a/vue_client/src/components/UserProfileModal.vue
+++ b/vue_client/src/components/UserProfileModal.vue
@@ -335,11 +335,17 @@ const isLookingUp = computed(() => whoisStore.isRefreshing(props.networkId, prop
 // 'waiting' otherwise covers being genuinely in the dark. If MONITOR already
 // knows they're offline the presence dot carries that, so we skip the
 // redundant line and let "Your note" stand on its own.
+//
+// ⚠ That last test reads isPeerOffline, NOT isOffline. isOffline folds a
+// not-found whois in with MONITOR's verdict, which is right for hiding Send DM
+// (a DM bounces either way) and wrong here: it would send a miss we're
+// re-checking down the quiet path and blank the modal — the very bug #818 is
+// about. The two questions only look like one.
 const statusLine = computed<'not-found' | 'waiting' | null>(() => {
   if (isNotFound.value && !isLookingUp.value) return 'not-found';
   if (hasDetails.value) return null;
-  if (isLookingUp.value || !isOffline.value) return 'waiting';
-  return null;
+  if (isNotFound.value) return 'waiting';
+  return isPeerOffline(peer.value) ? null : 'waiting';
 });
 
 // Any detail row present → render the table. Covers every row (identity +

--- a/vue_client/src/components/UserProfileModal.vue
+++ b/vue_client/src/components/UserProfileModal.vue
@@ -111,11 +111,23 @@
         </div>
       </section>
 
+      <!-- The lookup came back with nobody there. Say so: without this line the
+           modal renders a name, a note prompt and nothing else, which is
+           indistinguishable from a profile we simply have no details for — and
+           the header dot can't carry it either, since with no MONITOR data a
+           not-found nick reads as "Unknown" (#818). Wording matches the
+           channel-side 401 line so the same failure sounds the same
+           everywhere. -->
+      <section v-if="isNotFound" class="section status">
+        <p class="muted">
+          <i class="fa-solid fa-circle-question"></i> {{ nick }} isn't on this network.
+        </p>
+      </section>
       <!-- Transient waiting state — only while we're genuinely in the dark.
-           If we already know they're offline (MONITOR or not_found whois)
-           the presence dot in the header carries that, so we skip the
-           redundant line and let "Your note" stand on its own. -->
-      <section v-if="!hasDetails && !isOffline" class="section status">
+           If MONITOR already knows they're offline the presence dot in the
+           header carries that, so we skip the redundant line and let "Your
+           note" stand on its own. -->
+      <section v-else-if="!hasDetails && !isOffline" class="section status">
         <p class="muted">
           <i class="fa-solid fa-circle-notch fa-spin"></i> Waiting for whois reply…
         </p>
@@ -216,8 +228,12 @@ const presenceClass = computed(() => {
   if (isPeerOffline(peer.value)) return 'offline';
   if (isPeerAway(peer.value) || awayMessage.value) return 'away';
   if (isPeerOnline(peer.value)) return 'online';
-  // No presence data — if whois returned an identity we know they're online.
-  if (whois.value && !isNotFound.value) return 'online';
+  // No presence data — the whois reply settles it either way: an identity
+  // means they're online, and a not-found means there's nobody there to be
+  // anything else. Without the second branch a missing nick showed "Unknown",
+  // which is the one thing we do know it isn't (#818).
+  if (isNotFound.value) return 'offline';
+  if (whois.value) return 'online';
   return 'unknown';
 });
 const presenceLabel = computed(() => {

--- a/vue_client/src/components/UserProfileModal.vue
+++ b/vue_client/src/components/UserProfileModal.vue
@@ -111,23 +111,15 @@
         </div>
       </section>
 
-      <!-- The lookup came back with nobody there. Say so: without this line the
-           modal renders a name, a note prompt and nothing else, which is
-           indistinguishable from a profile we simply have no details for — and
-           the header dot can't carry it either, since with no MONITOR data a
-           not-found nick reads as "Unknown" (#818). Wording matches the
-           channel-side 401 line so the same failure sounds the same
-           everywhere. -->
-      <section v-if="isNotFound" class="section status">
+      <!-- One status line, chosen in `statusLine` — see the note there for why
+           the miss has to be said out loud rather than left to the header
+           dot (#818). -->
+      <section v-if="statusLine === 'not-found'" class="section status">
         <p class="muted">
           <i class="fa-solid fa-circle-question"></i> {{ nick }} isn't on this network.
         </p>
       </section>
-      <!-- Transient waiting state — only while we're genuinely in the dark.
-           If MONITOR already knows they're offline the presence dot in the
-           header carries that, so we skip the redundant line and let "Your
-           note" stand on its own. -->
-      <section v-else-if="!hasDetails && !isOffline" class="section status">
+      <section v-else-if="statusLine === 'waiting'" class="section status">
         <p class="muted">
           <i class="fa-solid fa-circle-notch fa-spin"></i> Waiting for whois reply…
         </p>
@@ -324,6 +316,30 @@ const channelsList = computed(() => {
       const m = token.match(/^([~&@%+]*)(.*)$/);
       return { prefix: m?.[1] || '', name: m?.[2] || token };
     });
+});
+
+const isLookingUp = computed(() => whoisStore.isRefreshing(props.networkId, props.nick));
+
+// What the body says when it has something to say about the lookup itself.
+//
+// 'not-found' is the fix for #818: a whois that answers "nobody there" used to
+// render a name, a note prompt and nothing else, which is indistinguishable
+// from a profile we simply have no details for. The header dot can't carry it
+// either — with no MONITOR data a not-found nick read as "Unknown", the one
+// status we can rule out.
+//
+// But only once the claim is current. A cached miss goes stale the instant a
+// refresh goes out (they may have connected since), so an in-flight lookup
+// demotes it back to 'waiting' rather than asserting they aren't there.
+//
+// 'waiting' otherwise covers being genuinely in the dark. If MONITOR already
+// knows they're offline the presence dot carries that, so we skip the
+// redundant line and let "Your note" stand on its own.
+const statusLine = computed<'not-found' | 'waiting' | null>(() => {
+  if (isNotFound.value && !isLookingUp.value) return 'not-found';
+  if (hasDetails.value) return null;
+  if (isLookingUp.value || !isOffline.value) return 'waiting';
+  return null;
 });
 
 // Any detail row present → render the table. Covers every row (identity +

--- a/vue_client/src/stores/whois.test.ts
+++ b/vue_client/src/stores/whois.test.ts
@@ -4,7 +4,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 
-// openViewer fires the WHOIS itself; nothing here needs a real socket.
+// openViewer fires the WHOIS itself; nothing here needs a real socket. It
+// defaults to a delivered send — the not-delivered case is its own test.
 vi.mock('../composables/useSocket.js', () => ({
   socketSend: vi.fn<(payload: Record<string, unknown>) => boolean>(),
 }));
@@ -22,7 +23,8 @@ const send = vi.mocked(socketSend);
 describe('whois store — in-flight tracking', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
-    send.mockClear();
+    send.mockReset();
+    send.mockReturnValue(true);
   });
 
   const NET = 1;
@@ -63,6 +65,32 @@ describe('whois store — in-flight tracking', () => {
 
     store.openViewer(NET, 'fartboy');
     expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("doesn't claim the slot for a WHOIS that never went out", () => {
+    // socketSend returns false with no live socket. Claiming the slot anyway
+    // wedges it exactly as a never-cleared one did — no reply is coming to
+    // free it — so a reconnected user could never look the nick up again.
+    const store = useWhoisStore();
+    send.mockReturnValue(false);
+    store.openViewer(NET, 'fartboy');
+    expect(store.refreshingKey).toBeNull();
+
+    send.mockReturnValue(true);
+    store.openViewer(NET, 'fartboy');
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(store.refreshingKey).not.toBeNull();
+  });
+
+  it('reports a lookup as in flight only for the nick it is out for', () => {
+    const store = useWhoisStore();
+    store.openViewer(NET, 'FartBoy');
+    expect(store.isRefreshing(NET, 'fartboy')).toBe(true);
+    expect(store.isRefreshing(NET, 'someoneelse')).toBe(false);
+    expect(store.isRefreshing(2, 'fartboy')).toBe(false);
+
+    store.applyResult(NET, { nick: 'fartboy', error: 'not_found' });
+    expect(store.isRefreshing(NET, 'fartboy')).toBe(false);
   });
 
   it('matches the reply to the request case-insensitively', () => {

--- a/vue_client/src/stores/whois.test.ts
+++ b/vue_client/src/stores/whois.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+// openViewer fires the WHOIS itself; nothing here needs a real socket.
+vi.mock('../composables/useSocket.js', () => ({
+  socketSend: vi.fn<(payload: Record<string, unknown>) => boolean>(),
+}));
+
+import { socketSend } from '../composables/useSocket.js';
+import { useWhoisStore } from './whois.js';
+
+const send = vi.mocked(socketSend);
+
+// refreshingKey is the in-flight marker for the viewer's own lookup. It used to
+// mean "we already asked for this nick at some point in this viewer session",
+// which read the same for a lookup that answered and one that never will — so a
+// nick whose WHOIS came back not-found kept the slot for the rest of the
+// session and could not be retried (#818).
+describe('whois store — in-flight tracking', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    send.mockClear();
+  });
+
+  const NET = 1;
+
+  it('kicks one WHOIS while the reply is still out', () => {
+    const store = useWhoisStore();
+    store.openViewer(NET, 'fartboy');
+    store.openViewer(NET, 'fartboy');
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a reopen retry a lookup that came back not-found', () => {
+    // The bug: a 401 answers the WHOIS with `error: 'not_found'`, which is an
+    // answer — the slot has to free even though there is no identity in it.
+    const store = useWhoisStore();
+    store.openViewer(NET, 'fartboy');
+    store.applyResult(NET, { nick: 'fartboy', error: 'not_found' });
+    expect(store.refreshingKey).toBeNull();
+
+    store.openViewer(NET, 'fartboy');
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('frees the slot on a successful reply too', () => {
+    const store = useWhoisStore();
+    store.openViewer(NET, 'someone');
+    store.applyResult(NET, { nick: 'someone', ident: 'u', hostname: 'h' });
+    expect(store.refreshingKey).toBeNull();
+  });
+
+  it("doesn't free the slot for a different nick's reply", () => {
+    // Results arrive for nicks nobody opened a viewer on — the modal isn't the
+    // only thing that can provoke a WHOIS. One must not clear another's marker.
+    const store = useWhoisStore();
+    store.openViewer(NET, 'fartboy');
+    store.applyResult(NET, { nick: 'someoneelse', ident: 'u' });
+    expect(store.refreshingKey).not.toBeNull();
+
+    store.openViewer(NET, 'fartboy');
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('matches the reply to the request case-insensitively', () => {
+    // IRC nicks are case-insensitive and servers echo whatever case they hold,
+    // so a reply cased differently from the request is the normal path, not an
+    // edge case. key() folds both, and this pins that it stays that way.
+    const store = useWhoisStore();
+    store.openViewer(NET, 'FartBoy');
+    store.applyResult(NET, { nick: 'fartboy', error: 'not_found' });
+    expect(store.refreshingKey).toBeNull();
+  });
+});

--- a/vue_client/src/stores/whois.ts
+++ b/vue_client/src/stores/whois.ts
@@ -56,8 +56,9 @@ export const useWhoisStore = defineStore('whois', {
   state: () => ({
     byKey: {} as Record<string, WhoisEntry>,
     viewer: { open: false, networkId: null, nick: '' } as WhoisViewerState,
-    // Tracks the nicks we've kicked a refresh for during this open viewer
-    // session, so reopening a different nick triggers its own refresh.
+    // The lookup currently in flight, if any. Set when the viewer kicks a
+    // WHOIS and cleared when that WHOIS answers (or the viewer closes), so a
+    // reopen while the reply is still out doesn't fire a second one.
     refreshingKey: null as string | null,
   }),
   getters: {
@@ -68,7 +69,14 @@ export const useWhoisStore = defineStore('whois', {
     applyResult(networkId: number | string, data: WhoisData) {
       const nick = (data && (data.nick as string)) || '';
       if (!networkId || !nick) return;
-      this.byKey[key(networkId, nick)] = { data };
+      const k = key(networkId, nick);
+      this.byKey[k] = { data };
+      // The lookup answered — with an identity, or with `error: 'not_found'`
+      // when the nick isn't on the network — so it is no longer in flight.
+      // Leaving refreshingKey set is what wedged a failed lookup: the slot
+      // stayed claimed for the rest of the viewer session, so reopening the
+      // same nick never retried it (#818).
+      if (this.refreshingKey === k) this.refreshingKey = null;
     },
     openViewer(networkId: number | string, nick: string) {
       if (!networkId || !nick) return;
@@ -76,9 +84,9 @@ export const useWhoisStore = defineStore('whois', {
       this.viewer = { open: true, networkId: Number(networkId), nick };
       // Always kick a fresh whois on open. The cached entry (if any) renders
       // immediately for instant feedback; the new data overwrites it when it
-      // arrives. Skip the refresh only if we already refreshed this exact
-      // (nick, network) during this viewer session — keeps reopens on the
-      // same nick from spamming the server.
+      // arrives. Skip only while a lookup for this exact (nick, network) is
+      // still out — keeps reopens on the same nick from spamming the server
+      // without leaving a failed lookup un-retryable.
       if (this.refreshingKey !== k) {
         this.refreshingKey = k;
         socketSend({ type: 'raw', networkId, line: `WHOIS ${nick}` });

--- a/vue_client/src/stores/whois.ts
+++ b/vue_client/src/stores/whois.ts
@@ -64,6 +64,13 @@ export const useWhoisStore = defineStore('whois', {
   getters: {
     entryFor: (state) => (networkId: number | string, nick: string) =>
       state.byKey[key(networkId, nick)] || null,
+    // Is a lookup for this nick still out? Callers need it to tell "we have no
+    // answer yet" from "the answer was nobody" — a cached miss is stale the
+    // moment a refresh goes out, and asserting it while one is in flight is
+    // how the modal would claim someone isn't on the network seconds after
+    // they joined (#818).
+    isRefreshing: (state) => (networkId: number | string, nick: string) =>
+      state.refreshingKey === key(networkId, nick),
   },
   actions: {
     applyResult(networkId: number | string, data: WhoisData) {
@@ -87,9 +94,12 @@ export const useWhoisStore = defineStore('whois', {
       // arrives. Skip only while a lookup for this exact (nick, network) is
       // still out — keeps reopens on the same nick from spamming the server
       // without leaving a failed lookup un-retryable.
+      // Claim the slot only if the WHOIS actually went out: socketSend returns
+      // false when there's no live socket, and a slot held for a request that
+      // never left wedges the same way a never-cleared one did — no reply is
+      // coming to free it, so reopening declines to retry forever.
       if (this.refreshingKey !== k) {
-        this.refreshingKey = k;
-        socketSend({ type: 'raw', networkId, line: `WHOIS ${nick}` });
+        if (socketSend({ type: 'raw', networkId, line: `WHOIS ${nick}` })) this.refreshingKey = k;
       }
     },
     closeViewer() {


### PR DESCRIPTION
Closes #817. Closes #818.

Both were filed while QA'ing #815, and they're the same shape: the user does something aimed at a nick that isn't on the network, and the answer lands somewhere they aren't looking — or nowhere at all.

## #817 — a first DM to a nick that doesn't exist

The 401 was routed into the query only when the user already had message history with that nick. Under echo-message a **first** message can never satisfy that, by construction: `ircManager` skips the optimistic publish and waits for the server to echo, the server answers 401 instead of echoing, so no row is ever written. History-only was blind to precisely the case that needs it most. The error went to the server buffer, and the optimistic query vanished on reload.

The gate now also accepts a recent send, which is what the sibling numeric (531 `ERR_CANNOTSENDTOUSER`) has always used through `handleSendRejection`. The publish is what leaves a buffer behind, too — an `error` row persists, so the query survives a reload.

**It stays narrow.** A `/whois` miss must not conjure a DM buffer, and neither may a `/ctcp` — `sendCtcpRequest` marks the send as well, and a CTCP already reports its outcome into the buffer it was issued from, so answering its 401 with a new query would fabricate a conversation *and* split the exchange in two. `lastUserSendAt` now carries a `conversational` flag; only say/action/notice/multiline can open a DM. Both still count for `handleSendRejection`, so a refused CTCP keeps surfacing its 531.

## #818 — the profile modal sits there empty

The failure signal was already arriving: irc-framework synthesizes `error: 'not_found'` on `RPL_ENDOFWHOIS` when nothing filled the whois cache, and the component already computed `isNotFound` from it. But that computed was only ever folded into `isOffline`, so nothing on screen said the lookup had failed — the modal rendered a name, a note prompt and nothing else, indistinguishable from a profile we simply have no details for. The header dot couldn't carry it either: with no MONITOR data a not-found nick fell through to **"Unknown"**, the one status we can rule out.

So the miss is now said out loud, and a not-found settles the dot as offline. Opening optimistically stays right — the user asked to look at someone and deserves an answer either way.

`refreshingKey` is also now a true in-flight marker: freed when a lookup answers (so a failed one can be retried), and claimed only when `socketSend` reports the WHOIS actually went out (a slot held for a request that never left wedges the same way). And an in-flight lookup demotes a cached miss back to the waiting state, so reopening a profile seconds after that nick connected doesn't assert they aren't there for a whole round-trip.

## One wording change beyond the two issues

The DM branch published the server's raw `reason` — on almost every ircd the literal `"No such nick/channel"` — while the channel routing (#815) and the modal both say `"<nick> isn't on this network."` All three now say the same sentence. This was near-invisible before, since the DM path only fired for a nick you already had history with; #817 is what makes it the common case.

## Not addressed

A WHOIS that is simply never answered still spins forever. That wants a timeout, which is its own decision.

## Testing

`npm run check` and `npm test` clean — 4010 tests, 281 files. Every production change here was mutation-tested: reverting each one fails specific new tests, so none of them are trivially green.

- `ircConnection.test.ts` — the first-DM routing, the `/whois` and `/ctcp` guard rails, that a refused CTCP still surfaces, reconnect attribution, and the unified wording
- `whois.test.ts` (new) — in-flight claim/release, the not-delivered send, case folding
- `UserProfileModal.test.ts` (new) — mounts the real component, since the bug lived entirely in what did and didn't render

🤖 Generated with [Claude Code](https://claude.com/claude-code)