### PR TITLE
Report a failed /ctcp where it was issued (#821)

### DIFF
--- a/server/services/ctcpWiring.test.ts
+++ b/server/services/ctcpWiring.test.ts
@@ -693,6 +693,56 @@ describe('a CTCP claims a failure only while it is the last thing sent (#821)', 
     }
   });
 
+  it('yields to a /whois issued after it', () => {
+    // Copilot, PR #823. A nick-only command records a lastNickIntent but is not
+    // a send, so the lastUserSendAt gate is blind to it — and the channel bucket
+    // CONSUMES that intent before the CTCP bucket runs, so the signal is gone by
+    // the time we look. The reachable case: bob exists and ignores the probe,
+    // then quits, then /whois bob draws the 401. That 401 answers the whois.
+    vi.useFakeTimers();
+    try {
+      const { conn, ctcpLines } = harness();
+      conn.client.raw = vi.fn<(line: string) => void>();
+      conn.sendCtcpRequest('#anime', 'bob', 'CLIENTINFO', '');
+      const before = ctcpLines().length;
+      const publish = vi.fn<(event: unknown) => void>();
+      conn.publish = publish;
+
+      vi.advanceTimersByTime(2000);
+      conn.raw('WHOIS bob');
+      conn.client.emit('irc error', { error: 'no_such_nick', nick: 'bob' });
+
+      expect(ctcpLines().slice(before)).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('still claims a request issued AFTER that /whois', () => {
+    // Per-entry, not a blanket refusal: the whois only disqualifies the requests
+    // that predate it. Otherwise one /whois would poison the routing for every
+    // subsequent /ctcp to that nick inside the window.
+    vi.useFakeTimers();
+    try {
+      const { conn, ctcpLines } = harness();
+      conn.client.raw = vi.fn<(line: string) => void>();
+      conn.sendCtcpRequest('#anime', 'bob', 'CLIENTINFO', '');
+      vi.advanceTimersByTime(1000);
+      conn.raw('WHOIS bob');
+      vi.advanceTimersByTime(1000);
+      conn.sendCtcpRequest('#manga', 'bob', 'VERSION', '');
+      const before = ctcpLines().length;
+
+      conn.client.emit('irc error', { error: 'no_such_nick', nick: 'bob' });
+
+      expect(said(ctcpLines().slice(before))).toEqual([
+        { target: '#manga', text: "bob isn't on this network." },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('stops claiming once the send window has passed, though the reply TTL has not', () => {
     // The two windows are deliberately different lengths: a reply may be slow,
     // a refusal comes back on the same round trip. An entry a peer never

--- a/server/services/ctcpWiring.test.ts
+++ b/server/services/ctcpWiring.test.ts
@@ -17,6 +17,7 @@ import { createUser } from '../db/users.js';
 import { createNetwork } from '../db/networks.js';
 import { APP_NAME, APP_VERSION } from '../utils/userAgent.js';
 import settingsService from './settingsService.js';
+import * as buffers from '../db/buffers.js';
 import ircManager from './ircManager.js';
 
 // The default ctcp.version template (`${name} ${version}`) expands to this.
@@ -460,5 +461,161 @@ describe('outbound CTCP needs a writable connection', () => {
     const sendCtcpRequest = stub('connected');
     expect(ircManager.ctcpRequest(1, 1, '#chan', 'bob', 'PING', '')).toBe(true);
     expect(sendCtcpRequest).toHaveBeenCalledWith('#chan', 'bob', 'PING', '');
+  });
+});
+
+// #821. The exchange already routes its two happy halves to the buffer the
+// command was typed in — the "→ CTCP VERSION to bob" echo and, via
+// ctcpOutstanding, the reply. Failures consulted none of it and routed by nick,
+// so the half that says "you tried" and the half that says "it failed" landed in
+// different buffers, and WHICH buffer depended on why it failed.
+describe('a failed /ctcp reports where it was issued (#821)', () => {
+  type Lines = () => Array<{ target: string; text: string }>;
+
+  // ctcpLines() hands back whole publish events; assertions here only care where
+  // a line went and what it said.
+  const said = (lines: Array<{ target: string; text: string }>) =>
+    lines.map((l) => ({ target: l.target, text: l.text }));
+
+  // Sends a /ctcp from #anime, then hands back only the lines that came after,
+  // so the outbound echo doesn't have to be filtered out of every assertion.
+  function issued(conn: IrcConnection, ctcpLines: Lines) {
+    conn.sendCtcpRequest('#anime', 'bob', 'VERSION', '');
+    const before = ctcpLines().length;
+    return () => said(ctcpLines().slice(before));
+  }
+
+  it('puts the echo and the failure in the same buffer', () => {
+    const { conn, ctcpLines } = harness();
+    conn.sendCtcpRequest('#anime', 'bob', 'VERSION', '');
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'bob' });
+
+    expect(said(ctcpLines())).toEqual([
+      { target: '#anime', text: '→ CTCP VERSION to bob' },
+      { target: '#anime', text: "bob isn't on this network." },
+    ]);
+  });
+
+  it('says it in the issuing buffer even when a DM with that nick exists', () => {
+    // The pre-fix split: with DM history the 401 fell to the DM-miss bucket, so
+    // the attempt showed in #anime and the outcome in the bob query.
+    const { conn, ctcpLines } = harness();
+    const after = issued(conn, ctcpLines);
+    conn.recentConversationalSend = (() => true) as never;
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'bob' });
+
+    expect(after()).toEqual([{ target: '#anime', text: "bob isn't on this network." }]);
+    expect(publish).not.toHaveBeenCalled(); // nothing landed in the bob query
+  });
+
+  it('routes a 531 to the same place as a 401 — the whole point', () => {
+    // ⚠ The two failure paths must move together. Fixing only the 401 is worse
+    // than fixing neither: one command would then report in two different
+    // buffers depending on whether the nick was absent or just refusing.
+    const { conn, ctcpLines } = harness();
+    const after = issued(conn, ctcpLines);
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('irc error', {
+      error: 'cannot_send_to_user',
+      nick: 'bob',
+      reason: 'You must be voiced',
+    });
+
+    expect(after()).toEqual([
+      { target: '#anime', text: 'Message not delivered — You must be voiced' },
+    ]);
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('still marks the target unsendable when it redirects a 531', () => {
+    // The redirect changes where the failure is SHOWN; the speak-permission mark
+    // that stops us firing typing TAGMSGs at a target that bounces them is a
+    // separate job and must survive it (#283).
+    const { conn } = harness();
+    conn.sendCtcpRequest('#anime', 'bob', 'VERSION', '');
+    conn.client.emit('irc error', { error: 'cannot_send_to_user', nick: 'bob' });
+    expect(conn.unsendableTargets.has('bob')).toBe(true);
+  });
+
+  it('consumes the request, so a later unrelated 401 is not claimed by it', () => {
+    // The hazard takeCommandChannel had to learn in #815: one command, one
+    // bounce. A spent entry left in the map lies in wait.
+    const { conn, ctcpLines } = harness();
+    const after = issued(conn, ctcpLines);
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'bob' });
+    expect(after()).toHaveLength(1);
+
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+    conn.client.say = vi.fn<(target: string, message: string) => void>(); // no real socket
+    conn.say('bob', 'hi'); // a real message, minutes later
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'bob' });
+
+    expect(after()).toHaveLength(1); // nothing new in #anime
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ target: 'bob' }));
+  });
+
+  it('pairs a burst of failures with the requests oldest-first, across types', () => {
+    // ctcpOutstanding is keyed by nick AND type; a 401 names only the nick. Each
+    // CTCP is its own PRIVMSG and draws its own numeric, so the Nth failure
+    // belongs to the Nth request regardless of which type it was.
+    const { conn, ctcpLines } = harness();
+    conn.sendCtcpRequest('#anime', 'bob', 'VERSION', '');
+    conn.sendCtcpRequest('#manga', 'bob', 'TIME', '');
+    const before = ctcpLines().length;
+
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'bob' });
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'bob' });
+
+    expect(
+      ctcpLines()
+        .slice(before)
+        .map((l) => l.target),
+    ).toEqual(['#anime', '#manga']);
+  });
+
+  it('leaves a 401 with no outstanding CTCP alone', () => {
+    // The gate that keeps this off every unrelated failure.
+    const { conn, ctcpLines } = harness();
+    conn.recentConversationalSend = (() => true) as never;
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'stranger' });
+
+    expect(ctcpLines()).toHaveLength(0);
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ target: 'stranger' }));
+  });
+
+  it('falls back to the server buffer when the issuing buffer was closed', () => {
+    // Same guard the reply path uses, and the reason it exists: wsHub drops an
+    // ephemeral event aimed at a closed buffer, so a /ctcp issued in a channel
+    // the user then closed would end in silence rather than in the server
+    // buffer. Really closes it rather than stubbing the lookup — the guard is
+    // shared with the reply path, so what needs proving is that the FAILURE path
+    // goes through it at all.
+    const { conn, ctcpLines } = harness();
+    buffers.ensureExists(1, 1, '#closed-later');
+    conn.sendCtcpRequest('#closed-later', 'bob', 'VERSION', '');
+    const before = ctcpLines().length;
+    expect(buffers.close(1, 1, '#closed-later')).toBe(true);
+
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'bob' });
+
+    expect(said(ctcpLines().slice(before))).toEqual([
+      { target: ':server:1', text: "bob isn't on this network." },
+    ]);
+  });
+
+  it('does not touch DCC, which reports to the nick on purpose', () => {
+    // DCC calls surfaceCtcp(nick, …) in many places and never records an
+    // outstanding request, so there is nothing here for a failure to claim.
+    const { conn } = harness();
+    expect(conn.takeCtcpIssuer('bob')).toBeNull();
   });
 });

--- a/server/services/ctcpWiring.test.ts
+++ b/server/services/ctcpWiring.test.ts
@@ -619,3 +619,137 @@ describe('a failed /ctcp reports where it was issued (#821)', () => {
     expect(conn.takeCtcpIssuer('bob')).toBeNull();
   });
 });
+
+// Applying the #821 review: the claim on a failure numeric has to be BOUNDED,
+// or an outstanding CTCP quietly becomes an attractor for every later failure
+// naming the same target.
+describe('a CTCP claims a failure only while it is the last thing sent (#821)', () => {
+  const said = (lines: Array<{ target: string; text: string }>) =>
+    lines.map((l) => ({ target: l.target, text: l.text }));
+
+  it('yields to a real message sent after it', () => {
+    // The #434 rule. /ctcp bob from #anime, bob ignores it (they exist), then
+    // the user messages bob and bob has since quit. That 401 answers the
+    // MESSAGE, so it belongs in bob's query as the persisted row #817 puts
+    // there — not pulled into #anime as transient CTCP status.
+    const { conn, ctcpLines } = harness();
+    conn.sendCtcpRequest('#anime', 'bob', 'CLIENTINFO', '');
+    const before = ctcpLines().length;
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+    conn.client.say = vi.fn<(target: string, message: string) => void>();
+
+    conn.say('bob', 'you there?');
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'bob' });
+
+    expect(ctcpLines().slice(before)).toHaveLength(0);
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ type: 'error', target: 'bob' }));
+  });
+
+  it('yields to a real message in a channel it was aimed at', () => {
+    // Same shape with a channel target: /ctcp #anime is legal, and a later
+    // refusal to SPEAK in #anime must stay the inline error #283 put there.
+    const { conn, ctcpLines } = harness();
+    conn.upsertChannel('#anime');
+    conn.sendCtcpRequest(':server:1', '#anime', 'VERSION', '');
+    const before = ctcpLines().length;
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+    conn.client.say = vi.fn<(target: string, message: string) => void>();
+
+    conn.say('#anime', 'hello');
+    conn.client.emit('irc error', {
+      error: 'cannot_send_to_channel',
+      channel: '#anime',
+      reason: 'You need voice',
+    });
+
+    expect(ctcpLines().slice(before)).toHaveLength(0);
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', target: '#anime' }),
+    );
+  });
+
+  it('pairs the failure with the LIVE request, not a stale one of another type', () => {
+    // The per-entry bound, which the last-send window alone does not give: a
+    // second /ctcp refreshes "last thing sent here", so without it the
+    // oldest-first scan would hand this 401 to the 20s-old VERSION request and
+    // report in the buffer that one came from.
+    vi.useFakeTimers();
+    try {
+      const { conn, ctcpLines } = harness();
+      conn.sendCtcpRequest('#anime', 'bob', 'VERSION', '');
+      vi.advanceTimersByTime(20_000); // VERSION is now past the send window
+      conn.sendCtcpRequest('#manga', 'bob', 'TIME', '');
+      const before = ctcpLines().length;
+
+      conn.client.emit('irc error', { error: 'no_such_nick', nick: 'bob' });
+
+      expect(said(ctcpLines().slice(before))).toEqual([
+        { target: '#manga', text: "bob isn't on this network." },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops claiming once the send window has passed, though the reply TTL has not', () => {
+    // The two windows are deliberately different lengths: a reply may be slow,
+    // a refusal comes back on the same round trip. An entry a peer never
+    // answered must stop catching unrelated failures long before it stops
+    // being able to catch its own late reply.
+    vi.useFakeTimers();
+    try {
+      const { conn, ctcpLines } = harness();
+      conn.sendCtcpRequest('#anime', 'bob', 'CLIENTINFO', '');
+      const before = ctcpLines().length;
+      const publish = vi.fn<(event: unknown) => void>();
+      conn.publish = publish;
+
+      vi.advanceTimersByTime(30_000); // past the 15s send window, inside the 60s TTL
+      conn.client.emit('irc error', { error: 'no_such_nick', nick: 'bob' });
+
+      expect(ctcpLines().slice(before)).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('CTCP routing survives the shapes clients actually send (#821 review)', () => {
+  it('routes a multi-token type, instead of building a key nothing can match', () => {
+    // Only the web client guarantees a single-token type; iOS and MCP pass
+    // through whatever was typed. `PING FOO` used to build the key
+    // `bob PING FOO`, which no lookup could match — costing the reply AND the
+    // failure their routing, silently.
+    const { conn, ctcpRequest, ctcpLines } = harness();
+    conn.sendCtcpRequest('#anime', 'bob', 'PING FOO', '');
+
+    // The spare word becomes args, exactly as parseCtcp would split it inbound.
+    expect(ctcpRequest).toHaveBeenCalledWith('bob', 'PING', 'FOO');
+
+    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'bob' });
+    expect(ctcpLines().map((l) => l.target)).toEqual(['#anime', '#anime']);
+  });
+
+  it('carries an outstanding request through a /nick, for the reply and the failure', () => {
+    // The re-key beside this one looked up the bare nick, but every key is
+    // `<nick-lc> <TYPE>` — so the queue never followed a rename at all.
+    const { conn, ctcpLines } = harness();
+    conn.sendCtcpRequest('#anime', 'bob', 'VERSION', '');
+    conn.client.emit('nick', { nick: 'bob', new_nick: 'rob' });
+
+    conn.client.emit('ctcp response', {
+      nick: 'rob',
+      ident: 'b',
+      hostname: 'h',
+      target: 'alice',
+      type: 'VERSION',
+      message: 'VERSION SomeClient 1.0',
+    });
+
+    const last = ctcpLines()[ctcpLines().length - 1];
+    expect(last.target).toBe('#anime'); // not the server buffer as unsolicited
+    expect(last.text).toContain('SomeClient 1.0');
+  });
+});

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1163,14 +1163,21 @@ describe('refused-message handler routing (#283)', () => {
     expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: 'fartboy' }));
   });
 
-  it('still surfaces a refused CTCP, which is what marks the send in the first place', () => {
+  it('still surfaces a refused CTCP — in the buffer it was issued from', () => {
     // The guard above must not go so far as to silence 531 for a CTCP:
     // handleSendRejection reads recentUserSend to tell a real send from a
     // typing bounce, and a CTCP is a real send.
+    //
+    // ⚠ Where it surfaces changed in #821. This used to publish a persisted
+    // error into the fartboy DM — one of the three different places the same
+    // command's failure could land — and now joins its own echo and reply in the
+    // issuing buffer. The assertion that matters is unchanged: not silenced.
     const conn = makeConn();
     conn.client.ctcpRequest = vi.fn<(target: string, type: string, payload?: string) => void>();
     const publish = vi.fn<(event: unknown) => void>();
+    const publishEphemeral = vi.fn<(event: Record<string, unknown>) => void>();
     conn.publish = publish;
+    conn.publishEphemeral = publishEphemeral;
 
     conn.sendCtcpRequest(':server:1', 'fartboy', 'VERSION', '');
     expect(conn.recentUserSend('fartboy')).toBe(true);
@@ -1181,7 +1188,14 @@ describe('refused-message handler routing (#283)', () => {
       nick: 'fartboy',
       reason: 'They are blocking messages',
     });
-    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ target: 'fartboy' }));
+    expect(publishEphemeral).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'ctcp',
+        target: ':server:1',
+        text: 'Message not delivered — They are blocking messages',
+      }),
+    );
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: 'fartboy' }));
   });
 
   it('forgets the send attribution across a reconnect, so a stale 401 stays put', () => {

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1372,6 +1372,71 @@ describe('refused-message handler routing (#283)', () => {
       }),
     );
   });
+
+  // Found by QA against a real ergo 2.18, not by reading the RFC: 477 has a
+  // THIRD meaning. A DM refused because the recipient only accepts messages from
+  // registered users (+R) answers 477 naming the NICK — where the code, and
+  // issue #821, both expected 531.
+  //
+  //   :ergo.test 477 me blocker :You must be registered to send a direct message
+  //
+  // params[1] is where a channel normally sits, so this raised a JOIN toast, in
+  // the peer's DM, telling the user "This channel requires a registered
+  // nickname" about a person.
+  it('treats a 477 that names a nick as a send rejection, not a join failure', () => {
+    const conn = makeConn();
+    const publish = vi.fn<(event: unknown) => void>();
+    const publishEphemeral = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+    conn.publishEphemeral = publishEphemeral;
+    conn.client.say = vi.fn<(target: string, message: string) => void>();
+    conn.say('blocker', 'hi'); // marks the send, so the rejection is attributable
+
+    conn.client.emit('unknown command', {
+      command: '477',
+      params: ['me', 'blocker', 'You must be registered to send a direct message to this user'],
+    });
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        target: 'blocker',
+        text: 'Message not delivered — You must be registered to send a direct message to this user',
+      }),
+    );
+    // Nothing can be joined that isn't a channel, so no join toast may fire.
+    expect(publishEphemeral).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'join-error' }),
+    );
+  });
+
+  it('routes a nick-targeted 477 for a /ctcp back to the issuing buffer', () => {
+    // The #821 rule has to hold for every way a CTCP can be refused, or the same
+    // command still reports in two places depending on which numeric the ircd
+    // happens to use — and on ergo this is the one it uses.
+    const conn = makeConn();
+    conn.upsertChannel('#anime');
+    conn.client.ctcpRequest = vi.fn<(target: string, type: string, payload?: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    const publishEphemeral = vi.fn<(event: Record<string, unknown>) => void>();
+    conn.publish = publish;
+    conn.publishEphemeral = publishEphemeral;
+
+    conn.sendCtcpRequest('#anime', 'blocker', 'VERSION', '');
+    conn.client.emit('unknown command', {
+      command: '477',
+      params: ['me', 'blocker', 'You must be registered to send a direct message to this user'],
+    });
+
+    expect(publishEphemeral).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'ctcp',
+        target: '#anime',
+        text: 'Message not delivered — You must be registered to send a direct message to this user',
+      }),
+    );
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: 'blocker' }));
+  });
 });
 
 // identd must be wired to the *pre-TLS* connect event. The IRC server fires its

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1048,7 +1048,8 @@ export class IrcConnection {
     c.on('unknown command', (cmd: { command?: string; params?: string[] }) => {
       const command = (cmd?.command || '').toString();
       const params = Array.isArray(cmd?.params) ? (cmd.params as string[]) : [];
-      // These numerics arrive as [nick, #channel, reason].
+      // These numerics arrive as [nick, <target>, reason] — usually a channel,
+      // but see the nick case below.
       const channel = typeof params[1] === 'string' ? params[1] : '';
       const reason = params[params.length - 1] || null;
       // ERR_NEEDREGGEDNICK (477) to a channel we're already in is a speak
@@ -1059,14 +1060,29 @@ export class IrcConnection {
         this.handleSendRejection(channel, reason, { command, params });
         return;
       }
+      // ⚠ 477 has a THIRD meaning, found by QA against ergo 2.18 (#821): a DM
+      // refused because the recipient takes messages only from registered users
+      // (+R) answers 477 naming the NICK, where 531 might be expected. Nothing
+      // can be joined that isn't a channel, so a 477 whose target is a nick
+      // cannot be a join failure at all — it is a send rejection, and routing it
+      // as one is what puts it in the DM (or, for a /ctcp, back in the buffer the
+      // command came from) instead of raising "This channel requires a registered
+      // nickname" as a join toast against a person.
+      if (channel && !isChannelTarget(channel) && joinRejectionMessage(command)) {
+        this.handleSendRejection(channel, reason, { command, params });
+        return;
+      }
       // Channel-join rejections irc-framework doesn't model (476/477) arrive
       // here too. Route them to the channel as an ephemeral toast so the failure
       // surfaces where the user tried to join, not buried in the server buffer
       // (#260). The client never opened the buffer (it waits for channel-joined),
       // so this is toast-only — the raw line is still logged to the server buffer
       // by the 'raw' handler, which is the additive authentic record.
+      // Gated on the target really being a channel: a join rejection names one by
+      // definition, and the branch above has already claimed the nick-targeted
+      // 477. Without the gate this is what aimed a "couldn't join" toast at a DM.
       const joinMsg = joinRejectionMessage(command);
-      if (joinMsg && channel) {
+      if (joinMsg && channel && isChannelTarget(channel)) {
         this.publishEphemeral({
           type: 'join-error',
           target: channel,

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2731,6 +2731,13 @@ export class IrcConnection {
       // aimed at a named channel, seconds ago — against "we have DM history
       // with this nick at some point in the past".
       if (tag === 'no_such_nick' && eventNick) {
+        // Read before takeCommandChannel consumes it: a nick-only command
+        // (/whois, /whowas) records an intent but is not a SEND, so
+        // takeCtcpIssuer's "is the CTCP still the last move here" gate — which
+        // reads lastUserSendAt — cannot see it on its own. Both maps record
+        // moves on a nick; the rule is only true to its own statement if it
+        // consults both (Copilot, PR #823).
+        const nickIntentAt = this.lastNickIntent.get(eventNick.toLowerCase())?.at ?? null;
         const commandChannel = this.takeCommandChannel(eventNick);
         const joined = commandChannel ? this.channelState(commandChannel) : undefined;
         if (joined) {
@@ -2753,7 +2760,7 @@ export class IrcConnection {
         // echo and the reply are both transient status. A persisted error row
         // would outlive the echo that gives it meaning and strand "bob isn't on
         // this network." in a channel after a reload.
-        const ctcpIssuer = this.takeCtcpIssuer(eventNick);
+        const ctcpIssuer = this.takeCtcpIssuer(eventNick, nickIntentAt);
         if (ctcpIssuer) {
           this.surfaceCtcp(ctcpIssuer, `${eventNick} isn't on this network.`);
           return;
@@ -3902,7 +3909,13 @@ export class IrcConnection {
     }
   }
 
-  takeCtcpIssuer(nick: string): string | null {
+  //
+  // `newerMoveAt` is the timestamp of a non-send move on this nick (a /whois),
+  // which the lastUserSendAt gate above is blind to. A request older than it is
+  // no longer the user's last move, so it must not claim this numeric — see the
+  // 401 bucket. Per-entry rather than a blanket refusal: with two requests
+  // outstanding and the whois between them, the NEWER one is still the answer.
+  takeCtcpIssuer(nick: string, newerMoveAt: number | null = null): string | null {
     const now = Date.now();
     this.pruneCtcpOutstanding(now);
     const lower = nick.toLowerCase();
@@ -3933,6 +3946,7 @@ export class IrcConnection {
       if (key.slice(0, key.lastIndexOf(' ')) !== lower) continue;
       const head = queue[0]; // each queue is already oldest-first
       if (head && now - head.sentAt > SEND_REJECTION_ATTRIBUTION_MS) continue;
+      if (head && newerMoveAt != null && head.sentAt < newerMoveAt) continue;
       if (head && head.sentAt < bestAt) {
         bestAt = head.sentAt;
         bestKey = key;

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2321,6 +2321,7 @@ export class IrcConnection {
       if (!isSelfNick) {
         this.markPeerEvent(eventNick, 'offline');
         this.markPeerEvent(eventNewNick, 'online');
+        this.rekeyCtcpOutstanding(eventNick, eventNewNick);
         this.renameDmForNickChange(eventNick, eventNewNick, userhost, event.time);
       }
     });
@@ -3226,7 +3227,13 @@ export class IrcConnection {
       // Per-target in-memory state follows the buffer. Each map is keyed by
       // the folded target; leaving an entry behind resurrects the exact bug
       // class renameChannel's comment catalogues (a stale can't-speak-here
-      // flag, a leaked one-shot WHO suppression, a stranded CTCP queue).
+      // flag, a leaked one-shot WHO suppression).
+      //
+      // ⚠ The outstanding-CTCP queue is NOT one of these, though it used to be
+      // listed here. It keys on the nick as ADDRESSED, not on a buffer, and a
+      // /ctcp can be issued from a channel with no DM at all — so it re-keys
+      // from the 'nick' handler, which fires for every peer rename rather than
+      // only the ones that rename a DM. See rekeyCtcpOutstanding.
       if (this.unsendableTargets.delete(oldLower)) this.unsendableTargets.add(newLower);
       const lastSend = this.lastUserSendAt.get(oldLower);
       if (lastSend !== undefined) {
@@ -3242,11 +3249,6 @@ export class IrcConnection {
       // and the stale entry it leaves can only ever suppress a channel
       // attribution, which is the safe direction. It expires on its own window
       // and is cleared wholesale by resetSendState.
-      const ctcpQueue = this.ctcpOutstanding.get(oldLower);
-      if (ctcpQueue) {
-        this.ctcpOutstanding.delete(oldLower);
-        this.ctcpOutstanding.set(newLower, ctcpQueue);
-      }
       const hint = this.e2eHintAt.get(oldLower);
       if (hint !== undefined) {
         this.e2eHintAt.delete(oldLower);
@@ -3869,17 +3871,68 @@ export class IrcConnection {
   // request. Each CTCP is its own PRIVMSG and draws its own numeric back, so
   // oldest-first pairs a burst of failures with the requests in the order they
   // were sent — the same FIFO discipline handleInboundCtcpReply uses per type.
+  // Follow a renamed peer, so a request we sent to their old nick still matches
+  // the reply that comes back from the new one — and so a failure naming them
+  // still finds the buffer it was issued from.
+  //
+  // ⚠ Keys are `<nick-lc> <TYPE>`, not the bare nick. The re-key this replaces
+  // read `ctcpOutstanding.get(oldNick)`, a key that cannot exist, so the queue
+  // never followed a rename at all. A rename ONTO a nick we already have
+  // requests out to merges rather than clobbers, re-sorted by send time so the
+  // FIFO pairing both consumers rely on still holds.
+  rekeyCtcpOutstanding(oldNick: string, newNick: string): void {
+    const oldLower = oldNick.toLowerCase();
+    const newLower = newNick.toLowerCase();
+    if (oldLower === newLower) return;
+    // Collected before mutating: the loop below both deletes and inserts keys,
+    // and a Map iterator walks entries added mid-iteration.
+    const moving: string[] = [];
+    for (const key of this.ctcpOutstanding.keys()) {
+      if (key.slice(0, key.lastIndexOf(' ')) === oldLower) moving.push(key);
+    }
+    for (const key of moving) {
+      const queue = this.ctcpOutstanding.get(key);
+      if (!queue) continue;
+      const moved = this.ctcpKey(newLower, key.slice(key.lastIndexOf(' ') + 1));
+      this.ctcpOutstanding.delete(key);
+      const existing = this.ctcpOutstanding.get(moved);
+      const merged = existing ? [...existing, ...queue] : queue;
+      merged.sort((a, b) => a.sentAt - b.sentAt);
+      this.ctcpOutstanding.set(moved, merged);
+    }
+  }
+
   takeCtcpIssuer(nick: string): string | null {
     const now = Date.now();
     this.pruneCtcpOutstanding(now);
     const lower = nick.toLowerCase();
+    // ⚠ Claim only while the CTCP is still the user's LAST move on this target
+    // — the #434 rule, and for the same reason it had to be learned there: a
+    // nick's failure numeric is ambiguous the moment you do two things with the
+    // nick. sendCtcpRequest records a NON-conversational send, and say / action /
+    // notice / multiline overwrite that with a conversational one, so this reads
+    // "the last thing sent here was a probe, not a message". Without it a real
+    // /msg to a nick who quit mid-probe would have its 401 pulled into the CTCP's
+    // buffer as transient status, losing the persisted row #817 puts in the query
+    // — and a plain message refused in a channel we'd CTCP'd would lose the
+    // inline error #283 puts there.
+    const lastSend = this.lastUserSendAt.get(lower);
+    if (!lastSend || lastSend.conversational) return null;
+    // ⚠ And only inside the SEND window, not the 60s reply TTL. A reply may
+    // legitimately be slow; a refusal comes back on the same round trip, so a
+    // numeric arriving a minute later is not this request's answer. The entry
+    // lives longer than the claim on purpose: a peer that silently ignores an
+    // unsupported type leaves one sitting there, and it must stop being able to
+    // catch an unrelated failure long before it stops being able to catch a reply.
+    if (now - lastSend.at > SEND_REJECTION_ATTRIBUTION_MS) return null;
     let bestKey: string | null = null;
     let bestAt = Infinity;
     for (const [key, queue] of this.ctcpOutstanding) {
-      // Keys are `<nick-lc> <TYPE>` and neither half can contain a space, so
-      // the last space splits them unambiguously.
+      // Keys are `<nick-lc> <TYPE>`; sendCtcpRequest guarantees the type is a
+      // single token, so the last space splits them unambiguously.
       if (key.slice(0, key.lastIndexOf(' ')) !== lower) continue;
       const head = queue[0]; // each queue is already oldest-first
+      if (head && now - head.sentAt > SEND_REJECTION_ATTRIBUTION_MS) continue;
       if (head && head.sentAt < bestAt) {
         bestAt = head.sentAt;
         bestKey = key;
@@ -4390,9 +4443,19 @@ export class IrcConnection {
   sendCtcpRequest(issuingTarget: string, target: string, type: string, args: string): void {
     if (this.disposed) return;
     const issuing = issuingTarget || this.serverTarget();
-    const t = type.toUpperCase();
     const now = Date.now();
-    let payload = args.trim();
+    // A CTCP type is a single token on the wire — parseCtcp splits the inbound
+    // side at the first space. Only the web client's own /ctcp guarantees that
+    // shape; iOS and MCP hand us whatever was typed, and a type of "PING FOO"
+    // used to build the key `bob PING FOO`, which no lookup could ever match —
+    // silently costing the reply AND the failure their routing. Split it the
+    // same way the receiving side does, so the extra words become args rather
+    // than being dropped.
+    const trimmedType = type.trim();
+    const sp = trimmedType.indexOf(' ');
+    const t = (sp === -1 ? trimmedType : trimmedType.slice(0, sp)).toUpperCase();
+    const spilled = sp === -1 ? '' : trimmedType.slice(sp + 1).trim();
+    let payload = [spilled, args.trim()].filter(Boolean).join(' ');
     if (t === 'PING' && !payload) payload = String(now);
     // Real enough for the rejection handler to surface a 531, but not a
     // conversation: the outcome belongs in `issuing`, not in a new query.

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2725,6 +2725,22 @@ export class IrcConnection {
           });
           return;
         }
+        // A /ctcp to this nick is outstanding, so the failure belongs where the
+        // attempt was announced — the exchange already put "→ CTCP VERSION to
+        // bob" there, and the reply would have landed there too (#821). Ahead of
+        // the DM-miss bucket below on purpose: with DM history the failure used
+        // to land in that query instead, splitting one command's visible attempt
+        // from its outcome.
+        //
+        // Ephemeral, via surfaceCtcp, because the rest of the exchange is: the
+        // echo and the reply are both transient status. A persisted error row
+        // would outlive the echo that gives it meaning and strand "bob isn't on
+        // this network." in a channel after a reload.
+        const ctcpIssuer = this.takeCtcpIssuer(eventNick);
+        if (ctcpIssuer) {
+          this.surfaceCtcp(ctcpIssuer, `${eventNick} isn't on this network.`);
+          return;
+        }
       }
       const isDmMiss = tag === 'no_such_nick' && eventNick && isDmTargetName(eventNick);
       // For ERR_NOSUCHNICK against a nick the user just messaged, or has any DM
@@ -2754,13 +2770,12 @@ export class IrcConnection {
       // notice / multiline) rather than recentUserSend, and not lastNickIntent,
       // which a whois writes to.
       //
-      // ⚠ "Conjure" is the exact scope, and the hasMessageForTarget fallback
-      // below is deliberately untouched: a /ctcp miss against a nick you
-      // ALREADY have a DM with still lands in that DM rather than in the buffer
-      // the ctcp was issued from. That predates this branch, and it's what
-      // handleSendRejection does with a 531 for a CTCP too — so it is at least
-      // consistent. Routing a CTCP failure back to its issuing buffer is a
-      // separate change, and it would have to move both paths together.
+      // ⚠ "Conjure" is the exact scope. A CTCP miss no longer reaches here at
+      // all — the bucket above claims it first and routes it to the buffer the
+      // /ctcp was issued from, 401 and 531 alike (#821). What this gate still
+      // decides is whether a 401 with no outstanding CTCP may open a NEW query,
+      // and the hasMessageForTarget fallback below stays the wider signal for a
+      // nick the user already has history with.
       if (
         isDmMiss &&
         (this.recentConversationalSend(eventNick as string) ||
@@ -3814,6 +3829,53 @@ export class IrcConnection {
     this.publishEphemeral({ type: 'ctcp', level: 'info', target, text });
   }
 
+  // Where an outcome for a /ctcp issued in `issuingTarget` can actually be
+  // shown. The buffer may have been closed since the request went out, and
+  // wsHub drops an ephemeral event aimed at a closed buffer — so the exchange
+  // would end in silence rather than in the server buffer.
+  private ctcpIssuingBuffer(issuingTarget: string): string {
+    return isBufferClosed(this.network.user_id, this.network.id, issuingTarget)
+      ? this.serverTarget()
+      : issuingTarget;
+  }
+
+  // The buffer a FAILED /ctcp to `nick` belongs in — the one it was issued from,
+  // the same place its echo and its reply go (#821). Returns null when no
+  // request to that nick is outstanding, which is what keeps this off every
+  // unrelated 401.
+  //
+  // ⚠ CONSUMES the entry, on the "one command, one bounce" discipline
+  // takeCommandChannel had to learn in #815: a spent CTCP left lying around is
+  // exactly the shape that lies in wait and claims a later unrelated failure.
+  //
+  // ⚠ ctcpOutstanding is keyed by nick AND type, but a 401 names only the nick,
+  // so this scans every type for that nick and takes the OLDEST outstanding
+  // request. Each CTCP is its own PRIVMSG and draws its own numeric back, so
+  // oldest-first pairs a burst of failures with the requests in the order they
+  // were sent — the same FIFO discipline handleInboundCtcpReply uses per type.
+  takeCtcpIssuer(nick: string): string | null {
+    const now = Date.now();
+    this.pruneCtcpOutstanding(now);
+    const lower = nick.toLowerCase();
+    let bestKey: string | null = null;
+    let bestAt = Infinity;
+    for (const [key, queue] of this.ctcpOutstanding) {
+      // Keys are `<nick-lc> <TYPE>` and neither half can contain a space, so
+      // the last space splits them unambiguously.
+      if (key.slice(0, key.lastIndexOf(' ')) !== lower) continue;
+      const head = queue[0]; // each queue is already oldest-first
+      if (head && head.sentAt < bestAt) {
+        bestAt = head.sentAt;
+        bestKey = key;
+      }
+    }
+    if (!bestKey) return null;
+    const queue = this.ctcpOutstanding.get(bestKey);
+    const entry = queue?.shift();
+    if (queue && queue.length === 0) this.ctcpOutstanding.delete(bestKey);
+    return entry ? this.ctcpIssuingBuffer(entry.issuingTarget) : null;
+  }
+
   // Route an INCOMING CTCP status line (a probe, or an unsolicited reply) per
   // the user's ctcp.msgbuffer setting — WeeChat's irc.msgbuffer.ctcp:
   //   server  → this network's server buffer (default)
@@ -4297,10 +4359,7 @@ export class IrcConnection {
       // buffer if it has since been closed — a wsHub guard would otherwise drop
       // an ephemeral event to a closed buffer). ctcp.msgbuffer governs only
       // UNSOLICITED CTCP, never a reply the user explicitly asked for.
-      const target = isBufferClosed(this.network.user_id, this.network.id, pending.issuingTarget)
-        ? this.serverTarget()
-        : pending.issuingTarget;
-      this.surfaceCtcp(target, line);
+      this.surfaceCtcp(this.ctcpIssuingBuffer(pending.issuingTarget), line);
       return;
     }
     // Unsolicited reply: rate-limit per-peer, then route per ctcp.msgbuffer.
@@ -5091,6 +5150,18 @@ export class IrcConnection {
   // buffer with "Message not delivered".
   handleSendRejection(target: string, reason: string | null | undefined, raw: unknown): void {
     this.unsendableTargets.add(target.toLowerCase());
+    // ⚠ MUST move together with the 401 path above (#821). 401 (the nick isn't
+    // there) and 531 (the nick won't take it) are the two ways a /ctcp fails, so
+    // fixing only one is worse than fixing neither: the same command would then
+    // report in the issuing buffer or in the peer's DM depending on WHY it
+    // failed. Ahead of the recentUserSend gate because an outstanding request is
+    // the stronger claim — the user asked for this outcome by name, and the two
+    // windows are not the same length.
+    const ctcpIssuer = this.takeCtcpIssuer(target);
+    if (ctcpIssuer) {
+      this.surfaceCtcp(ctcpIssuer, sendRejectionText(reason));
+      return;
+    }
     if (!this.recentUserSend(target)) return;
     this.publish({ type: 'error', target, text: sendRejectionText(reason), raw });
   }


### PR DESCRIPTION
Closes #821.

## The problem

The CTCP exchange already routed its two happy halves to the buffer the command was typed in — `sendCtcpRequest` surfaces `→ CTCP VERSION to bob` there, and `ctcpOutstanding` exists so the reply comes back to the same place. Failures consulted none of it and routed by nick, so the half that says *you tried* and the half that says *it failed* landed in different buffers — and **which** buffer depended on why it failed.

## What live QA changed about this issue

The issue says 401 and 531 are the two ways a `/ctcp` fails. Against a real **ergo 2.18**, neither is what happens. A DM refused because the recipient only accepts messages from registered accounts (`+R`) answers **477 naming the nick**:

```
:ergo.test 477 me blocker :You must be registered to send a direct message to this user
```

`params[1]` is where a channel normally sits, so this fell through to the join-rejection branch and produced, observed live:

```
[ephemeral] join-error  blocker  This channel requires a registered nickname.
```

A join error for something that was never a join, calling a person a channel, in the peer's DM. So the issue's table of three wrong destinations was missing a fourth, and the ugliest. Without fixing it, this PR's headline claim would simply be false on ergo.

**This also fixes ordinary messaging:** a plain DM to a `+R` user said *"This channel requires a registered nickname"* as a toast, and now says *"Message not delivered — &lt;the server's own reason&gt;"* inline in the query.

## The fix

`takeCtcpIssuer(nick)` pops the oldest outstanding request for a nick and returns the buffer it came from. `ctcpOutstanding` is keyed by nick **and** type but a failure names only the nick, so it scans every type and takes the oldest — confirmed live that ergo sends one numeric per CTCP, in order.

All three failure paths move together — 401, 531, and 477-naming-a-nick. Fixing a subset is worse than fixing none: the same command would report in different places depending on which numeric the ircd happens to use.

The line goes out through `surfaceCtcp`, not `publish`, because the rest of the exchange is ephemeral. A persisted error row would outlive the echo that gives it meaning and strand `bob isn't on this network.` in a channel across a reload.

## Bounding the claim (from review)

An outstanding entry is only consumed by a reply or a bounce, so a peer who ignores an unsupported type leaves one sitting there — making it an attractor for unrelated failures. Two bounds, saying different things:

- **The CTCP must still be the user's last move on that target** — the #434 rule, reusing `lastUserSendAt`'s existing `conversational` flag. Without it, a real `/msg` to a nick who quit mid-probe loses the persisted row #817 puts in the query.
- **And only within the send window, not the 60s reply TTL** — a reply may be slow; a refusal returns on the same round trip. Not redundant with the first: a second `/ctcp` refreshes "last thing sent here", and the oldest-first scan would otherwise hand the new failure to the stale request.

Two more from review: `sendCtcpRequest` now splits a multi-token type the way `parseCtcp` splits it inbound (`PING FOO` built key `bob PING FOO`, which no lookup could match — iOS and MCP don't guarantee a single token); and the `/nick` re-key moves out of the DM-rename block, where it read `ctcpOutstanding.get(oldNick)` against `<nick> <TYPE>` keys and so had never worked at all.

## Verification

Every scenario run against the ergo at `von-braun.local`, before and after:

| scenario | result |
|---|---|
| `/ctcp` from `#anime`, nick absent | echo + failure both in `#anime` |
| two CTCPs, different types and buffers | two 401s paired **oldest-first**, `#anime` then `:server:1` |
| `/ctcp` a nick we already DM | `#anime` — no longer stolen by the query |
| plain message after the CTCP was answered | back to the DM, persisted — consume discipline holds |
| `/ctcp` a `+R` user (477) | `#anime`, with the server's own reason |
| plain DM to a `+R` user | inline in the query, not a join toast |

Every guard was mutation-validated individually, including the half-fixed state the issue warns about (401 fixed, 531 not) — caught by exactly the test that exists for it. One existing test was updated rather than worked around: a 531 for a CTCP used to publish into the peer's DM, one of the wrong places this fixes.

Full suite green: 283 files / 4044 tests. `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)