### PR TITLE
Fold op and voice churn into consolidation summaries

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -772,18 +772,30 @@ whose token you've superseded.
 
 ### `countBy` — what `limit` counts
 
-`limit` counts **stored rows**. If you consolidate presence noise — both
-first-party clients fold runs of `join`/`part`/`quit`/`nick`/`chghost` into one
-summary line, per `shared/consolidate.ts`, which is the canonical set — that is
-not the unit you render in, and on a busy channel the
-gap is enormous: a 100-row page out of a netsplit can render as three visible
-lines. You fetch, fold it to nothing, notice the page was short, fetch again —
-and the user watches the buffer assemble itself.
+`limit` counts **stored rows**. If you consolidate presence noise — the web
+client folds runs of `join`/`part`/`quit`/`nick`/`chghost`, **plus `mode` rows
+that only grant or revoke member status**, into one summary line, per
+`shared/consolidate.ts` — that is not the unit you render in, and on a busy
+channel the gap is enormous: a 100-row page out of a netsplit can render as
+three visible lines. You fetch, fold it to nothing, notice the page was short,
+fetch again — and the user watches the buffer assemble itself.
+
+⚠ **`CONSOLIDATABLE_TYPES` is not the fold set.** It is the five presence types,
+and it is deliberately narrower than what folds: `mode` stays out of it because
+that set also defines the `renderable` unit for every client, including shipped
+ones. `foldsIntoRun` answers what folds; `countsTowardPage` answers what counts.
+The two agree on churn modes and are free to diverge elsewhere.
 
 Send **`countBy:'renderable'`** (every `history` mode, and `open-buffer`) and the
-server sizes the page in rows that render as their own line. The consolidatable
-rows still come back — consolidation needs the whole run to summarize it — they
-just don't spend the budget. Default is `'event'`, i.e. today's behavior; an
+server sizes the page in rows that render as their own line — the five presence
+types, and a `mode` row whose every change is a member-status grant or
+revocation (§7.4). The folded rows still come back — consolidation needs the
+whole run to summarize it — they just don't spend the budget.
+
+If you fold presence but **not** mode, `renderable` is still safe: you receive
+mode rows that cost nothing, so your page renders longer than you asked rather
+than shorter. The rule to keep on the right side of is that the unit must never
+be **finer** than what you draw. Default is `'event'`, i.e. today's behavior; an
 older server ignores the field and answers exactly as before.
 
 Send **`countBy:'chat'`** instead if you hide event noise **entirely** — the

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -88,6 +88,24 @@ function event(networkId: number, target: string, type: string, nick: string | n
   return { id: Number(result.id), alt: result.alt };
 }
 
+/** A mode row carrying a stamped change list, the way ircConnection publishes it. */
+function modeEvent(
+  networkId: number,
+  target: string,
+  modes: Array<{ mode: string; param?: string; kind?: string }>,
+) {
+  const result = insertMessage({
+    networkId,
+    target,
+    time: new Date().toISOString(),
+    type: 'mode',
+    nick: 'ChanServ',
+    self: false,
+    extra: { modes },
+  });
+  return { id: Number(result.id), alt: result.alt };
+}
+
 function altsFor(networkId: number, target: string) {
   return listMessages(networkId, target, { limit: 1000 }).map((m) => m.alt);
 }
@@ -1460,6 +1478,44 @@ describe("listMessagesCounted unit: 'chat' (#666)", () => {
     expect(renderable.filter((e) => e.type === 'message')).toHaveLength(1);
     // 'chat' spends all six on messages.
     expect(chatUnit.filter((e) => e.type === 'message')).toHaveLength(6);
+  });
+
+  it('stops spending `renderable` budget on op churn that folds away (#673)', () => {
+    // The regression this guards: a netsplit rejoin on an auto-op channel is one
+    // ChanServ `+o` per join, and a folding client draws the whole run as ONE
+    // summary line. While those rows still counted, a `limit`-unit page could be
+    // satisfied entirely by rows that render as nothing — the short-page loop
+    // that `renderable` exists to prevent.
+    const net = netFor('unit-renderable-modefold');
+    for (let i = 1; i <= 10; i += 1) {
+      for (let j = 0; j < 5; j += 1) {
+        modeEvent(net, '#a', [{ mode: '+o', param: `n${j}`, kind: 'prefix' }]);
+      }
+      chat(net, '#a', 'alice', `m${i}`);
+    }
+
+    const rows = listMessagesCounted(net, '#a', 'renderable', { limit: 6 });
+    expect(rows.filter((e) => e.type === 'message')).toHaveLength(6);
+  });
+
+  it('still spends `renderable` budget on mode rows that stand alone', () => {
+    // Bans, channel flags, mixed messages and unstamped backlog never fold, so
+    // making them free would push the unit the other way and over-fetch.
+    const net = netFor('unit-renderable-modestand');
+    for (let i = 1; i <= 3; i += 1) {
+      modeEvent(net, '#a', [{ mode: '+b', param: '*!*@host', kind: 'list' }]);
+      modeEvent(net, '#a', [
+        { mode: '+o', param: 'alice', kind: 'prefix' },
+        { mode: '-b', param: '*!*@host', kind: 'list' },
+      ]);
+      modeEvent(net, '#a', [{ mode: '+o', param: 'alice' }]);
+      chat(net, '#a', 'alice', `m${i}`);
+    }
+    const rows = listMessagesCounted(net, '#a', 'renderable', { limit: 4 });
+    // Four slots buy the three standalone mode rows plus one message, not four
+    // messages.
+    expect(rows.filter((e) => e.type === 'message')).toHaveLength(1);
+    expect(rows.filter((e) => e.type === 'mode')).toHaveLength(3);
   });
 
   it('still spends the budget on kicks, topics and invites', () => {

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -9,6 +9,7 @@ import {
 } from './bufferResolve.js';
 import { countsTowardPage } from '../../shared/eventFilter.js';
 import type { PageUnit } from '../../shared/eventFilter.js';
+import type { ModeChange } from '../../shared/modes.js';
 
 // Buffer identity is buffers.id as of schema 17: every predicate in this file
 // filters on `buffer_id`, and `target` is written at insert as an observation
@@ -320,6 +321,24 @@ function listMessagesById(
 // motivated the feature.
 export const RENDERABLE_MAX_SCAN = 2000;
 
+/**
+ * A scanned mode row's change list, for the `renderable` count.
+ *
+ * Only mode rows carry an `extra` here (the scan's CASE sees to that), so this
+ * is null for everything else. Malformed JSON reads as "no changes", which makes
+ * the row count — the fail-visible direction, and the same way rowToEvent
+ * tolerates it.
+ */
+function parseScannedModes(extra: string | null): ModeChange[] | null {
+  if (!extra) return null;
+  try {
+    const parsed = JSON.parse(extra) as { modes?: ModeChange[] };
+    return Array.isArray(parsed?.modes) ? parsed.modes : null;
+  } catch (_) {
+    return null;
+  }
+}
+
 /** Cursor + sizing options shared by every paging entry point here. */
 interface PageOptions {
   before?: number;
@@ -372,16 +391,25 @@ function listMessagesCountedById(
 
   // Step 1: walk out from the cursor and stop at whichever comes first — the
   // `limit`-th COUNTING row, or `maxScan` rows.
+  // `extra` comes back only for mode rows: it is the one type whose countability
+  // depends on its contents (member-status churn folds, a ban doesn't), and
+  // pulling the column for every scanned row would cost bytes on a scan bounded
+  // at RENDERABLE_MAX_SCAN for no gain.
+  const cols = `id, type, CASE WHEN type = 'mode' THEN extra END AS extra`;
   const scanSql = forward
-    ? `SELECT id, type FROM messages WHERE buffer_id = ? AND id > ? ORDER BY id ASC LIMIT ?`
+    ? `SELECT ${cols} FROM messages WHERE buffer_id = ? AND id > ? ORDER BY id ASC LIMIT ?`
     : before
-      ? `SELECT id, type FROM messages WHERE buffer_id = ? AND id < ? ORDER BY id DESC LIMIT ?`
-      : `SELECT id, type FROM messages WHERE buffer_id = ? ORDER BY id DESC LIMIT ?`;
+      ? `SELECT ${cols} FROM messages WHERE buffer_id = ? AND id < ? ORDER BY id DESC LIMIT ?`
+      : `SELECT ${cols} FROM messages WHERE buffer_id = ? ORDER BY id DESC LIMIT ?`;
   const cursor = forward ? afterId : before;
   const scanParams: Array<number | string> = cursor
     ? [bufferId, cursor, maxScan]
     : [bufferId, maxScan];
-  const scanned = db.prepare(scanSql).all(...scanParams) as Array<{ id: number; type: string }>;
+  const scanned = db.prepare(scanSql).all(...scanParams) as Array<{
+    id: number;
+    type: string;
+    extra: string | null;
+  }>;
   if (scanned.length === 0) return [];
 
   // The last row to include. Landing ON the `limit`-th counting row (rather
@@ -390,7 +418,7 @@ function listMessagesCountedById(
   let boundary = scanned[scanned.length - 1].id;
   let counted = 0;
   for (const row of scanned) {
-    if (!countsTowardPage(row.type, unit)) continue;
+    if (!countsTowardPage({ type: row.type, modes: parseScannedModes(row.extra) }, unit)) continue;
     counted += 1;
     if (counted === limit) {
       boundary = row.id;

--- a/shared/consolidate.test.ts
+++ b/shared/consolidate.test.ts
@@ -44,11 +44,15 @@ function onlyRow(messages: ConsolidatableMessage[], maxNames = 5): Consolidation
   return rows[0] as ConsolidationRow;
 }
 
-/** Groups as a plain `kind → nicks` map, for terse assertions. */
+/**
+ * Groups as a plain `kind → nicks` map, for terse assertions. Mode groups key
+ * on `kind:letter`, since one run can carry `modeGranted` for both `o` and `v`.
+ */
 function summarize(groups: ConsolidationGroup[]): Record<string, string[]> {
   const out: Record<string, string[]> = {};
   for (const g of groups) {
-    out[g.kind] = g.visible.map((v) =>
+    const key = g.letter ? `${g.kind}:${g.letter}` : g.kind;
+    out[key] = g.visible.map((v) =>
       'from' in v ? `${(v as RenameEntry).from}→${(v as RenameEntry).to}` : (v as NickEntry).nick,
     );
   }
@@ -66,10 +70,168 @@ describe('CONSOLIDATABLE_TYPES', () => {
     ]);
   });
 
+  // Two separate reasons, both still true now that mode rows DO fold:
+  //
   // The setter-vs-target problem (#593): a mode line's `nick` is whoever SET
-  // the mode, not who it was applied to, so it can't feed the identity map.
+  // the mode, not who it was applied to, so it can't feed the identity map —
+  // which is why modeGroups is a second pass rather than another member here.
+  //
+  // And this set defines the `renderable` page unit (shared/eventFilter.ts).
+  // Moving `mode` in would change what a `countBy:'renderable'` page contains
+  // for every client, shipped iOS builds included. Whether a row FOLDS is
+  // asked by foldsIntoRun instead.
   it('excludes mode', () => {
     expect(CONSOLIDATABLE_TYPES.has('mode')).toBe(false);
+  });
+});
+
+// Helpers for mode rows. `nick` on a mode event is the SETTER; the targets ride
+// in `modes`, each stamped with the class the server assigned it.
+function grant(letter: string, ...nicks: string[]) {
+  return ev('mode', 'ChanServ', {
+    modes: nicks.map((n) => ({ mode: `+${letter}`, param: n, kind: 'prefix' as const })),
+  });
+}
+function revoke(letter: string, ...nicks: string[]) {
+  return ev('mode', 'ChanServ', {
+    modes: nicks.map((n) => ({ mode: `-${letter}`, param: n, kind: 'prefix' as const })),
+  });
+}
+
+describe('mode consolidation (#673)', () => {
+  it('no longer breaks a run', () => {
+    // The case that motivated this: a netsplit rejoin on an auto-op channel
+    // used to come out as summary, mode, summary, mode, summary.
+    const row = onlyRow([
+      ev('join', 'alice'),
+      grant('o', 'alice'),
+      ev('join', 'bob'),
+      grant('o', 'bob'),
+      ev('join', 'carol'),
+    ]);
+    expect(summarize(row.groups)).toEqual({
+      joined: ['alice', 'bob', 'carol'],
+      'modeGranted:o': ['alice', 'bob'],
+    });
+  });
+
+  it('puts presence first and modes after', () => {
+    const row = onlyRow([ev('join', 'alice'), grant('o', 'alice')]);
+    expect(row.groups.map((g) => g.kind)).toEqual(['joined', 'modeGranted']);
+  });
+
+  it('groups by letter and by direction', () => {
+    const row = onlyRow([grant('o', 'alice'), grant('v', 'bob'), revoke('v', 'carol')]);
+    expect(summarize(row.groups)).toEqual({
+      'modeGranted:o': ['alice'],
+      'modeGranted:v': ['bob'],
+      'modeRevoked:v': ['carol'],
+    });
+  });
+
+  it('reports the end state of a pair that cancels, and never drops the nick', () => {
+    // Deliberately unlike join/part, which vanish when they cancel. The summary
+    // has no expand affordance, so dropping a nick here deletes information
+    // with no way to get it back.
+    const row = onlyRow([grant('o', 'alice'), revoke('o', 'alice'), ev('join', 'bob')]);
+    expect(summarize(row.groups)).toEqual({ joined: ['bob'], 'modeRevoked:o': ['alice'] });
+  });
+
+  it('reports a re-grant as granted', () => {
+    const row = onlyRow([revoke('o', 'alice'), grant('o', 'alice'), ev('join', 'bob')]);
+    expect(summarize(row.groups)).toEqual({ joined: ['bob'], 'modeGranted:o': ['alice'] });
+  });
+
+  it('keeps a nick in one group per letter, however many changes it saw', () => {
+    const row = onlyRow([grant('o', 'alice'), grant('o', 'alice'), grant('o', 'alice')]);
+    expect(summarize(row.groups)).toEqual({ 'modeGranted:o': ['alice'] });
+  });
+
+  it('tracks each letter for a nick separately', () => {
+    const row = onlyRow([grant('o', 'alice'), revoke('v', 'alice')]);
+    expect(summarize(row.groups)).toEqual({
+      'modeGranted:o': ['alice'],
+      'modeRevoked:v': ['alice'],
+    });
+  });
+
+  it('folds every target of a multi-target message', () => {
+    const row = onlyRow([grant('o', 'alice', 'bob', 'carol'), ev('join', 'dave')]);
+    expect(summarize(row.groups)).toEqual({
+      joined: ['dave'],
+      'modeGranted:o': ['alice', 'bob', 'carol'],
+    });
+  });
+
+  it('does not let a mode target reach the identity pass', () => {
+    // alice never joined inside the run; being opped must not invent a
+    // presence verdict for her.
+    const row = onlyRow([grant('o', 'alice'), ev('join', 'bob')]);
+    expect(summarize(row.groups)).toEqual({ joined: ['bob'], 'modeGranted:o': ['alice'] });
+  });
+
+  it('caps and counts mode nicks like any other category', () => {
+    const row = onlyRow([grant('o', 'a', 'b', 'c', 'd'), ev('join', 'z')], 2);
+    const modeGroup = row.groups.find((g) => g.kind === 'modeGranted')!;
+    expect(modeGroup.visible).toHaveLength(2);
+    expect(modeGroup.hidden).toBe(2);
+    expect(modeGroup.letter).toBe('o');
+  });
+
+  it('still renders a lone mode row as its own line', () => {
+    // A run of one passes through, so a solitary `+o alice` keeps its narrated
+    // line rather than becoming a one-name summary.
+    const rows = consolidateMessages([grant('o', 'alice')]);
+    expect(rows).toHaveLength(1);
+    expect(isConsolidation(rows[0])).toBe(false);
+  });
+});
+
+describe('mode rows that must NOT fold', () => {
+  const ban = () =>
+    ev('mode', 'op', { modes: [{ mode: '+b', param: '*!*@host', kind: 'list' as const }] });
+
+  it('a ban still breaks the run', () => {
+    const rows = consolidateMessages([ev('join', 'alice'), ban(), ev('join', 'bob')]);
+    expect(rows).toHaveLength(3);
+    expect(rows.some(isConsolidation)).toBe(false);
+  });
+
+  it('a channel flag still breaks the run', () => {
+    const flag = ev('mode', 'op', { modes: [{ mode: '+m', kind: 'chan' as const }] });
+    const rows = consolidateMessages([ev('join', 'alice'), flag, ev('join', 'bob')]);
+    expect(rows).toHaveLength(3);
+  });
+
+  it('a message mixing an op change with a ban breaks the run', () => {
+    // The whole-message gate: one non-prefix change anywhere and the row stands
+    // alone, so a ban can never be folded away behind "alice was opped".
+    const mixed = ev('mode', 'op', {
+      modes: [
+        { mode: '+o', param: 'alice', kind: 'prefix' as const },
+        { mode: '-b', param: '*!*@host', kind: 'list' as const },
+      ],
+    });
+    const rows = consolidateMessages([ev('join', 'alice'), mixed, ev('join', 'bob')]);
+    expect(rows).toHaveLength(3);
+  });
+
+  it('an unstamped mode row breaks the run', () => {
+    // Backlog older than the server-side `kind` stamp. Without the class there
+    // is no way to know whether `+q alice` grants ownership or quiets a mask,
+    // so it is shown rather than guessed at.
+    const unstamped = ev('mode', 'op', { modes: [{ mode: '+o', param: 'alice' }] });
+    const rows = consolidateMessages([ev('join', 'alice'), unstamped, ev('join', 'bob')]);
+    expect(rows).toHaveLength(3);
+  });
+
+  it('a mode row with no change list breaks the run', () => {
+    const rows = consolidateMessages([
+      ev('join', 'alice'),
+      ev('mode', 'op', { modes: [] }),
+      ev('join', 'bob'),
+    ]);
+    expect(rows).toHaveLength(3);
   });
 });
 

--- a/shared/consolidate.test.ts
+++ b/shared/consolidate.test.ts
@@ -129,17 +129,47 @@ describe('mode consolidation (#673)', () => {
     });
   });
 
-  it('reports the end state of a pair that cancels, and never drops the nick', () => {
-    // Deliberately unlike join/part, which vanish when they cancel. The summary
-    // has no expand affordance, so dropping a nick here deletes information
-    // with no way to get it back.
+  it('reads a cancelled pair as "briefly", the way joinedAndLeft does', () => {
+    // First change implies the prior state, exactly as in the presence walk: an
+    // opening `+o` means they did not hold it before, so `+o` then `-o` is the
+    // mode-side of joined-and-left rather than a plain deop.
     const row = onlyRow([grant('o', 'alice'), revoke('o', 'alice'), ev('join', 'bob')]);
-    expect(summarize(row.groups)).toEqual({ joined: ['bob'], 'modeRevoked:o': ['alice'] });
+    expect(summarize(row.groups)).toEqual({ joined: ['bob'], 'modeBriefly:o': ['alice'] });
   });
 
-  it('reports a re-grant as granted', () => {
+  it('reads a regained mode as "again", the way reconnected does', () => {
+    // An opening `-o` means they DID hold it before the run.
     const row = onlyRow([revoke('o', 'alice'), grant('o', 'alice'), ev('join', 'bob')]);
-    expect(summarize(row.groups)).toEqual({ joined: ['bob'], 'modeGranted:o': ['alice'] });
+    expect(summarize(row.groups)).toEqual({ joined: ['bob'], 'modeRegranted:o': ['alice'] });
+  });
+
+  it('classifies every letter the same way, not just op', () => {
+    const row = onlyRow([
+      grant('v', 'alice'),
+      revoke('v', 'alice'),
+      revoke('v', 'bob'),
+      grant('v', 'bob'),
+      grant('h', 'carol'),
+      revoke('q', 'dave'),
+    ]);
+    expect(summarize(row.groups)).toEqual({
+      'modeBriefly:v': ['alice'],
+      'modeRegranted:v': ['bob'],
+      'modeGranted:h': ['carol'],
+      'modeRevoked:q': ['dave'],
+    });
+  });
+
+  it('ignores the churn between the first and last change', () => {
+    const row = onlyRow([
+      grant('o', 'alice'),
+      revoke('o', 'alice'),
+      grant('o', 'alice'),
+      revoke('o', 'alice'),
+      ev('join', 'bob'),
+    ]);
+    // Started without it, ended without it, blipped in between.
+    expect(summarize(row.groups)).toEqual({ joined: ['bob'], 'modeBriefly:o': ['alice'] });
   });
 
   it('keeps a nick in one group per letter, however many changes it saw', () => {

--- a/shared/consolidate.ts
+++ b/shared/consolidate.ts
@@ -89,14 +89,19 @@ export type ConsolidationKind =
   | 'renamed'
   | 'rehosted'
   | 'modeGranted'
-  | 'modeRevoked';
+  | 'modeRevoked'
+  | 'modeBriefly'
+  | 'modeRegranted';
 
 /**
  * The kinds the per-identity walk can produce. Split out so the bucket record
  * below stays exhaustive by construction: adding a mode kind to
  * ConsolidationKind must not silently leave a hole there.
  */
-type IdentityKind = Exclude<ConsolidationKind, 'modeGranted' | 'modeRevoked'>;
+type IdentityKind = Exclude<
+  ConsolidationKind,
+  'modeGranted' | 'modeRevoked' | 'modeBriefly' | 'modeRegranted'
+>;
 
 /** A nick that joined / left / reconnected / rehosted within the run. */
 export interface NickEntry {
@@ -115,7 +120,7 @@ export interface ConsolidationGroup {
   visible: Array<NickEntry | RenameEntry>;
   hidden: number;
   /**
-   * For `modeGranted` / `modeRevoked` only: the member-prefix letter the group
+   * For the four `mode*` kinds only: the member-prefix letter the group
    * is about (`o`, `v`, …). The WORDS for it are the renderer's business —
    * each client picks its own phrasing, the way it already does for joined /
    * left — so only the letter travels.
@@ -171,10 +176,14 @@ const CONSOLIDATABLE_TYPES: ReadonlySet<string> = new Set([
  * of that set — because that set also defines the `renderable` page unit
  * (shared/eventFilter.ts), and moving `mode` into it would change what a
  * `countBy:'renderable'` page contains for every client, shipped iOS builds
- * included. Folding is a render-time concern; the page unit only has to be no
- * FINER than what a client draws, so a folding client just gets a page that
- * renders shorter than budgeted — the harmless direction, never the empty-page
- * under-count of the netsplit bug.
+ * included.
+ *
+ * What folds and what counts are therefore two questions, and they must stay in
+ * step: `countsTowardPage` subtracts churn modes under `renderable` for exactly
+ * this reason. Folding MORE than the unit counts is the harmful direction — the
+ * page renders shorter than budgeted and the client re-fetches (#10). Folding
+ * LESS is harmless: the page renders longer than asked, which is where a client
+ * that folds presence but not mode sits.
  */
 function foldsIntoRun(m: ConsolidatableMessage): boolean {
   if (CONSOLIDATABLE_TYPES.has(m.type)) return true;
@@ -230,8 +239,32 @@ function cap<T extends { nick?: string; to?: string }>(
 interface ModeState {
   nick: string;
   letter: string;
-  sign: '+' | '-';
+  /** The run's first change to this pair — which implies the state BEFORE it. */
+  first: '+' | '-';
+  /** The run's last change, i.e. the state after. */
+  last: '+' | '-';
   seenIndex: number;
+}
+
+/**
+ * Classify a (nick, letter) pair by its first and last change in the run —
+ * the same first/last reading `classify()` gives a presence identity, and for
+ * the same reason: the FIRST change implies the prior state. An opening `-o`
+ * means they held op before the run started.
+ *
+ *   +…+  didn't have it, does now          → modeGranted     "was opped"
+ *   -…-  had it, doesn't now               → modeRevoked     "was deopped"
+ *   +…-  didn't have it, blipped, doesn't  → modeBriefly     "was briefly opped"
+ *   -…+  had it, lost it, has it again     → modeRegranted   "was opped again"
+ *
+ * The last two are the mode-side of `joinedAndLeft` and `reconnected`. Keeping
+ * them means a cancelled pair is never silently dropped OR misreported as its
+ * end state alone — which matters here more than for presence, because the
+ * summary row has no expand affordance to recover the detail from.
+ */
+function classifyMode(first: '+' | '-', last: '+' | '-'): ConsolidationKind {
+  if (first === '+') return last === '+' ? 'modeGranted' : 'modeBriefly';
+  return last === '+' ? 'modeRegranted' : 'modeRevoked';
 }
 
 /**
@@ -245,13 +278,12 @@ interface ModeState {
  * second summary vocabulary, which is exactly what the lurker-ios prototype
  * flagged when it tried this and backed it out; we pay it deliberately.
  *
- * **The last change to a (nick, letter) in the run wins, and nothing is ever
- * dropped.** `+o alice` then `-o alice` reads "alice was deopped" rather than
- * vanishing the way a join/part pair does. The asymmetry is deliberate: the
- * summary row has no expand affordance, so a nick dropped here is information
- * deleted with no way to get it back. The Lounge can afford to drop a cancelled
- * pair because a click restores the raw lines; we can't. Reporting the end
- * state keeps every affected nick visible exactly once.
+ * Each pair is classified by its first and last change (see classifyMode), so a
+ * nick appears exactly once per letter and a cancelled pair reads "was briefly
+ * opped" — the mode-side of `joinedAndLeft`, and the same vocabulary the
+ * presence half already uses for the same shape. Nothing is ever dropped: the
+ * summary row has no expand affordance, so a nick dropped here would be
+ * information deleted with no way to get it back.
  *
  * Renames are NOT followed. The identity walk migrates a nick across an 'R'
  * action; this keys on the parameter as written, so alice→bob opped as bob is
@@ -273,13 +305,17 @@ function modeGroups(
       const letter = modeLetter(c.mode);
       if (!letter) continue;
       const key = `${c.param.toLowerCase()}\u0000${letter}`;
+      const sign: '+' | '-' = c.mode.startsWith('-') ? '-' : '+';
       const prev = net.get(key);
       net.set(key, {
         nick: c.param,
         letter,
-        sign: c.mode.startsWith('-') ? '-' : '+',
+        // The first change is captured once and never overwritten — it is what
+        // says whether they held the mode before the run.
+        first: prev ? prev.first : sign,
+        last: sign,
         // First appearance fixes the display order; later changes to the same
-        // pair overwrite the verdict without moving it.
+        // pair update the verdict without moving it.
         seenIndex: prev ? prev.seenIndex : seen++,
       });
     }
@@ -293,15 +329,11 @@ function modeGroups(
   }
   const buckets = new Map<string, Bucket>();
   for (const st of Array.from(net.values()).toSorted((a, b) => a.seenIndex - b.seenIndex)) {
-    const bucketKey = `${st.sign}${st.letter}`;
+    const kind = classifyMode(st.first, st.last);
+    const bucketKey = `${kind}${st.letter}`;
     let bucket = buckets.get(bucketKey);
     if (!bucket) {
-      bucket = {
-        kind: st.sign === '+' ? 'modeGranted' : 'modeRevoked',
-        letter: st.letter,
-        entries: [],
-        seenIndex: st.seenIndex,
-      };
+      bucket = { kind, letter: st.letter, entries: [], seenIndex: st.seenIndex };
       buckets.set(bucketKey, bucket);
     }
     bucket.entries.push({ nick: st.nick });

--- a/shared/consolidate.ts
+++ b/shared/consolidate.ts
@@ -2,13 +2,18 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // Consolidation of join/part/quit/nick/chghost "noise" events into a per-identity
-// net effect, IRCCloud-style. Pure, side-effect-free, no DOM/Vue deps — safe
-// to import from the Vue renderer, the Node demo script, and tests.
+// net effect, IRCCloud-style, plus op/voice churn folded alongside it. Pure,
+// side-effect-free, no DOM/Vue deps — safe to import from the Vue renderer, the
+// Node demo script, and tests.
 //
 // Algorithm:
-//   1. Walk a stream of message rows; group consecutive consolidatable events
-//      into a "run". Any non-consolidatable row (real message, kick, mode,
-//      topic, divider, etc.) terminates the run.
+//   1. Walk a stream of message rows; group consecutive foldable events into a
+//      "run". Any other row (a real message, a kick, a topic, a divider)
+//      terminates it. A `mode` row folds when it is pure member-status churn
+//      and terminates the run otherwise — one ban or channel flag in the
+//      message and it stands alone (see foldsIntoRun / isChurnMode). Before
+//      that, EVERY mode row broke the run, which is why a netsplit rejoin on an
+//      auto-op channel came out as summary, mode, summary, mode, summary.
 //   2. Inside a run, walk per nick and accumulate an action sequence:
 //        'J' = join
 //        'L' = leave (part or quit)
@@ -28,8 +33,15 @@
 //      sequence is [J, H]; that must read as a plain "joined" rather than
 //      splitting the summary into "N joined" plus "N changed host". The
 //      host change only earns its own category when nothing else happened.
-//   4. A run of exactly one event is passed through unchanged (so a lone
-//      "Alice joined" still renders with the familiar --> styling).
+//   4. Mode rows are folded by a SECOND pass, keyed on (nick, letter) rather
+//      than on identity, since a mode change has no join/leave sequence and its
+//      target need never have joined inside the run. The run's last change to a
+//      pair wins and nothing is dropped — see modeGroups.
+//   5. A run of exactly one event is passed through unchanged (so a lone
+//      "Alice joined" still renders with the familiar --> styling, and a lone
+//      "+o alice" still renders as its narrated mode line).
+
+import { isChurnMode, modeLetter, type ModeChange } from './modes.js';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -41,6 +53,8 @@ export interface ConsolidatableMessage {
   newNick?: string;
   time: string;
   to?: string;
+  /** A `mode` row's parsed change list, each entry stamped with its `kind`. */
+  modes?: readonly ModeChange[] | null;
 }
 
 /**
@@ -59,14 +73,30 @@ export interface MessageStreamRow {
  */
 type EventAction = 'J' | 'L' | 'R' | 'H';
 
-/** The six ways a run's net effect on an identity can be classified. */
+/**
+ * How a run's net effect is classified.
+ *
+ * The first six are per-identity: one nick, one verdict, derived from its
+ * join/leave/rename/rehost sequence. The last two are per-(nick, mode letter)
+ * and come from a separate pass — see modeGroups for why they can't share the
+ * identity chain.
+ */
 export type ConsolidationKind =
   | 'joined'
   | 'left'
   | 'reconnected'
   | 'joinedAndLeft'
   | 'renamed'
-  | 'rehosted';
+  | 'rehosted'
+  | 'modeGranted'
+  | 'modeRevoked';
+
+/**
+ * The kinds the per-identity walk can produce. Split out so the bucket record
+ * below stays exhaustive by construction: adding a mode kind to
+ * ConsolidationKind must not silently leave a hole there.
+ */
+type IdentityKind = Exclude<ConsolidationKind, 'modeGranted' | 'modeRevoked'>;
 
 /** A nick that joined / left / reconnected / rehosted within the run. */
 export interface NickEntry {
@@ -84,6 +114,13 @@ export interface ConsolidationGroup {
   kind: ConsolidationKind;
   visible: Array<NickEntry | RenameEntry>;
   hidden: number;
+  /**
+   * For `modeGranted` / `modeRevoked` only: the member-prefix letter the group
+   * is about (`o`, `v`, …). The WORDS for it are the renderer's business —
+   * each client picks its own phrasing, the way it already does for joined /
+   * left — so only the letter travels.
+   */
+  letter?: string;
 }
 
 /** Synthetic row that replaces a run of consolidated presence-noise rows. */
@@ -126,7 +163,25 @@ const CONSOLIDATABLE_TYPES: ReadonlySet<string> = new Set([
   'chghost',
 ]);
 
-function classify(actions: readonly EventAction[]): ConsolidationKind {
+/**
+ * Whether a message can sit inside a consolidation run.
+ *
+ * Wider than CONSOLIDATABLE_TYPES, and deliberately a separate question. A
+ * `mode` row folds when it is pure member-status churn, but it is NOT a member
+ * of that set — because that set also defines the `renderable` page unit
+ * (shared/eventFilter.ts), and moving `mode` into it would change what a
+ * `countBy:'renderable'` page contains for every client, shipped iOS builds
+ * included. Folding is a render-time concern; the page unit only has to be no
+ * FINER than what a client draws, so a folding client just gets a page that
+ * renders shorter than budgeted — the harmless direction, never the empty-page
+ * under-count of the netsplit bug.
+ */
+function foldsIntoRun(m: ConsolidatableMessage): boolean {
+  if (CONSOLIDATABLE_TYPES.has(m.type)) return true;
+  return m.type === 'mode' && isChurnMode(m.modes);
+}
+
+function classify(actions: readonly EventAction[]): IdentityKind {
   const jl = actions.filter((a) => a === 'J' || a === 'L');
   // No presence change: a rename outranks a rehost, since "alice → bob" says
   // more than "alice changed host" for an identity that did both.
@@ -171,6 +226,95 @@ function cap<T extends { nick?: string; to?: string }>(
   };
 }
 
+/** Mutable per-(nick, letter) bookkeeping while walking a run's mode changes. */
+interface ModeState {
+  nick: string;
+  letter: string;
+  sign: '+' | '-';
+  seenIndex: number;
+}
+
+/**
+ * Fold a run's member-status changes into per-(nick, letter) net effects.
+ *
+ * This is a SEPARATE pass from the identity walk, and has to be. That walk is
+ * keyed on identity and classifies by a join/leave sequence; a mode change has
+ * neither shape — its subject is a (nick, letter) pair, its verdict is a sign,
+ * and its target need never have joined inside the run at all. Trying to reuse
+ * the identity chain would mean two meanings for one bucket. The cost is a
+ * second summary vocabulary, which is exactly what the lurker-ios prototype
+ * flagged when it tried this and backed it out; we pay it deliberately.
+ *
+ * **The last change to a (nick, letter) in the run wins, and nothing is ever
+ * dropped.** `+o alice` then `-o alice` reads "alice was deopped" rather than
+ * vanishing the way a join/part pair does. The asymmetry is deliberate: the
+ * summary row has no expand affordance, so a nick dropped here is information
+ * deleted with no way to get it back. The Lounge can afford to drop a cancelled
+ * pair because a click restores the raw lines; we can't. Reporting the end
+ * state keeps every affected nick visible exactly once.
+ *
+ * Renames are NOT followed. The identity walk migrates a nick across an 'R'
+ * action; this keys on the parameter as written, so alice→bob opped as bob is
+ * reported as bob. Threading two identity models through one run costs more
+ * than it buys.
+ */
+function modeGroups(
+  events: readonly ConsolidatableMessage[],
+  maxNames: number,
+  speakersLc: ReadonlySet<string> | null,
+): ConsolidationGroup[] {
+  const net = new Map<string, ModeState>();
+  let seen = 0;
+  for (const e of events) {
+    for (const c of e.modes ?? []) {
+      // Only member-status changes fold. A run can only contain mode rows that
+      // passed isChurnMode, so this is a narrowing rather than a second filter.
+      if (!c || c.kind !== 'prefix' || !c.param) continue;
+      const letter = modeLetter(c.mode);
+      if (!letter) continue;
+      const key = `${c.param.toLowerCase()}\u0000${letter}`;
+      const prev = net.get(key);
+      net.set(key, {
+        nick: c.param,
+        letter,
+        sign: c.mode.startsWith('-') ? '-' : '+',
+        // First appearance fixes the display order; later changes to the same
+        // pair overwrite the verdict without moving it.
+        seenIndex: prev ? prev.seenIndex : seen++,
+      });
+    }
+  }
+
+  interface Bucket {
+    kind: ConsolidationKind;
+    letter: string;
+    entries: NickEntry[];
+    seenIndex: number;
+  }
+  const buckets = new Map<string, Bucket>();
+  for (const st of Array.from(net.values()).toSorted((a, b) => a.seenIndex - b.seenIndex)) {
+    const bucketKey = `${st.sign}${st.letter}`;
+    let bucket = buckets.get(bucketKey);
+    if (!bucket) {
+      bucket = {
+        kind: st.sign === '+' ? 'modeGranted' : 'modeRevoked',
+        letter: st.letter,
+        entries: [],
+        seenIndex: st.seenIndex,
+      };
+      buckets.set(bucketKey, bucket);
+    }
+    bucket.entries.push({ nick: st.nick });
+  }
+
+  const groups: ConsolidationGroup[] = [];
+  for (const bucket of Array.from(buckets.values()).toSorted((a, b) => a.seenIndex - b.seenIndex)) {
+    const { visible, hidden } = cap(bucket.entries, maxNames, speakersLc);
+    groups.push({ kind: bucket.kind, visible, hidden, letter: bucket.letter });
+  }
+  return groups;
+}
+
 function consolidateRun(
   events: readonly ConsolidatableMessage[],
   opts: RunOptions,
@@ -180,6 +324,11 @@ function consolidateRun(
     : null;
   const maxNames = Math.max(1, opts.maxNames || 5);
 
+  // The two passes read disjoint slices of the run: the identity walk below
+  // takes presence events, modeGroups takes the mode rows.
+  const modeEvents = events.filter((e) => e.type === 'mode');
+  const presenceEvents = modeEvents.length > 0 ? events.filter((e) => e.type !== 'mode') : events;
+
   // identityKey (lowercased current nick) → identity bookkeeping
   const ids = new Map<string, IdentityState>();
   // Preserve first-seen order across rename migrations: when a rename moves an
@@ -188,7 +337,7 @@ function consolidateRun(
   // appeared in the run.
   let seenCounter = 0;
 
-  for (const e of events) {
+  for (const e of presenceEvents) {
     if (e.type === 'nick') {
       const oldLc = String(e.nick || '').toLowerCase();
       const newLc = String(e.newNick || '').toLowerCase();
@@ -226,7 +375,7 @@ function consolidateRun(
 
   // Uniform element type per bucket so the generic `cap()` infers a single
   // entry type; `renamed` happens to only ever receive RenameEntry values.
-  const buckets: Record<ConsolidationKind, Array<NickEntry | RenameEntry>> = {
+  const buckets: Record<IdentityKind, Array<NickEntry | RenameEntry>> = {
     joined: [],
     left: [],
     reconnected: [],
@@ -246,7 +395,7 @@ function consolidateRun(
 
   // Fixed display order across all categories so the readout reads the same
   // way every time.
-  const groupOrder: ConsolidationKind[] = [
+  const groupOrder: IdentityKind[] = [
     'joined',
     'left',
     'reconnected',
@@ -260,6 +409,9 @@ function consolidateRun(
     const { visible, hidden } = cap(buckets[kind], maxNames, speakersLc);
     groups.push({ kind, visible, hidden });
   }
+  // Mode groups trail the presence ones: who is here reads first, what they
+  // were given second.
+  groups.push(...modeGroups(modeEvents, maxNames, speakersLc));
   return groups;
 }
 
@@ -288,6 +440,16 @@ export function consolidateRows<R extends MessageStreamRow>(
     // Every row in `run` was pushed only after `r.m` was confirmed present.
     const events = run.map((r) => r.m as ConsolidatableMessage);
     const groups = consolidateRun(events, opts);
+    // A run that produced nothing to say renders as its own rows rather than as
+    // an empty summary. Unreachable today — every foldable row contributes a
+    // group — but it is the guard that keeps it that way, since widening
+    // foldsIntoRun without teaching a pass about the new type would otherwise
+    // swallow those rows into a blank line. lurker-ios has had this since #59.
+    if (groups.length === 0) {
+      out.push(...run);
+      run = [];
+      return;
+    }
     out.push({
       consolidation: true,
       groups,
@@ -301,7 +463,7 @@ export function consolidateRows<R extends MessageStreamRow>(
   };
 
   for (const r of rows) {
-    if (r && r.m && CONSOLIDATABLE_TYPES.has(r.m.type)) {
+    if (r && r.m && foldsIntoRun(r.m)) {
       run.push(r);
     } else {
       flush();

--- a/shared/eventFilter.test.ts
+++ b/shared/eventFilter.test.ts
@@ -134,23 +134,65 @@ describe('page sizing', () => {
     expect(pageUnitFor('none', false)).toBe('chat');
   });
 
+  const churnMode = {
+    type: 'mode',
+    modes: [{ mode: '+o', param: 'alice', kind: 'prefix' as const }],
+  };
+  const banMode = {
+    type: 'mode',
+    modes: [{ mode: '+b', param: '*!*@host', kind: 'list' as const }],
+  };
+
   it('counts every row under `event`', () => {
     for (const type of [...NOISE_TYPES, 'message', 'kick']) {
-      expect(countsTowardPage(type, 'event')).toBe(true);
+      expect(countsTowardPage({ type }, 'event')).toBe(true);
     }
+    expect(countsTowardPage(churnMode, 'event')).toBe(true);
   });
 
-  it('makes mode free under `chat` but not under `renderable`', () => {
-    expect(countsTowardPage('mode', 'renderable')).toBe(true);
-    expect(countsTowardPage('mode', 'chat')).toBe(false);
+  it('makes no mode row count under `chat`', () => {
+    // `none` hides every mode row, churn or not, so none of them spend budget.
+    expect(countsTowardPage(churnMode, 'chat')).toBe(false);
+    expect(countsTowardPage(banMode, 'chat')).toBe(false);
+    expect(countsTowardPage({ type: 'mode' }, 'chat')).toBe(false);
+  });
+
+  it('stops counting folded op/voice churn under `renderable`', () => {
+    // The unit has to be no FINER than what the client draws. A folding client
+    // collapses a whole run of `+o` rows into one summary line, so counting
+    // them would hand back a page of `limit` units that renders as two lines —
+    // exactly the short-page loop this unit exists to prevent.
+    expect(countsTowardPage(churnMode, 'renderable')).toBe(false);
+  });
+
+  it('keeps counting the mode rows that still stand alone', () => {
+    expect(countsTowardPage(banMode, 'renderable')).toBe(true);
+    // Mixed: one ban in the message and the whole row renders, so it counts.
+    expect(
+      countsTowardPage(
+        {
+          type: 'mode',
+          modes: [
+            { mode: '+o', param: 'alice', kind: 'prefix' as const },
+            { mode: '-b', param: '*!*@host', kind: 'list' as const },
+          ],
+        },
+        'renderable',
+      ),
+    ).toBe(true);
+    // Unstamped backlog never folds, so it must never stop counting either.
+    expect(
+      countsTowardPage({ type: 'mode', modes: [{ mode: '+o', param: 'alice' }] }, 'renderable'),
+    ).toBe(true);
+    expect(countsTowardPage({ type: 'mode' }, 'renderable')).toBe(true);
   });
 
   it('makes presence churn free under both of the counted units', () => {
     for (const unit of ['renderable', 'chat'] as const) {
-      expect(countsTowardPage('join', unit)).toBe(false);
-      expect(countsTowardPage('quit', unit)).toBe(false);
-      expect(countsTowardPage('message', unit)).toBe(true);
-      expect(countsTowardPage('kick', unit)).toBe(true);
+      expect(countsTowardPage({ type: 'join' }, unit)).toBe(false);
+      expect(countsTowardPage({ type: 'quit' }, unit)).toBe(false);
+      expect(countsTowardPage({ type: 'message' }, unit)).toBe(true);
+      expect(countsTowardPage({ type: 'kick' }, unit)).toBe(true);
     }
   });
 

--- a/shared/eventFilter.ts
+++ b/shared/eventFilter.ts
@@ -17,6 +17,7 @@
 // need is the page UNIT (see PageUnit below), which the client asks for.
 
 import { CONSOLIDATABLE_TYPES } from './consolidate.js';
+import { isChurnMode, type ModeChange } from './modes.js';
 
 // ─── The tier ──────────────────────────────────────────────────────────────
 
@@ -66,10 +67,17 @@ export function asEventMode(value: unknown): EventMode {
  * by "event noise", so consolidation, smart filtering, and page sizing can't
  * drift apart on the definition.
  *
- * It is CONSOLIDATABLE_TYPES plus `mode`. Mode changes are excluded from
- * consolidation (they render as their own line and don't fold into a per-nick
- * net effect), but a reader who asked for no event noise means op/voice/ban
- * churn too — that's the point of the tier's strictest rung.
+ * It is CONSOLIDATABLE_TYPES plus `mode`. The two sets differ because they
+ * answer different questions: CONSOLIDATABLE_TYPES is the per-identity fold set
+ * AND the definition of the `renderable` page unit, while this is "what does
+ * `none` hide". A reader who asked for no event noise means op/voice/ban churn
+ * too — including the bans and channel flags that never fold — which is the
+ * point of the tier's strictest rung.
+ *
+ * ⚠ `mode` being absent from CONSOLIDATABLE_TYPES does NOT mean mode rows never
+ * fold. Member-status churn folds into the summary (shared/consolidate.ts,
+ * foldsIntoRun); it just does so without being a member of the set that sizes
+ * pages. Don't "fix" the divergence by merging them.
  *
  * Deliberately NOT included, because they are content rather than churn:
  * `kick` (someone was removed, and by whom), `topic`, `invite`, `error`,
@@ -112,13 +120,39 @@ export function asPageUnit(value: unknown): PageUnit {
   return value === 'renderable' || value === 'chat' ? value : 'event';
 }
 
+/** The parts of a stored row that decide whether it spends page budget. */
+export interface PageCountable {
+  type: string;
+  /** A `mode` row's parsed change list, when it has one. */
+  modes?: readonly ModeChange[] | null;
+}
+
 /**
  * Whether a row spends page budget under the given unit. `event` counts
- * everything; the other two subtract their respective noise set.
+ * everything; the other two subtract what their client doesn't draw.
+ *
+ * ⚠ The invariant, and the direction that matters: the unit must be no FINER
+ * than what the client renders. Counting rows that collapse to nothing is what
+ * produces a page of `limit` units that draws as two lines — the reader watches
+ * the buffer assemble itself while the client re-fetches (#10, and
+ * docs/CLIENT_PROTOCOL.md's `countBy` section). Counting FEWER rows than are
+ * drawn is harmless by comparison: the page simply renders longer than asked.
+ *
+ * So `renderable` subtracts member-status mode churn as well as
+ * CONSOLIDATABLE_TYPES, because a folding client draws one summary line for the
+ * whole run. This needs the row rather than its type alone — whether a mode row
+ * is churn lives in its `modes`, and the type string can't answer it.
+ *
+ * A client that folds presence but NOT mode (any iOS build before the fold
+ * lands) is on the safe side of this: it gets pages carrying uncounted mode
+ * rows, which render as extra lines rather than missing ones.
  */
-export function countsTowardPage(type: string, unit: PageUnit): boolean {
-  if (unit === 'renderable') return !CONSOLIDATABLE_TYPES.has(type);
-  if (unit === 'chat') return !NOISE_TYPES.has(type);
+export function countsTowardPage(row: PageCountable, unit: PageUnit): boolean {
+  if (unit === 'renderable') {
+    if (CONSOLIDATABLE_TYPES.has(row.type)) return false;
+    return !(row.type === 'mode' && isChurnMode(row.modes));
+  }
+  if (unit === 'chat') return !NOISE_TYPES.has(row.type);
   return true;
 }
 

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -857,10 +857,10 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'the settings below are shared.',
   },
 
-  // ─── Join/part consolidation (IRCCloud-style summary line) ────────────
+  // ─── Event consolidation (IRCCloud-style summary line) ────────────────
   {
     key: 'chat.consolidate_joins',
-    label: 'Consolidate join/part/quit/nick/host-change events',
+    label: 'Consolidate join/part/quit/nick/host-change and op/voice events',
     category: 'events',
     group: 'consolidate',
     type: 'bool',
@@ -869,6 +869,10 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     description:
       'Merge consecutive join/part/quit/nick/host-change events into a single summary line ' +
       'per nick (e.g. "Alice and Bob joined; Dave left; Eve → Eve_afk"). ' +
+      'Mode changes that only grant or revoke member status join the same line ' +
+      '("…; Alice and Bob were opped"), reporting who ended up with what rather ' +
+      'than who set it — bans, channel keys, limits and channel flags always keep ' +
+      'their own line. ' +
       'Off shows every event individually. Composes with the "smart" tier — events ' +
       'it hides are excluded from the summary.',
   },
@@ -885,7 +889,8 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     // transitively through chat.consolidate_joins.
     dependsOn: [{ key: 'chat.consolidate_joins', in: [true] }],
     description:
-      'In each category (joined / left / reconnected / renamed / changed host) of a summary ' +
+      'In each category (joined / left / reconnected / renamed / changed host / ' +
+      'opped / voiced) of a summary ' +
       'line, show at most this many nicks before collapsing the rest into ' +
       '"and N others". Recent speakers (those tracked for nick completion) ' +
       'are preferred when picking which names to show.',

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -870,9 +870,9 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'Merge consecutive join/part/quit/nick/host-change events into a single summary line ' +
       'per nick (e.g. "Alice and Bob joined; Dave left; Eve → Eve_afk"). ' +
       'Mode changes that only grant or revoke member status join the same line ' +
-      '("…; Alice and Bob were opped"), reporting who ended up with what rather ' +
-      'than who set it — bans, channel keys, limits and channel flags always keep ' +
-      'their own line. ' +
+      '("…; Alice and Bob were opped; Carol was briefly voiced"), naming who it ' +
+      'was done to rather than who did it — bans, channel keys, limits and ' +
+      'channel flags always keep their own line. ' +
       'Off shows every event individually. Composes with the "smart" tier — events ' +
       'it hides are excluded from the summary.',
   },
@@ -890,7 +890,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     dependsOn: [{ key: 'chat.consolidate_joins', in: [true] }],
     description:
       'In each category (joined / left / reconnected / renamed / changed host / ' +
-      'opped / voiced) of a summary ' +
+      'opped / voiced / briefly opped …) of a summary ' +
       'line, show at most this many nicks before collapsing the rest into ' +
       '"and N others". Recent speakers (those tracked for nick completion) ' +
       'are preferred when picking which names to show.',

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -89,7 +89,10 @@
             ><template v-else-if="g.kind === 'left'"> left</template
             ><template v-else-if="g.kind === 'reconnected'"> reconnected</template
             ><template v-else-if="g.kind === 'joinedAndLeft'"> joined briefly</template
-            ><template v-else-if="g.kind === 'rehosted'"> changed host</template></template
+            ><template v-else-if="g.kind === 'rehosted'"> changed host</template
+            ><template v-else-if="g.kind === 'modeGranted' || g.kind === 'modeRevoked'">{{
+              modePhrase(g)
+            }}</template></template
           >
         </span>
       </div>
@@ -1509,6 +1512,32 @@ function asRename(item: NickEntry | RenameEntry): RenameEntry {
 }
 function asNick(item: NickEntry | RenameEntry): NickEntry {
   return item as NickEntry;
+}
+
+// The verb for a folded run of member-status changes, e.g. " were opped".
+//
+// Only the LETTER travels on the group — the words are each client's own
+// business, the same way "joined" and "changed host" are — so this table lives
+// here rather than in shared/consolidate.ts.
+//
+// `o` and `v` are effectively all real traffic and get proper verbs. Anything
+// else falls back to the token: inventing English for `+a` on an ircd nobody
+// in the room runs would be guessing, and `was given +a` is honest and
+// readable. Revocation says "lost", which needs no copula, so it reads the
+// same for one name or ten.
+const MODE_VERBS: Record<string, [string, string]> = {
+  o: ['opped', 'deopped'],
+  v: ['voiced', 'devoiced'],
+};
+
+function modePhrase(g: ConsolidationGroup): string {
+  const granted = g.kind === 'modeGranted';
+  const letter = g.letter ?? '';
+  const plural = g.visible.length + g.hidden !== 1;
+  const verb = MODE_VERBS[letter];
+  if (verb) return `${plural ? ' were ' : ' was '}${granted ? verb[0] : verb[1]}`;
+  if (granted) return `${plural ? ' were ' : ' was '}given +${letter}`;
+  return ` lost +${letter}`;
 }
 
 function requestMoreHistory() {

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -90,9 +90,7 @@
             ><template v-else-if="g.kind === 'reconnected'"> reconnected</template
             ><template v-else-if="g.kind === 'joinedAndLeft'"> joined briefly</template
             ><template v-else-if="g.kind === 'rehosted'"> changed host</template
-            ><template v-else-if="g.kind === 'modeGranted' || g.kind === 'modeRevoked'">{{
-              modePhrase(g)
-            }}</template></template
+            ><template v-else-if="g.letter">{{ modePhrase(g) }}</template></template
           >
         </span>
       </div>


### PR DESCRIPTION
Closes #673. PR 5 of the mode-noise plan (`lurker-dev/MODE_EVENT_NOISE.md` §4.4), on top of
the `kind` stamp (#825) and the narration (#826).

## Why

A mode row terminated a consolidation run, so the case that motivated the issue — a netsplit
rejoin on an auto-op channel — came out chopped into pieces:

```
before:  alice joined                    after:  alice, bob and carol joined;
         ChanServ gave op to alice               alice and bob were opped
         bob joined
         ChanServ gave op to bob
         carol joined
```

## Answering #673's four questions

**1. What folds.** Only member-status churn, and only when *every* change in the message is
one — the same `isChurnMode` gate the smart rung uses. A ban, a channel flag, a message
mixing an op change with either, an unstamped row, and a lone mode row all still stand alone.

**2. Vocabulary.** A second pass keyed on `(nick, letter)`, not the identity chain. It has
to be: a mode change has no join/leave sequence, its subject is a pair rather than a nick,
and its target need never have joined inside the run. That second vocabulary is the cost the
lurker-ios prototype named when it tried this and backed it out — it's also the thing being
asked for, so it's paid deliberately. Only the **letter** travels on the group; the words are
each client's business, the way "joined" already is.

**3. What a cancelled pair does.** **Reports the end state, and never drops the nick.**
`+o alice` then `-o alice` reads "alice was deopped" rather than vanishing the way a
join/part pair does.

The asymmetry is the point: our summary has **no expand affordance**. The Lounge can drop a
cancelled pair because a click restores the raw lines; we'd be deleting information with no
way back. The trade — "alice was deopped" reads oddly if she wasn't opped before the run,
though it's true of the end state — is the thing most worth a second opinion in QA. §4.4(3)
has "briefly opped" as the alternative.

**4. Page units.** `mode` does **not** join `CONSOLIDATABLE_TYPES`. That set defines the
`renderable` unit for every client including shipped iOS builds, and merging them would also
collapse `chat` and `renderable` into one unit — the knock-on the issue flagged. What *folds*
is now a separate question (`foldsIntoRun`) from what *counts* (`countsTowardPage`).

## ⚠ The regression review caught, and the invariant

My first pass folded churn modes while still **counting** them, and the commit message
justified it with the rule applied backwards. Worth stating plainly since it's the subtle
part:

> The page unit must be no **finer** than what the client draws.

Counting rows that collapse to nothing hands back a page of `limit` units that renders as two
lines — the reader watches the buffer assemble itself while the client re-fetches. That's
#10, and it was reachable in *exactly* the scenario this PR exists for: one ChanServ `+o` per
join means a `renderable` page could be satisfied entirely by rows that fold into one line.

So `renderable` no longer counts them. That needs the row rather than its type — whether a
mode row is churn lives in its `modes` — so `countsTowardPage` takes `{type, modes}`, and the
paging scan pulls `extra` for mode rows only (via a `CASE`, so a 2000-row scan doesn't drag
the column along for everything else).

**Safe for shipped clients.** iOS folds presence but not mode, so it now receives mode rows
that cost nothing: its pages render *longer* than asked rather than shorter — the side of the
invariant you want to be on.

## Docs and copy the change invalidated

- The comment on `NOISE_TYPES` claimed mode rows never fold, which was the stated reason the
  two sets differ. They still differ, for a different reason, now spelled out — with a
  warning not to "fix" it by merging them.
- `CLIENT_PROTOCOL.md`'s `countBy` section told third-party clients `CONSOLIDATABLE_TYPES`
  was the canonical fold set. It isn't.
- `chat.consolidate_joins` / `chat.consolidate_max_names` described only presence categories,
  while every user on defaults now gets op/voice folded — including that the summary reports
  who ended up with what rather than who set it.

## Tests

`consolidate.test.ts` gains 16: run continuity, per-letter grouping, the net-sign rule, a
mode target not inventing a presence verdict, capping, and five separate "must NOT fold"
cases. `messages.test.ts` gains the end-to-end tripwire for the paging regression above, plus
its converse. Full suite green: 285 files, 4118 tests.

## Not here

iOS (PR 6). Until it lands the two clients fold differently — which is safe in the direction
described above, but is why 6 shouldn't wait long.

## Known, unchanged

There's no way to opt out of the mode half of consolidation short of turning consolidation
off. That matches how the feature already treats its five presence types, and a per-type
toggle would be a knob per event kind.
