### PR TITLE
A deleted user's invite let a stranger in (#590)

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -2256,6 +2256,15 @@ if (schemaVersion < 19 && tableExists('contacts')) {
 // the next revival; without this sweep every already-revived link on an
 // instance that has ever deleted a user stays redeemable.
 //
+// Deleting them is what makes history CONSISTENT rather than what makes it
+// lossy: from here on a user deletion takes the invite with it, so these rows
+// are exactly the ones that would already be gone had the constraint been right
+// when their redeemer was removed. The sweep finishes a deletion that was
+// botched. Carrying them forward instead is the asymmetric option — an
+// ownerless consumed row that could only ever exist for deletions predating
+// this upgrade. Only a count is logged, deliberately: an invite token is a
+// credential and does not belong in the log.
+//
 // Gated on the live constraint rather than on schema_version alone: fresh
 // installs get CASCADE from the CREATE TABLE above and must copy nothing.
 if (schemaVersion < 20) {
@@ -2264,6 +2273,14 @@ if (schemaVersion < 20) {
   ).find((f) => f.from === 'used_by_user_id');
   if (usedByFk && usedByFk.on_delete !== 'CASCADE') {
     const rebuild = db.transaction(() => {
+      const doomed = (
+        db
+          .prepare(
+            `SELECT COUNT(*) AS n FROM invite_tokens
+             WHERE used_by_user_id IS NULL AND used_at IS NOT NULL`,
+          )
+          .get() as { n: number }
+      ).n;
       db.exec(`DROP INDEX IF EXISTS idx_invite_tokens_unused`);
       db.exec(`
         CREATE TABLE invite_tokens_new (
@@ -2291,20 +2308,17 @@ if (schemaVersion < 20) {
       db.exec(`ALTER TABLE invite_tokens_new RENAME TO invite_tokens`);
       db.exec(`CREATE INDEX IF NOT EXISTS idx_invite_tokens_unused
                ON invite_tokens(token) WHERE used_by_user_id IS NULL`);
+      return doomed;
     });
     const prevFk = db.pragma('foreign_keys', { simple: true });
     db.pragma('foreign_keys = OFF');
     let purged = 0;
     try {
-      purged = (
-        db
-          .prepare(
-            `SELECT COUNT(*) AS n FROM invite_tokens
-             WHERE used_by_user_id IS NULL AND used_at IS NOT NULL`,
-          )
-          .get() as { n: number }
-      ).n;
-      rebuild();
+      // .immediate(), because this transaction opens with a read: on a hosted
+      // cell a deferred BEGIN takes a snapshot that Litestream's once-a-second
+      // sync can stale, and the write upgrade then dies with SQLITE_BUSY_SNAPSHOT,
+      // which busy_timeout does not retry (see lurker#603).
+      purged = rebuild.immediate();
     } finally {
       db.pragma(`foreign_keys = ${prevFk ? 'ON' : 'OFF'}`);
     }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -263,8 +263,14 @@ function migrate() {
       used_by_user_id INTEGER,
       used_at TEXT,
       created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+      -- Both ends CASCADE: an invite row describes a transaction between two
+      -- live accounts, so it dies with either. used_by_user_id was SET NULL
+      -- (#590) — which silently RESURRECTED a spent invite when its redeemer
+      -- was deleted: used_by_user_id went NULL, inviteStatus() read 'valid'
+      -- again, and a one-time link admins believed was spent became live for a
+      -- second stranger. See the schemaVersion 20 rebuild for existing DBs.
       FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE,
-      FOREIGN KEY (used_by_user_id) REFERENCES users(id) ON DELETE SET NULL
+      FOREIGN KEY (used_by_user_id) REFERENCES users(id) ON DELETE CASCADE
     );
     CREATE INDEX IF NOT EXISTS idx_invite_tokens_unused
       ON invite_tokens(token) WHERE used_by_user_id IS NULL;
@@ -929,6 +935,20 @@ interface TableInfoRow {
   pk: number;
 }
 
+// PRAGMA foreign_key_list(<table>) — one row per foreign key. Used to detect a
+// constraint that a migration needs to rewrite, since SQLite can only change a
+// foreign key by rebuilding the table.
+interface ForeignKeyListRow {
+  id: number;
+  seq: number;
+  table: string;
+  from: string;
+  to: string | null;
+  on_update: string;
+  on_delete: string;
+  match: string;
+}
+
 function ensureColumn(table: string, column: string, def: string): void {
   const cols = db.prepare(`PRAGMA table_info(${table})`).all() as TableInfoRow[];
   if (!cols.find((c) => c.name === column)) {
@@ -1267,7 +1287,7 @@ ensureColumn('push_subscriptions', 'transport', "TEXT NOT NULL DEFAULT 'webpush'
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new
 // recovery block, and delete blocks for versions far enough in the past.
-const SCHEMA_VERSION = 19;
+const SCHEMA_VERSION = 20;
 const schemaVersionRow = db
   .prepare(`SELECT value FROM app_meta WHERE key = 'schema_version'`)
   .get() as { value: string } | undefined;
@@ -2220,6 +2240,78 @@ if (schemaVersion < 19 && tableExists('contacts')) {
   const seeded = db.transaction(() => seedFavoritesFromContacts(db));
   const count = seeded.immediate();
   if (count > 0) console.log(`[db] migrated ${count} friend(s) into buffer favorites`);
+}
+
+// Issue #590: invite_tokens.used_by_user_id carried ON DELETE SET NULL, so
+// deleting a user RESURRECTED the invite they had redeemed — the id went NULL,
+// inviteStatus() saw no redeemer and reported 'valid', and a one-time link the
+// admin considered spent was live again for whoever still had the URL. Rebuild
+// the table with ON DELETE CASCADE (SQLite cannot alter a foreign key in place)
+// — same swap shape as the #301/#350 migrations above.
+//
+// Then purge the invites this already resurrected. `consumeInvite` writes
+// used_by_user_id and used_at together, so a row with used_at set but no
+// redeemer is not an ambiguous case: it is precisely an invite that WAS spent
+// and whose redeemer has since been deleted. Flipping the constraint only stops
+// the next revival; without this sweep every already-revived link on an
+// instance that has ever deleted a user stays redeemable.
+//
+// Gated on the live constraint rather than on schema_version alone: fresh
+// installs get CASCADE from the CREATE TABLE above and must copy nothing.
+if (schemaVersion < 20) {
+  const usedByFk = (
+    db.prepare(`PRAGMA foreign_key_list(invite_tokens)`).all() as ForeignKeyListRow[]
+  ).find((f) => f.from === 'used_by_user_id');
+  if (usedByFk && usedByFk.on_delete !== 'CASCADE') {
+    const rebuild = db.transaction(() => {
+      db.exec(`DROP INDEX IF EXISTS idx_invite_tokens_unused`);
+      db.exec(`
+        CREATE TABLE invite_tokens_new (
+          token TEXT PRIMARY KEY,
+          created_by INTEGER NOT NULL,
+          expires_at TEXT,
+          used_by_user_id INTEGER,
+          used_at TEXT,
+          created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+          FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE,
+          FOREIGN KEY (used_by_user_id) REFERENCES users(id) ON DELETE CASCADE
+        )
+      `);
+      // Copy everything EXCEPT the resurrected rows — they are spent invites
+      // wearing a pending row's shape, and carrying them over would leave the
+      // very links this migration exists to close still usable.
+      db.exec(`
+        INSERT INTO invite_tokens_new
+          (token, created_by, expires_at, used_by_user_id, used_at, created_at)
+        SELECT token, created_by, expires_at, used_by_user_id, used_at, created_at
+        FROM invite_tokens
+        WHERE NOT (used_by_user_id IS NULL AND used_at IS NOT NULL)
+      `);
+      db.exec(`DROP TABLE invite_tokens`);
+      db.exec(`ALTER TABLE invite_tokens_new RENAME TO invite_tokens`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_invite_tokens_unused
+               ON invite_tokens(token) WHERE used_by_user_id IS NULL`);
+    });
+    const prevFk = db.pragma('foreign_keys', { simple: true });
+    db.pragma('foreign_keys = OFF');
+    let purged = 0;
+    try {
+      purged = (
+        db
+          .prepare(
+            `SELECT COUNT(*) AS n FROM invite_tokens
+             WHERE used_by_user_id IS NULL AND used_at IS NOT NULL`,
+          )
+          .get() as { n: number }
+      ).n;
+      rebuild();
+    } finally {
+      db.pragma(`foreign_keys = ${prevFk ? 'ON' : 'OFF'}`);
+    }
+    if (purged > 0) {
+      console.log(`[db] closed ${purged} invite(s) resurrected by a user deletion (#590)`);
+    }
+  }
 }
 
 // Issue #510: seed the uploader data model — instance x0/catbox rows +

--- a/server/db/inviteRevivalMigration.test.ts
+++ b/server/db/inviteRevivalMigration.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import Database from 'better-sqlite3';
+
+// Integration test for the schemaVersion-20 cutover (#590): invite_tokens
+// carried `used_by_user_id ... ON DELETE SET NULL`, so deleting a user handed
+// their spent invite back to whoever still had the link.
+//
+// The fixture is built by letting db/index.ts create the real schema, then
+// putting ONLY invite_tokens back into its pre-v20 shape and winding
+// schema_version back to 19 — rather than hand-writing a v19 DB, which can't be
+// done from the base DDL alone (several tables reach their current shape through
+// version-gated rebuilds, so pinning an old version skips the very migrations
+// that made them current). Re-importing with a reset module registry then runs
+// migrate() again against that downgraded table.
+//
+// Two things have to be true afterwards, and the second is the one a
+// constraint-only fix would miss: new deletions cascade, AND the invites the old
+// constraint already resurrected are closed rather than carried forward as
+// live-looking links.
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-invmig-'));
+const dbPath = path.join(tmpDir, 'test.db');
+process.env.DATABASE_PATH = dbPath;
+
+let db: typeof import('./index.js').default;
+let invites: typeof import('./invites.js');
+
+interface FkRow {
+  from: string;
+  on_delete: string;
+}
+
+beforeAll(async () => {
+  // Phase 1 — real, fully-migrated schema.
+  const fresh = (await import('./index.js')).default;
+  fresh.close();
+
+  // Phase 2 — downgrade invite_tokens to the pre-v20 constraint and seed the
+  // three row shapes that matter.
+  const raw = new Database(dbPath);
+  raw.pragma('foreign_keys = OFF');
+  raw.exec(`
+    DROP TABLE invite_tokens;
+    CREATE TABLE invite_tokens (
+      token TEXT PRIMARY KEY,
+      created_by INTEGER NOT NULL,
+      expires_at TEXT,
+      used_by_user_id INTEGER,
+      used_at TEXT,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+      FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (used_by_user_id) REFERENCES users(id) ON DELETE SET NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_invite_tokens_unused
+      ON invite_tokens(token) WHERE used_by_user_id IS NULL;
+    INSERT INTO users (id, username) VALUES (1, 'admin'), (2, 'joined');
+    UPDATE app_meta SET value = '19' WHERE key = 'schema_version';
+
+    -- still redeemable: must survive untouched
+    INSERT INTO invite_tokens (token, created_by, expires_at)
+      VALUES ('tok-pending', 1, NULL);
+    -- properly consumed by a user who still exists
+    INSERT INTO invite_tokens (token, created_by, used_by_user_id, used_at)
+      VALUES ('tok-consumed', 1, 2, '2026-01-01T00:00:00.000Z');
+    -- ALREADY RESURRECTED: consumed, then its redeemer was deleted and SET NULL
+    -- wiped the only column anyone was reading
+    INSERT INTO invite_tokens (token, created_by, used_by_user_id, used_at)
+      VALUES ('tok-revived', 1, NULL, '2026-01-02T00:00:00.000Z');
+  `);
+  raw.close();
+
+  // Phase 3 — boot again; this is the run under test.
+  vi.resetModules();
+  ({ default: db } = await import('./index.js'));
+  invites = await import('./invites.js');
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('invite_tokens v20 migration (#590)', () => {
+  it('rewrites the redeemer foreign key to CASCADE', () => {
+    const fk = (db.prepare(`PRAGMA foreign_key_list(invite_tokens)`).all() as FkRow[]).find(
+      (f) => f.from === 'used_by_user_id',
+    );
+    expect(fk?.on_delete).toBe('CASCADE');
+  });
+
+  it('closes an invite the old constraint already resurrected', () => {
+    // The whole point: before this migration `tok-revived` read as a live link
+    // that a stranger holding the URL could still redeem.
+    expect(invites.inviteStatus('tok-revived').status).toBe('unknown');
+    expect(invites.consumeInvite('tok-revived', 2)).toBe(false);
+  });
+
+  it('leaves a genuinely pending invite redeemable', () => {
+    expect(invites.inviteStatus('tok-pending').status).toBe('valid');
+  });
+
+  it('keeps a consumed invite whose redeemer still exists', () => {
+    expect(invites.inviteStatus('tok-consumed').status).toBe('consumed');
+    expect(invites.listInvites().find((i) => i.token === 'tok-consumed')?.usedByUsername).toBe(
+      'joined',
+    );
+  });
+
+  it('restores the partial index the rebuild drops', () => {
+    const idx = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?`)
+      .get('idx_invite_tokens_unused');
+    expect(idx).toBeTruthy();
+  });
+
+  it('bumps schema_version so the rebuild is one-shot', () => {
+    const row = db.prepare(`SELECT value FROM app_meta WHERE key = 'schema_version'`).get() as
+      | { value: string }
+      | undefined;
+    expect(parseInt(row!.value, 10)).toBeGreaterThanOrEqual(20);
+  });
+});

--- a/server/db/invites.test.ts
+++ b/server/db/invites.test.ts
@@ -16,13 +16,22 @@ let listInvites: typeof import('./invites.js').listInvites;
 let inviteStatus: typeof import('./invites.js').inviteStatus;
 let consumeInvite: typeof import('./invites.js').consumeInvite;
 let deleteInvite: typeof import('./invites.js').deleteInvite;
+let isInviteSpent: typeof import('./invites.js').isInviteSpent;
+let deleteUser: typeof import('./users.js').deleteUser;
 let admin: ReturnType<typeof import('./users.js').createUser>;
 let invitee: ReturnType<typeof import('./users.js').createUser>;
 
 beforeAll(async () => {
-  ({ createUser } = await import('./users.js'));
-  ({ createInvite, getInvite, listInvites, inviteStatus, consumeInvite, deleteInvite } =
-    await import('./invites.js'));
+  ({ createUser, deleteUser } = await import('./users.js'));
+  ({
+    createInvite,
+    getInvite,
+    listInvites,
+    inviteStatus,
+    consumeInvite,
+    deleteInvite,
+    isInviteSpent,
+  } = await import('./invites.js'));
   admin = createUser('admin', { role: 'admin' });
   invitee = createUser('invitee');
 });
@@ -98,5 +107,51 @@ describe('invites', () => {
     expect(deleteInvite(inv!.token)).toBe(true);
     expect(getInvite(inv!.token)).toBeNull();
     expect(deleteInvite(inv!.token)).toBe(false);
+  });
+});
+
+// #590. The redeemer column used to be ON DELETE SET NULL, so removing a user
+// handed their one-time link back to whoever still had the URL — a revoked
+// account's invite silently became a way in for a stranger.
+describe('a spent invite outlives its redeemer', () => {
+  it('deleting the redeemer takes the invite with it, rather than reviving it', () => {
+    const joiner = createUser('cascade-joiner');
+    const inv = createInvite(admin.id)!;
+    expect(consumeInvite(inv.token, joiner.id)).toBe(true);
+
+    expect(deleteUser(joiner.id)).toBe(true);
+
+    // The row is gone, so the token is unknown — NOT a row with a null redeemer
+    // that inviteStatus() would have read as live.
+    expect(getInvite(inv.token)).toBeNull();
+    expect(inviteStatus(inv.token).status).toBe('unknown');
+    expect(consumeInvite(inv.token, admin.id)).toBe(false);
+  });
+
+  it('deleting an unrelated user leaves a consumed invite alone', () => {
+    const joiner = createUser('cascade-bystander-joiner');
+    const bystander = createUser('cascade-bystander');
+    const inv = createInvite(admin.id)!;
+    consumeInvite(inv.token, joiner.id);
+
+    deleteUser(bystander.id);
+
+    expect(inviteStatus(inv.token).status).toBe('consumed');
+    expect(getInvite(inv.token)!.usedByUserId).toBe(joiner.id);
+  });
+
+  it('reads used_at as spent even if the redeemer id is gone', async () => {
+    const { default: db } = await import('./index.js');
+    // Belt and braces for the same invariant: used_by_user_id and used_at are
+    // written together, but only the id is a foreign key, so only the id can be
+    // rewritten out from under us. Forced here rather than produced by a
+    // deletion, since the constraint above now prevents that shape arising.
+    const inv = createInvite(admin.id)!;
+    consumeInvite(inv.token, invitee.id);
+    db.prepare(`UPDATE invite_tokens SET used_by_user_id = NULL WHERE token = ?`).run(inv.token);
+
+    expect(isInviteSpent(getInvite(inv.token)!)).toBe(true);
+    expect(inviteStatus(inv.token).status).toBe('consumed');
+    expect(consumeInvite(inv.token, admin.id)).toBe(false);
   });
 });

--- a/server/db/invites.ts
+++ b/server/db/invites.ts
@@ -90,6 +90,20 @@ export function deleteInvite(token: string): boolean {
   return info.changes > 0;
 }
 
+// An invite is spent if EITHER half of the consume is on the row. consumeInvite
+// writes used_by_user_id and used_at together, so under normal operation the two
+// always agree — but only the id is a foreign key, so only the id can be rewritten
+// out from under us by a user deletion. Reading both means a row that loses its
+// redeemer stays spent instead of turning back into a live link (#590), and it is
+// the one rule the admin list and the redemption path have to agree on, so they
+// share it rather than each re-deriving it.
+export function isInviteSpent(row: {
+  usedByUserId: number | null;
+  usedAt: string | null;
+}): boolean {
+  return row.usedByUserId != null || row.usedAt != null;
+}
+
 // Check status without mutating. Returns one of:
 //   { status: 'unknown' } — no row for this token
 //   { status: 'consumed' } — already redeemed
@@ -98,7 +112,7 @@ export function deleteInvite(token: string): boolean {
 export function inviteStatus(token: string): InviteStatusResult {
   const invite = getInvite(token);
   if (!invite) return { status: 'unknown' };
-  if (invite.usedByUserId != null) return { status: 'consumed' };
+  if (isInviteSpent(invite)) return { status: 'consumed' };
   if (invite.expiresAt && Date.parse(invite.expiresAt) < Date.now()) {
     return { status: 'expired' };
   }
@@ -106,15 +120,16 @@ export function inviteStatus(token: string): InviteStatusResult {
 }
 
 // Mark an invite consumed atomically. Returns true if we won the race; false
-// if it was already used or doesn't exist. The UPDATE guards on
-// used_by_user_id IS NULL so two simultaneous redemptions can't both succeed.
+// if it was already used or doesn't exist. The UPDATE guards on the same
+// spent-ness rule isInviteSpent() reads, so two simultaneous redemptions can't
+// both succeed AND a row whose redeemer was deleted can't be redeemed again.
 export function consumeInvite(token: string, userId: number): boolean {
   const info = db
     .prepare(
       `
     UPDATE invite_tokens
     SET used_by_user_id = ?, used_at = datetime('now')
-    WHERE token = ? AND used_by_user_id IS NULL
+    WHERE token = ? AND used_by_user_id IS NULL AND used_at IS NULL
   `,
     )
     .run(userId, token);

--- a/server/routes/admin.test.ts
+++ b/server/routes/admin.test.ts
@@ -399,15 +399,37 @@ describe('invites', () => {
     expect(create.body.invite.expiresAt).toBeTruthy();
   });
 
-  it('refuses to delete a consumed invite (audit history)', async () => {
+  it('a consumed invite can be cleared out of the list (#590)', async () => {
     const { createInvite, consumeInvite } = await import('../db/invites.js');
-    const { createUser } = await import('../db/users.js');
+    const { createUser, findUserById } = await import('../db/users.js');
     const consumer = createUser('invite-consumer');
     const invite = createInvite(admin.id, { expiresInDays: 7 })!;
     consumeInvite(invite.token, consumer.id);
 
     const res = await adminAgent.delete(`/api/admin/invites/${invite.token}`);
-    expect(res.status).toBe(409);
+    expect(res.status).toBe(200);
+
+    const list = await adminAgent.get('/api/admin/invites');
+    expect(list.body.invites.find((i: { token: string }) => i.token === invite.token)).toBeFalsy();
+    // Clearing the record doesn't touch the account it let in.
+    expect(findUserById(consumer.id)).toBeTruthy();
+  });
+
+  it('deleting the user who redeemed an invite does not revive it (#590)', async () => {
+    const { createInvite, consumeInvite } = await import('../db/invites.js');
+    const { createUser } = await import('../db/users.js');
+    const consumer = createUser('invite-revival-victim');
+    const invite = createInvite(admin.id, { expiresInDays: 7 })!;
+    consumeInvite(invite.token, consumer.id);
+
+    expect((await adminAgent.delete(`/api/admin/users/${consumer.id}`)).status).toBe(200);
+
+    // Before the fix this listed as a pending invite again — and it was: see
+    // auth.test.ts for the redemption attempt that the old shape let through.
+    const list = await adminAgent.get('/api/admin/invites');
+    expect(list.body.invites.find((i: { token: string }) => i.token === invite.token)).toBeFalsy();
+    const { inviteStatus } = await import('../db/invites.js');
+    expect(inviteStatus(invite.token).status).toBe('unknown');
   });
 
   it('404 on deleting an unknown invite', async () => {

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -13,7 +13,13 @@ import {
   setUserIdent,
 } from '../db/users.js';
 import type { User } from '../db/users.js';
-import { createInvite, listInvites, deleteInvite, getInvite } from '../db/invites.js';
+import {
+  createInvite,
+  listInvites,
+  deleteInvite,
+  getInvite,
+  isInviteSpent,
+} from '../db/invites.js';
 import ircManager from '../services/ircManager.js';
 import { presenceDiagnostics } from '../services/wsHub.js';
 import { isIdentdEnabled, isOidentdFileEnabled } from '../services/identd.js';
@@ -35,7 +41,7 @@ router.use('/networks', adminNetworksRouter);
 // invites.ts is still untyped — row shape inferred as any from the JS module
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function deriveInviteStatus(row: any): string {
-  if (row.usedByUserId != null) return 'consumed';
+  if (isInviteSpent(row)) return 'consumed';
   if (row.expiresAt && Date.parse(row.expiresAt) < Date.now()) return 'expired';
   return 'pending';
 }
@@ -319,15 +325,14 @@ router.delete('/invites/:token', (req: Request<{ token: string }>, res: Response
     res.status(400).json({ error: 'missing token' });
     return;
   }
-  // Refuse to delete consumed invites — they're audit history (which user
-  // joined via which admin's invitation). Pending/expired are fair game.
+  // Any invite can be removed, consumed ones included (#590). The list doubles
+  // as a record of who joined via whose invitation, but it is a management view
+  // and not an audit log — refusing the delete only left admins with a roster of
+  // spent links they had no way to clear. Deleting a consumed row cannot revive
+  // anything: the row IS the invite, so removing it makes the token unknown.
   const existing = getInvite(token);
   if (!existing) {
     res.status(404).json({ error: 'not found' });
-    return;
-  }
-  if (existing.usedByUserId != null) {
-    res.status(409).json({ error: 'cannot delete a consumed invite' });
     return;
   }
   deleteInvite(token);

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -325,11 +325,13 @@ router.delete('/invites/:token', (req: Request<{ token: string }>, res: Response
     res.status(400).json({ error: 'missing token' });
     return;
   }
-  // Any invite can be removed, consumed ones included (#590). The list doubles
-  // as a record of who joined via whose invitation, but it is a management view
-  // and not an audit log — refusing the delete only left admins with a roster of
-  // spent links they had no way to clear. Deleting a consumed row cannot revive
-  // anything: the row IS the invite, so removing it makes the token unknown.
+  // Any invite can be removed, consumed ones included (#590). The 409 that used
+  // to guard consumed rows called them audit history, but the list is a
+  // management view, not an audit log — and it cannot be one either way, since
+  // an invite now CASCADEs with the member it let in. Refusing the delete only
+  // left admins with a roster of spent links they had no way to clear. Removing
+  // a consumed row cannot revive anything: the row IS the invite, so deleting it
+  // makes the token unknown rather than pending.
   const existing = getInvite(token);
   if (!existing) {
     res.status(404).json({ error: 'not found' });

--- a/server/routes/auth.test.ts
+++ b/server/routes/auth.test.ts
@@ -316,6 +316,29 @@ describe('POST /api/auth/invite/:token/password', () => {
     });
     expect(reuse.status).toBe(404);
   });
+
+  it('deleting the user who redeemed an invite does not reopen the link (#590)', async () => {
+    const { findUserByUsername, deleteUser } = await import('../db/users.js');
+    const { createInvite } = await import('../db/invites.js');
+    const admin = findUserByUsername('firstadmin')!;
+    const invite = createInvite(admin.id, { expiresInDays: 1 })!;
+    const ok = await testRequest(app).post(`/api/auth/invite/${invite.token}/password`).send({
+      username: 'later-removed',
+      password: 'longenoughpw',
+    });
+    expect(ok.status).toBe(200);
+
+    deleteUser(findUserByUsername('later-removed')!.id);
+
+    // The redeemer column was ON DELETE SET NULL, so removing the account it let
+    // in handed the one-time link back to anyone still holding the URL.
+    const sneak = await testRequest(app).post(`/api/auth/invite/${invite.token}/password`).send({
+      username: 'sneaked-in',
+      password: 'longenoughpw',
+    });
+    expect(sneak.status).toBe(404);
+    expect(findUserByUsername('sneaked-in')).toBeFalsy();
+  });
 });
 
 // The native-app front door: password in, session token out, no browser needed.

--- a/vue_client/src/components/admin-panes/InvitesPane.test.ts
+++ b/vue_client/src/components/admin-panes/InvitesPane.test.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+// #590 gave the consumed rows a working control where a disabled em-dash used to
+// sit, and the two states now share one button whose label, tooltip, confirm text
+// and error message all branch on the row. That is exactly the label-vs-action
+// drift shape: a button that says "revoke" while doing something else, or that
+// reads the wrong row at click time, is invisible to any test of the handler
+// alone. Mount it and click.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+import { useAdminStore, type AdminInvite } from '../../stores/admin.js';
+import InvitesPane from './InvitesPane.vue';
+
+function invite(over: Partial<AdminInvite> & { token: string }): AdminInvite {
+  return {
+    url: `https://example.test/invite/${over.token}`,
+    status: 'pending',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    expiresAt: '2026-02-01T00:00:00.000Z',
+    usedAt: null,
+    usedByUsername: null,
+    ...over,
+  };
+}
+
+const PENDING = invite({ token: 'tok-pending' });
+const CONSUMED = invite({
+  token: 'tok-consumed',
+  status: 'consumed',
+  usedAt: '2026-01-05T00:00:00.000Z',
+  usedByUsername: 'newcomer',
+});
+
+let deleteInvite: ReturnType<typeof vi.fn<(token: string) => Promise<void>>>;
+
+// happy-dom ships no window.confirm, so there is nothing to spy on — install one.
+function stubConfirm(answer: boolean) {
+  // Typed with the message parameter so the recorded calls carry the prompt
+  // text these tests read back.
+  const fn = vi.fn<(message?: string) => boolean>((_message?: string) => answer);
+  window.confirm = fn as unknown as typeof window.confirm;
+  return fn;
+}
+
+function mountPane(invites: AdminInvite[]): VueWrapper {
+  const store = useAdminStore();
+  store.invites = invites;
+  store.invitesLoaded = true;
+  store.fetchInvites = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+  deleteInvite = vi.fn<(token: string) => Promise<void>>().mockResolvedValue(undefined);
+  store.deleteInvite = deleteInvite as unknown as typeof store.deleteInvite;
+  return mount(InvitesPane);
+}
+
+// The row action is the last button in each row.
+function rowButton(wrapper: VueWrapper, token: string) {
+  const row = wrapper.findAll('.invite-row').find((r) => r.text().includes(token));
+  if (!row) throw new Error(`no row for ${token}`);
+  const buttons = row.findAll('button');
+  return buttons[buttons.length - 1];
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  vi.restoreAllMocks();
+});
+
+describe('InvitesPane row action (#590)', () => {
+  it('offers a working control on a consumed invite, not a disabled placeholder', async () => {
+    const wrapper = mountPane([CONSUMED]);
+    const btn = rowButton(wrapper, 'tok-consumed');
+    expect(btn.text()).toBe('remove');
+    expect(btn.attributes('disabled')).toBeUndefined();
+  });
+
+  it('calls it revoke while the link can still be redeemed', () => {
+    const wrapper = mountPane([PENDING]);
+    expect(rowButton(wrapper, 'tok-pending').text()).toBe('revoke');
+  });
+
+  it('deletes the row it was clicked on, not whichever is active', async () => {
+    // Both rows present: the handler has to carry the row through, so a global
+    // read (or a stale closure) shows up here as the wrong token.
+    const wrapper = mountPane([PENDING, CONSUMED]);
+    stubConfirm(true);
+
+    await rowButton(wrapper, 'tok-consumed').trigger('click');
+    expect(deleteInvite).toHaveBeenCalledWith('tok-consumed');
+
+    await rowButton(wrapper, 'tok-pending').trigger('click');
+    expect(deleteInvite).toHaveBeenLastCalledWith('tok-pending');
+  });
+
+  it('warns about the link only when there is still a link to kill', async () => {
+    const wrapper = mountPane([PENDING, CONSUMED]);
+    const confirmed = stubConfirm(true);
+
+    await rowButton(wrapper, 'tok-pending').trigger('click');
+    expect(confirmed.mock.calls[0][0]).toMatch(/no longer be able to use it/);
+
+    await rowButton(wrapper, 'tok-consumed').trigger('click');
+    // Says who stays, so "remove" can't be read as removing the member.
+    expect(confirmed.mock.calls[1][0]).toMatch(/newcomer stays/);
+  });
+
+  it('does nothing when the confirm is dismissed', async () => {
+    const wrapper = mountPane([CONSUMED]);
+    stubConfirm(false);
+    await rowButton(wrapper, 'tok-consumed').trigger('click');
+    expect(deleteInvite).not.toHaveBeenCalled();
+  });
+});

--- a/vue_client/src/components/admin-panes/InvitesPane.vue
+++ b/vue_client/src/components/admin-panes/InvitesPane.vue
@@ -3,7 +3,9 @@
   SPDX-License-Identifier: MPL-2.0
 
   Admin panel → Invites. Generate one-time invite links, revoke pending ones, and
-  clear out spent ones once they're just clutter (#590). Split out of the old combined
+  clear out spent ones once they're just clutter (#590). A spent invite belongs to
+  the member it let in and is removed with them, so this list tracks live accounts
+  rather than standing as a permanent record. Split out of the old combined
   settings-panes/UsersPane so members and invites get their own admin tabs.
   Drives the same `admin` Pinia store; the route/sidebar gate this to admins.
 -->
@@ -12,8 +14,8 @@
   <section id="admin-invites" class="settings-pane">
     <h2>invites</h2>
     <p class="section-desc">
-      Invite friends with a one-time link. A link works once; consumed ones stay listed so you can
-      see who joined, until you remove them.
+      Invite friends with a one-time link. A link works once. Used ones stay listed showing who
+      joined, until you remove the invite or the member.
     </p>
     <p v-if="adminError" class="error inline">{{ adminError }}</p>
 
@@ -109,7 +111,7 @@ async function onDeleteInvite(invite: AdminInvite) {
   // at click time — the same label/action drift the menu work kept hitting.
   const spent = invite.status === 'consumed';
   const prompt = spent
-    ? `Remove this used invite? ${invite.usedByUsername ?? 'The user'} stays; only the record goes.`
+    ? `Remove this used invite? ${invite.usedByUsername ?? 'The member'} stays; only the record goes.`
     : 'Revoke this invite? Anyone holding the link will no longer be able to use it.';
   if (!confirm(prompt)) return;
   adminError.value = '';

--- a/vue_client/src/components/admin-panes/InvitesPane.vue
+++ b/vue_client/src/components/admin-panes/InvitesPane.vue
@@ -2,8 +2,8 @@
   Copyright (c) 2026 Brad Root
   SPDX-License-Identifier: MPL-2.0
 
-  Admin panel → Invites. Generate one-time invite links and revoke pending ones;
-  consumed invites are kept as an audit trail. Split out of the old combined
+  Admin panel → Invites. Generate one-time invite links, revoke pending ones, and
+  clear out spent ones once they're just clutter (#590). Split out of the old combined
   settings-panes/UsersPane so members and invites get their own admin tabs.
   Drives the same `admin` Pinia store; the route/sidebar gate this to admins.
 -->
@@ -12,7 +12,8 @@
   <section id="admin-invites" class="settings-pane">
     <h2>invites</h2>
     <p class="section-desc">
-      Invite friends with a one-time link. Consumed invites are kept below as an audit trail.
+      Invite friends with a one-time link. A link works once; consumed ones stay listed so you can
+      see who joined, until you remove them.
     </p>
     <p v-if="adminError" class="error inline">{{ adminError }}</p>
 
@@ -39,16 +40,19 @@
           <template v-else-if="inv.expiresAt">expires {{ formatRelative(inv.expiresAt) }}</template>
           <template v-else>no expiry</template>
         </span>
+        <!-- Two words for two different acts: revoking kills a link someone could
+             still redeem, removing only clears the record of one already spent. -->
         <button
-          v-if="inv.status !== 'consumed'"
           class="link danger"
           :disabled="adminBusy"
-          @click="onRevokeInvite(inv)"
+          :title="
+            inv.status === 'consumed'
+              ? 'remove this record — the link is already spent'
+              : 'revoke this link so it can no longer be redeemed'
+          "
+          @click="onDeleteInvite(inv)"
         >
-          revoke
-        </button>
-        <button v-else class="link" disabled title="consumed invites are kept as an audit trail">
-          —
+          {{ inv.status === 'consumed' ? 'remove' : 'revoke' }}
         </button>
       </li>
     </ul>
@@ -100,14 +104,20 @@ async function onCreateInvite() {
   }
 }
 
-async function onRevokeInvite(invite: AdminInvite) {
-  if (!confirm(`Revoke this invite?`)) return;
+async function onDeleteInvite(invite: AdminInvite) {
+  // Take the decision from the row we were handed, not by re-reading the store
+  // at click time — the same label/action drift the menu work kept hitting.
+  const spent = invite.status === 'consumed';
+  const prompt = spent
+    ? `Remove this used invite? ${invite.usedByUsername ?? 'The user'} stays; only the record goes.`
+    : 'Revoke this invite? Anyone holding the link will no longer be able to use it.';
+  if (!confirm(prompt)) return;
   adminError.value = '';
   adminBusy.value = true;
   try {
     await adminStore.deleteInvite(invite.token);
   } catch (e: any) {
-    adminError.value = e.message || 'failed to revoke invite';
+    adminError.value = e.message || (spent ? 'failed to remove invite' : 'failed to revoke invite');
   } finally {
     adminBusy.value = false;
   }


### PR DESCRIPTION
Closes #590.

## The bug

`invite_tokens.used_by_user_id` carried `ON DELETE SET NULL`. Delete a user and the invite they had redeemed came back to life: the id went NULL, `inviteStatus()` found no redeemer and reported `valid`, and a one-time link the admin considered spent worked again for whoever still had the URL.

On a self-hosted instance, removing an account reopened the door it came in through — and the invite reappeared in the admin list as pending, so the admin could see it happen and had no idea why.

Reproduced end-to-end before fixing. With the fix reverted, `POST /api/auth/invite/:token/password` on a spent link returns **200** and creates the account.

## The fix

Three layers, because the constraint alone isn't enough:

| | |
|---|---|
| **Constraint** | `ON DELETE CASCADE` — an invite dies with either account it describes. SQLite can't alter a foreign key, so existing DBs get a `schemaVersion`-20 table rebuild. |
| **Repair** | The migration purges invites this already resurrected. `consumeInvite` writes `used_by_user_id` and `used_at` together, so a row with `used_at` set and no redeemer is unambiguous. Flipping the constraint only stops the *next* revival. |
| **Read rule** | `inviteStatus()` and `consumeInvite()` treat `used_at` as spent too. Both columns record one fact, but only the id is a foreign key — so only the id can be rewritten out from under us. |

The rule the redemption path and the admin list must agree on is now shared as `isInviteSpent()` rather than re-derived in each.

Purging rather than keeping those rows is what makes history *consistent*: from here on a user deletion takes the invite with it, so they're exactly the rows that would already be gone had the constraint been right at the time. Only a count is logged — an invite token is a credential.

## The issue's other half

Consumed invites can now be deleted. The 409 called them audit history, but the list is a management view, and it can't be an audit log either way now that an invite cascades with its member. Refusing the delete just left admins with a roster of spent links they couldn't clear.

The row's disabled `—` becomes a real button, labelled for what it does: **revoke** kills a link someone could still redeem, **remove** only clears the record of one already spent.

## Tests

- `inviteRevivalMigration.test.ts` (new) — boots the real schema, downgrades *only* `invite_tokens` to the pre-v20 shape, re-imports. A hand-written v19 fixture isn't possible here: several tables reach their current shape through version-gated rebuilds, so pinning an old version skips the migrations that made them current.
- `invites.test.ts` — the cascade, a bystander deletion leaving a consumed invite alone, and the `used_at` rule on a forced row shape.
- `auth.test.ts` — the end-to-end redemption attempt. This is the one that returns 200 without the fix.
- `admin.test.ts` — a consumed invite can be cleared; the member survives it.
- `InvitesPane.test.ts` (new) — the label/action branch, and that a click deletes the row it was clicked on.

Each new test was verified to go red against the pre-fix code, including breaking the pane on purpose to confirm the component test catches label drift and a wrong-row read.

Full suite green: 283 files / 4027 tests. `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)