### PR TITLE
Buy the export test's page crossings with pages, not rows (#820)

### DIFF
--- a/server/services/exportService.test.ts
+++ b/server/services/exportService.test.ts
@@ -293,9 +293,17 @@ describe('export under concurrent IRC writes (lurker#175 regression)', () => {
       tls: true,
       nick: 'c',
     }) as Network;
-    // Several pages' worth (MESSAGE_PAGE = 2000) so the paged stream yields to
-    // the loop multiple times, giving the writer below room to interleave.
-    for (let i = 0; i < 8000; i += 1) {
+    // What this test needs is that the stream crosses page boundaries several
+    // times, so the writer below has room to interleave. It used to buy those
+    // crossings with ROWS — 8000 of them, to clear the production MESSAGE_PAGE
+    // of 2000 four times over — which made its cost scale with a constant while
+    // its 15s timeout stayed fixed, and it duly timed out on a loaded CI runner
+    // (#820). Buy them with the page size instead: 300 rows over pages of 25 is
+    // twelve crossings, three times as many as before, for a twenty-sixth of the
+    // seeding work.
+    const PAGE = 25;
+    const SEEDED = 300; // twelve pages of seeded rows before the writer adds any
+    for (let i = 0; i < SEEDED; i += 1) {
       insertMessage({
         networkId: net.id,
         target: '#c',
@@ -310,6 +318,15 @@ describe('export under concurrent IRC writes (lurker#175 regression)', () => {
     const sink = new PassThrough();
     const chunks: Buffer[] = [];
     sink.on('data', (c: Buffer) => chunks.push(c));
+
+    // Progress fires once per page, plus once at the end — so counting the calls
+    // is how many pages were actually walked. Asserted below rather than left to
+    // a comment: the whole property under test is "it yields between pages", and
+    // a single-page export would satisfy every other assertion here silently.
+    let progressCalls = 0;
+    const onProgress = (): void => {
+      progressCalls += 1;
+    };
 
     // Hammer the SAME shared connection the export reads from. The export pages
     // its reads with discrete `.all()` queries and never holds a cursor across
@@ -347,7 +364,13 @@ describe('export under concurrent IRC writes (lurker#175 regression)', () => {
     setImmediate(pump);
 
     try {
-      await buildExportZip(db, u.id, { includeMessages: true }, sink);
+      await buildExportZip(
+        db,
+        u.id,
+        { includeMessages: true, messagePageSize: PAGE },
+        sink,
+        onProgress,
+      );
     } finally {
       building = false;
     }
@@ -355,7 +378,52 @@ describe('export under concurrent IRC writes (lurker#175 regression)', () => {
     expect(writeError).toBeNull();
     expect(liveWrites).toBeGreaterThan(0);
     expect(Buffer.concat(chunks).slice(0, 2).toString()).toBe('PK');
-  }, 15_000);
+    // Deliberately NOT asserting the page count here. Progress fires once per
+    // page, but the live writer keeps pushing rows past the cursor, so the count
+    // is dominated by the interleaving rather than by the seeded rows crossing
+    // page boundaries — it reads as ~108 either way, and would pass even if the
+    // page size were ignored entirely. The sibling test below is what holds the
+    // fixture to spanning pages; this one owns the concurrency property.
+    expect(progressCalls).toBeGreaterThan(0);
+  });
+
+  it('pages the stream at the requested size, so the fixture stays cheap', () => {
+    // The guard on #820's fix. The test above needs its stream to cross page
+    // boundaries many times, and buys that with a small page rather than with
+    // thousands of rows — so if the page size ever stopped being honoured, that
+    // test would quietly become a single-page export still passing every one of
+    // its assertions, and the regression it exists to catch would go untested.
+    // No concurrent writer here: nothing must move the cursor but the pages.
+    const u = createUser('paged-reader');
+    const net = createNetwork(u.id, {
+      name: 'libera',
+      host: 'irc.libera.chat',
+      port: 6697,
+      tls: true,
+      nick: 'p',
+    }) as Network;
+    for (let i = 0; i < 300; i += 1) {
+      insertMessage({
+        networkId: net.id,
+        target: '#p',
+        time: '2026-05-17T10:00:00Z',
+        type: 'message',
+        nick: 'p',
+        text: `seed ${i}`,
+        self: false,
+      });
+    }
+
+    const sink = new PassThrough();
+    sink.resume();
+    let pages = 0;
+    return buildExportZip(db, u.id, { includeMessages: true, messagePageSize: 25 }, sink, () => {
+      pages += 1;
+    }).then(() => {
+      // 300 rows at 25 a page is 12 pages, plus the final progress report.
+      expect(pages).toBe(13);
+    });
+  });
 });
 
 describe('buildExportFilename', () => {

--- a/server/services/exportService.test.ts
+++ b/server/services/exportService.test.ts
@@ -319,13 +319,13 @@ describe('export under concurrent IRC writes (lurker#175 regression)', () => {
     const chunks: Buffer[] = [];
     sink.on('data', (c: Buffer) => chunks.push(c));
 
-    // Progress fires once per page, plus once at the end — so counting the calls
-    // is how many pages were actually walked. Asserted below rather than left to
-    // a comment: the whole property under test is "it yields between pages", and
-    // a single-page export would satisfy every other assertion here silently.
-    let progressCalls = 0;
-    const onProgress = (): void => {
-      progressCalls += 1;
+    // The denominator must never trail the numerator. `total` is a COUNT(*) taken
+    // before the walk, and the writer below commits rows after it — so this is
+    // the one place the generator's `Math.max(total, processed)` can actually be
+    // observed doing its job. Counting PAGES here would prove nothing (see below).
+    let progressBackwards = 0;
+    const onProgress = (processed: number, total: number): void => {
+      if (total < processed) progressBackwards += 1;
     };
 
     // Hammer the SAME shared connection the export reads from. The export pages
@@ -378,13 +378,14 @@ describe('export under concurrent IRC writes (lurker#175 regression)', () => {
     expect(writeError).toBeNull();
     expect(liveWrites).toBeGreaterThan(0);
     expect(Buffer.concat(chunks).slice(0, 2).toString()).toBe('PK');
-    // Deliberately NOT asserting the page count here. Progress fires once per
-    // page, but the live writer keeps pushing rows past the cursor, so the count
-    // is dominated by the interleaving rather than by the seeded rows crossing
-    // page boundaries — it reads as ~108 either way, and would pass even if the
-    // page size were ignored entirely. The sibling test below is what holds the
-    // fixture to spanning pages; this one owns the concurrency property.
-    expect(progressCalls).toBeGreaterThan(0);
+    // A write that lands after the COUNT(*) must not produce "1200 of 1000".
+    expect(progressBackwards).toBe(0);
+    // ⚠ Deliberately NOT asserting the page COUNT here, though this test is the
+    // reason the fixture spans pages at all. The live writer keeps pushing rows
+    // past the keyset cursor, so that count is dominated by the interleaving
+    // rather than by seeded rows crossing page boundaries — it reads ~108 whether
+    // or not the page size is honoured, and passes with the seam broken. The
+    // sibling test below owns that property; this one owns concurrency.
   });
 
   it('pages the stream at the requested size, so the fixture stays cheap', () => {
@@ -423,6 +424,28 @@ describe('export under concurrent IRC writes (lurker#175 regression)', () => {
       // 300 rows at 25 a page is 12 pages, plus the final progress report.
       expect(pages).toBe(13);
     });
+  });
+
+  it('falls back to the default page rather than building invalid SQL', async () => {
+    // The page size is interpolated into the LIMIT, so a nonsense value has to
+    // degrade to the default instead of failing prepare(). Infinity is the one a
+    // plain positive-integer clamp lets through: it survives Math.max and
+    // interpolates literally, as does anything from 1e21 up in exponent form.
+    const u = createUser('bad-page-size');
+    createNetwork(u.id, {
+      name: 'libera',
+      host: 'irc.libera.chat',
+      port: 6697,
+      tls: true,
+      nick: 'b',
+    });
+    for (const bad of [Number.POSITIVE_INFINITY, Number.NaN, 0, -5, 1e21]) {
+      const sink = new PassThrough();
+      sink.resume();
+      await expect(
+        buildExportZip(db, u.id, { includeMessages: true, messagePageSize: bad }, sink),
+      ).resolves.toBeUndefined();
+    }
   });
 });
 

--- a/server/services/exportService.ts
+++ b/server/services/exportService.ts
@@ -136,9 +136,15 @@ async function* messagesNdjsonGenerator(
   const def = EXPORT_TABLES.messages as ExportTableDefWithScope;
   const { where, params } = scopeFilter(def.scope, userId);
   const cols = def.columns.join(', ');
-  // Interpolated, like the default was, but from a caller-supplied value now —
-  // so coerce to a positive integer rather than trusting it into the SQL.
-  const limit = Math.max(1, Math.floor(pageSize)) || MESSAGE_PAGE;
+  // Interpolated, like the default was, but from a caller-supplied value now, so
+  // it has to be coerced rather than trusted into the SQL. Finite as well as
+  // positive: Infinity survives a Math.max clamp and interpolates as
+  // `LIMIT Infinity`, and anything from 1e21 up stringifies in exponent form —
+  // both are syntax errors that would fail the whole export at prepare() rather
+  // than degrade to a sane page.
+  const requested = Math.floor(pageSize);
+  const limit =
+    Number.isFinite(requested) && requested >= 1 ? Math.min(requested, 1_000_000) : MESSAGE_PAGE;
   const pageStmt = db.prepare(
     `SELECT ${cols} FROM messages ${where} AND id > ? ORDER BY id ASC LIMIT ${limit}`,
   );

--- a/server/services/exportService.ts
+++ b/server/services/exportService.ts
@@ -108,6 +108,12 @@ function projectRow(
 // Rows read (and progress reported) per page. Big enough that per-page query
 // overhead is negligible, small enough that the synchronous chunk between
 // event-loop yields stays short.
+//
+// Overridable per call (`messagePageSize`) so a test can span many pages on a
+// few hundred rows instead of seeding several thousand to cross this one.
+// What the paging behaviour needs proving against is the NUMBER of yields, not
+// the row count — and buying those yields with rows makes a test whose cost
+// scales with this constant while its timeout does not (#820).
 const MESSAGE_PAGE = 2000;
 
 // Stream a user's messages as NDJSON, paginated by id (keyset), yielding to the
@@ -125,12 +131,16 @@ async function* messagesNdjsonGenerator(
   userId: number,
   total: number,
   onProgress?: ExportProgressFn,
+  pageSize: number = MESSAGE_PAGE,
 ): AsyncGenerator<string> {
   const def = EXPORT_TABLES.messages as ExportTableDefWithScope;
   const { where, params } = scopeFilter(def.scope, userId);
   const cols = def.columns.join(', ');
+  // Interpolated, like the default was, but from a caller-supplied value now —
+  // so coerce to a positive integer rather than trusting it into the SQL.
+  const limit = Math.max(1, Math.floor(pageSize)) || MESSAGE_PAGE;
   const pageStmt = db.prepare(
-    `SELECT ${cols} FROM messages ${where} AND id > ? ORDER BY id ASC LIMIT ${MESSAGE_PAGE}`,
+    `SELECT ${cols} FROM messages ${where} AND id > ? ORDER BY id ASC LIMIT ${limit}`,
   );
   let lastId = 0;
   let processed = 0;
@@ -218,7 +228,7 @@ function getSchemaVersion(db: Database): number {
 export async function buildExportZip(
   db: Database,
   userId: number,
-  { includeMessages = false } = {},
+  { includeMessages = false, messagePageSize = MESSAGE_PAGE } = {},
   destStream: Writable,
   onProgress?: ExportProgressFn,
 ): Promise<void> {
@@ -283,9 +293,10 @@ export async function buildExportZip(
     // it's cheap on the indexed selection and known before the stream drains.
     const total = countExportMessages(db, userId);
     counts.messages = total;
-    const messagesStream = Readable.from(messagesNdjsonGenerator(db, userId, total, onProgress), {
-      encoding: 'utf8',
-    });
+    const messagesStream = Readable.from(
+      messagesNdjsonGenerator(db, userId, total, onProgress, messagePageSize),
+      { encoding: 'utf8' },
+    );
     archive.append(messagesStream, { name: 'messages.ndjson' });
 
     // ---- bookmarks.json ----


### PR DESCRIPTION
Closes #820.

## The failure mode

`exportService.test.ts`'s lurker#175 regression test timed out at 15s on a loaded CI runner. Nothing about the invariant it guards was implicated — it never reached the concurrent write it exists to prove is safe.

The test needs its stream to cross page boundaries several times, so the interleaved writer has room to land between them. It bought those crossings with **rows**: 8000 of them, to clear the production `MESSAGE_PAGE` of 2000 four times over. That makes its cost scale with a constant while its timeout stays a fixed wall-clock number — the work is real, the budget doesn't grow with the load.

## The fix

`MESSAGE_PAGE` is now overridable per call. The test buys its crossings with page size instead:

| | before | after |
|---|---|---|
| duration | 513ms | **31ms** |
| page crossings | 4 | **12** |
| seeded rows | 8000 | 300 |
| timeout | explicit `15_000` | default |

Cheaper *and* sharper — three times the yields for a twenty-sixth of the seeding work — which is why this beats simply raising the timeout (the issue's option 2 over option 1). The explicit `15_000` goes with it: at 31ms the default budget leaves ~160× headroom, against the ~29× slowdown that produced the CI failure.

Production behaviour is unchanged — same default, same keyset walk, cursor still released before each yield. `messagePageSize` isn't reachable from request input; `exportJobs` and the route pass only `includeMessages`.

## Two tests I had to fix after writing them

**The paging assertion was in the wrong test.** My first version counted progress calls inside the *concurrency* test. That proves nothing: the live writer keeps pushing rows past the keyset cursor, so the count is dominated by interleaving rather than by seeded rows crossing pages — it reads ~108 whether or not the page size is honoured, and passed with the seam deliberately broken. The paging assertion now lives in its own writer-free test, where 300 rows at 25 a page is exactly 13 progress calls and a broken seam sees 2.

**What the concurrency test asserts instead** is an invariant only it can reach: `total` is a `COUNT(*)` taken before the walk and the writer commits rows after it, which is exactly why the generator reports `max(total, processed)`. That was documented in the production code with no test; breaking the `Math.max` now produces 96 backwards reports.

Also from review: the coercion comment claimed it was what made interpolating the page size into the `LIMIT` safe, and it wasn't — `Infinity` survives a `Math.max` clamp and interpolates as `LIMIT Infinity`. Verified: the old form dies with `SqliteError: no such column: Infinity`. Now finite-checked and bounded, with a test over the values that get there.

## On the sibling flake

#820 asks whether it shares a trigger with #637. **It doesn't.** `adminNetworks.test.ts` has zero heavy fixtures and no explicit timeouts — it fails inside the shared `createTestApp` harness, so it's a socket/agent lifecycle fault, not a fixed budget losing to growing work. Same family, different mechanism; this change does nothing for it, and it needs a harness investigation rather than a fixture one.

Full suite green: 283 files / 4048 tests. `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)