### PR TITLE
Narrate mode lines instead of printing the wire form

### DIFF
--- a/shared/modeNarration.test.ts
+++ b/shared/modeNarration.test.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { describeMode, type ModeSegment } from './modeNarration.js';
+import type { ModeChange } from './modes.js';
+
+/** The narration as a plain string, for readable assertions. */
+function say(modes: ModeChange[] | null | undefined, rawText?: string | null): string {
+  return describeMode(modes, rawText)
+    .map((s: ModeSegment) => (s.t === 'nick' ? s.nick : s.text))
+    .join('');
+}
+
+const prefix = (mode: string, param: string): ModeChange => ({ mode, param, kind: 'prefix' });
+const list = (mode: string, param: string): ModeChange => ({ mode, param, kind: 'list' });
+const chan = (mode: string, param?: string): ModeChange => ({ mode, param, kind: 'chan' });
+
+describe('describeMode — member status', () => {
+  it('narrates the grants and revocations people actually see', () => {
+    expect(say([prefix('+o', 'alice')])).toBe(' gave op to alice');
+    expect(say([prefix('-o', 'alice')])).toBe(' took op from alice');
+    expect(say([prefix('+v', 'carol')])).toBe(' gave voice to carol');
+    expect(say([prefix('-v', 'carol')])).toBe(' took voice from carol');
+    expect(say([prefix('+h', 'dave')])).toBe(' gave half-op to dave');
+    expect(say([prefix('+q', 'erin')])).toBe(' gave owner to erin');
+    expect(say([prefix('+a', 'frank')])).toBe(' gave admin to frank');
+  });
+
+  it('emits the target as a nick segment, so it can be rendered as one', () => {
+    expect(describeMode([prefix('+o', 'alice')])).toEqual([
+      { t: 'text', text: ' gave op to ' },
+      { t: 'nick', nick: 'alice' },
+    ]);
+  });
+
+  it('falls back to the token for a prefix letter it has no name for', () => {
+    // The letter set here is only phrasing — whether it IS a prefix mode was
+    // settled server-side by ISUPPORT, so an exotic network still narrates.
+    expect(say([prefix('+y', 'gwen')])).toBe(' gave +y to gwen');
+    expect(say([prefix('-y', 'gwen')])).toBe(' took +y from gwen');
+  });
+});
+
+describe('describeMode — list modes', () => {
+  it('narrates bans, quiets and exceptions', () => {
+    expect(say([list('+b', '*!*@host')])).toBe(' banned *!*@host');
+    expect(say([list('-b', '*!*@host')])).toBe(' unbanned *!*@host');
+    expect(say([list('+q', '*!*@host')])).toBe(' quieted *!*@host');
+    expect(say([list('+e', '*!*@host')])).toBe(' added a ban exemption for *!*@host');
+    expect(say([list('-I', '*!*@host')])).toBe(' removed the invite exception for *!*@host');
+  });
+
+  it('names the list for a letter it does not know', () => {
+    expect(say([list('+d', 'mask')])).toBe(' added mask to the +d list');
+    expect(say([list('-d', 'mask')])).toBe(' removed mask from the +d list');
+  });
+
+  it('never emits a mask as a nick segment', () => {
+    // `+b alice` is a mask that happens to look like a nick. Rendering it as a
+    // nick would give it a colour, a nick menu, and a whois — for a ban.
+    expect(describeMode([list('+b', 'alice')]).some((s) => s.t === 'nick')).toBe(false);
+  });
+});
+
+describe('describeMode — channel modes', () => {
+  it('narrates the common flags', () => {
+    expect(say([chan('+t')])).toBe(' locked the topic');
+    expect(say([chan('-t')])).toBe(' unlocked the topic');
+    expect(say([chan('+m')])).toBe(' made the channel moderated');
+    expect(say([chan('-m')])).toBe(' removed moderation');
+    expect(say([chan('+i')])).toBe(' made the channel invite-only');
+    expect(say([chan('+s')])).toBe(' made the channel secret');
+    expect(say([chan('+p')])).toBe(' made the channel private');
+  });
+
+  it('gets +n the right way round', () => {
+    // +n BLOCKS messages from outside the channel. gamja narrates `+n` as
+    // "allowed external messages", which is inverted; this pins ours.
+    expect(say([chan('+n')])).toBe(' blocked outside messages');
+    expect(say([chan('-n')])).toBe(' allowed outside messages');
+  });
+
+  it('narrates the user limit with its value', () => {
+    expect(say([chan('+l', '50')])).toBe(' set the user limit to 50');
+    expect(say([chan('-l')])).toBe(' removed the user limit');
+  });
+
+  it('never prints the channel key (#476)', () => {
+    expect(say([chan('+k', 'hunter2')])).toBe(' set a channel key');
+    expect(say([chan('+k', 'hunter2')])).not.toContain('hunter2');
+    expect(say([chan('-k', 'hunter2')])).toBe(' removed the channel key');
+  });
+
+  it('falls back to the token for an unknown letter', () => {
+    expect(say([chan('+C')])).toBe(' set +C');
+    expect(say([chan('-C')])).toBe(' unset +C');
+    expect(say([chan('+j', '5:1')])).toBe(' set +j to 5:1');
+  });
+});
+
+describe('describeMode — the fallbacks', () => {
+  it('shows a compact mode string when a message carries several changes', () => {
+    expect(say([prefix('+o', 'alice'), list('-b', '*!*@host')])).toBe(' set +o alice -b *!*@host');
+  });
+
+  it('withholds the key in the multi-change form too', () => {
+    // The row's raw `text` is the wire form and carries the key, which is why
+    // this rebuilds from the parsed list instead of reusing it.
+    const said = say([chan('+k', 'hunter2'), chan('+m')]);
+    expect(said).toBe(' set +k +m');
+    expect(said).not.toContain('hunter2');
+  });
+
+  it('does not narrate an unstamped change, because it cannot know what it is', () => {
+    // Without `kind`, `+q alice` might grant ownership or quiet a mask. Guessing
+    // is the bug the stamp exists to prevent, so this shows the mode string.
+    expect(say([{ mode: '+q', param: 'alice' }])).toBe(' set +q alice');
+    expect(say([{ mode: '+o', param: 'alice' }])).toBe(' set +o alice');
+  });
+
+  it('uses the row text when there is no parsed list at all', () => {
+    expect(say([], '+o alice')).toBe(' set +o alice');
+    expect(say(null, '+nt')).toBe(' set +nt');
+  });
+
+  it('still says something when the row has nothing usable', () => {
+    expect(say([], '')).toBe(' changed the channel modes');
+    expect(say(null, null)).toBe(' changed the channel modes');
+  });
+
+  it('ignores malformed entries rather than narrating them', () => {
+    expect(say([{ mode: '', param: 'x' }, prefix('+o', 'alice')])).toBe(' gave op to alice');
+  });
+});

--- a/shared/modeNarration.test.ts
+++ b/shared/modeNarration.test.ts
@@ -124,6 +124,22 @@ describe('describeMode — the fallbacks', () => {
     expect(say(null, '+nt')).toBe(' set +nt');
   });
 
+  it('withholds the key from the raw-text path too, by dropping every param', () => {
+    // Reachable, not theoretical: rows written before `modes` was persisted take
+    // this path, and their `text` is the wire form. Which param is the key can't
+    // be worked out without CHANMODES — and a row with no parsed list has no
+    // classification either — so the letters stay and the params go.
+    expect(say([], '+k hunter2')).toBe(' set +k');
+    expect(say([], '+ok alice hunter2')).toBe(' set +ok');
+    expect(say([], '-k hunter2')).toBe(' set -k');
+    expect(say([], '+k hunter2')).not.toContain('hunter2');
+  });
+
+  it('leaves a key-less raw text with its params intact', () => {
+    expect(say([], '+b *!*@host')).toBe(' set +b *!*@host');
+    expect(say([], '+l 50')).toBe(' set +l 50');
+  });
+
   it('still says something when the row has nothing usable', () => {
     expect(say([], '')).toBe(' changed the channel modes');
     expect(say(null, null)).toBe(' changed the channel modes');

--- a/shared/modeNarration.ts
+++ b/shared/modeNarration.ts
@@ -146,6 +146,26 @@ function rawSegments(modes: readonly ModeChange[]): ModeSegment[] {
 }
 
 /**
+ * The wire text of a mode message, with its parameters dropped when a `k` is
+ * among the letters.
+ *
+ * `text` is `raw_modes` followed by every parameter, so it carries the channel
+ * key — and this is the one path that would show it, since it is the parsed
+ * list that lets rawSegments withhold it everywhere else. Which parameter is
+ * the key can't be worked out here: mapping parameters to letters needs
+ * CHANMODES, and a row with no parsed list has no classification either. So
+ * when a key may be present, keep the letters and drop every parameter — the
+ * same trade the channel-mode display already makes (#476).
+ *
+ * Reachable rather than theoretical: mode rows written before `modes` was
+ * persisted take this path.
+ */
+function withoutKeyParam(text: string): string {
+  const modeToken = text.split(/\s+/)[0] ?? '';
+  return modeToken.includes('k') ? modeToken : text;
+}
+
+/**
  * Narrate a MODE row: the segments that follow the actor's nick.
  *
  * Every segment list starts with a leading space, so a caller renders the actor
@@ -163,8 +183,9 @@ export function describeMode(
 
   if (list.length === 0) {
     // No parsed changes. Show whatever the row does have rather than nothing —
-    // this is pre-stamp backlog, and its text is the only description it has.
-    const text = (rawText ?? '').trim();
+    // this is backlog old enough to predate `modes` being persisted at all, and
+    // its raw text is the only description it has.
+    const text = withoutKeyParam((rawText ?? '').trim());
     if (!text) return [{ t: 'text', text: ' changed the channel modes' }];
     return [
       { t: 'text', text: ' set ' },

--- a/shared/modeNarration.ts
+++ b/shared/modeNarration.ts
@@ -1,0 +1,188 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Turning a MODE row into a sentence.
+//
+// The line used to render as `mode by ChanServ: +o alice` — the raw wire form
+// with a label bolted on, which asks the reader to know IRC mode syntax to find
+// out that somebody got opped. gamja narrates these instead
+// (`components/buffer.js`), and it reads enormously better; this is that idea,
+// built on the `kind` stamp from shared/modes.ts so it can tell `+o alice` (a
+// nick) from `+b alice` (a mask that happens to look like one).
+//
+// Output is a SEGMENT LIST rather than a string so the caller can render the
+// affected nick as a real nick — clickable, colored, with the nick menu on it,
+// which the raw form never offered. It also keeps this file free of any view
+// framework, so the phone can port it as-is.
+//
+// Only a SINGLE-change message is narrated. A message carrying several changes
+// falls back to a compact mode string, matching gamja (which gates its
+// narration on `modeStr.length === 2`): "gave op to alice and banned *!*@host
+// and set the user limit to 50" is worse than `+o-b+l alice *!*@host 50`, and
+// the multi-change case is overwhelmingly services bursts rather than something
+// a human typed.
+
+import { modeLetter, type ModeChange } from './modes.js';
+
+/** A piece of a narrated mode line. */
+export type ModeSegment =
+  /** Narration prose. Rendered as-is. */
+  | { t: 'text'; text: string }
+  /** A nick the mode acted on. Render it as a nick — this is only ever emitted
+   *  for a `prefix` change, so it is a real member and never a mask. */
+  | { t: 'nick'; nick: string }
+  /** A literal argument: a ban mask, a limit, a raw mode string. Never a nick,
+   *  so it must never be rendered as one. */
+  | { t: 'arg'; text: string };
+
+/** What a member-prefix letter grants, for the "gave X to" phrasing. */
+const PREFIX_NAMES: Record<string, string> = {
+  q: 'owner',
+  a: 'admin',
+  o: 'op',
+  h: 'half-op',
+  v: 'voice',
+};
+
+/**
+ * Narrate a change that grants or revokes member status.
+ *
+ * The letter set is only a phrasing table — whether a letter IS a prefix mode
+ * was decided server-side by ISUPPORT and is already on `kind`. An unlisted
+ * letter narrates with its token rather than being misread as something else.
+ */
+function prefixSegments(sign: string, letter: string, param: string): ModeSegment[] {
+  const name = PREFIX_NAMES[letter] ?? `+${letter}`;
+  return [
+    { t: 'text', text: sign === '+' ? ` gave ${name} to ` : ` took ${name} from ` },
+    { t: 'nick', nick: param },
+  ];
+}
+
+/** Narrate a mask going onto or off a list mode (bans, exemptions, quiets). */
+function listSegments(sign: string, letter: string, param: string): ModeSegment[] {
+  const add = sign === '+';
+  const phrase: Record<string, [string, string]> = {
+    b: [' banned ', ' unbanned '],
+    q: [' quieted ', ' unquieted '],
+    e: [' added a ban exemption for ', ' removed the ban exemption for '],
+    I: [' added an invite exception for ', ' removed the invite exception for '],
+  };
+  const known = phrase[letter];
+  if (known) {
+    return [
+      { t: 'text', text: add ? known[0] : known[1] },
+      { t: 'arg', text: param },
+    ];
+  }
+  // An unknown list mode still reads correctly said plainly, and says which
+  // list it was — better than inventing a verb for a letter we don't know.
+  return [
+    { t: 'text', text: add ? ' added ' : ' removed ' },
+    { t: 'arg', text: param },
+    { t: 'text', text: add ? ` to the +${letter} list` : ` from the +${letter} list` },
+  ];
+}
+
+/** Narrate a channel flag or parameter mode. */
+function chanSegments(sign: string, letter: string, param?: string): ModeSegment[] {
+  const add = sign === '+';
+  const text = (t: string): ModeSegment[] => [{ t: 'text', text: t }];
+
+  // ⚠ The channel key is never printed. Every member of the channel saw the
+  // MODE that set it, so it is not a secret from them — but it lands in
+  // scrollback and in the database, and Lurker already keeps it out of the
+  // channel-mode display for that reason (#476). This is the other half.
+  if (letter === 'k') return text(add ? ' set a channel key' : ' removed the channel key');
+  if (letter === 'l') {
+    if (!add) return text(' removed the user limit');
+    return param
+      ? [
+          { t: 'text', text: ' set the user limit to ' },
+          { t: 'arg', text: param },
+        ]
+      : text(' set a user limit');
+  }
+  if (letter === 't') return text(add ? ' locked the topic' : ' unlocked the topic');
+  // ⚠ +n BLOCKS messages from outside the channel; it does not allow them.
+  // gamja has this pair inverted (`components/buffer.js`, the "n" case reads
+  // "allowed" for `+n`) — narrate the mode, not the reference.
+  if (letter === 'n') return text(add ? ' blocked outside messages' : ' allowed outside messages');
+  if (letter === 'i') return text(add ? ' made the channel invite-only' : ' removed invite-only');
+  if (letter === 'm') return text(add ? ' made the channel moderated' : ' removed moderation');
+  if (letter === 's') return text(add ? ' made the channel secret' : ' removed secret');
+  if (letter === 'p') return text(add ? ' made the channel private' : ' removed private');
+
+  // Unknown letter. With a value it reads as an assignment; without one, as a
+  // flag. Either way the token is shown rather than guessed at.
+  if (param && add) {
+    return [
+      { t: 'text', text: ` set +${letter} to ` },
+      { t: 'arg', text: param },
+    ];
+  }
+  return text(add ? ` set +${letter}` : ` unset +${letter}`);
+}
+
+/**
+ * A compact mode string for a message carrying more than one change, and for
+ * anything else this can't narrate.
+ *
+ * Rebuilt from the parsed list rather than reusing the row's raw `text`,
+ * because `text` is the wire form INCLUDING a `+k` key. Reconstructing is what
+ * lets the key be dropped here the way it already is everywhere else (#476).
+ */
+function rawSegments(modes: readonly ModeChange[]): ModeSegment[] {
+  const parts = modes.map((m) => {
+    // The one param that is withheld; the letter still shows, so the reader
+    // knows a key was set.
+    if (modeLetter(m.mode) === 'k') return m.mode;
+    return m.param ? `${m.mode} ${m.param}` : m.mode;
+  });
+  return [
+    { t: 'text', text: ' set ' },
+    { t: 'arg', text: parts.join(' ') },
+  ];
+}
+
+/**
+ * Narrate a MODE row: the segments that follow the actor's nick.
+ *
+ * Every segment list starts with a leading space, so a caller renders the actor
+ * and then these, with no separator of its own.
+ *
+ * @param modes the row's parsed change list, each stamped with its `kind`.
+ * @param rawText the row's raw `text`, used only when there is no parsed list
+ *   at all — backlog old enough to predate it.
+ */
+export function describeMode(
+  modes: readonly ModeChange[] | null | undefined,
+  rawText?: string | null,
+): ModeSegment[] {
+  const list = (modes ?? []).filter((m) => m && m.mode);
+
+  if (list.length === 0) {
+    // No parsed changes. Show whatever the row does have rather than nothing —
+    // this is pre-stamp backlog, and its text is the only description it has.
+    const text = (rawText ?? '').trim();
+    if (!text) return [{ t: 'text', text: ' changed the channel modes' }];
+    return [
+      { t: 'text', text: ' set ' },
+      { t: 'arg', text },
+    ];
+  }
+
+  if (list.length > 1) return rawSegments(list);
+
+  const only = list[0];
+  const sign = only.mode.startsWith('-') ? '-' : '+';
+  const letter = modeLetter(only.mode);
+
+  // An unstamped row can't be narrated: without `kind` there is no way to know
+  // whether `+q alice` grants ownership or quiets a mask, and guessing is
+  // exactly the bug the stamp exists to prevent. Fall back to the mode string.
+  if (only.kind === 'prefix' && only.param) return prefixSegments(sign, letter, only.param);
+  if (only.kind === 'list' && only.param) return listSegments(sign, letter, only.param);
+  if (only.kind === 'chan') return chanSegments(sign, letter, only.param);
+  return rawSegments(list);
+}

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -257,14 +257,19 @@
               />{{ eventHostSuffix(row.m) }}</template
             >
             <template v-else-if="row.m?.type === 'mode'"
-              >mode by
-              <NickRef
+              ><NickRef
                 :nick="row.m.nick ?? ''"
                 interactive
-                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)" /><template
-                v-if="row.m.text"
-                >: <LinkedText :text="row.m.text" /></template
-            ></template>
+                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
+              /><template v-for="(seg, si) in describeMode(row.m.modes, row.m.text)" :key="si"
+                ><template v-if="seg.t === 'nick'"
+                  ><NickRef
+                    :nick="seg.nick"
+                    interactive
+                    @click.stop.prevent="onNickMenu($event, seg.nick, row.m)" /></template
+                ><template v-else>{{ seg.text }}</template></template
+              ></template
+            >
             <template v-else-if="row.m?.type === 'topic'"
               >topic set by
               <NickRef
@@ -365,6 +370,7 @@ import { collapseDisplay } from '../utils/collapseDisplay.js';
 import { parseRelayChain } from '../../../shared/parseRelay.js';
 import { asEventMode, eventModeKey, isNoiseType } from '../../../shared/eventFilter.js';
 import { smartHidesMode } from '../../../shared/modes.js';
+import { describeMode } from '../../../shared/modeNarration.js';
 import type { ModeChange } from '../../../shared/modes.js';
 import NickRef from './NickRef.vue';
 import LinkedText from './LinkedText.vue';

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -266,7 +266,7 @@
                   ><NickRef
                     :nick="seg.nick"
                     interactive
-                    @click.stop.prevent="onNickMenu($event, seg.nick, row.m)" /></template
+                    @click.stop.prevent="onNickMenu($event, seg.nick)" /></template
                 ><template v-else>{{ seg.text }}</template></template
               ></template
             >


### PR DESCRIPTION
PR 4 of the mode-noise plan (`lurker-dev/MODE_EVENT_NOISE.md` §4.5). Builds on the `kind`
stamp from #825. Independent of consolidation (#673), which is still to come.

## Why

`mode by ChanServ: +o alice` was the least readable line in the message list — the wire form
with a label bolted on, asking the reader to know IRC mode syntax to discover that somebody
got opped.

```
- mode by ChanServ: +o alice          →  ChanServ gave op to alice
- mode by op: +b *!*@host             →  op banned *!*@host
- mode by op: +l 50                   →  op set the user limit to 50
- mode by op: +t                      →  op locked the topic
- mode by op: +k hunter2              →  op set a channel key
```

`alice` is now a **real nick** — coloured, clickable, with the nick menu on her. The raw
form never offered that.

## Why it needed the stamp first

Without `kind` this isn't safe to do. `+q alice` either grants ownership or quiets a mask
depending on the network, and `+b alice` is a mask that merely *looks* like a nick —
rendering it as one would hand a ban a colour, a whois and a nick menu. `describeMode` only
emits a nick segment for a change the server classified `prefix`, and an **unstamped** row
isn't narrated at all; it falls back to the mode string rather than being guessed at.

## Shape

`describeMode` returns **segments**, not a string, so the caller decides what a nick looks
like and iOS can port the file untouched:

```ts
type ModeSegment =
  | { t: 'text'; text: string }   // narration prose
  | { t: 'nick'; nick: string }   // only ever a `prefix` target
  | { t: 'arg';  text: string }   // a mask, a limit — never rendered as a nick
```

Only **single-change** messages narrate, matching gamja's own gate (`modeStr.length === 2`).
A services burst reads better as `+o-b alice *!*@host` than as a run-on sentence, and
multi-change messages are overwhelmingly bursts rather than something a human typed.

## Two details worth review

**The channel key is never printed — including in the multi-change form.** Every member saw
the MODE that set it, so it's no secret from them, but it lands in scrollback and in the
database, and we already keep it out of the channel-mode display (#476). This is the other
half of that. Note the multi-change form is **rebuilt from the parsed list** rather than
reusing the row's raw `text`, precisely so the key can be withheld there too — `text` is the
wire form and contains it.

**`+n` blocks outside messages; it does not allow them.** gamja narrates `+n` as "allowed
external messages" (`components/buffer.js`, the `"n"` case), which is inverted. Ours narrates
the mode rather than the reference, and there's a test pinning the pair.

## Fallbacks

| case | renders |
| --- | --- |
| several changes | ` set +o alice -b *!*@host` |
| unstamped row (pre-#825 backlog) | ` set +o alice` |
| no parsed list, only text | ` set ` + the row's text, params dropped if a key may be in them |
| nothing usable | ` changed the channel modes` |

## Tests

`shared/modeNarration.test.ts`, 17 cases. The ones that encode a decision: a mask never
becomes a nick segment; the key never appears, in either form; `+n` is the right way round;
an unstamped `+q alice` is not narrated.

Full suite green.

## Not here

Consolidation (#673) and the iOS port. `prefixText` still returns `--` for mode, matching
nick/topic.

## Review

`/code-review high` found no correctness bug in the narration itself; it confirmed the
`kind`-gated `+q` split matches `classifyModeChange`'s contract and that the single render
site is the whole surface. Two low findings, both applied in the last commit:

- **The target's nick menu was borrowing the actor's host.** It passed the mode row to
  `onNickMenu`, which falls back to that row's `userhost` for a nick no longer in the member
  list — and on a MODE row the userhost is ChanServ's, not the target's. On backlog reading
  "ChanServ gave op to alice" where alice has since left, Ban/Ignore would have built the
  mask from ChanServ's host. Inert today only because the mode publish never sets
  `userhost`, so it was one server line from live. The kick line already omits `m` for the
  kicked user for exactly this reason.
- **The raw-text fallback still printed the key,** undoing what `rawSegments` goes out of
  its way to withhold — and that path is reachable, since rows predating `modes` persistence
  take it. Which param is the key can't be determined there (mapping params to letters needs
  CHANMODES, and an unclassified row has no `kind` either), so when a key may be present the
  letters stay and every param goes.

One thing worth knowing: a full-suite run wedged at near-zero CPU partway through, most
likely a stuck vitest worker fork contending with the review agent's own run. It did not
reproduce — the suite is green at 285 files / 4098 tests in ~7s — and it was a runner hang
rather than a failing test, so there is nothing to chase yet.
