### PR TITLE
Smart filter: bring MODE into the event-noise tier

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -379,7 +379,9 @@ names/hosts — fetch `GET /api/networks` for the roster (the iOS app does this
 before opening the socket; it doubles as a token validity check).
 
 Member `modes` are **prefix-mode letters, highest first** (`q a o h v`), _not_
-sigils (`~ & @ % +`). Map to sigils yourself for display.
+sigils (`~ & @ % +`). Map to sigils yourself for display. That letter list is a
+display ordering, not a classification set — don't reuse it to decide what a
+mode letter _means_ on a given network (§7.4).
 
 ### 5.2 Buffers
 
@@ -675,7 +677,7 @@ Also the `type` of rows inside `backlog`/`history` `events[]`. **P** = persisted
 | `kick`                        | P   | `kicked`, `text`                                                              |
 | `nick`                        | P   | `newNick`                                                                     |
 | `own-nick`                    | E   | your nick changed — `nick` is the new one                                     |
-| `mode`                        | P   | `text`, `modes[]`                                                             |
+| `mode`                        | P   | `text`, `modes[]` — see §7.4 for the entry shape and `kind`                   |
 | `usermode`                    | E   | your user modes, whole string                                                 |
 | `topic`                       | P   | a topic _change_ (renders as a line)                                          |
 | `channel-topic`               | E   | RPL_TOPIC on join — set state, render nothing                                 |
@@ -708,6 +710,45 @@ Route them to that network's `:server:` buffer. `motd` is deliberately the
 catch-all for all "server voice" text that has no better home — don't build a
 taxonomy on top of it. `system` events (with `networkId:null`) belong to
 `:system:`.
+
+### 7.4 `mode` events: the `modes[]` entry shape
+
+A single MODE message carries a list of changes. `text` is the raw form
+(`"+o-b alice *!*@host"`) for display; `modes[]` is the parsed list, and each
+entry is:
+
+```
+{ mode: "+o",            // the signed token
+  param?: "alice",       // the argument, when the mode takes one
+  kind?: "prefix" | "list" | "chan" }
+```
+
+`kind` is the server's classification of the letter, and it is **the only
+correct way to tell one kind of change from another**:
+
+| `kind`   | meaning                                        | examples                 |
+| -------- | ---------------------------------------------- | ------------------------ |
+| `prefix` | a member's status changed; `param` is a nick   | `+o alice`, `-v bob`     |
+| `list`   | a mask was added to / removed from a list mode | `+b *!*@host`, `-e mask` |
+| `chan`   | a channel flag or parameter mode               | `+m`, `+k key`, `+l 50`  |
+
+⚠ **Do not classify mode letters yourself.** It requires the network's ISUPPORT
+`PREFIX` and `CHANMODES`, which is not in any client-facing frame, and the
+obvious shortcut is wrong: a hardcoded `q a o h v` prefix set disagrees with
+solanum, where `+q` is a _quiet_ (a list mode) whose mask is often a bare nick —
+so `+q troll` looks exactly like an owner grant and is nothing of the sort. That
+is a real bug we shipped once (lurker#486). The member-`modes` letters in §5.1
+are a **display** ordering for sigils and are not a classification set; don't
+reuse them here.
+
+An entry with **no `kind`** was stored before the server stamped it. Treat
+missing as "not `prefix`": show the row, and don't fold or filter it. There is
+no backfill.
+
+Clients use this to decide what counts as presence churn. Lurker's own rule, in
+`shared/modes.ts`: a mode row is churn only if **every** entry in it is `prefix`
+with a `param` — one ban or channel flag anywhere in the message and the whole
+row is shown, since a row renders as a single line and can't be half-hidden.
 
 ---
 

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -3000,6 +3000,131 @@ describe('channel mode display (status bar)', () => {
     ];
   }
 
+  // Grab the latest published `mode` row — the one that carries the stamped
+  // change list the clients filter on.
+  function latestModeRow(
+    publish: ReturnType<typeof vi.fn>,
+  ): { modes?: Array<{ mode: string; param?: string; kind?: string }> } | undefined {
+    const calls = publish.mock.calls
+      .map(
+        (c) =>
+          c[0] as { type: string; modes?: Array<{ mode: string; param?: string; kind?: string }> },
+      )
+      .filter((e) => e.type === 'mode');
+    return calls.at(-1);
+  }
+
+  it('stamps each change with its class, so the clients can filter without ISUPPORT', () => {
+    const conn = makeConn();
+    solanumIsupport(conn);
+    conn.upsertChannel('#chan');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('mode', {
+      target: '#chan',
+      modes: [
+        { mode: '+o', param: 'alice' },
+        { mode: '+b', param: '*!*@host' },
+        { mode: '+m' },
+        { mode: '+k', param: 'hunter2' },
+      ],
+      raw_modes: '+obmk',
+      raw_params: ['alice', '*!*@host', 'hunter2'],
+    });
+
+    expect(latestModeRow(publish)?.modes).toEqual([
+      { mode: '+o', param: 'alice', kind: 'prefix' },
+      { mode: '+b', param: '*!*@host', kind: 'list' },
+      { mode: '+m', kind: 'chan' },
+      { mode: '+k', param: 'hunter2', kind: 'chan' },
+    ]);
+  });
+
+  it('stamps solanum +q as list even though its param is a real member (#486)', () => {
+    // The stamp and the member map have to reach the same verdict here, or a
+    // quiet is filtered as op churn while being applied as a ban. They share
+    // classifyModeChange precisely so they can't diverge — this pins both ends.
+    const conn = makeConn();
+    solanumIsupport(conn);
+    const ch = conn.upsertChannel('#chan');
+    ch.members.set('troll', {
+      nick: 'troll',
+      modes: [],
+      away: false,
+      user: null,
+      host: null,
+      account: null,
+    });
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('mode', {
+      target: '#chan',
+      modes: [{ mode: '+q', param: 'troll' }],
+      raw_modes: '+q',
+      raw_params: ['troll'],
+    });
+
+    expect(latestModeRow(publish)?.modes).toEqual([{ mode: '+q', param: 'troll', kind: 'list' }]);
+    // …and the member map agrees: no phantom owner badge.
+    expect(ch.members.get('troll')?.modes).toEqual([]);
+  });
+
+  it('stamps a param-less member mode as chan, matching where the handler applies it', () => {
+    const conn = makeConn();
+    solanumIsupport(conn);
+    const ch = conn.upsertChannel('#chan');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('mode', {
+      target: '#chan',
+      modes: [{ mode: '+o' }],
+      raw_modes: '+o',
+      raw_params: [],
+    });
+
+    expect(latestModeRow(publish)?.modes).toEqual([{ mode: '+o', kind: 'chan' }]);
+    // Tracked as a channel flag, which is what the handler has always done with
+    // a malformed bare +o.
+    expect(ch.modes.has('o')).toBe(true);
+  });
+
+  it('stamps modes for a channel it is not tracking members for', () => {
+    // The class is a property of the letters and 005, not of whether the
+    // channel is in our map — so the stamp must not sit behind the `ch` guard.
+    const conn = makeConn();
+    solanumIsupport(conn);
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('mode', {
+      target: '#untracked',
+      modes: [{ mode: '+o', param: 'alice' }],
+      raw_modes: '+o',
+      raw_params: ['alice'],
+    });
+
+    expect(latestModeRow(publish)?.modes).toEqual([{ mode: '+o', param: 'alice', kind: 'prefix' }]);
+  });
+
+  it('stamps against the PREFIX fallback before 005 lands', () => {
+    const conn = makeConn();
+    conn.upsertChannel('#chan');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('mode', {
+      target: '#chan',
+      modes: [{ mode: '+o', param: 'alice' }],
+      raw_modes: '+o',
+      raw_params: ['alice'],
+    });
+
+    expect(latestModeRow(publish)?.modes?.[0]?.kind).toBe('prefix');
+  });
+
   it('routes solanum +q to the list-mode path, not the member-prefix path (#486)', () => {
     const conn = makeConn();
     solanumIsupport(conn);

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -40,6 +40,8 @@ import { APP_NAME, APP_VERSION } from '../utils/userAgent.js';
 import { findUserById } from '../db/users.js';
 import { isNodeMode } from '../utils/edition.js';
 import { deriveIdent } from '../../shared/ident.js';
+import { classifyModeChange, modeLetter } from '../../shared/modes.js';
+import type { ModeChange } from '../../shared/modes.js';
 import { registerIdent, unregisterIdent, isIdentdEnabled, isOidentdFileEnabled } from './identd.js';
 import { MESSAGE_MAX_BYTES, partitionMultiline, reassembleMultiline } from './messageSplit.js';
 import type { MultilineLimits } from './messageSplit.js';
@@ -287,10 +289,10 @@ interface ChannelState {
   modes: Set<string>;
 }
 
-interface ModeEntry {
-  mode: string;
-  param?: string;
-}
+// irc-framework hands us `{mode, param}`; we add `kind` before publishing (see
+// the `mode` handler), so the stored row carries the classification the clients
+// can't compute for themselves.
+type ModeEntry = ModeChange;
 
 interface AwayState {
   active: boolean;
@@ -2393,14 +2395,28 @@ export class IrcConnection {
       let chanModesChanged = false;
       const listModes = this.listModes();
       const prefixModes = this.prefixModes();
+      // Classify each change once, up front, and carry the class onto the row we
+      // publish. The clients never see ISUPPORT, so this stamp is the only way
+      // they can tell op/voice churn from a ban — which is what the event
+      // filters need in order to hide the first without hiding the second.
+      //
+      // Stamped unconditionally, before the `ch` guard: the class is a property
+      // of the letters and the server's 005, not of whether we happen to be
+      // tracking this channel's members. And it is the SAME call the member
+      // branch below now switches on, so a change can never be filtered as one
+      // thing and applied as another.
+      const stampedModes: ModeEntry[] = eventModes
+        .filter((m) => m && m.mode)
+        .map((m) => ({ ...m, kind: classifyModeChange(m, prefixModes, listModes) }));
       if (ch) {
-        for (const m of eventModes) {
-          if (!m || !m.mode) continue;
+        for (const m of stampedModes) {
           const sign = m.mode[0];
-          const letter = m.mode.slice(1);
+          const letter = modeLetter(m.mode);
           // Per-user prefix mode: lands on the member, not on the channel.
-          if (m.param && prefixModes.has(letter)) {
-            const member = ch.members.get(m.param.toLowerCase());
+          if (m.kind === 'prefix') {
+            // classifyModeChange only returns 'prefix' for a change that has a
+            // param, so this is a narrowing rather than a second condition.
+            const member = ch.members.get(m.param!.toLowerCase());
             if (!member) continue;
             const set = new Set(member.modes);
             if (sign === '+') set.add(letter);
@@ -2411,8 +2427,10 @@ export class IrcConnection {
           }
           // Channel-level flag mode (or parameter mode like +k/+l). We track
           // them to surface them in the status bar, but exclude list-type modes
-          // (bans/exceptions/quiets) so their masks don't pollute the display.
-          if (!listModes.has(letter)) {
+          // (bans/exceptions/quiets) so their masks don't pollute the display —
+          // which is exactly what `kind` already says, so read it rather than
+          // re-testing listModes and giving the two a chance to drift.
+          if (m.kind === 'chan') {
             if (sign === '+' && !ch.modes.has(letter)) {
               ch.modes.add(letter);
               chanModesChanged = true;
@@ -2437,7 +2455,7 @@ export class IrcConnection {
         target,
         nick: eventNick,
         text,
-        modes: eventModes,
+        modes: stampedModes,
         time: event.time,
       });
       if (memberModesChanged && ch) {

--- a/shared/eventFilter.test.ts
+++ b/shared/eventFilter.test.ts
@@ -99,6 +99,9 @@ describe('tier resolution', () => {
       'chat.smart_filter_join',
       'chat.smart_filter_quit',
       'chat.smart_filter_nick',
+      // The event kinds read in wire order — join, part/quit, nick, mode — with
+      // the join-specific unmask tuning left trailing behind them.
+      'chat.smart_filter_mode',
       'chat.smart_filter_join_unmask',
     ]);
     expect([...new Set(events.map((o) => o.group))]).toEqual([

--- a/shared/modes.test.ts
+++ b/shared/modes.test.ts
@@ -1,0 +1,225 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import {
+  classifyModeChange,
+  isChurnMode,
+  modeLetter,
+  modeTargets,
+  smartHidesMode,
+  type ModeChange,
+} from './modes.js';
+
+// solanum's actual shape: `q` is a quiet LIST mode and is absent from PREFIX.
+const SOLANUM_PREFIX = new Set(['o', 'v']);
+const SOLANUM_LIST = new Set(['e', 'I', 'b', 'q']);
+
+// UnrealIRCd-shaped: `q` IS an owner prefix here, and not a list mode.
+const UNREAL_PREFIX = new Set(['q', 'a', 'o', 'h', 'v']);
+const UNREAL_LIST = new Set(['b', 'e', 'I']);
+
+describe('modeLetter', () => {
+  it('strips a leading sign', () => {
+    expect(modeLetter('+o')).toBe('o');
+    expect(modeLetter('-b')).toBe('b');
+  });
+
+  it('passes an unsigned token through rather than eating its first character', () => {
+    // irc-framework always signs its tokens, but slicing blindly would turn a
+    // malformed `o` into the empty letter — which classifies as a channel flag
+    // and would then be tracked as one. Letting it through keeps the letter
+    // meaningful, and keeps this function agreeing with its callers.
+    expect(modeLetter('o')).toBe('o');
+  });
+});
+
+describe('classifyModeChange', () => {
+  it('classifies a member-status change with a param as prefix', () => {
+    expect(classifyModeChange({ mode: '+o', param: 'alice' }, SOLANUM_PREFIX, SOLANUM_LIST)).toBe(
+      'prefix',
+    );
+    expect(classifyModeChange({ mode: '-v', param: 'bob' }, SOLANUM_PREFIX, SOLANUM_LIST)).toBe(
+      'prefix',
+    );
+  });
+
+  it('routes solanum +q to list, even with a bare nick as its param (#486)', () => {
+    // The case a hardcoded q/a/o/h/v set got wrong: on solanum a quiet's mask
+    // can be a plain nick, so `+q troll` looks exactly like an owner grant and
+    // is nothing of the sort.
+    expect(classifyModeChange({ mode: '+q', param: 'troll' }, SOLANUM_PREFIX, SOLANUM_LIST)).toBe(
+      'list',
+    );
+  });
+
+  it('routes the same +q to prefix when the server declares it in PREFIX', () => {
+    expect(classifyModeChange({ mode: '+q', param: 'owner' }, UNREAL_PREFIX, UNREAL_LIST)).toBe(
+      'prefix',
+    );
+  });
+
+  it('classifies bans and exceptions as list', () => {
+    expect(
+      classifyModeChange({ mode: '+b', param: '*!*@host' }, SOLANUM_PREFIX, SOLANUM_LIST),
+    ).toBe('list');
+    expect(
+      classifyModeChange({ mode: '-e', param: '*!*@host' }, SOLANUM_PREFIX, SOLANUM_LIST),
+    ).toBe('list');
+  });
+
+  it('classifies channel flags and parameter modes as chan', () => {
+    expect(classifyModeChange({ mode: '+m' }, SOLANUM_PREFIX, SOLANUM_LIST)).toBe('chan');
+    expect(classifyModeChange({ mode: '+k', param: 'hunter2' }, SOLANUM_PREFIX, SOLANUM_LIST)).toBe(
+      'chan',
+    );
+    expect(classifyModeChange({ mode: '+l', param: '50' }, SOLANUM_PREFIX, SOLANUM_LIST)).toBe(
+      'chan',
+    );
+  });
+
+  it('does not call a param-less member mode a prefix change', () => {
+    // A bare `+o` with no argument is malformed. The handler has always fallen
+    // through and tracked it as a channel flag; the classifier has to agree, or
+    // the row is filtered as one thing and applied as another.
+    expect(classifyModeChange({ mode: '+o' }, SOLANUM_PREFIX, SOLANUM_LIST)).toBe('chan');
+  });
+
+  it('falls back to chan on an empty ISUPPORT rather than throwing', () => {
+    expect(classifyModeChange({ mode: '+o', param: 'alice' }, new Set(), new Set())).toBe('chan');
+  });
+});
+
+const prefix = (mode: string, param: string): ModeChange => ({ mode, param, kind: 'prefix' });
+
+describe('isChurnMode', () => {
+  it('is true for a message of nothing but member-status changes', () => {
+    expect(isChurnMode([prefix('+o', 'alice')])).toBe(true);
+    expect(isChurnMode([prefix('+o', 'alice'), prefix('-v', 'bob')])).toBe(true);
+  });
+
+  it('is false when anything else rides along — the whole-message gate', () => {
+    // `+o-b alice *!*@host` must show in full. This is the rule that stops the
+    // filter from swallowing a ban because an op change shared its line.
+    expect(isChurnMode([prefix('+o', 'alice'), { mode: '-b', param: '*!*@h', kind: 'list' }])).toBe(
+      false,
+    );
+    expect(isChurnMode([prefix('+o', 'alice'), { mode: '+m', kind: 'chan' }])).toBe(false);
+  });
+
+  it('is false for a bare ban, key or flag', () => {
+    expect(isChurnMode([{ mode: '+b', param: '*!*@h', kind: 'list' }])).toBe(false);
+    expect(isChurnMode([{ mode: '+k', param: 'hunter2', kind: 'chan' }])).toBe(false);
+    expect(isChurnMode([{ mode: '+m', kind: 'chan' }])).toBe(false);
+  });
+
+  it('is false for an unstamped row, so old backlog shows rather than hiding', () => {
+    // Rows written before the server stamped `kind`. Fail-visible: no class
+    // means no filtering, not "assume it was churn".
+    expect(isChurnMode([{ mode: '+o', param: 'alice' }])).toBe(false);
+  });
+
+  it('is false for an empty or missing change list', () => {
+    expect(isChurnMode([])).toBe(false);
+    expect(isChurnMode(null)).toBe(false);
+    expect(isChurnMode(undefined)).toBe(false);
+  });
+
+  it('is false for a prefix entry that somehow lost its param', () => {
+    expect(isChurnMode([{ mode: '+o', kind: 'prefix' }])).toBe(false);
+  });
+});
+
+describe('modeTargets', () => {
+  it('returns the nicks a message acted on, in order', () => {
+    expect(
+      modeTargets([
+        { mode: '+o', param: 'alice', kind: 'prefix' },
+        { mode: '+o', param: 'bob', kind: 'prefix' },
+        { mode: '-v', param: 'carol', kind: 'prefix' },
+      ]),
+    ).toEqual(['alice', 'bob', 'carol']);
+  });
+
+  it('never returns a ban mask or a channel key as if it were a nick', () => {
+    expect(
+      modeTargets([
+        { mode: '+b', param: '*!*@host', kind: 'list' },
+        { mode: '+k', param: 'hunter2', kind: 'chan' },
+      ]),
+    ).toEqual([]);
+  });
+
+  it('returns nothing for an unstamped or empty list', () => {
+    expect(modeTargets([{ mode: '+o', param: 'alice' }])).toEqual([]);
+    expect(modeTargets(null)).toEqual([]);
+  });
+});
+
+describe('smartHidesMode', () => {
+  // A speaker set standing in for "spoke inside the window ending at this
+  // event" — the comparison each client owns.
+  const spoken = (...nicks: string[]) => {
+    const set = new Set(nicks.map((n) => n.toLowerCase()));
+    return (nick: string) => set.has(nick.toLowerCase());
+  };
+  const none = () => false;
+
+  it('hides an op grant on someone nobody was talking to', () => {
+    expect(smartHidesMode([prefix('+o', 'lurker')], 'ChanServ', 'me', none)).toBe(true);
+  });
+
+  it('shows it when the target spoke recently — the target, not the author', () => {
+    // ChanServ never speaks in the channel. Keying on the author would hide
+    // every mode change on the network; keying on the target is what makes the
+    // rung mean anything. This is the test that would have caught halloy's shape.
+    expect(smartHidesMode([prefix('+o', 'alice')], 'ChanServ', 'me', spoken('alice'))).toBe(false);
+    // …and the author speaking is NOT what saves it.
+    expect(smartHidesMode([prefix('+o', 'alice')], 'ChanServ', 'me', spoken('ChanServ'))).toBe(
+      true,
+    );
+  });
+
+  it('shows a mode we set ourselves', () => {
+    expect(smartHidesMode([prefix('+o', 'lurker')], 'me', 'me', none)).toBe(false);
+    expect(smartHidesMode([prefix('+o', 'lurker')], 'ME', 'me', none)).toBe(false);
+  });
+
+  it('shows a mode set on us', () => {
+    expect(smartHidesMode([prefix('+o', 'me')], 'ChanServ', 'me', none)).toBe(false);
+    expect(smartHidesMode([prefix('+o', 'Me')], 'ChanServ', 'me', none)).toBe(false);
+  });
+
+  it('shows a multi-target message when any one target spoke', () => {
+    // `+ooo a b c` where only b spoke. Hiding it would drop a and c's grants on
+    // the floor, so the whole row survives.
+    const modes = [prefix('+o', 'a'), prefix('+o', 'b'), prefix('+o', 'c')];
+    expect(smartHidesMode(modes, 'ChanServ', 'me', spoken('b'))).toBe(false);
+    expect(smartHidesMode(modes, 'ChanServ', 'me', none)).toBe(true);
+  });
+
+  it('never hides a message that carries a ban, key or channel flag', () => {
+    expect(
+      smartHidesMode(
+        [prefix('+o', 'lurker'), { mode: '-b', param: '*!*@h', kind: 'list' }],
+        'ChanServ',
+        'me',
+        none,
+      ),
+    ).toBe(false);
+    expect(smartHidesMode([{ mode: '+b', param: '*!*@h', kind: 'list' }], 'op', 'me', none)).toBe(
+      false,
+    );
+    expect(smartHidesMode([{ mode: '+m', kind: 'chan' }], 'op', 'me', none)).toBe(false);
+  });
+
+  it('never hides an unstamped row', () => {
+    expect(smartHidesMode([{ mode: '+o', param: 'lurker' }], 'ChanServ', 'me', none)).toBe(false);
+  });
+
+  it('still filters when our own nick is unknown', () => {
+    // A buffer with no resolved self nick shouldn't stop the rung working; it
+    // just loses the two "it's about me" exemptions.
+    expect(smartHidesMode([prefix('+o', 'lurker')], 'ChanServ', null, none)).toBe(true);
+  });
+});

--- a/shared/modes.ts
+++ b/shared/modes.ts
@@ -128,6 +128,15 @@ export function modeTargets(modes: readonly ModeChange[] | null | undefined): st
  * already owns that comparison. The rest of the decision is identical
  * everywhere, so it lives here rather than being written twice.
  *
+ * ⚠ Known trade-off, inherited from weechat's default and not yet decided
+ * against: in a moderated (+m) channel, `+v alice` is the permission for alice
+ * to START speaking, so "has the target spoken recently" is guaranteed false and
+ * the grant is always hidden — in exactly the channels where voice grants carry
+ * the most meaning. The candidate remedy is to extend the join-unmask idea to
+ * mode grants (reveal the row when the target speaks shortly AFTER it), which
+ * this signature has room for. Left alone for now rather than diverging from the
+ * reference on a guess.
+ *
  * @param actorNick who sent the MODE. Used only to spot our own.
  * @param ownNickLc our nick on this network, lowercased; null when unknown.
  * @param spokeRecently whether a nick spoke inside the window ending at this event.

--- a/shared/modes.ts
+++ b/shared/modes.ts
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Mode-change classification, and the "is this row churn?" question the event
+// filters ask of it.
+//
+// A single IRC MODE message carries a list of changes, and the three classes
+// behave nothing alike:
+//
+//   +o alice          a MEMBER's status changed — the op/voice churn that
+//                     motivates every filter in this file
+//   +b *!*@host       a LIST mode: a mask was added to the ban/exception/quiet
+//                     list. Consequential, and never churn.
+//   +m / +k / +l 50   a CHANNEL flag or parameter mode. Also not churn.
+//
+// Telling them apart requires the server's ISUPPORT PREFIX and CHANMODES
+// tokens, which the browser has never seen and has no business parsing — so
+// the SERVER classifies each change at publish time and stamps `kind` onto it
+// (see classifyModeChange). The stamp rides `extra.modes` into storage, so a
+// backlog row answers the question the same way a live one does.
+//
+// ⚠ Do NOT reintroduce a hardcoded q/a/o/h/v set on either side. It was tried
+// and it disagreed with solanum, where `+q` is a quiet LIST mode rather than an
+// owner prefix — see the comment on IrcConnection.prefixModes().
+
+/** Which of the three worlds a single mode change belongs to. */
+export type ModeChangeKind = 'prefix' | 'list' | 'chan';
+
+/** One entry of a MODE message's change list, as stored and sent to clients. */
+export interface ModeChange {
+  /** The signed token, e.g. `+o` or `-b`. */
+  mode: string;
+  /** The argument, when the mode takes one: a nick, a mask, a key, a limit. */
+  param?: string;
+  /**
+   * The class, stamped by the server. Absent on rows written before the stamp
+   * existed — treat missing as "not prefix", which is the fail-visible
+   * direction: an unclassified row shows and never folds.
+   */
+  kind?: ModeChangeKind;
+}
+
+/** The letter of a signed mode token, i.e. `+o` → `o`. */
+export function modeLetter(mode: string): string {
+  return mode.startsWith('+') || mode.startsWith('-') ? mode.slice(1) : mode;
+}
+
+/**
+ * Classify one change against a server's ISUPPORT sets. Server-side only — the
+ * clients read the stamped `kind` instead.
+ *
+ * ⚠ The precedence here is load-bearing and must stay identical to the branch
+ * order in IrcConnection's `mode` handler, which applies the same test to
+ * decide whether a change lands on the member map or on the channel. If the two
+ * ever disagree, a row is filtered as one thing and applied as another. They
+ * share this function precisely so they can't.
+ *
+ *   1. a change WITH a param whose letter is a member prefix → `prefix`
+ *   2. otherwise, a letter in CHANMODES group A → `list`
+ *   3. otherwise → `chan`
+ *
+ * Note step 1's param requirement: a bare `+o` with no argument is malformed,
+ * and falls through to be tracked as a channel flag — which is what the handler
+ * has always done with it.
+ */
+export function classifyModeChange(
+  change: ModeChange,
+  prefixModes: ReadonlySet<string>,
+  listModes: ReadonlySet<string>,
+): ModeChangeKind {
+  const letter = modeLetter(change.mode);
+  if (change.param && prefixModes.has(letter)) return 'prefix';
+  if (listModes.has(letter)) return 'list';
+  return 'chan';
+}
+
+/**
+ * Whether a MODE row is presence churn — the single predicate the smart filter
+ * and (later) consolidation both ask.
+ *
+ * True only when the message carries at least one change and EVERY change in it
+ * grants or revokes member status. One ban, key, or channel flag anywhere in the
+ * message makes the whole row non-churn.
+ *
+ * That whole-message gate is deliberate, and matches weechat (`irc-mode.c`,
+ * where `smart_filter` is cleared the moment any ineligible letter appears).
+ * We render one row per MODE message and have no way to draw half of one, so a
+ * mixed `+o-b alice *!*@host` has to be all-or-nothing — and showing it is the
+ * direction that can't silently swallow a ban.
+ */
+export function isChurnMode(modes: readonly ModeChange[] | null | undefined): boolean {
+  if (!modes || modes.length === 0) return false;
+  // `kind === 'prefix'` already implies a param on anything the server stamped;
+  // the explicit param test also covers a hand-built or hand-edited row.
+  return modes.every((m) => !!m && m.kind === 'prefix' && !!m.param);
+}
+
+/**
+ * The nicks a MODE message acted ON — the params of its member-status changes.
+ *
+ * These, not the message's author, are the subject the smart filter judges. The
+ * author of a mode line is usually ChanServ or an op bot that never speaks in
+ * the channel, so keying on it would hide essentially every mode change. weechat
+ * keys on the target too (`irc-mode.c`, the nick-speaking-time check sits in the
+ * per-nick mode branch); halloy keys on the author, and that looks like a bug.
+ */
+export function modeTargets(modes: readonly ModeChange[] | null | undefined): string[] {
+  if (!modes) return [];
+  const out: string[] = [];
+  for (const m of modes) {
+    if (m && m.kind === 'prefix' && m.param) out.push(m.param);
+  }
+  return out;
+}
+
+/**
+ * Whether the smart rung hides this MODE row.
+ *
+ * Shown — never hidden — when any of these hold:
+ *
+ *   - the message isn't pure member-status churn (see isChurnMode);
+ *   - we sent it;
+ *   - it acted on us;
+ *   - any nick it acted on has spoken recently.
+ *
+ * The last two are why this takes a callback rather than a speaker map: "spoke
+ * recently" is a window ending at the event's own timestamp, and each client
+ * already owns that comparison. The rest of the decision is identical
+ * everywhere, so it lives here rather than being written twice.
+ *
+ * @param actorNick who sent the MODE. Used only to spot our own.
+ * @param ownNickLc our nick on this network, lowercased; null when unknown.
+ * @param spokeRecently whether a nick spoke inside the window ending at this event.
+ */
+export function smartHidesMode(
+  modes: readonly ModeChange[] | null | undefined,
+  actorNick: string | null | undefined,
+  ownNickLc: string | null,
+  spokeRecently: (nick: string) => boolean,
+): boolean {
+  if (!isChurnMode(modes)) return false;
+  if (ownNickLc && actorNick && actorNick.toLowerCase() === ownNickLc) return false;
+  const targets = modeTargets(modes);
+  if (ownNickLc && targets.some((t) => t.toLowerCase() === ownNickLc)) return false;
+  // Any one recent speaker shows the whole row, matching the whole-message gate
+  // above rather than hiding a `+ooo a b c` because two of the three were
+  // strangers.
+  return !targets.some((t) => spokeRecently(t));
+}

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -924,7 +924,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'that collapse into the consolidation summary above stay account-less.',
   },
 
-  // ─── Smart filter tuning (join/part/quit/nick noise) ──────────────────
+  // ─── Smart filter tuning (join/part/quit/nick/mode noise) ─────────────
   // Last of the three Events groups, and the narrowest — it only does anything
   // on one rung of the filter.
   //
@@ -942,9 +942,11 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     default: 5,
     dependsOn: EVENTS_SMART,
     description:
-      'Window in minutes for "recently spoke". A join/part/quit/nick event is hidden ' +
-      'if the affected nick has not posted a message within this many minutes before ' +
-      'the event.',
+      'Window in minutes for "recently spoke". An event is hidden if the nick it ' +
+      'concerns has not posted a message within this many minutes before it. For ' +
+      'joins, parts, quits and nick changes that is the nick the event is about; ' +
+      'for op and voice changes it is the nick being opped or voiced, not whoever ' +
+      'set the mode.',
   },
   {
     key: 'chat.smart_filter_join',

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -977,6 +977,21 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     description: 'Apply smart filter to NICK change events.',
   },
   {
+    key: 'chat.smart_filter_mode',
+    label: 'Filter op and voice changes',
+    category: 'events',
+    group: 'smart-filter',
+    type: 'bool',
+    default: true,
+    dependsOn: EVENTS_SMART,
+    description:
+      'Apply smart filter to MODE events that only grant or revoke member status ' +
+      '(+o, +v, and the equivalents your network offers). The event is hidden when ' +
+      'none of the nicks it acts on has spoken recently. Bans, channel keys, user ' +
+      'limits and channel flags are never hidden, and a single MODE that mixes one ' +
+      'of those in with an op change is shown in full.',
+  },
+  {
     key: 'chat.smart_filter_join_unmask',
     label: 'Reveal join when user speaks (minutes)',
     category: 'events',

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -364,6 +364,8 @@ import type { ConsolidationGroup, NickEntry, RenameEntry } from '../../../shared
 import { collapseDisplay } from '../utils/collapseDisplay.js';
 import { parseRelayChain } from '../../../shared/parseRelay.js';
 import { asEventMode, eventModeKey, isNoiseType } from '../../../shared/eventFilter.js';
+import { smartHidesMode } from '../../../shared/modes.js';
+import type { ModeChange } from '../../../shared/modes.js';
 import NickRef from './NickRef.vue';
 import LinkedText from './LinkedText.vue';
 import RenderSegments from './RenderSegments.vue';
@@ -424,6 +426,10 @@ interface ChatMessage {
   // These exist only on the per-render display clone, never on the stored row.
   relayBot?: string;
   relaySource?: string | null;
+  // MODE rows (#673 / MODE_EVENT_NOISE.md): the message's change list, each
+  // entry carrying the class the server stamped on it. The browser never sees
+  // ISUPPORT, so `kind` is the only way to tell op churn from a ban.
+  modes?: ModeChange[];
   [key: string]: unknown;
 }
 
@@ -933,6 +939,7 @@ const smartFilterUnmaskMs = computed(
 const smartFilterJoin = computed(() => !!settings.effective('chat.smart_filter_join'));
 const smartFilterQuit = computed(() => !!settings.effective('chat.smart_filter_quit'));
 const smartFilterNick = computed(() => !!settings.effective('chat.smart_filter_nick'));
+const smartFilterMode = computed(() => !!settings.effective('chat.smart_filter_mode'));
 
 // At the `none` tier there are no event rows left to fold, so the consolidation
 // pass is skipped outright rather than run over a stream it can't match.
@@ -1018,6 +1025,7 @@ const renderRows = computed((): RenderRow[] => {
   const fJoin = smartFilterJoin.value;
   const fQuit = smartFilterQuit.value;
   const fNick = smartFilterNick.value;
+  const fMode = smartFilterMode.value;
 
   const dividerAfterId = buf?.dividerAfterId || 0;
   // Skip divider insertion entirely when there's nothing to mark (no pointer
@@ -1138,27 +1146,50 @@ const renderRows = computed((): RenderRow[] => {
     }
 
     if (filterOn && m.nick && !m.self) {
-      const filterable =
-        (m.type === 'join' && fJoin) ||
-        // chghost rides the quit toggle rather than adding a fourth setting:
-        // it's the same churn from the same silent lurkers (identifying to
-        // services after a netsplit fires one per shared channel), which is
-        // exactly what smart filtering exists to absorb. weechat ships a
-        // dedicated smart_filter_chghost for the same reason (#591).
-        ((m.type === 'part' || m.type === 'quit' || m.type === 'chghost') && fQuit) ||
-        (m.type === 'nick' && fNick);
-      if (filterable && m.nick.toLowerCase() !== ownNickLc) {
-        const lastSpoke = buf?.speakers[m.nick.toLowerCase()]?.lastTime;
-        const eventTime = Date.parse(m.time ?? '') || 0;
-        const recentlySpoke =
-          lastSpoke != null && lastSpoke <= eventTime && eventTime - lastSpoke <= delayMs;
-        const unmasked =
-          m.type === 'join' &&
-          unmaskMs > 0 &&
-          lastSpoke != null &&
-          lastSpoke > eventTime &&
-          lastSpoke - eventTime <= unmaskMs;
-        if (!recentlySpoke && !unmasked) hidden = true;
+      const eventTime = Date.parse(m.time ?? '') || 0;
+      const lastSpokeOf = (nick: string): number | undefined =>
+        buf?.speakers[nick.toLowerCase()]?.lastTime;
+      // Did this nick speak in the window ENDING at the event? Shared by the two
+      // branches below, which differ only in whose name they put through it.
+      const spokeRecently = (nick: string): boolean => {
+        const lastSpoke = lastSpokeOf(nick);
+        return lastSpoke != null && lastSpoke <= eventTime && eventTime - lastSpoke <= delayMs;
+      };
+
+      if (m.type === 'mode') {
+        // A MODE row is judged on the nicks it acted ON, never on the nick that
+        // sent it. The author of a mode line is nearly always ChanServ or an op
+        // bot, and those never speak in the channel — key on the author and the
+        // rung degenerates into "hide every mode change". weechat judges the
+        // target (irc-mode.c, where the speaking-time test sits inside the
+        // per-nick mode branch); halloy judges the author, and that looks like
+        // a bug rather than a choice.
+        //
+        // The decision itself is shared (and unit-tested) rather than written
+        // out here, because iOS has to reach the same verdict row for row.
+        if (fMode && smartHidesMode(m.modes, m.nick, ownNickLc, spokeRecently)) hidden = true;
+      } else {
+        const filterable =
+          (m.type === 'join' && fJoin) ||
+          // chghost rides the quit toggle rather than adding a fourth setting:
+          // it's the same churn from the same silent lurkers (identifying to
+          // services after a netsplit fires one per shared channel), which is
+          // exactly what smart filtering exists to absorb. weechat ships a
+          // dedicated smart_filter_chghost for the same reason (#591).
+          ((m.type === 'part' || m.type === 'quit' || m.type === 'chghost') && fQuit) ||
+          (m.type === 'nick' && fNick);
+        if (filterable && m.nick.toLowerCase() !== ownNickLc) {
+          const lastSpoke = lastSpokeOf(m.nick);
+          const unmasked =
+            m.type === 'join' &&
+            unmaskMs > 0 &&
+            lastSpoke != null &&
+            lastSpoke > eventTime &&
+            lastSpoke - eventTime <= unmaskMs;
+          // Joins only: a mode is never revived by what its target says next.
+          // weechat scopes smart_filter_join_unmask the same way.
+          if (!spokeRecently(m.nick) && !unmasked) hidden = true;
+        }
       }
     }
 

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -426,9 +426,10 @@ interface ChatMessage {
   // These exist only on the per-render display clone, never on the stored row.
   relayBot?: string;
   relaySource?: string | null;
-  // MODE rows (#673 / MODE_EVENT_NOISE.md): the message's change list, each
-  // entry carrying the class the server stamped on it. The browser never sees
-  // ISUPPORT, so `kind` is the only way to tell op churn from a ban.
+  // MODE rows: the message's change list, each entry carrying the class the
+  // server stamped on it (`prefix` / `list` / `chan`). The browser never sees
+  // ISUPPORT, so `kind` is the only way to tell op churn from a ban — see
+  // shared/modes.ts and docs/CLIENT_PROTOCOL.md §7.4.
   modes?: ModeChange[];
   [key: string]: unknown;
 }
@@ -1027,6 +1028,18 @@ const renderRows = computed((): RenderRow[] => {
   const fNick = smartFilterNick.value;
   const fMode = smartFilterMode.value;
 
+  // "Did this nick speak in the window ending at `at`?" — the one comparison
+  // both smart-filter branches make, differing only in whose name goes in: the
+  // presence branch asks about an event's actor, the mode branch about each
+  // nick it acted on. Hoisted out of the row loop below so an ordinary chat
+  // line doesn't allocate a pair of closures it will never call.
+  const lastSpokeOf = (nick: string): number | undefined =>
+    buf?.speakers[nick.toLowerCase()]?.lastTime;
+  const spokeRecently = (nick: string, at: number): boolean => {
+    const lastSpoke = lastSpokeOf(nick);
+    return lastSpoke != null && lastSpoke <= at && at - lastSpoke <= delayMs;
+  };
+
   const dividerAfterId = buf?.dividerAfterId || 0;
   // Skip divider insertion entirely when there's nothing to mark (no pointer
   // yet, or pointer at 0 = brand-new buffer where every message is "first
@@ -1145,17 +1158,12 @@ const renderRows = computed((): RenderRow[] => {
       });
     }
 
-    if (filterOn && m.nick && !m.self) {
-      const eventTime = Date.parse(m.time ?? '') || 0;
-      const lastSpokeOf = (nick: string): number | undefined =>
-        buf?.speakers[nick.toLowerCase()]?.lastTime;
-      // Did this nick speak in the window ENDING at the event? Shared by the two
-      // branches below, which differ only in whose name they put through it.
-      const spokeRecently = (nick: string): boolean => {
-        const lastSpoke = lastSpokeOf(nick);
-        return lastSpoke != null && lastSpoke <= eventTime && eventTime - lastSpoke <= delayMs;
-      };
+    // Parsed once and reused by the smart filter and the presence dividers
+    // below — this is a string parse on every surviving row, so it should
+    // happen exactly once.
+    const mTimeMs = Date.parse(m.time ?? '') || 0;
 
+    if (filterOn && m.nick && !m.self) {
       if (m.type === 'mode') {
         // A MODE row is judged on the nicks it acted ON, never on the nick that
         // sent it. The author of a mode line is nearly always ChanServ or an op
@@ -1167,7 +1175,12 @@ const renderRows = computed((): RenderRow[] => {
         //
         // The decision itself is shared (and unit-tested) rather than written
         // out here, because iOS has to reach the same verdict row for row.
-        if (fMode && smartHidesMode(m.modes, m.nick, ownNickLc, spokeRecently)) hidden = true;
+        if (
+          fMode &&
+          smartHidesMode(m.modes, m.nick, ownNickLc, (nick) => spokeRecently(nick, mTimeMs))
+        ) {
+          hidden = true;
+        }
       } else {
         const filterable =
           (m.type === 'join' && fJoin) ||
@@ -1184,11 +1197,11 @@ const renderRows = computed((): RenderRow[] => {
             m.type === 'join' &&
             unmaskMs > 0 &&
             lastSpoke != null &&
-            lastSpoke > eventTime &&
-            lastSpoke - eventTime <= unmaskMs;
+            lastSpoke > mTimeMs &&
+            lastSpoke - mTimeMs <= unmaskMs;
           // Joins only: a mode is never revived by what its target says next.
           // weechat scopes smart_filter_join_unmask the same way.
-          if (!spokeRecently(m.nick) && !unmasked) hidden = true;
+          if (!spokeRecently(m.nick, mTimeMs) && !unmasked) hidden = true;
         }
       }
     }
@@ -1209,7 +1222,6 @@ const renderRows = computed((): RenderRow[] => {
       lastDayKey = dayKey;
     }
 
-    const mTimeMs = Date.parse(m.time ?? '') || 0;
     if (!awayInserted && awaySinceMs != null && mTimeMs > awaySinceMs) {
       pushAwayDivider();
       awayInserted = true;

--- a/vue_client/src/utils/settingsRegistry.test.ts
+++ b/vue_client/src/utils/settingsRegistry.test.ts
@@ -139,6 +139,7 @@ describe('optionEnabled (#666)', () => {
       'chat.smart_filter_join',
       'chat.smart_filter_quit',
       'chat.smart_filter_nick',
+      'chat.smart_filter_mode',
       'chat.smart_filter_join_unmask',
     ]) {
       expect(optionEnabled(opt(key), mobileSmart)).toBe(true);


### PR DESCRIPTION
Brings `mode` into the smart rung of the event filter, and lays the classification
groundwork the fold (#673) and a rendering pass both need.

Plan and reference audit: `lurker-dev/MODE_EVENT_NOISE.md`.

## Why

The smart rung has only ever known about join, part, quit, chghost and nick, so someone
running it still ate every ChanServ op burst. This closes the gap between what the rung is
called and what it does.

## The blocker this had to clear first

Deciding whether a MODE row is churn means telling `+o alice` from `+b alice` — and that
needs the server's ISUPPORT `PREFIX` / `CHANMODES`, which no client has ever seen.

Hardcoding `q/a/o/h/v` is not the way out: that was tried and it disagreed with solanum,
where `+q` is a quiet LIST mode whose mask can be a bare nick (see the comment on
`prefixModes()`). So the server classifies and sends the answer — each entry of a mode
row's change list now carries `kind: 'prefix' | 'list' | 'chan'`, riding `extra.modes` into
storage so a backlog row answers the same way a live one does.

The classifier is the **same call** the handler now switches on when deciding whether a
change lands on the member map or on the channel, so a change can't be filtered as one
thing and applied as another. It is stamped before the `ch` guard, since the class is a
property of the letters and 005 rather than of whether we're tracking that channel's
members.

## The rule

**A MODE row is judged on the nicks it acted ON, never on the nick that sent it.** The
author is nearly always ChanServ or an op bot, and those never speak in the channel — key
on the author and the rung degenerates into "hide every mode change". weechat judges the
target (`irc-mode.c`, where the speaking-time test sits inside the per-nick mode branch);
halloy judges the author, and that looks like a bug rather than a choice.

**Only pure member-status churn is eligible.** One ban, key, limit or channel flag anywhere
in the message shows the whole row, so a mixed `+o-b alice *!*@host` survives intact. That
whole-message gate is weechat's too, and it's the direction that can't silently swallow a
ban.

Never hidden: a mode we set, a mode set on us, or one whose target spoke recently. For a
multi-target `+ooo a b c`, one recent speaker among them shows the row rather than dropping
the other two grants.

## What's NOT here

- **Consolidation** (#673) — mode still terminates a run. Deliberately separate; it needs
  its own summary vocabulary.
- **Rendering** — `mode by ChanServ: +o alice` is unchanged. The `kind` stamp is what makes
  the gamja-style verbalization cheap, and that's the next PR.
- **iOS** — ports after the fold lands, so the two clients can't disagree about what folds.
- **Page units** — untouched. `mode` stays out of `CONSOLIDATABLE_TYPES`, so `renderable`
  and `chat` mean exactly what they did.

## ⚠ One open question for QA

In a **moderated (`+m`) channel**, `+v alice` is the permission for alice to *start*
speaking — so "has the target spoken recently" is guaranteed false and the grant is
**always** hidden, in exactly the channels where voice grants matter most.

This is weechat's behaviour rather than a decision anyone made here, so the branch leaves it
alone. The candidate remedy is to extend the join-unmask idea to mode grants (reveal the row
when the target speaks shortly *after* it); `smartHidesMode`'s signature has room for it.
Ruled out already: exempting `+v` wholesale (loses the win on unmoderated channels, where
`+v` is decoration) and testing the channel's `+m` flag (the client knows the *current*
flags, not the flags as of the event).

## Behaviour change

`chat.smart_filter_mode` defaults **on**, matching its three siblings and weechat. Existing
smart-filter users will see op/voice churn start collapsing away — that's the point, and it
wants a release note rather than a migration.

## Compatibility

Rows written before this have no `kind`, and every consumer treats missing as "not prefix":
an unclassified row shows and never folds. Fail-visible, no backfill. Older clients ignore
the new field.

## Tests

`shared/modes.test.ts` (26) covers the classifier, the churn predicate and the decision
itself; `ircConnection.test.ts` gains five stamp tests reusing the existing solanum/Unreal
ISUPPORT fixtures. Notable ones:

- solanum `+q troll` stamps `list` **and** leaves the member map alone — both ends of the
  "can't disagree" property in one test.
- The same `+q` stamps `prefix` when the server declares it in `PREFIX`.
- ChanServ (never speaks) ops alice (spoke a minute ago) → shown; the author speaking is
  *not* what saves a row. That's the test that would have caught halloy's shape.
- A mixed `+o-b` neither hides nor folds.
- An unstamped row shows.

Full suite green: 284 files, 4079 tests.

## Review

`/code-review high` found no correctness bug. Six low-severity findings, all applied in
`24c566a`: a hot-path regression (`Date.parse` + two closures on every row, and the
timestamp parsed twice), the undocumented `modes[]` entry shape in the protocol spec, stale
`chat.smart_filter_delay` copy, the unpinned gating test, and a dangling doc reference. The
sixth is the `+m`/`+v` question above.

The spec gap was the one worth catching: without §7.4 an implementer reads the doc, finds no
`kind`, and reimplements the hardcoded `q a o h v` set — which is #486 — and §5.1's member
`modes` list was actively handing them those letters. Both ends now say not to.
