### PR TITLE
Add the IRC engine: a standalone holder for IRC sockets (#386, 1/3)

### DIFF
--- a/server/engine.ts
+++ b/server/engine.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The IRC engine: a second entrypoint in the same image (`tsx server/engine.ts`)
+// that holds the IRC sockets so the app process (`server/server.ts`) can be
+// redeployed without dropping them. It has no database, no credentials, and no
+// idea who its connections belong to — see server/engine/protocol.ts for the
+// contract and docs/SELF_HOSTING.md for how to run it.
+
+// First import on purpose, as in server.ts: the fatal-exception guard has to be
+// in place before anything else evaluates.
+import { installFatalExceptionExit } from './utils/processGuards.js';
+import 'dotenv/config';
+import { loadEngineConfig } from './engine/config.js';
+import { EngineServer } from './engine/server.js';
+import { PROTOCOL_MAJOR, PROTOCOL_MINOR } from './engine/protocol.js';
+import { APP_VERSION } from './utils/userAgent.js';
+import {
+  startIdentd,
+  stopIdentd,
+  identdPort,
+  identdBindHost,
+  isIdentdEnabled,
+  isOidentdFileEnabled,
+  initOidentdFile,
+  stopOidentdFile,
+} from './services/identd.js';
+
+// There is no durable log here — the guard's own console.error is the record.
+installFatalExceptionExit(() => {});
+
+let config;
+try {
+  config = loadEngineConfig();
+} catch (err) {
+  console.error(`[engine] ${(err as Error).message}`);
+  process.exit(1);
+}
+
+// identd is keyed on the socket 4-tuple, so whichever process holds the sockets
+// must answer :113 — in this topology, this one. Same two modes as the app.
+if (isIdentdEnabled()) startIdentd(identdPort(), identdBindHost());
+if (isOidentdFileEnabled()) {
+  if (isIdentdEnabled()) {
+    console.warn(
+      '[engine] both LURKER_IDENTD_ENABLED and LURKER_OIDENTD_FILE are set — running both is usually unintended, pick one',
+    );
+  }
+  initOidentdFile();
+}
+
+const engine = new EngineServer({
+  secret: config.secret,
+  bufferBytes: config.bufferBytes,
+  bufferTotalBytes: config.bufferTotalBytes,
+  orphanMs: config.orphanMs,
+  version: APP_VERSION,
+});
+
+// Say which ident mode this process resolved, because the variables that
+// choose it are easy to leave on the wrong container: an operator whose identd
+// silently ended up nowhere finds out here, not from ~ident on the network.
+const identMode = isIdentdEnabled()
+  ? `built-in identd on :${identdPort()}`
+  : isOidentdFileEnabled()
+    ? 'oidentd file mode'
+    : 'none (LURKER_IDENTD_ENABLED / LURKER_OIDENTD_FILE unset here — the network sees ~ident)';
+console.log(`[engine] ident: ${identMode}`);
+
+void (async () => {
+  try {
+    const { host, port } = await engine.listen(config.listenPort, config.listenHost);
+    console.log(
+      `[engine] listening on ${host}:${port} — protocol ${PROTOCOL_MAJOR}.${PROTOCOL_MINOR}, lurker ${APP_VERSION}; per-connection buffer ${config.bufferBytes} bytes, total ${config.bufferTotalBytes}`,
+    );
+  } catch (err) {
+    console.error(
+      `[engine] failed to listen on ${config.listenHost}:${config.listenPort}: ${(err as Error).message}`,
+    );
+    process.exit(1);
+  }
+})();
+
+let stopping = false;
+function shutdown(signal: string): void {
+  if (stopping) return;
+  stopping = true;
+  const held = engine.connectionCount();
+  console.log(
+    `[engine] received ${signal}, shutting down — ${held} IRC connection(s) will drop; the app reconnects them`,
+  );
+  void engine.shutdown('Lurker engine restarting').then(() => {
+    stopIdentd();
+    stopOidentdFile();
+    process.exit(0);
+  });
+  setTimeout(() => process.exit(1), 5000).unref();
+}
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/server/engine/config.test.ts
+++ b/server/engine/config.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { loadEngineConfig } from './config.js';
+
+const base = { LURKER_ENGINE_SECRET: 's3cret' } as NodeJS.ProcessEnv;
+
+describe('loadEngineConfig', () => {
+  // The security-relevant default. LURKER_ENGINE_SECRET is the only thing
+  // between a reachable engine and every connection it holds, so an engine
+  // nobody configured must not be reachable off-box. Docker gets a wider bind
+  // from the compose overlay (containers do not share a network namespace);
+  // server/engine/topology.test.ts pins that the overlay actually sets it.
+  it('binds loopback when nothing says otherwise', () => {
+    const c = loadEngineConfig(base);
+    expect(c.listenHost).toBe('127.0.0.1');
+    expect(c.listenPort).toBe(8016);
+  });
+
+  it('honours an explicit bind, including a wide one', () => {
+    expect(loadEngineConfig({ ...base, LURKER_ENGINE_LISTEN: '0.0.0.0:8016' }).listenHost).toBe(
+      '0.0.0.0',
+    );
+    expect(loadEngineConfig({ ...base, LURKER_ENGINE_LISTEN: '9000' })).toMatchObject({
+      listenHost: '127.0.0.1',
+      listenPort: 9000,
+    });
+    expect(loadEngineConfig({ ...base, LURKER_ENGINE_LISTEN: '[::1]:9000' })).toMatchObject({
+      listenHost: '::1',
+      listenPort: 9000,
+    });
+  });
+
+  it('refuses to start without a secret', () => {
+    expect(() => loadEngineConfig({})).toThrow(/LURKER_ENGINE_SECRET is required/);
+    expect(() => loadEngineConfig({ LURKER_ENGINE_SECRET: '   ' })).toThrow(/required/);
+  });
+});

--- a/server/engine/config.ts
+++ b/server/engine/config.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Engine-side configuration. All LURKER_ENGINE_* — the app side reads its own two
+// (LURKER_ENGINE_URL / LURKER_ENGINE_SECRET) in services/engineTransport.ts.
+
+import { parseHostPort } from './protocol.js';
+
+export interface EngineConfig {
+  listenHost: string;
+  listenPort: number;
+  secret: string;
+  // Per-connection backlog ceiling, and the ceiling across every connection.
+  bufferBytes: number;
+  bufferTotalBytes: number;
+  // A session no app has claimed for this long is ended: the backstop for an
+  // app that never comes back, or one this engine refused (a protocol-major
+  // mismatch), whose sessions would otherwise sit on the network as ghosts.
+  orphanMs: number;
+}
+
+const MiB = 1024 * 1024;
+
+function envBytes(name: string, fallback: number): number {
+  const raw = (process.env[name] || '').trim();
+  if (!raw) return fallback;
+  // Digits only — a suffixed value would parse to its leading digits and
+  // silently mean something other than what was typed.
+  if (!/^\d+$/.test(raw)) throw new Error(`${name} must be a whole number of bytes (got "${raw}")`);
+  const n = Number(raw);
+  if (n < 64 * 1024) {
+    throw new Error(`${name} must be at least 65536 bytes to hold a single IRC burst (got ${raw})`);
+  }
+  return n;
+}
+
+function envMs(name: string, fallback: number): number {
+  const raw = (process.env[name] || '').trim();
+  if (!raw) return fallback;
+  if (!/^\d+$/.test(raw))
+    throw new Error(`${name} must be a whole number of milliseconds (got "${raw}")`);
+  return Number(raw);
+}
+
+export function loadEngineConfig(env: NodeJS.ProcessEnv = process.env): EngineConfig {
+  const secret = (env.LURKER_ENGINE_SECRET || '').trim();
+  if (!secret) {
+    throw new Error(
+      'LURKER_ENGINE_SECRET is required — the app authenticates to the engine with it; set the same value on both',
+    );
+  }
+  const listen = parseHostPort(env.LURKER_ENGINE_LISTEN || '', { host: '0.0.0.0', port: 8016 });
+  const bufferBytes = envBytes('LURKER_ENGINE_BUFFER_BYTES', 4 * MiB);
+  const bufferTotalBytes = envBytes('LURKER_ENGINE_BUFFER_TOTAL_BYTES', 256 * MiB);
+  return {
+    listenHost: listen.host,
+    listenPort: listen.port,
+    secret,
+    bufferBytes,
+    bufferTotalBytes: Math.max(bufferTotalBytes, bufferBytes),
+    orphanMs: envMs('LURKER_ENGINE_ORPHAN_MS', 60 * 60 * 1000),
+  };
+}

--- a/server/engine/config.ts
+++ b/server/engine/config.ts
@@ -49,7 +49,17 @@ export function loadEngineConfig(env: NodeJS.ProcessEnv = process.env): EngineCo
       'LURKER_ENGINE_SECRET is required — the app authenticates to the engine with it; set the same value on both',
     );
   }
-  const listen = parseHostPort(env.LURKER_ENGINE_LISTEN || '', { host: '0.0.0.0', port: 8016 });
+  // Loopback by DEFAULT. The engine's secret is the only thing between a
+  // reachable engine and every connection it holds, so the safe default is the
+  // one that cannot be reached from another host at all — the ordinary
+  // self-host runs the engine beside the app.
+  //
+  // ⚠ Containers do not share a network namespace, so an engine in its own
+  // container must be told to bind wider or its sibling app cannot reach it:
+  // docker-compose.engine.yml sets LURKER_ENGINE_LISTEN for exactly that, and
+  // publishes no port. Widening this default to save that one line would
+  // silently expose every bare-metal engine instead.
+  const listen = parseHostPort(env.LURKER_ENGINE_LISTEN || '', { host: '127.0.0.1', port: 8016 });
   const bufferBytes = envBytes('LURKER_ENGINE_BUFFER_BYTES', 4 * MiB);
   const bufferTotalBytes = envBytes('LURKER_ENGINE_BUFFER_TOTAL_BYTES', 256 * MiB);
   return {

--- a/server/engine/engine.test.ts
+++ b/server/engine/engine.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { EngineServer } from './server.js';
 import { PROTOCOL_MAJOR } from './protocol.js';
 import type { EngineToApp } from './protocol.js';
+import { MAX_BURST_BYTES } from './upstream.js';
 import { FakeIrcd } from '../test-utils/fakeIrcd.js';
 import { TestLink } from '../test-utils/engineLink.js';
 import { createIdentdServer } from '../services/identd.js';
@@ -259,6 +260,48 @@ describe('attach after the app is gone', () => {
       await gone(engine, id);
     } finally {
       await noMotd.close();
+    }
+  });
+
+  // The sibling of the 422 case: the cap that stops a long MOTD growing the
+  // burst forever must not take the terminator with it. Without it the replay
+  // opens a MOTD it never closes, and irc-framework only emits 'motd' — the one
+  // thing that renders the block, since 372/375/376 are on the app's numeric
+  // denylist — on 376/422.
+  it('keeps the burst terminator when a long MOTD fills the cap', async () => {
+    // ~85 KiB of MOTD against a 64 KiB cap.
+    const padLines = 80;
+    const bigMotd = await FakeIrcd.start({ motdPadLines: padLines });
+    try {
+      const id = `bigmotd:${++counter}`;
+      const a = await link();
+      a.send(connectFrame(id, { port: bigMotd.port }));
+      await a.waitFor((f) => f.op === 'open');
+      a.send({ op: 'write', id, line: 'NICK bigmotd' });
+      a.send({ op: 'write', id, line: 'USER bigmotd 0 * :b' });
+      await a.waitForLine(id, / 376 /);
+      ackAll(a, id);
+      a.kill();
+      const b = await link();
+      b.send(connectFrame(id, { port: bigMotd.port }));
+      const att = await b.waitFor<Attached>((f) => f.op === 'attached');
+      // The control: the cap really did engage, so the terminator surviving is
+      // not just "everything fit".
+      const motd = att.replay.filter((x) => / 372 /.test(x));
+      expect(motd.length).toBeGreaterThan(0);
+      expect(motd.length).toBeLessThan(padLines + 1);
+      expect(att.replay.join('\n').length).toBeGreaterThan(MAX_BURST_BYTES / 2);
+      // What survives is a PREFIX, not a subset with the long lines punched
+      // out: the pad lines are numbered, and the ones we kept run 0..n-1.
+      const kept = motd.map((x) => x.match(/:- (\d{4}) /)?.[1]).filter((x) => x !== undefined);
+      expect(kept).toEqual(kept.map((_, i) => String(i).padStart(4, '0')));
+      // And the prefix still ends where a consumer expects it to.
+      expect(att.replay.at(-1)).toMatch(/ 376 /);
+      expect(att.nick).toBe('bigmotd');
+      b.send({ op: 'close', id });
+      await gone(engine, id);
+    } finally {
+      await bigMotd.close();
     }
   });
 

--- a/server/engine/engine.test.ts
+++ b/server/engine/engine.test.ts
@@ -626,7 +626,12 @@ describe('review findings', () => {
     await l.waitForNew((f) => f.op === 'open' && f.id === id);
     l.send({ op: 'write', id, line: 'NICK reclose2' });
     l.send({ op: 'write', id, line: 'USER reclose2 0 * :r' });
-    await l.waitForLine(id, / 001 reclose2 /);
+    // Wait for the END of the burst, not 001. `held()` reports a session only
+    // once it is REGISTERED, and the engine sets that on 376/422 — so asserting
+    // anywhere between 001 and 376 is a race, and one that only loses under the
+    // event-loop pressure of a full-suite run. The engine sets burstDone before
+    // it flushes the line, so seeing 376 here is ordering, not timing.
+    await l.waitForLine(id, / 376 reclose2 /);
     expect(engine.held()).toContain(id);
     // The old socket's death was silent for this link.
     expect(l.frames.some((f) => f.op === 'closed' && f.id === id)).toBe(false);

--- a/server/engine/engine.test.ts
+++ b/server/engine/engine.test.ts
@@ -13,7 +13,7 @@ import { PROTOCOL_MAJOR } from './protocol.js';
 import type { EngineToApp } from './protocol.js';
 import { MAX_BURST_BYTES } from './upstream.js';
 import { FakeIrcd } from '../test-utils/fakeIrcd.js';
-import { TestLink } from '../test-utils/engineLink.js';
+import { TestLink, TEST_INSTANCE } from '../test-utils/engineLink.js';
 import { createIdentdServer } from '../services/identd.js';
 
 const SECRET = 'spike-secret';
@@ -791,6 +791,7 @@ describe('third review round', () => {
       op: 'hello',
       protocol: PROTOCOL_MAJOR,
       secret: SECRET,
+      instance: TEST_INSTANCE,
       app: { version: 'old', startedAt: 1000 },
     });
     await older.waitFor((f) => f.op === 'hello');
@@ -801,6 +802,7 @@ describe('third review round', () => {
       op: 'hello',
       protocol: PROTOCOL_MAJOR,
       secret: SECRET,
+      instance: TEST_INSTANCE,
       app: { version: 'new', startedAt: 2000 },
     });
     await newer.waitFor((f) => f.op === 'hello');
@@ -899,5 +901,81 @@ describe('orphan reaper', () => {
     } finally {
       await own.shutdown('done', 200);
     }
+  });
+});
+
+// The failure this partition exists to prevent is IRCCloud's July 2020 log
+// exposure: two connection servers minted colliding ids in one id space, and a
+// backlog fetch by id returned both users' logs. Lurker's ids are
+// `<instance>:<userId>:<networkId>` where the last two are rowids from ONE
+// Lurker database, so two Lurker instances on one engine would both mint
+// `…:1:1` for unrelated people. `matchesDial` does not save you: two users on
+// the same popular network dial the identical host/port/tls.
+describe('instance isolation', () => {
+  const OTHER = 'test-instance-b';
+
+  it('refuses a hello with no instance at all', async () => {
+    const l = await TestLink.open(enginePort);
+    links.push(l);
+    l.send({
+      op: 'hello',
+      protocol: PROTOCOL_MAJOR,
+      secret: SECRET,
+      app: { version: 'no-instance' },
+    } as never);
+    const f = await l.waitFor((x) => x.op === 'hello' || x.op === 'error');
+    expect(f.op).toBe('error');
+    expect((f as { message: string }).message).toMatch(/instance/);
+  });
+
+  it('does not let another instance attach to, write to, or close a held session', async () => {
+    // Same id AND the same dial parameters — the collision matchesDial cannot see.
+    const id = `${TEST_INSTANCE}:1:1`;
+    const a = await link();
+    await register(a, id, 'ownernick');
+    a.send({ op: 'write', id, line: 'JOIN #secret' });
+    await a.waitForLine(id, /JOIN #secret/);
+    ackAll(a, id);
+    a.kill();
+    await new Promise((r) => setTimeout(r, 30));
+    expect(engine.held()).toContain(id);
+
+    const intruder = await TestLink.connect(enginePort, SECRET, { instance: OTHER });
+    links.push(intruder);
+    // It is not even told the session exists.
+    expect(intruder.hello?.held).not.toContain(id);
+
+    // Attaching to it is refused outright — not silently closed and redialed,
+    // which would hand the intruder a socket under the owner's id.
+    intruder.send(connectFrame(id));
+    const err = await intruder.waitFor((f) => f.op === 'error' || f.op === 'attached');
+    expect(err.op).toBe('error');
+    expect((err as { message: string }).message).toMatch(/another instance/);
+    expect(engine.held()).toContain(id);
+
+    // Driving it is refused too — every op, not just attach. waitForNew,
+    // because the refusal above is already sitting in `frames`.
+    for (const op of ['write', 'ack', 'detach', 'close'] as const) {
+      intruder.send(
+        op === 'write'
+          ? { op, id, line: 'PRIVMSG #secret :hello' }
+          : op === 'ack'
+            ? { op, id, seq: 1 }
+            : { op, id },
+      );
+      const f = await intruder.waitForNew((x) => x.op === 'error', 3000);
+      expect((f as { message: string }).message).toMatch(/another instance/);
+    }
+    expect(engine.held()).toContain(id);
+
+    // And the owner still gets its own session back, intact.
+    const owner = await link();
+    expect(owner.hello?.held).toContain(id);
+    owner.send(connectFrame(id));
+    const att = await owner.waitFor<Attached>((f) => f.op === 'attached');
+    expect(att.nick).toBe('ownernick');
+    expect(att.channels).toEqual(['#secret']);
+    owner.send({ op: 'close', id });
+    await gone(engine, id);
   });
 });

--- a/server/engine/engine.test.ts
+++ b/server/engine/engine.test.ts
@@ -1,0 +1,860 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The engine against a real socket on both sides: a fake ircd upstream and a
+// bare frame-level link standing in for the app. Every claim in
+// IRC_ENGINE_PLAN.md §5.1 has a case here.
+
+import net from 'node:net';
+import { once } from 'node:events';
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { EngineServer } from './server.js';
+import { PROTOCOL_MAJOR } from './protocol.js';
+import type { EngineToApp } from './protocol.js';
+import { FakeIrcd } from '../test-utils/fakeIrcd.js';
+import { TestLink } from '../test-utils/engineLink.js';
+import { createIdentdServer } from '../services/identd.js';
+
+const SECRET = 'spike-secret';
+type Attached = Extract<EngineToApp, { op: 'attached' }>;
+
+let ircd: FakeIrcd;
+let engine: EngineServer;
+let enginePort: number;
+const links: TestLink[] = [];
+
+beforeAll(async () => {
+  ircd = await FakeIrcd.start();
+  engine = new EngineServer({
+    secret: SECRET,
+    // Small on purpose so the overflow case is cheap to reach.
+    bufferBytes: 4096,
+    bufferTotalBytes: 64 * 1024,
+    version: 'test',
+    log: () => {},
+  });
+  enginePort = (await engine.listen(0, '127.0.0.1')).port;
+});
+
+afterAll(async () => {
+  await engine.shutdown('tests done', 500);
+  await ircd.close();
+});
+
+afterEach(() => {
+  for (const l of links.splice(0)) l.kill();
+});
+
+async function link(): Promise<TestLink> {
+  const l = await TestLink.connect(enginePort, SECRET);
+  links.push(l);
+  return l;
+}
+
+let counter = 0;
+function connectFrame(
+  id: string,
+  extra: Partial<{ tls: boolean; rejectUnauthorized: boolean; ident: string; port: number }> = {},
+) {
+  return {
+    op: 'connect' as const,
+    id,
+    host: '127.0.0.1',
+    port: extra.port ?? ircd.port,
+    tls: extra.tls ?? false,
+    rejectUnauthorized: extra.rejectUnauthorized ?? false,
+    ...(extra.ident ? { ident: extra.ident } : {}),
+  };
+}
+
+// Dial through the engine and register on the fake ircd with plain NICK/USER.
+async function register(l: TestLink, id: string, nick: string): Promise<void> {
+  l.send(connectFrame(id));
+  await l.waitFor((f) => f.op === 'open' && f.id === id);
+  l.send({ op: 'write', id, line: `NICK ${nick}` });
+  l.send({ op: 'write', id, line: `USER ${nick} 0 * :${nick}` });
+  await l.waitForLine(id, / 376 /);
+}
+
+function until(pred: () => boolean, ms: number, what: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + ms;
+    const tick = () => {
+      if (pred()) return resolve();
+      if (Date.now() > deadline) return reject(new Error(`timed out waiting for ${what}`));
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+// A close the app asked for is never answered with `closed` (the app's
+// transport ends its own side as it asks); "it worked" is the socket being gone.
+const gone = (srv: EngineServer, id: string) =>
+  until(() => !srv.hasConnection(id), 3000, `${id} gone from the engine`);
+
+function ackAll(l: TestLink, id: string): void {
+  const last = l.frames.filter((f) => f.op === 'line' && f.id === id).pop() as
+    | Extract<EngineToApp, { op: 'line' }>
+    | undefined;
+  if (last) l.send({ op: 'ack', id, seq: last.seq });
+}
+
+describe('hello', () => {
+  it('refuses a bad secret and a wrong protocol major, accepts the right pair', async () => {
+    const bad = await TestLink.connect(enginePort, 'nope');
+    expect(bad.frames[0]).toMatchObject({ op: 'error', message: 'bad secret' });
+    await bad.waitForClose();
+
+    const skew = await TestLink.connect(enginePort, SECRET, { protocol: PROTOCOL_MAJOR + 1 });
+    expect(skew.frames[0]).toMatchObject({ op: 'error' });
+    expect((skew.frames[0] as { message: string }).message).toMatch(/protocol major mismatch/);
+    await skew.waitForClose();
+
+    const ok = await link();
+    expect(ok.hello).toMatchObject({ op: 'hello', protocol: PROTOCOL_MAJOR, held: [] });
+  });
+
+  it('answers a plain HTTP probe on the same port', async () => {
+    const s = net.connect(enginePort, '127.0.0.1');
+    await once(s, 'connect');
+    s.write('GET /healthz HTTP/1.0\r\n\r\n');
+    let out = '';
+    s.setEncoding('utf8');
+    s.on('data', (d: string) => (out += d));
+    await once(s, 'close');
+    expect(out).toMatch(/^HTTP\/1\.1 200 OK/);
+    expect(out).toMatch(/"ok":true/);
+  });
+
+  it('drops a link that sends garbage', async () => {
+    const l = await link();
+    l.socket.write('{"op":"' + 'x'.repeat(300 * 1024) + '"}\n');
+    await l.waitForClose();
+    expect(l.closed).toBe(true);
+  });
+});
+
+describe('dial and relay', () => {
+  it('dials, reports the 4-tuple, relays both ways with increasing seqs', async () => {
+    const l = await link();
+    const id = `relay:${++counter}`;
+    l.send(connectFrame(id));
+    expect(await l.waitFor((f) => f.op === 'dialing')).toMatchObject({ id });
+    const open = await l.waitFor<Extract<EngineToApp, { op: 'open' }>>((f) => f.op === 'open');
+    expect(open.remote.port).toBe(ircd.port);
+    expect(open.local.port).toBeGreaterThan(0);
+    l.send({ op: 'write', id, line: 'NICK relay1' });
+    l.send({ op: 'write', id, line: 'USER relay1 0 * :r' });
+    await l.waitForLine(id, / 376 /);
+    const seqs = l.frames
+      .filter((f): f is Extract<EngineToApp, { op: 'line' }> => f.op === 'line')
+      .map((f) => f.seq);
+    expect(seqs).toEqual(seqs.map((_, i) => i + 1));
+    expect(ircd.registrations.filter((r) => r.nick === 'relay1')).toHaveLength(1);
+  });
+
+  it('answers server PINGs itself and never forwards them', async () => {
+    const l = await link();
+    const id = `ping:${++counter}`;
+    await register(l, id, 'pinger');
+    ircd.ping('pinger', 'tok-1');
+    expect(await ircd.waitForLine((line) => line === 'PONG :tok-1')).toBe('PONG :tok-1');
+    // Give a forwarded PING every chance to arrive, then assert it didn't.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(l.lines(id).some((x) => x.startsWith('PING'))).toBe(false);
+  });
+
+  it('reports an unknown id as an error and ends the socket on close', async () => {
+    const l = await link();
+    l.send({ op: 'write', id: 'nobody', line: 'PING x' });
+    expect(await l.waitFor((f) => f.op === 'error')).toMatchObject({ id: 'nobody' });
+    const id = `close:${++counter}`;
+    await register(l, id, 'closer');
+    l.send({ op: 'close', id });
+    await gone(engine, id);
+    expect(engine.held()).not.toContain(id);
+  });
+});
+
+describe('attach after the app is gone', () => {
+  it('holds the socket, buffers, replays burst + NICKs + JOINs, then drains and goes live', async () => {
+    const id = `attach:${++counter}`;
+    const a = await link();
+    await register(a, id, 'vic');
+    a.send({ op: 'write', id, line: 'JOIN #a' });
+    await a.waitForLine(id, /JOIN #a/);
+    a.send({ op: 'write', id, line: 'JOIN #b' });
+    await a.waitForLine(id, /JOIN #b/);
+    a.send({ op: 'write', id, line: 'NICK vic2' });
+    await a.waitForLine(id, /NICK :vic2/);
+    a.send({ op: 'write', id, line: 'PART #a' });
+    await a.waitForLine(id, /PART #a/);
+    ackAll(a, id);
+    const sentBefore = ircd.client('vic2')!.sent.length;
+
+    // The app dies. No QUIT, no detach.
+    a.kill();
+    await new Promise((r) => setTimeout(r, 30));
+    expect(engine.held()).toContain(id);
+
+    // Life goes on without it.
+    ircd.say('peer', '#b', 'one');
+    ircd.say('peer', 'vic2', 'two');
+    ircd.setTopic('peer', '#b', 'while away');
+    ircd.ping('vic2', 'detached');
+    await ircd.waitForLine((line) => line === 'PONG :detached');
+
+    const b = await link();
+    expect(b.hello?.held).toContain(id);
+    b.send(connectFrame(id));
+    const att = await b.waitFor<Attached>((f) => f.op === 'attached');
+    expect(att.nick).toBe('vic2');
+    expect(att.channels).toEqual(['#b']);
+    expect(att.detachedForMs).toBeGreaterThan(0);
+    // Burst: 001-005, 251, 375, 372, 376 = 9 lines; then the NICK; then #b.
+    expect(att.replay).toHaveLength(11);
+    expect(att.replay[0]).toMatch(/ 001 vic /);
+    expect(att.replay[8]).toMatch(/ 376 /);
+    expect(att.replay[9]).toMatch(/^(@\S+ )?:vic!~vic@fake.host NICK :vic2$/);
+    expect(att.replay[10]).toBe(':vic2!~vic@fake.host JOIN #b');
+
+    await b.waitFor((f) => f.op === 'live' && f.id === id);
+    const backlog = b.lines(id);
+    expect(backlog.map((x) => x.replace(/^@\S+ /, ''))).toEqual([
+      ':peer!~peer@peer.fake PRIVMSG #b :one',
+      ':peer!~peer@peer.fake PRIVMSG vic2 :two',
+      ':peer!~peer@peer.fake TOPIC #b :while away',
+    ]);
+    // Order on the wire: attached, then the backlog, then live.
+    const ops = b.frames.filter((f) => 'id' in f && f.id === id).map((f) => f.op);
+    expect(ops).toEqual(['attached', 'line', 'line', 'line', 'live']);
+    // Seqs continue from where the old link left off.
+    const firstSeq = (b.frames.find((f) => f.op === 'line') as { seq: number }).seq;
+    expect(firstSeq).toBeGreaterThan(1);
+
+    // The server saw one registration and not one extra command.
+    expect(ircd.registrations.filter((r) => r.nick === 'vic')).toHaveLength(1);
+    expect(ircd.client('vic2')!.sent.slice(sentBefore)).toEqual(['PONG :detached']);
+  });
+
+  it('ends the burst at 422 when there is no MOTD', async () => {
+    const noMotd = await FakeIrcd.start({ motd: false });
+    try {
+      const id = `motd:${++counter}`;
+      const a = await link();
+      a.send(connectFrame(id, { port: noMotd.port }));
+      await a.waitFor((f) => f.op === 'open');
+      a.send({ op: 'write', id, line: 'NICK nomotd' });
+      a.send({ op: 'write', id, line: 'USER nomotd 0 * :n' });
+      await a.waitForLine(id, / 422 /);
+      ackAll(a, id);
+      a.kill();
+      const b = await link();
+      b.send(connectFrame(id, { port: noMotd.port }));
+      const att = await b.waitFor<Attached>((f) => f.op === 'attached');
+      expect(att.replay.at(-1)).toMatch(/ 422 /);
+      expect(att.nick).toBe('nomotd');
+      b.send({ op: 'close', id });
+      await gone(engine, id);
+    } finally {
+      await noMotd.close();
+    }
+  });
+
+  it('forgets a channel it was kicked from and follows a server-forced nick', async () => {
+    const id = `kick:${++counter}`;
+    const a = await link();
+    await register(a, id, 'kicked');
+    a.send({ op: 'write', id, line: 'JOIN #k' });
+    await a.waitForLine(id, /JOIN #k/);
+    ircd.kick('#k', 'kicked');
+    await a.waitForLine(id, /KICK #k kicked/);
+    ircd.forceNick('kicked', 'renamed');
+    await a.waitForLine(id, /NICK :renamed/);
+    ackAll(a, id);
+    a.kill();
+    const b = await link();
+    b.send(connectFrame(id));
+    const att = await b.waitFor<Attached>((f) => f.op === 'attached');
+    expect(att.channels).toEqual([]);
+    expect(att.nick).toBe('renamed');
+    expect(att.replay.filter((x) => /JOIN/.test(x))).toHaveLength(0);
+  });
+
+  it('newest link wins: the old link is told, not closed', async () => {
+    const id = `takeover:${++counter}`;
+    const a = await link();
+    await register(a, id, 'shared');
+    const b = await link();
+    b.send(connectFrame(id));
+    await b.waitFor((f) => f.op === 'attached');
+    expect(await a.waitFor((f) => f.op === 'detached')).toMatchObject({ id, reason: 'taken-over' });
+    expect(a.frames.some((f) => f.op === 'closed')).toBe(false);
+    ircd.say('peer', 'shared', 'to-b');
+    await b.waitForLine(id, /to-b/);
+    expect(a.lines(id).some((x) => /to-b/.test(x))).toBe(false);
+    // The old link can no longer drive the socket either.
+    a.send({ op: 'write', id, line: 'PRIVMSG shared :from-the-dead' });
+    expect(await a.waitFor((f) => f.op === 'error' && f.id === id)).toMatchObject({
+      message: 'not attached to this connection',
+    });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(ircd.client('shared')!.sent.some((l) => /from-the-dead/.test(l))).toBe(false);
+  });
+
+  it('acked lines are not replayed; unacked ones are', async () => {
+    const id = `ack:${++counter}`;
+    const a = await link();
+    await register(a, id, 'acker');
+    ackAll(a, id);
+    ircd.say('peer', 'acker', 'acked-1');
+    const f1 = await a.waitFor<Extract<EngineToApp, { op: 'line' }>>(
+      (f) => f.op === 'line' && /acked-1/.test(f.line),
+    );
+    a.send({ op: 'ack', id, seq: f1.seq });
+    ircd.say('peer', 'acker', 'unacked-2');
+    await a.waitForLine(id, /unacked-2/);
+    await new Promise((r) => setTimeout(r, 20));
+    a.kill();
+    const b = await link();
+    b.send(connectFrame(id));
+    await b.waitFor((f) => f.op === 'live');
+    expect(b.lines(id).map((x) => x.replace(/^@\S+ /, ''))).toEqual([
+      ':peer!~peer@peer.fake PRIVMSG acker :unacked-2',
+    ]);
+  });
+
+  it('reports a gap when the app stayed away longer than the buffer covers', async () => {
+    const id = `gap:${++counter}`;
+    const a = await link();
+    await register(a, id, 'gappy');
+    ackAll(a, id);
+    a.kill();
+    await new Promise((r) => setTimeout(r, 20));
+    // 4096-byte buffer; 100 lines of ~90 bytes.
+    for (let i = 0; i < 100; i++) ircd.say('peer', 'gappy', `line ${i} ${'x'.repeat(50)}`);
+    await new Promise((r) => setTimeout(r, 80)); // let the writes land
+    const b = await link();
+    b.send(connectFrame(id));
+    await b.waitFor((f) => f.op === 'live');
+    const ops = b.frames.filter((f) => 'id' in f && f.id === id).map((f) => f.op);
+    expect(ops.slice(0, 2)).toEqual(['attached', 'gap']);
+    const gap = b.frames.find((f) => f.op === 'gap') as Extract<EngineToApp, { op: 'gap' }>;
+    expect(gap.gap.firstDroppedSeq).toBeGreaterThan(0);
+    expect(gap.gap.lastDroppedSeq).toBeGreaterThan(gap.gap.firstDroppedSeq);
+    const got = b.lines(id);
+    expect(got.length).toBeLessThan(100);
+    expect(got.at(-1)).toMatch(/line 99 /);
+  });
+
+  it('a socket that died while detached is forgotten; a CONNECT dials afresh', async () => {
+    const id = `dead:${++counter}`;
+    const a = await link();
+    await register(a, id, 'doomed');
+    a.kill();
+    await new Promise((r) => setTimeout(r, 20));
+    ircd.drop('doomed');
+    await new Promise((r) => setTimeout(r, 50));
+    expect(engine.held()).not.toContain(id);
+    const b = await link();
+    expect(b.hello?.held).not.toContain(id);
+    // A CONNECT now is a fresh dial.
+    b.send(connectFrame(id));
+    expect(await b.waitFor((f) => f.op === 'dialing' || f.op === 'attached')).toMatchObject({
+      op: 'dialing',
+    });
+  });
+});
+
+describe('TLS and identd', () => {
+  it('dials TLS upstreams and honours rejectUnauthorized', async () => {
+    const secure = await FakeIrcd.start({ tls: true });
+    try {
+      const l = await link();
+      const id = `tls:${++counter}`;
+      l.send(connectFrame(id, { port: secure.port, tls: true, rejectUnauthorized: false }));
+      await l.waitFor((f) => f.op === 'open' && f.id === id);
+      l.send({ op: 'write', id, line: 'NICK tlsy' });
+      l.send({ op: 'write', id, line: 'USER tlsy 0 * :t' });
+      await l.waitForLine(id, / 001 /);
+
+      const strict = `tls-strict:${++counter}`;
+      l.send(connectFrame(strict, { port: secure.port, tls: true, rejectUnauthorized: true }));
+      const closed = await l.waitFor<Extract<EngineToApp, { op: 'closed' }>>(
+        (f) => f.op === 'closed' && f.id === strict,
+      );
+      expect(closed.error).toMatch(/self.signed|certificate/i);
+    } finally {
+      await secure.close();
+    }
+  });
+
+  it('registers the ident on the raw TCP connect — before the TLS handshake — and releases it on close', async () => {
+    process.env.LURKER_IDENTD_ENABLED = '1';
+    const identd = createIdentdServer({ graceMs: 50, graceStepMs: 10 });
+    await new Promise<void>((r) => identd.listen(0, '127.0.0.1', r));
+    const identdPort = (identd.address() as net.AddressInfo).port;
+    const query = (line: string): Promise<string> =>
+      new Promise((resolve, reject) => {
+        const c = net.connect(identdPort, '127.0.0.1', () => c.write(line));
+        let out = '';
+        c.setEncoding('utf8');
+        c.on('data', (d: string) => (out += d));
+        c.on('end', () => resolve(out.trim()));
+        c.on('error', reject);
+      });
+    try {
+      const l = await link();
+      const id = `ident:${++counter}`;
+      l.send(connectFrame(id, { ident: 'brad' }));
+      const open = await l.waitFor<Extract<EngineToApp, { op: 'open' }>>(
+        (f) => f.op === 'open' && f.id === id,
+      );
+      expect(await query(`${open.local.port}, ${open.remote.port}\r\n`)).toBe(
+        `${open.local.port}, ${open.remote.port} : USERID : UNIX : brad`,
+      );
+      l.send({ op: 'close', id });
+      await gone(engine, id);
+      expect(await query(`${open.local.port}, ${open.remote.port}\r\n`)).toMatch(/NO-USER/);
+
+      // TLS: the ircd asks :113 the instant it accepts TCP, while the handshake
+      // is still in flight — so the entry must exist by then, not after.
+      const secure = await FakeIrcd.start({ tls: true });
+      try {
+        const tid = `ident-tls:${++counter}`;
+        l.send(connectFrame(tid, { port: secure.port, tls: true, ident: 'brad' }));
+        const topen = await l.waitFor<Extract<EngineToApp, { op: 'open' }>>(
+          (f) => f.op === 'open' && f.id === tid,
+        );
+        expect(await query(`${topen.local.port}, ${topen.remote.port}\r\n`)).toBe(
+          `${topen.local.port}, ${topen.remote.port} : USERID : UNIX : brad`,
+        );
+        l.send({ op: 'close', id: tid });
+        await gone(engine, tid);
+      } finally {
+        await secure.close();
+      }
+    } finally {
+      delete process.env.LURKER_IDENTD_ENABLED;
+      identd.close();
+    }
+  });
+});
+
+describe('shutdown', () => {
+  it('QUITs every held socket and drops the links', async () => {
+    const own = new EngineServer({
+      secret: SECRET,
+      bufferBytes: 4096,
+      bufferTotalBytes: 65536,
+      version: 'test',
+      log: () => {},
+    });
+    const port = (await own.listen(0, '127.0.0.1')).port;
+    const l = await TestLink.connect(port, SECRET);
+    const id = 'bye:1';
+    l.send(connectFrame(id));
+    await l.waitFor((f) => f.op === 'open');
+    l.send({ op: 'write', id, line: 'NICK bye' });
+    l.send({ op: 'write', id, line: 'USER bye 0 * :b' });
+    await l.waitForLine(id, / 376 /);
+    await own.shutdown('engine restarting');
+    expect(ircd.client('bye')).toBeUndefined();
+    expect(await ircd.waitForLine((line) => line === 'QUIT :engine restarting')).toBeTruthy();
+    await l.waitForClose();
+    expect(own.held()).toEqual([]);
+  });
+});
+
+describe('review findings', () => {
+  it('refuses a connect with a bad port or bind address without dying', async () => {
+    const l = await link();
+    const healthy = `healthy:${++counter}`;
+    await register(l, healthy, 'healthy');
+    l.send({ ...connectFrame(`bad:${++counter}`), port: 70000 });
+    expect(await l.waitFor((f) => f.op === 'error')).toMatchObject({
+      message: expect.stringMatching(/invalid port/),
+    });
+    l.send({ ...connectFrame(`bad:${++counter}`), outgoingAddr: 'eth0' });
+    expect(await l.waitFor((f) => f.op === 'error' && /outgoingAddr/.test(f.message))).toBeTruthy();
+    // Still here, still holding the healthy one, still able to dial.
+    expect(engine.held()).toContain(healthy);
+    ircd.say('peer', 'healthy', 'alive');
+    await l.waitForLine(healthy, /alive/);
+  });
+
+  it('follows a nick forced during registration and the channels joined after it', async () => {
+    const forcing = await FakeIrcd.start({ burstNickTo: 'forced' });
+    try {
+      const id = `forced:${++counter}`;
+      const a = await link();
+      a.send(connectFrame(id, { port: forcing.port }));
+      await a.waitFor((f) => f.op === 'open' && f.id === id);
+      a.send({ op: 'write', id, line: 'NICK before' });
+      a.send({ op: 'write', id, line: 'USER before 0 * :b' });
+      await a.waitForLine(id, / 376 /);
+      a.send({ op: 'write', id, line: 'JOIN #after' });
+      await a.waitForLine(id, /JOIN #after/);
+      ackAll(a, id);
+      a.kill();
+      const b = await link();
+      b.send(connectFrame(id, { port: forcing.port }));
+      const att = await b.waitFor<Attached>((f) => f.op === 'attached');
+      expect(att.nick).toBe('forced');
+      expect(att.channels).toEqual(['#after']);
+      // The forced NICK is in the burst verbatim, so no synthesised one follows.
+      expect(att.replay.filter((x) => / NICK /.test(x))).toEqual([
+        expect.stringMatching(/^:before!~before@fake.host NICK :forced$/),
+      ]);
+      expect(att.replay.at(-1)).toBe(':forced!~before@fake.host JOIN #after');
+      b.send({ op: 'close', id });
+      await gone(engine, id);
+    } finally {
+      await forcing.close();
+    }
+  });
+
+  it('redials afresh, not an error, for a socket whose registration never finished', async () => {
+    const id = `half:${++counter}`;
+    const a = await link();
+    a.send(connectFrame(id));
+    await a.waitFor((f) => f.op === 'open' && f.id === id);
+    a.send({ op: 'write', id, line: 'NICK half' }); // no USER: never registers
+    await new Promise((r) => setTimeout(r, 30));
+    // Not a session, so not advertised as one.
+    expect(engine.held()).not.toContain(id);
+    a.kill();
+    const b = await link();
+    expect(b.hello?.held).not.toContain(id);
+    b.send(connectFrame(id));
+    const next = await b.waitFor((f) => 'id' in f && f.id === id);
+    expect(next.op).toBe('dialing');
+    await b.waitFor((f) => f.op === 'open' && f.id === id);
+    b.send({ op: 'write', id, line: 'NICK half2' });
+    b.send({ op: 'write', id, line: 'USER half2 0 * :h' });
+    await b.waitForLine(id, / 001 half2 /);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(b.frames.some((f) => f.op === 'closed' && f.id === id)).toBe(false);
+    expect(engine.held()).toContain(id);
+  });
+
+  it('does not deliver an unacked burst twice — the replay is its delivery', async () => {
+    const id = `noack:${++counter}`;
+    const a = await link();
+    await register(a, id, 'noack'); // deliberately never acked
+    a.kill();
+    const b = await link();
+    b.send(connectFrame(id));
+    const att = await b.waitFor<Attached>((f) => f.op === 'attached');
+    await b.waitFor((f) => f.op === 'live' && f.id === id);
+    expect(att.replay.some((x) => / 001 /.test(x))).toBe(true);
+    expect(b.lines(id).some((x) => / 001 /.test(x))).toBe(false);
+  });
+
+  it('reports a gap to the next attach, not to the link that already had the lines', async () => {
+    const id = `gapwho:${++counter}`;
+    const a = await link();
+    await register(a, id, 'gapwho');
+    ackAll(a, id);
+    // Attached but never acking: 100 lines against a 4 KiB buffer.
+    for (let i = 0; i < 100; i++) ircd.say('peer', 'gapwho', `line ${i} ${'x'.repeat(50)}`);
+    await a.waitForLine(id, /line 99 /);
+    expect(a.lines(id).filter((x) => /line \d+ /.test(x))).toHaveLength(100);
+    expect(a.frames.some((f) => f.op === 'gap')).toBe(false);
+    a.kill();
+    const b = await link();
+    b.send(connectFrame(id));
+    await b.waitFor((f) => f.op === 'live' && f.id === id);
+    const ops = b.frames.filter((f) => 'id' in f && f.id === id).map((f) => f.op);
+    expect(ops.slice(0, 2)).toEqual(['attached', 'gap']);
+  });
+
+  it('a CONNECT right after a close dials afresh instead of attaching to the dying socket', async () => {
+    const id = `reclose:${++counter}`;
+    const l = await link();
+    await register(l, id, 'reclose');
+    l.send({ op: 'close', id });
+    l.send(connectFrame(id));
+    const next = await l.waitForNew(
+      (f) => 'id' in f && f.id === id && (f.op === 'dialing' || f.op === 'attached'),
+    );
+    expect(next.op).toBe('dialing');
+    await l.waitForNew((f) => f.op === 'open' && f.id === id);
+    l.send({ op: 'write', id, line: 'NICK reclose2' });
+    l.send({ op: 'write', id, line: 'USER reclose2 0 * :r' });
+    await l.waitForLine(id, / 001 reclose2 /);
+    expect(engine.held()).toContain(id);
+    // The old socket's death was silent for this link.
+    expect(l.frames.some((f) => f.op === 'closed' && f.id === id)).toBe(false);
+  });
+
+  it('lets any link close a socket nobody claims, and no link close one someone else does', async () => {
+    const id = `orphan:${++counter}`;
+    const a = await link();
+    await register(a, id, 'orphan');
+    a.kill();
+    await new Promise((r) => setTimeout(r, 30));
+    const b = await link();
+    b.send({ op: 'close', id });
+    await gone(engine, id);
+    expect(engine.held()).not.toContain(id);
+
+    const id2 = `owned:${++counter}`;
+    const owner = await link();
+    await register(owner, id2, 'owned');
+    const stranger = await link();
+    stranger.send({ op: 'close', id: id2 });
+    expect(await stranger.waitFor((f) => f.op === 'error' && f.id === id2)).toMatchObject({
+      message: 'not attached to this connection',
+    });
+    expect(engine.held()).toContain(id2);
+  });
+});
+
+describe('second review round', () => {
+  // A listener that accepts TCP and then says nothing: to a TLS dial that is a
+  // handshake that never completes.
+  async function tarpit(): Promise<{ port: number; close(): void }> {
+    const srv = net.createServer(() => {});
+    await new Promise<void>((r) => srv.listen(0, '127.0.0.1', r));
+    return { port: (srv.address() as net.AddressInfo).port, close: () => srv.close() };
+  }
+
+  it('gives up on a dial whose handshake never completes', async () => {
+    const own = new EngineServer({
+      secret: SECRET,
+      bufferBytes: 4096,
+      bufferTotalBytes: 65536,
+      version: 'test',
+      log: () => {},
+      dialTimeoutMs: 200,
+    });
+    const port = (await own.listen(0, '127.0.0.1')).port;
+    const pit = await tarpit();
+    try {
+      const l = await TestLink.connect(port, SECRET);
+      const id = 'pit:1';
+      l.send(connectFrame(id, { port: pit.port, tls: true }));
+      const closed = await l.waitFor<Extract<EngineToApp, { op: 'closed' }>>(
+        (f) => f.op === 'closed' && f.id === id,
+        3000,
+      );
+      expect(closed.error).toMatch(/timed out/);
+      expect(l.frames.some((f) => f.op === 'open')).toBe(false);
+      l.kill();
+    } finally {
+      pit.close();
+      await own.shutdown('done', 200);
+    }
+  });
+
+  it('a close while still dialing cuts the dial off — no open, no ident, prompt closed', async () => {
+    const pit = await tarpit();
+    try {
+      const l = await link();
+      const id = `abort:${++counter}`;
+      l.send(connectFrame(id, { port: pit.port, tls: true }));
+      await l.waitFor((f) => f.op === 'dialing' && f.id === id);
+      l.send({ op: 'close', id });
+      await gone(engine, id);
+      expect(l.frames.some((f) => f.op === 'open' && f.id === id)).toBe(false);
+      expect(l.frames.some((f) => f.op === 'closed' && f.id === id)).toBe(false);
+      expect(engine.held()).not.toContain(id);
+    } finally {
+      pit.close();
+    }
+  });
+
+  it('a closed orphan never sends its `closed` to the fresh socket that took its id', async () => {
+    const id = `orphan-redial:${++counter}`;
+    const a = await link();
+    await register(a, id, 'orph');
+    a.kill();
+    await new Promise((r) => setTimeout(r, 30));
+    const b = await link();
+    b.send({ op: 'close', id }); // reconcile: nobody claims it, so allowed
+    b.send(connectFrame(id)); // …and immediately wanted again
+    const next = await b.waitFor((f) => 'id' in f && f.id === id);
+    expect(next.op).toBe('dialing');
+    await b.waitFor((f) => f.op === 'open' && f.id === id);
+    b.send({ op: 'write', id, line: 'NICK orph2' });
+    b.send({ op: 'write', id, line: 'USER orph2 0 * :o' });
+    await b.waitForLine(id, / 001 orph2 /);
+    // The old socket has long since FINed; its death must not have been routed
+    // to the new one.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(b.frames.some((f) => f.op === 'closed' && f.id === id)).toBe(false);
+    expect(engine.held()).toContain(id);
+  });
+
+  it('accepts a late ack from the link that was just taken over', async () => {
+    const id = `lateack:${++counter}`;
+    const a = await link();
+    await register(a, id, 'lateack');
+    ackAll(a, id);
+    ircd.say('peer', 'lateack', 'in flight');
+    const f = await a.waitFor<Extract<EngineToApp, { op: 'line' }>>(
+      (x) => x.op === 'line' && /in flight/.test(x.line),
+    );
+    const b = await link();
+    b.send(connectFrame(id));
+    await b.waitFor((x) => x.op === 'live' && x.id === id);
+    await a.waitFor((x) => x.op === 'detached');
+    // The old process persisted the line and now says so. Not refused.
+    a.send({ op: 'ack', id, seq: f.seq });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(a.frames.some((x) => x.op === 'error')).toBe(false);
+    b.send({ op: 'list' });
+    const listing = await b.waitFor<Extract<EngineToApp, { op: 'listing' }>>(
+      (x) => x.op === 'listing',
+    );
+    expect(listing.connections.find((c) => c.id === id)?.bufferedLines).toBe(0);
+  });
+
+  it('binds the address family with the source address (dual-stack hosts)', async () => {
+    const l = await link();
+    const id = `family:${++counter}`;
+    l.send({ ...connectFrame(id), host: 'localhost', outgoingAddr: '127.0.0.1' });
+    const open = await l.waitFor<Extract<EngineToApp, { op: 'open' }>>(
+      (f) => f.op === 'open' && f.id === id,
+    );
+    expect(open.local.address).toBe('127.0.0.1');
+    expect(open.remote.port).toBe(ircd.port);
+    l.send({ op: 'close', id });
+    await gone(engine, id);
+  });
+});
+
+describe('third review round', () => {
+  it('advertises to a link only what no other link claims, and answers ping', async () => {
+    const id = `heldfor:${++counter}`;
+    const a = await link();
+    await register(a, id, 'heldfor');
+    const b = await link();
+    expect(b.hello?.held).not.toContain(id);
+    a.kill();
+    await new Promise((r) => setTimeout(r, 30));
+    const c = await link();
+    expect(c.hello?.held).toContain(id);
+    c.send({ op: 'ping' });
+    await c.waitFor((f) => f.op === 'pong');
+  });
+
+  it('an older process cannot steal a session from a newer one', async () => {
+    const id = `gen:${++counter}`;
+    const older = await TestLink.open(enginePort);
+    older.send({
+      op: 'hello',
+      protocol: PROTOCOL_MAJOR,
+      secret: SECRET,
+      app: { version: 'old', startedAt: 1000 },
+    });
+    await older.waitFor((f) => f.op === 'hello');
+    links.push(older);
+    await register(older, id, 'gen');
+    const newer = await TestLink.open(enginePort);
+    newer.send({
+      op: 'hello',
+      protocol: PROTOCOL_MAJOR,
+      secret: SECRET,
+      app: { version: 'new', startedAt: 2000 },
+    });
+    await newer.waitFor((f) => f.op === 'hello');
+    links.push(newer);
+    newer.send(connectFrame(id));
+    await newer.waitFor((f) => f.op === 'live' && f.id === id);
+    await older.waitFor((f) => f.op === 'detached' && f.id === id);
+    // The older one comes back for it — and is told no.
+    older.send(connectFrame(id));
+    const answer = await older.waitForNew((f) => 'id' in f && f.id === id);
+    expect(answer).toMatchObject({ op: 'detached', reason: 'taken-over' });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(newer.frames.some((f) => f.op === 'detached')).toBe(false);
+    ircd.say('peer', 'gen', 'still yours');
+    await newer.waitForLine(id, /still yours/);
+  });
+
+  it('a CONNECT with different dial parameters is a new session, not the old socket', async () => {
+    const other = await FakeIrcd.start();
+    try {
+      const id = `redial:${++counter}`;
+      const l = await link();
+      await register(l, id, 'redial');
+      l.send(connectFrame(id, { port: other.port }));
+      const next = await l.waitForNew((f) => 'id' in f && f.id === id);
+      expect(next.op).toBe('dialing');
+      await l.waitForNew((f) => f.op === 'open' && f.id === id);
+      l.send({ op: 'write', id, line: 'NICK redial2' });
+      l.send({ op: 'write', id, line: 'USER redial2 0 * :r' });
+      await other.waitForRegistration('redial2');
+      await new Promise((r) => setTimeout(r, 50));
+      expect(ircd.client('redial')).toBeUndefined();
+      expect(l.frames.some((f) => f.op === 'closed' && f.id === id)).toBe(false);
+    } finally {
+      await other.close();
+    }
+  });
+
+  it('flags a session the engine registered while no app was attached', async () => {
+    const id = `unattended:${++counter}`;
+    const a = await link();
+    a.send(connectFrame(id));
+    await a.waitFor((f) => f.op === 'open' && f.id === id);
+    a.send({ op: 'write', id, line: 'NICK unatt' });
+    a.send({ op: 'write', id, line: 'USER unatt 0 * :u' });
+    // Die before the ircd answers.
+    a.kill();
+    await ircd.waitForRegistration('unatt');
+    await new Promise((r) => setTimeout(r, 30));
+    expect(engine.held()).toContain(id);
+    const b = await link();
+    b.send(connectFrame(id));
+    const att = await b.waitFor<Attached>((f) => f.op === 'attached');
+    expect(att.unattended).toBe(true);
+    expect(att.channels).toEqual([]);
+    // …and one that was attached at registration is not flagged.
+    const id2 = `attended:${++counter}`;
+    await register(b, id2, 'attd');
+    b.kill();
+    const c = await link();
+    c.send(connectFrame(id2));
+    const att2 = await c.waitFor<Attached>((f) => f.op === 'attached' && f.id === id2);
+    expect(att2.unattended).toBe(false);
+  });
+});
+
+describe('orphan reaper', () => {
+  it('ends a session no link has claimed for orphanMs', async () => {
+    const own = new EngineServer({
+      secret: SECRET,
+      bufferBytes: 4096,
+      bufferTotalBytes: 65536,
+      version: 'test',
+      log: () => {},
+      orphanMs: 200,
+    });
+    const port = (await own.listen(0, '127.0.0.1')).port;
+    try {
+      const l = await TestLink.connect(port, SECRET);
+      const id = 'orphan-reap:1';
+      l.send(connectFrame(id));
+      await l.waitFor((f) => f.op === 'open' && f.id === id);
+      l.send({ op: 'write', id, line: 'NICK reaped' });
+      l.send({ op: 'write', id, line: 'USER reaped 0 * :r' });
+      await l.waitForLine(id, / 376 /);
+      const record = ircd.client('reaped')!;
+      l.kill();
+      // The sweep runs every LINK_SILENCE_MS/3 (30 s) in production; drive it
+      // directly here rather than wait.
+      await new Promise((r) => setTimeout(r, 250));
+      (own as unknown as { reapOrphans(): void }).reapOrphans();
+      await until(() => !own.held().includes(id), 3000, 'session ended');
+      // The QUIT is on the wire; give the ircd its turn to read it.
+      await ircd.waitForLine((x) => x.startsWith('QUIT :Lurker: no app returned'));
+      expect(record.sent.some((x) => x.startsWith('QUIT :Lurker: no app returned'))).toBe(true);
+    } finally {
+      await own.shutdown('done', 200);
+    }
+  });
+});

--- a/server/engine/lineBuffer.test.ts
+++ b/server/engine/lineBuffer.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { ByteBudget, LineBuffer } from './lineBuffer.js';
+
+const seqs = (b: LineBuffer) => b.pending().map((l) => l.seq);
+
+describe('LineBuffer', () => {
+  it('numbers lines from 1 and keeps them until acked', () => {
+    const b = new LineBuffer(1024 * 1024, new ByteBudget(1024 * 1024));
+    expect(b.push('a')).toBe(1);
+    expect(b.push('b')).toBe(2);
+    expect(b.push('c')).toBe(3);
+    expect(seqs(b)).toEqual([1, 2, 3]);
+    b.ack(2);
+    expect(seqs(b)).toEqual([3]);
+    // An ack below what is already gone is a no-op, not an error.
+    b.ack(1);
+    expect(seqs(b)).toEqual([3]);
+    b.ack(3);
+    expect(b.length).toBe(0);
+    expect(b.lastSeq).toBe(3);
+    expect(b.takeGap()).toBeNull();
+  });
+
+  it('drops the OLDEST lines past its byte cap and records one gap', () => {
+    // Each line is 10 bytes + CRLF = 12; cap fits four.
+    const b = new LineBuffer(48, new ByteBudget(1024 * 1024));
+    for (let i = 1; i <= 6; i++) b.push('x'.repeat(10));
+    expect(seqs(b)).toEqual([3, 4, 5, 6]);
+    expect(b.bytes).toBe(48);
+    const gap = b.takeGap();
+    expect(gap).toMatchObject({ firstDroppedSeq: 1, lastDroppedSeq: 2 });
+    // Reported once.
+    expect(b.takeGap()).toBeNull();
+  });
+
+  it('never drops the newest line, even when it alone exceeds the cap', () => {
+    const b = new LineBuffer(16, new ByteBudget(1024 * 1024));
+    b.push('short');
+    b.push('a'.repeat(100));
+    expect(seqs(b)).toEqual([2]);
+  });
+
+  it('sheds from the LARGEST buffer when the process-wide budget is full', () => {
+    const budget = new ByteBudget(60);
+    const hoarder = new LineBuffer(1024, budget);
+    const quiet = new LineBuffer(1024, budget);
+    for (let i = 0; i < 4; i++) hoarder.push('x'.repeat(10)); // 48 bytes
+    quiet.push('y'.repeat(10)); // 60: exactly full
+    quiet.push('y'.repeat(10)); // 72: over — the hoarder pays, not the pusher
+    expect(quiet.length).toBe(2);
+    expect(hoarder.length).toBe(3);
+    expect(hoarder.takeGap()).toMatchObject({ firstDroppedSeq: 1, lastDroppedSeq: 1 });
+    expect(quiet.takeGap()).toBeNull();
+    expect(budget.used).toBe(60);
+    hoarder.dispose();
+    expect(budget.used).toBe(24);
+    // A disposed buffer is out of the running.
+    for (let i = 0; i < 4; i++) quiet.push('z'.repeat(10));
+    expect(quiet.length).toBe(5);
+    expect(budget.used).toBe(60);
+  });
+
+  it('shrinks a recorded gap as acks land inside it', () => {
+    const b = new LineBuffer(48, new ByteBudget(1024 * 1024));
+    for (let i = 1; i <= 8; i++) b.push('x'.repeat(10)); // keeps 5..8, dropped 1..4
+    expect(b.peekGap()).toMatchObject({ firstDroppedSeq: 1, lastDroppedSeq: 4 });
+    b.ack(2); // the app had 1..2 after all
+    expect(b.peekGap()).toMatchObject({ firstDroppedSeq: 3, lastDroppedSeq: 4 });
+    b.ack(4); // and the rest
+    expect(b.peekGap()).toBeNull();
+    expect(b.length).toBe(4);
+  });
+
+  it('extends an open gap rather than opening a second one', () => {
+    const b = new LineBuffer(24, new ByteBudget(1024 * 1024));
+    for (let i = 1; i <= 4; i++) b.push('x'.repeat(10));
+    expect(b.takeGap()).toMatchObject({ firstDroppedSeq: 1, lastDroppedSeq: 2 });
+    b.push('x'.repeat(10));
+    b.push('x'.repeat(10));
+    expect(b.takeGap()).toMatchObject({ firstDroppedSeq: 3, lastDroppedSeq: 4 });
+  });
+});

--- a/server/engine/lineBuffer.ts
+++ b/server/engine/lineBuffer.ts
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The per-connection backlog: every inbound IRC line the app has not yet acked,
+// numbered so a re-attaching app can resume exactly where the last one stopped.
+//
+// Bounded in BYTES, not lines, because one busy channel and one quiet one differ
+// by orders of magnitude in line length and what we actually protect is the
+// engine's memory. When the cap is hit the OLDEST lines go — the app will learn
+// the shape of the hole from the recorded gap and can say so (or backfill from
+// CHATHISTORY where the network offers it). Newer lines are kept because they
+// are the ones that describe the state the app is about to attach to.
+//
+// Deliberately in memory only. The app's SQLite is the durable store; this
+// buffer exists to bridge a redeploy, not to be a second message log. A
+// spill-to-disk implementation would slot in behind the same interface if
+// cross-host engines ever need to cover hour-long detaches.
+
+import type { Gap } from './protocol.js';
+
+export interface BufferedLine {
+  seq: number;
+  line: string;
+}
+
+// Shared across every buffer in the process so the total is bounded too. A cell
+// with a hundred connections mid-netsplit must not be able to take the engine
+// down by each staying under its own cap. Under global pressure it is the
+// LARGEST backlog that sheds, not whichever connection happened to receive the
+// next line — otherwise one quiet DM would be squeezed to nothing while the
+// hoarders kept their full 4 MiB each.
+export class ByteBudget {
+  used = 0;
+  private readonly buffers = new Set<LineBuffer>();
+  constructor(readonly max: number) {}
+
+  register(b: LineBuffer): void {
+    this.buffers.add(b);
+  }
+
+  unregister(b: LineBuffer): void {
+    this.buffers.delete(b);
+  }
+
+  // Drop oldest lines from the largest buffer until the total fits (a buffer is
+  // never emptied below one line, so a single over-long line can't wedge this).
+  reclaim(): void {
+    while (this.used > this.max) {
+      let largest: LineBuffer | null = null;
+      for (const b of this.buffers) {
+        if (b.length > 1 && (!largest || b.bytes > largest.bytes)) largest = b;
+      }
+      if (!largest) return;
+      largest.dropOldest();
+    }
+  }
+}
+
+const lineBytes = (line: string): number => Buffer.byteLength(line, 'utf8') + 2;
+
+export class LineBuffer {
+  private lines: BufferedLine[] = [];
+  private nextSeq = 1;
+  private gap: Gap | null = null;
+  bytes = 0;
+
+  constructor(
+    private readonly maxBytes: number,
+    private readonly budget: ByteBudget,
+  ) {
+    budget.register(this);
+  }
+
+  get length(): number {
+    return this.lines.length;
+  }
+
+  // Latest seq handed out; 0 before the first line.
+  get lastSeq(): number {
+    return this.nextSeq - 1;
+  }
+
+  push(line: string): number {
+    const seq = this.nextSeq++;
+    const size = lineBytes(line);
+    this.lines.push({ seq, line });
+    this.bytes += size;
+    this.budget.used += size;
+    while (this.lines.length > 1 && this.bytes > this.maxBytes) this.dropOldest();
+    this.budget.reclaim();
+    return seq;
+  }
+
+  // Also called by the budget on whichever buffer is largest; not part of the
+  // public contract otherwise.
+  dropOldest(): void {
+    const dropped = this.lines.shift();
+    if (!dropped) return;
+    const size = lineBytes(dropped.line);
+    this.bytes -= size;
+    this.budget.used -= size;
+    // Extend a gap that is already open rather than recording a second one:
+    // the app only needs the outer bounds of the hole.
+    if (this.gap) {
+      this.gap.lastDroppedSeq = dropped.seq;
+      this.gap.at = Date.now();
+    } else {
+      this.gap = { firstDroppedSeq: dropped.seq, lastDroppedSeq: dropped.seq, at: Date.now() };
+    }
+  }
+
+  ack(seq: number): void {
+    // An ack into the hole says the app had those lines after all (it was
+    // attached and simply slow to ack, or the burst replay just delivered
+    // them): shrink the reported hole to what is actually unaccounted for.
+    if (this.gap) {
+      if (seq >= this.gap.lastDroppedSeq) this.gap = null;
+      else if (seq >= this.gap.firstDroppedSeq) this.gap.firstDroppedSeq = seq + 1;
+    }
+    let freed = 0;
+    let i = 0;
+    while (i < this.lines.length && this.lines[i].seq <= seq) {
+      freed += lineBytes(this.lines[i].line);
+      i++;
+    }
+    if (i === 0) return;
+    this.lines.splice(0, i);
+    this.bytes -= freed;
+    this.budget.used -= freed;
+  }
+
+  pending(): readonly BufferedLine[] {
+    return this.lines;
+  }
+
+  peekGap(): Gap | null {
+    return this.gap;
+  }
+
+  // Hand over the recorded hole (if any) and forget it, so it is reported once.
+  takeGap(): Gap | null {
+    const g = this.gap;
+    this.gap = null;
+    return g;
+  }
+
+  // Release this buffer's share of the budget; called when the connection ends.
+  dispose(): void {
+    this.budget.used -= this.bytes;
+    this.bytes = 0;
+    this.lines = [];
+    this.budget.unregister(this);
+  }
+}

--- a/server/engine/protocol.test.ts
+++ b/server/engine/protocol.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { FrameReader, MAX_FRAME_BYTES, encodeFrame, parseHostPort } from './protocol.js';
+
+describe('FrameReader', () => {
+  it('reassembles frames split across chunks and ignores blank lines', () => {
+    const r = new FrameReader();
+    const a = encodeFrame({ op: 'list' });
+    const b = encodeFrame({ op: 'ack', id: 'x', seq: 4 });
+    const all = a + '\n' + b;
+    const mid = Math.floor(all.length / 2);
+    expect(r.push(all.slice(0, mid))).toEqual([{ op: 'list' }]);
+    expect(r.push(all.slice(mid))).toEqual([{ op: 'ack', id: 'x', seq: 4 }]);
+  });
+
+  it('refuses a frame without an op', () => {
+    const r = new FrameReader();
+    expect(() => r.push('{"nope":1}\n')).toThrow(/malformed/);
+  });
+
+  it('refuses an over-long line before it is complete', () => {
+    const r = new FrameReader();
+    expect(() => r.push('{"op":"' + 'x'.repeat(MAX_FRAME_BYTES))).toThrow(/too long/);
+  });
+});
+
+describe('parseHostPort', () => {
+  const d = { host: '0.0.0.0', port: 8016 };
+  it('handles every accepted shape', () => {
+    expect(parseHostPort('', d)).toEqual(d);
+    expect(parseHostPort('9000', d)).toEqual({ host: '0.0.0.0', port: 9000 });
+    expect(parseHostPort('127.0.0.1:9000', d)).toEqual({ host: '127.0.0.1', port: 9000 });
+    expect(parseHostPort('engine', d)).toEqual({ host: 'engine', port: 8016 });
+    expect(parseHostPort('[::1]:9000', d)).toEqual({ host: '::1', port: 9000 });
+    expect(parseHostPort('[::1]', d)).toEqual({ host: '::1', port: 8016 });
+  });
+  it('rejects a bad port', () => {
+    expect(() => parseHostPort('host:70000', d)).toThrow(/invalid port/);
+    expect(() => parseHostPort('host:abc', d)).toThrow(/invalid port/);
+  });
+});

--- a/server/engine/protocol.test.ts
+++ b/server/engine/protocol.test.ts
@@ -36,8 +36,14 @@ describe('parseHostPort', () => {
     expect(parseHostPort('[::1]:9000', d)).toEqual({ host: '::1', port: 9000 });
     expect(parseHostPort('[::1]', d)).toEqual({ host: '::1', port: 8016 });
   });
-  it('rejects a bad port', () => {
+  it('rejects a bad port in every shape that names one', () => {
     expect(() => parseHostPort('host:70000', d)).toThrow(/invalid port/);
     expect(() => parseHostPort('host:abc', d)).toThrow(/invalid port/);
+    // The bare-port and [v6]:port forms validate too — deferring these to
+    // listen()/connect() turns a typo into an opaque ERR_SOCKET_BAD_PORT.
+    expect(() => parseHostPort('70000', d)).toThrow(/invalid port/);
+    expect(() => parseHostPort('0', d)).toThrow(/invalid port/);
+    expect(() => parseHostPort('[::1]:70000', d)).toThrow(/invalid port/);
+    expect(() => parseHostPort('[::1]:0', d)).toThrow(/invalid port/);
   });
 });

--- a/server/engine/protocol.ts
+++ b/server/engine/protocol.ts
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The wire contract between the IRC engine (server/engine.ts) and the app tier.
+//
+// Newline-delimited JSON over one TCP link per app process. The engine is a
+// line-level holder of IRC sockets: it relays raw IRC lines in both directions
+// and keeps the socket — and the server's idea of who is connected — alive while
+// the app is being redeployed. Everything that understands IRC beyond a handful
+// of commands lives on the app side, in irc-framework and ircConnection.ts.
+//
+// Version skew is expected and allowed in one direction at a time: the engine is
+// the thing that DOESN'T get redeployed, so an app of any minor version must be
+// able to talk to it. `PROTOCOL_MAJOR` is the compatibility line — a mismatch is
+// refused at `hello`, and the app falls back to dialing IRC itself (which is
+// exactly what it did before the engine existed). Adding an optional field or a
+// new op is a minor change; renaming or re-meaning one is a major.
+
+export const PROTOCOL_MAJOR = 1;
+export const PROTOCOL_MINOR = 1;
+
+// One frame is one JSON object on one line. Most wrap a single IRC line (≤ 8191
+// bytes with tags); the one large frame is `attached`, whose replay is bounded by
+// the engine's burst cap (upstream.ts MAX_BURST_BYTES) plus one JOIN per channel,
+// and is size-checked by the engine before it is sent. Enforced by the framer on
+// both sides so a misbehaving link can't make either process buffer without
+// bound.
+export const MAX_FRAME_BYTES = 256 * 1024;
+
+export interface Endpoint {
+  address: string;
+  port: number;
+}
+
+// A run of inbound lines the engine had to drop because the app stayed away
+// longer than its buffer covers. Delivered in sequence position so the app can
+// say exactly where the hole is.
+export interface Gap {
+  firstDroppedSeq: number;
+  lastDroppedSeq: number;
+  // ms since epoch when the last line was dropped.
+  at: number;
+}
+
+export interface ConnectionInfo {
+  id: string;
+  state: 'dialing' | 'open' | 'closing';
+  attached: boolean;
+  nick: string | null;
+  // A count, not the names: a listing of a busy cell must stay one bounded frame.
+  channelCount: number;
+  bufferedLines: number;
+  bufferedBytes: number;
+  detachedForMs: number | null;
+}
+
+export type AppToEngine =
+  // `startedAt` is the app process's generation: when two processes overlap
+  // (a rolling deploy), a connection goes to the NEWER one and an older one is
+  // refused rather than allowed to steal it back.
+  | { op: 'hello'; protocol: number; secret: string; app: { version: string; startedAt?: number } }
+  // Link liveness, both directions: the engine answers `pong`; the app sends
+  // `ping` on a timer and drops a link that answers nothing for a while.
+  | { op: 'ping' }
+  | { op: 'pong' }
+  // Connect-or-attach. The app never has to know which one it is getting: the
+  // engine answers `dialing` for a fresh socket and `attached` for one it holds.
+  | {
+      op: 'connect';
+      id: string;
+      host: string;
+      port: number;
+      tls: boolean;
+      rejectUnauthorized: boolean;
+      // Source address for the outbound socket (LURKER_OUTGOING_ADDR today).
+      outgoingAddr?: string;
+      // The RFC 1413 ident to answer for this connection, if identd is on. Set by
+      // the app because it is derived from the account, which the engine never
+      // sees.
+      ident?: string;
+    }
+  | { op: 'write'; id: string; line: string }
+  // Everything up to and including `seq` has been persisted; the engine may
+  // forget it.
+  | { op: 'ack'; id: string; seq: number }
+  // Leave the socket alive and stop delivering to this link. The link closing is
+  // the implicit form.
+  | { op: 'detach'; id: string }
+  // End the IRC socket. This is what QUIT ends in. Allowed from the link that
+  // holds the claim — or from any link when NOBODY does (an orphan left behind
+  // by a previous process).
+  | { op: 'close'; id: string }
+  | { op: 'list' };
+
+export type EngineToApp =
+  | { op: 'hello'; protocol: number; minor: number; engine: { version: string }; held: string[] }
+  | { op: 'ping' }
+  | { op: 'pong' }
+  | { op: 'dialing'; id: string }
+  | { op: 'open'; id: string; local: Endpoint; remote: Endpoint }
+  | {
+      op: 'attached';
+      id: string;
+      local: Endpoint;
+      remote: Endpoint;
+      // Lines to feed the app's fresh irc-framework Client so it believes it just
+      // registered: the recorded registration burst, then our own NICK changes in
+      // order, then one synthesised JOIN per channel we are in.
+      replay: string[];
+      nick: string | null;
+      channels: string[];
+      detachedForMs: number;
+      // Registration completed while NO app was attached: the previous app
+      // wrote NICK/USER and died before 001, so nothing ever ran the post-
+      // registration steps (connect commands, autojoin). The app treats this
+      // like a first registration, minus the history.
+      unattended: boolean;
+    }
+  // The unacked backlog follows `attached` as ordinary `line` frames, then `live`
+  // marks the point after which frames are real-time.
+  | { op: 'line'; id: string; seq: number; line: string }
+  | { op: 'live'; id: string }
+  | { op: 'gap'; id: string; gap: Gap }
+  // The engine stopped serving this id to THIS link because a newer app process
+  // claimed the connection. Not a socket event: the socket is alive elsewhere,
+  // so the receiver must not reconnect.
+  | { op: 'detached'; id: string; reason: 'taken-over' }
+  // The IRC socket is gone. The engine forgets the id.
+  | { op: 'closed'; id: string; error?: string }
+  | { op: 'listing'; connections: ConnectionInfo[] }
+  | { op: 'error'; id?: string; message: string };
+
+export type Frame = AppToEngine | EngineToApp;
+
+export function encodeFrame(frame: Frame): string {
+  return JSON.stringify(frame) + '\n';
+}
+
+// Incremental NDJSON reader shared by both ends. Feed chunks in; complete frames
+// come out. Throws on an over-long line, and the caller should drop the link —
+// nothing legitimate is that big.
+export class FrameReader {
+  private buf = '';
+
+  push(chunk: string): Frame[] {
+    this.buf += chunk;
+    const out: Frame[] = [];
+    let nl: number;
+    while ((nl = this.buf.indexOf('\n')) >= 0) {
+      const raw = this.buf.slice(0, nl);
+      this.buf = this.buf.slice(nl + 1);
+      if (!raw.trim()) continue;
+      if (raw.length > MAX_FRAME_BYTES) throw new Error('frame too long');
+      const parsed: unknown = JSON.parse(raw);
+      if (!isFrame(parsed)) throw new Error('malformed frame');
+      out.push(parsed);
+    }
+    if (this.buf.length > MAX_FRAME_BYTES) throw new Error('frame too long');
+    return out;
+  }
+}
+
+function isFrame(v: unknown): v is Frame {
+  return typeof v === 'object' && v !== null && typeof (v as { op?: unknown }).op === 'string';
+}
+
+// Parse `host:port` / `[v6]:port` / `port` for the listen address. Exported so
+// the app side can parse LURKER_ENGINE_URL's authority with the same rules.
+export function parseHostPort(
+  raw: string,
+  defaults: { host: string; port: number },
+): { host: string; port: number } {
+  const s = raw.trim();
+  if (!s) return { ...defaults };
+  const v6 = /^\[([^\]]+)\](?::(\d+))?$/.exec(s);
+  if (v6) return { host: v6[1], port: v6[2] ? Number(v6[2]) : defaults.port };
+  if (/^\d+$/.test(s)) return { host: defaults.host, port: Number(s) };
+  const colon = s.lastIndexOf(':');
+  if (colon < 0) return { host: s, port: defaults.port };
+  const port = Number(s.slice(colon + 1));
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`invalid port in "${raw}"`);
+  }
+  return { host: s.slice(0, colon) || defaults.host, port };
+}

--- a/server/engine/protocol.ts
+++ b/server/engine/protocol.ts
@@ -172,14 +172,21 @@ export function parseHostPort(
 ): { host: string; port: number } {
   const s = raw.trim();
   if (!s) return { ...defaults };
+  // Every shape that names a port checks it the same way. Letting `70000` or
+  // `[::1]:70000` through when `host:70000` throws only defers the failure to
+  // listen()/connect(), which reports it as an opaque ERR_SOCKET_BAD_PORT with
+  // no mention of the setting that carried it.
+  const checkPort = (text: string): number => {
+    const n = Number(text);
+    if (!Number.isInteger(n) || n <= 0 || n > 65535) {
+      throw new Error(`invalid port in "${raw}"`);
+    }
+    return n;
+  };
   const v6 = /^\[([^\]]+)\](?::(\d+))?$/.exec(s);
-  if (v6) return { host: v6[1], port: v6[2] ? Number(v6[2]) : defaults.port };
-  if (/^\d+$/.test(s)) return { host: defaults.host, port: Number(s) };
+  if (v6) return { host: v6[1], port: v6[2] ? checkPort(v6[2]) : defaults.port };
+  if (/^\d+$/.test(s)) return { host: defaults.host, port: checkPort(s) };
   const colon = s.lastIndexOf(':');
   if (colon < 0) return { host: s, port: defaults.port };
-  const port = Number(s.slice(colon + 1));
-  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
-    throw new Error(`invalid port in "${raw}"`);
-  }
-  return { host: s.slice(0, colon) || defaults.host, port };
+  return { host: s.slice(0, colon) || defaults.host, port: checkPort(s.slice(colon + 1)) };
 }

--- a/server/engine/protocol.ts
+++ b/server/engine/protocol.ts
@@ -58,7 +58,21 @@ export type AppToEngine =
   // `startedAt` is the app process's generation: when two processes overlap
   // (a rolling deploy), a connection goes to the NEWER one and an older one is
   // refused rather than allowed to steal it back.
-  | { op: 'hello'; protocol: number; secret: string; app: { version: string; startedAt?: number } }
+  // `instance` identifies the Lurker DATABASE this app speaks for, and it is
+  // required. Connection ids are `<instance>:<userId>:<networkId>`, and userId
+  // and networkId are rowids from that database — so two Lurker instances
+  // pointed at one engine would otherwise both mint `1:1` for unrelated people.
+  // `matchesDial` would not catch it either: two users on the same popular
+  // network dial the identical host/port/tls. That is how IRCCloud leaked logs
+  // between accounts in July 2020 (two servers, one id space). The engine
+  // partitions every session by this value and refuses a hello without one.
+  | {
+      op: 'hello';
+      protocol: number;
+      secret: string;
+      instance: string;
+      app: { version: string; startedAt?: number };
+    }
   // Link liveness, both directions: the engine answers `pong`; the app sends
   // `ping` on a timer and drops a link that answers nothing for a while.
   | { op: 'ping' }

--- a/server/engine/server.ts
+++ b/server/engine/server.ts
@@ -1,0 +1,476 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The engine's listener: accepts app links, authenticates them, and routes
+// frames to the held upstream sockets. One app process holds one link and may
+// claim any number of connections over it.
+//
+// "Newest link wins": a CONNECT for an id another link already holds moves the
+// connection to the new link and tells the old one `detached`. That is what
+// lets a deploy start the new app before the old one has finished dying — and
+// it is not a socket event, so the old app must not treat it as one.
+
+import net from 'node:net';
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { ByteBudget } from './lineBuffer.js';
+import { EngineUpstream } from './upstream.js';
+import type { FrameSink } from './upstream.js';
+import {
+  FrameReader,
+  MAX_FRAME_BYTES,
+  PROTOCOL_MAJOR,
+  PROTOCOL_MINOR,
+  encodeFrame,
+} from './protocol.js';
+import type { AppToEngine, EngineToApp } from './protocol.js';
+
+export interface EngineServerOptions {
+  secret: string;
+  bufferBytes: number;
+  bufferTotalBytes: number;
+  version: string;
+  log?: (line: string) => void;
+  // Test seam; production takes the upstream's default.
+  dialTimeoutMs?: number;
+  // End a session no link has claimed for this long. 0 disables.
+  orphanMs?: number;
+}
+
+// Past this much unsent data queued on a link the upstreams stop pushing and let
+// their buffers hold the backlog (see EngineUpstream.flush). Node would otherwise
+// queue without bound. Generous, because a burst is normal right after attach.
+const LINK_HIGH_WATER = 1024 * 1024;
+
+const digest = (s: string): Buffer => createHash('sha256').update(s).digest();
+
+// A link that has said nothing for this long — not even a ping — is dead,
+// whatever TCP thinks: its claims are released so a successor can attach.
+const LINK_SILENCE_MS = 90_000;
+
+class AppLink implements FrameSink {
+  authed = false;
+  readonly reader = new FrameReader();
+  readonly claimed = new Set<EngineUpstream>();
+  // The first bytes decide whether this is a peer or a health probe.
+  sniffed = false;
+  // The app process's generation (hello.app.startedAt). Newer wins a contested
+  // connection; an older process is refused rather than allowed to steal.
+  generation = 0;
+  lastSeen = Date.now();
+
+  constructor(
+    readonly socket: net.Socket,
+    readonly peer: string,
+  ) {}
+
+  send(frame: EngineToApp): boolean {
+    if (this.socket.destroyed) return false;
+    const ok = this.socket.write(encodeFrame(frame));
+    return ok && this.socket.writableLength < LINK_HIGH_WATER;
+  }
+
+  fail(message: string, id?: string): void {
+    this.send({ op: 'error', ...(id ? { id } : {}), message });
+  }
+}
+
+export class EngineServer {
+  private readonly upstreams = new Map<string, EngineUpstream>();
+  private readonly links = new Set<AppLink>();
+  private readonly budget: ByteBudget;
+  private readonly server: net.Server;
+  private readonly log: (line: string) => void;
+  private readonly secretDigest: Buffer;
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private readonly opts: EngineServerOptions) {
+    this.budget = new ByteBudget(opts.bufferTotalBytes);
+    this.log = opts.log ?? ((line) => console.log(`[engine] ${line}`));
+    this.secretDigest = digest(opts.secret);
+    this.server = net.createServer({ highWaterMark: LINK_HIGH_WATER }, (socket) =>
+      this.accept(socket),
+    );
+  }
+
+  listen(port: number, host: string): Promise<{ port: number; host: string }> {
+    return new Promise((resolve, reject) => {
+      this.server.once('error', reject);
+      this.server.listen(port, host, () => {
+        this.server.off('error', reject);
+        const addr = this.server.address() as net.AddressInfo;
+        this.sweepTimer = setInterval(() => {
+          this.sweepSilentLinks();
+          this.reapOrphans();
+        }, LINK_SILENCE_MS / 3);
+        this.sweepTimer.unref();
+        resolve({ port: addr.port, host: addr.address });
+      });
+    });
+  }
+
+  // A session nobody has claimed for orphanMs has no app coming back for it —
+  // or the app that did come back was refused (a protocol-major mismatch) and
+  // is dialing its own sockets, colliding with this ghost. Say goodbye.
+  private reapOrphans(): void {
+    const limit = this.opts.orphanMs ?? 0;
+    if (limit <= 0) return;
+    const cutoff = Date.now() - limit;
+    for (const u of this.upstreams.values()) {
+      if (u.attached || u.closing || u.state !== 'open') continue;
+      const since = u.detachedSince;
+      if (since !== null && since < cutoff) {
+        this.log(`${u.id}: no app has claimed it for ${limit}ms — ending the session`);
+        u.quit('Lurker: no app returned for this connection');
+      }
+    }
+  }
+
+  private sweepSilentLinks(): void {
+    const cutoff = Date.now() - LINK_SILENCE_MS;
+    for (const link of this.links) {
+      if (link.lastSeen < cutoff) {
+        this.log(`dropping link ${link.peer}: silent for ${LINK_SILENCE_MS}ms`);
+        link.socket.destroy();
+      }
+    }
+  }
+
+  // The sessions a given link may attach to: everything held that no OTHER
+  // link currently claims. A session another process owns is not offered.
+  private heldFor(link: AppLink): string[] {
+    return [...this.upstreams.values()]
+      .filter((u) => u.state === 'open' && u.registered && !u.closing)
+      .filter((u) => ![...this.links].some((l) => l !== link && l.claimed.has(u)))
+      .map((u) => u.id);
+  }
+
+  // The sessions an app can attach to: open, registered, and not on their way
+  // out. Anything else in the map is not a session — a dial in progress, or a
+  // socket the previous app never finished registering — and advertising it
+  // would only make the app adopt something that ends in a fresh dial anyway.
+  held(): string[] {
+    return [...this.upstreams.values()]
+      .filter((u) => u.state === 'open' && u.registered && !u.closing)
+      .map((u) => u.id);
+  }
+
+  connectionCount(): number {
+    return this.upstreams.size;
+  }
+
+  // Whether the engine still has a socket (in any state) under this id.
+  hasConnection(id: string): boolean {
+    return this.upstreams.has(id);
+  }
+
+  // Stop accepting, drop every link, and — because the engine going away IS
+  // the sockets going away — say goodbye on each upstream. Resolves when every
+  // socket has closed or `graceMs` has passed, whichever is first.
+  async shutdown(message: string, graceMs = 2000): Promise<void> {
+    if (this.sweepTimer) clearInterval(this.sweepTimer);
+    this.server.close();
+    for (const link of this.links) link.socket.destroy();
+    this.links.clear();
+    const pending = [...this.upstreams.values()];
+    const closed = Promise.all(
+      pending.map(
+        (u) =>
+          new Promise<void>((resolve) => {
+            if (u.state === 'closed') return resolve();
+            u.once('closed', () => resolve());
+            u.quit(message);
+          }),
+      ),
+    );
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    await Promise.race([
+      closed,
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, graceMs);
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+    for (const u of pending) u.destroy();
+  }
+
+  private accept(socket: net.Socket): void {
+    const link = new AppLink(socket, `${socket.remoteAddress}:${socket.remotePort}`);
+    this.links.add(link);
+    socket.setEncoding('utf8');
+    // Detect a dead peer host (the app can be on another box) rather than hold
+    // its connections "attached" to a link that will never ack again.
+    socket.setKeepAlive(true, 10_000);
+    socket.on('data', (chunk: string) => this.onData(link, chunk));
+    socket.on('drain', () => {
+      for (const u of link.claimed) u.resume();
+    });
+    socket.on('error', () => {});
+    socket.on('close', () => this.onLinkClose(link));
+  }
+
+  private onData(link: AppLink, chunk: string): void {
+    link.lastSeen = Date.now();
+    if (!link.sniffed) {
+      link.sniffed = true;
+      // A plain HTTP probe on the same port keeps the health check dependency-
+      // free for whoever runs the container. An NDJSON peer's first byte is `{`.
+      if (/^(GET|HEAD) /.test(chunk)) {
+        const body = JSON.stringify({ ok: true, held: this.upstreams.size });
+        link.socket.end(
+          `HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${Buffer.byteLength(body)}\r\nConnection: close\r\n\r\n${body}`,
+        );
+        return;
+      }
+    }
+    let frames: AppToEngine[];
+    try {
+      frames = link.reader.push(chunk) as AppToEngine[];
+    } catch (err) {
+      this.log(`dropping link ${link.peer}: ${(err as Error).message}`);
+      link.socket.destroy();
+      return;
+    }
+    for (const frame of frames) {
+      if (link.socket.destroyed) return;
+      this.dispatch(link, frame);
+    }
+  }
+
+  private dispatch(link: AppLink, frame: AppToEngine): void {
+    if (!link.authed) {
+      if (frame.op !== 'hello') {
+        link.fail('hello first');
+        link.socket.destroy();
+        return;
+      }
+      if (frame.protocol !== PROTOCOL_MAJOR) {
+        link.fail(
+          `protocol major mismatch: engine speaks ${PROTOCOL_MAJOR}, app speaks ${frame.protocol}`,
+        );
+        link.socket.destroy();
+        return;
+      }
+      const theirs = digest(typeof frame.secret === 'string' ? frame.secret : '');
+      if (!timingSafeEqual(theirs, this.secretDigest)) {
+        this.log(`refused link ${link.peer}: bad secret`);
+        link.fail('bad secret');
+        link.socket.destroy();
+        return;
+      }
+      link.authed = true;
+      link.generation = Number(frame.app?.startedAt) || 0;
+      link.send({
+        op: 'hello',
+        protocol: PROTOCOL_MAJOR,
+        minor: PROTOCOL_MINOR,
+        engine: { version: this.opts.version },
+        held: this.heldFor(link),
+      });
+      this.log(
+        `app ${frame.app?.version ?? '?'} (gen ${link.generation}) attached from ${link.peer}`,
+      );
+      return;
+    }
+    switch (frame.op) {
+      case 'hello':
+        return; // already authed; ignore a repeat
+      case 'ping':
+        return void link.send({ op: 'pong' });
+      case 'pong':
+        return;
+      case 'connect':
+        return this.connect(link, frame);
+      case 'list':
+        return void link.send({
+          op: 'listing',
+          connections: [...this.upstreams.values()].map((u) => u.info()),
+        });
+      case 'write':
+      case 'ack':
+      case 'detach':
+      case 'close': {
+        const u = this.upstreams.get(frame.id);
+        if (!u) return link.fail('unknown connection', frame.id);
+        // Only the link that holds the claim may drive the socket: a process
+        // that was taken over is on its way out and must not get a line onto a
+        // connection it no longer owns. Two exceptions. An `ack` from anyone is
+        // welcome — it only says "persisted", and the process that was just taken
+        // over is exactly the one whose in-flight acks decide whether its
+        // successor sees those lines a second time. And ending a socket NOBODY
+        // claims is what reconciling orphans after a restart is.
+        if (!link.claimed.has(u) && frame.op !== 'ack') {
+          const claimedElsewhere = [...this.links].some((l) => l.claimed.has(u));
+          if (frame.op !== 'close' || claimedElsewhere) {
+            return link.fail('not attached to this connection', frame.id);
+          }
+        }
+        if (frame.op === 'write') u.write(frame.line);
+        else if (frame.op === 'ack') u.ack(frame.seq);
+        else if (frame.op === 'detach') this.release(link, u);
+        else u.close();
+        return;
+      }
+      default:
+        return link.fail(`unknown op ${(frame as { op: string }).op}`);
+    }
+  }
+
+  private connect(link: AppLink, frame: Extract<AppToEngine, { op: 'connect' }>): void {
+    const { id } = frame;
+    if (typeof id !== 'string' || !id || typeof frame.host !== 'string' || !frame.host) {
+      return link.fail('connect needs an id and a host', id);
+    }
+    // Node throws SYNCHRONOUSLY from net.connect for a bad port or a bind
+    // address that isn't an IP — and an uncaught throw here is the whole engine,
+    // every held socket with it. Refuse those frames instead.
+    const port = Number(frame.port);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      return link.fail(`connect: invalid port ${String(frame.port)}`, id);
+    }
+    if (
+      frame.outgoingAddr !== undefined &&
+      frame.outgoingAddr !== '' &&
+      !net.isIP(frame.outgoingAddr)
+    ) {
+      return link.fail(
+        `connect: outgoingAddr must be an IP address (got ${String(frame.outgoingAddr)})`,
+        id,
+      );
+    }
+    let u = this.upstreams.get(id);
+    if (u && (u.closing || u.state === 'closed')) {
+      // A socket on its way out (the app asked to close it and the FIN hasn't
+      // round-tripped) is not one to attach to: this CONNECT is the app coming
+      // back, and it gets a fresh dial. The old one finishes dying on its own —
+      // and quietly, so its `closed` never reaches a link that has moved on.
+      for (const l of this.links) l.claimed.delete(u);
+      u.silence();
+      u = undefined;
+    }
+    if (
+      u &&
+      !u.matchesDial({ host: frame.host, port, tls: !!frame.tls, outgoingAddr: frame.outgoingAddr })
+    ) {
+      // Same id, different destination: the user edited the network. That is a
+      // new session, not this one under new settings.
+      this.log(`${id}: connect parameters changed — closing the held socket and dialing afresh`);
+      for (const l of this.links) l.claimed.delete(u);
+      u.silence();
+      u.close();
+      u = undefined;
+    }
+    let payload: ReturnType<EngineUpstream['attach']> | null = null;
+    if (u) {
+      // Someone else's? Take it over — unless that someone is a NEWER process,
+      // in which case this is an older one trying to steal back what it lost.
+      for (const other of this.links) {
+        if (other !== link && other.claimed.has(u)) {
+          if (other.generation > link.generation) {
+            this.log(
+              `${id}: refused ${link.peer} (gen ${link.generation}); held by newer ${other.peer} (gen ${other.generation})`,
+            );
+            link.send({ op: 'detached', id, reason: 'taken-over' });
+            return;
+          }
+          other.claimed.delete(u);
+          other.send({ op: 'detached', id, reason: 'taken-over' });
+          this.log(`${id}: taken over by ${link.peer} from ${other.peer}`);
+        }
+      }
+      link.claimed.add(u);
+      payload = u.attach(link);
+      if (payload === 'dialing') {
+        // Still dialing: this link simply inherits the `open` when it comes.
+        link.send({ op: 'dialing', id });
+        return;
+      }
+      if (payload === 'unregistered') {
+        // The previous app died before registration finished. There is no
+        // session to hand over — but nothing went wrong on the network either,
+        // so this is a fresh dial under the same id, not an error: the old
+        // socket dies quietly and the app sees `dialing` → `open` as usual.
+        this.log(`${id}: attach before registration completed — dialing afresh`);
+        link.claimed.delete(u);
+        u.silence();
+        u.close();
+        u = undefined;
+        payload = null;
+      }
+    }
+    if (u && payload && typeof payload === 'object') {
+      const attached = encodeFrame({ op: 'attached', id, ...payload });
+      if (attached.length > MAX_FRAME_BYTES) {
+        // Can't happen within the burst cap short of thousands of channels, but
+        // a frame the app's reader would refuse must never leave here: it would
+        // drop the link, and the reconnect would fetch the same frame again.
+        this.log(`${id}: replay too large (${attached.length} bytes) — closing so the app redials`);
+        link.claimed.delete(u);
+        u.silence();
+        u.close();
+        link.send({ op: 'closed', id, error: 'replay too large to hand over' });
+        return;
+      }
+      link.socket.write(attached);
+      u.flushAfterAttach();
+      this.log(
+        `${id}: attached (replay ${payload.replay.length}, pending ${u.buffer.length}, away ${payload.detachedForMs}ms, nick ${payload.nick ?? '?'})`,
+      );
+      return;
+    }
+    u = new EngineUpstream(
+      {
+        id,
+        host: frame.host,
+        port,
+        tls: !!frame.tls,
+        rejectUnauthorized: frame.rejectUnauthorized !== false,
+        outgoingAddr: frame.outgoingAddr || undefined,
+        ident: frame.ident || undefined,
+        dialTimeoutMs: this.opts.dialTimeoutMs,
+      },
+      this.opts.bufferBytes,
+      this.budget,
+    );
+    this.upstreams.set(id, u);
+    link.claimed.add(u);
+    u.on('open', (local, remote) => {
+      this.log(`${id}: open ${local.address}:${local.port} -> ${remote.address}:${remote.port}`);
+    });
+    const created = u;
+    u.on('closed', (error?: string) => {
+      this.log(`${id}: closed${error ? ` (${error})` : ''}`);
+      // Only if the id still means this socket — a fresh dial may have taken
+      // the key while this one was closing.
+      if (this.upstreams.get(id) === created) this.upstreams.delete(id);
+      for (const l of this.links) l.claimed.delete(created);
+    });
+    u.attach(link);
+    link.send({ op: 'dialing', id });
+    this.log(`${id}: dialing ${frame.host}:${port}${frame.tls ? ' (TLS)' : ''}`);
+    try {
+      u.dial();
+    } catch (err) {
+      // Belt and braces for whatever Node decides to throw on top of the
+      // validation above; report it as a failed dial, not a dead engine.
+      this.log(`${id}: dial threw: ${(err as Error).message}`);
+      this.upstreams.delete(id);
+      link.claimed.delete(created);
+      link.send({ op: 'closed', id, error: (err as Error).message });
+    }
+  }
+
+  private release(link: AppLink, u: EngineUpstream): void {
+    if (!link.claimed.delete(u)) return;
+    u.detach();
+    this.log(`${u.id}: detached by ${link.peer} (pending ${u.buffer.length})`);
+  }
+
+  private onLinkClose(link: AppLink): void {
+    if (!this.links.delete(link)) return;
+    for (const u of link.claimed) {
+      u.detach();
+      this.log(`${u.id}: link ${link.peer} lost — holding (pending ${u.buffer.length})`);
+    }
+    link.claimed.clear();
+  }
+}

--- a/server/engine/server.ts
+++ b/server/engine/server.ts
@@ -56,6 +56,9 @@ class AppLink implements FrameSink {
   // The app process's generation (hello.app.startedAt). Newer wins a contested
   // connection; an older process is refused rather than allowed to steal.
   generation = 0;
+  // The Lurker database this app speaks for (hello.instance). Every session the
+  // link touches must belong to it.
+  instance = '';
   lastSeen = Date.now();
 
   constructor(
@@ -139,6 +142,7 @@ export class EngineServer {
   // link currently claims. A session another process owns is not offered.
   private heldFor(link: AppLink): string[] {
     return [...this.upstreams.values()]
+      .filter((u) => u.opts.instance === link.instance)
       .filter((u) => u.state === 'open' && u.registered && !u.closing)
       .filter((u) => ![...this.links].some((l) => l !== link && l.claimed.has(u)))
       .map((u) => u.id);
@@ -257,7 +261,17 @@ export class EngineServer {
         link.socket.destroy();
         return;
       }
+      // Fail CLOSED. An app that sends no instance would otherwise share an id
+      // space with every other app on this engine, which is exactly the
+      // collision this field exists to prevent.
+      if (typeof frame.instance !== 'string' || !frame.instance) {
+        this.log(`refused link ${link.peer}: hello without an instance`);
+        link.fail('hello needs an instance');
+        link.socket.destroy();
+        return;
+      }
       link.authed = true;
+      link.instance = frame.instance;
       link.generation = Number(frame.app?.startedAt) || 0;
       link.send({
         op: 'hello',
@@ -291,6 +305,15 @@ export class EngineServer {
       case 'close': {
         const u = this.upstreams.get(frame.id);
         if (!u) return link.fail('unknown connection', frame.id);
+        // Another instance's session is not this app's to read, write, end or
+        // adopt. Said plainly rather than hidden behind 'unknown connection':
+        // anyone who gets this far already holds the engine secret, so there is
+        // no attacker to withhold it from — while the case that actually
+        // produces it is two Lurker instances misconfigured onto one engine,
+        // and that operator needs to be told exactly what is wrong.
+        if (u.opts.instance !== link.instance) {
+          return link.fail('connection id belongs to another instance', frame.id);
+        }
         // Only the link that holds the claim may drive the socket: a process
         // that was taken over is on its way out and must not get a line onto a
         // connection it no longer owns. Two exceptions. An `ack` from anyone is
@@ -338,6 +361,15 @@ export class EngineServer {
       );
     }
     let u = this.upstreams.get(id);
+    // Belt and braces over the `<instance>:…` id prefix. If a session under this
+    // id belongs to someone else's database, this app does not get to attach to
+    // it, take it over, or close it out of the way and dial its own in its
+    // place — any of which would put one person's socket behind another
+    // person's session. Refuse, loudly, and leave the held socket alone.
+    if (u && u.opts.instance !== link.instance) {
+      this.log(`${id}: refused ${link.peer} — held for another instance`);
+      return link.fail('connection id belongs to another instance', id);
+    }
     if (u && (u.closing || u.state === 'closed')) {
       // A socket on its way out (the app asked to close it and the FIN hasn't
       // round-tripped) is not one to attach to: this CONNECT is the app coming
@@ -420,6 +452,7 @@ export class EngineServer {
     u = new EngineUpstream(
       {
         id,
+        instance: link.instance,
         host: frame.host,
         port,
         tls: !!frame.tls,

--- a/server/engine/upstream.ts
+++ b/server/engine/upstream.ts
@@ -45,6 +45,11 @@ import {
 
 export interface UpstreamOptions {
   id: string;
+  // The app instance (Lurker database) this session belongs to. The id already
+  // carries it, but the engine checks this field on every operation rather than
+  // trusting the string: an app that minted a colliding id still cannot reach
+  // another instance's socket.
+  instance: string;
   host: string;
   port: number;
   tls: boolean;

--- a/server/engine/upstream.ts
+++ b/server/engine/upstream.ts
@@ -1,0 +1,547 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// One held IRC socket. The engine's whole reason to exist is that this object
+// outlives the app process that asked for it.
+//
+// It understands exactly six IRC things, and nothing else:
+//   1. PING       — answered here, always, never forwarded. A detached (or
+//                   stalled) app can't ping out because the app isn't in the loop.
+//   2. 001        — our nick, as the server confirmed it.
+//   3. 376 / 422  — the end of the registration burst we record for replay.
+//   4. own NICK   — so a replay lands on the live nick.
+//   5. own JOIN / PART / KICK — the channel set a replay must re-enter.
+//   6. own CHGHOST — the hostmask the synthesised JOINs carry.
+// Every other line is bytes: numbered, buffered until acked, relayed.
+//
+// Re-attach is a replay: the recorded burst (verbatim — irc-framework walks it
+// exactly as it walked the real one), then ONE synthesised NICK if the nick has
+// changed since the burst ended, then one synthesised JOIN per channel we are
+// in. The app's fresh Client ends up registered, on the right nick, with the
+// right caps and ISUPPORT, in the right channels, without the server having seen
+// a single extra command. The NICK goes BEFORE the JOINs on purpose: the app's
+// nick handler fans a per-channel "now known as" row out to every channel it
+// knows, and at that point it knows none.
+//
+// The replay is built from tracked STATE, not from history, so it stays bounded
+// no matter how long the socket has lived: the burst is capped in bytes, the
+// nick is one line, and the channel set is what we are in NOW (own JOIN/PART/
+// KICK lines are deliberately not recorded into the burst, so a channel joined
+// during registration and left later is not replayed as joined).
+
+import net from 'node:net';
+import tls from 'node:tls';
+import { EventEmitter } from 'node:events';
+import { ircLineParser } from 'irc-framework';
+import { LineBuffer } from './lineBuffer.js';
+import type { ByteBudget } from './lineBuffer.js';
+import type { ConnectionInfo, Endpoint, EngineToApp } from './protocol.js';
+import {
+  registerIdent,
+  unregisterIdent,
+  isIdentdEnabled,
+  isOidentdFileEnabled,
+} from '../services/identd.js';
+
+export interface UpstreamOptions {
+  id: string;
+  host: string;
+  port: number;
+  tls: boolean;
+  rejectUnauthorized: boolean;
+  outgoingAddr?: string;
+  ident?: string;
+  // How long a dial (TCP + TLS handshake) may take before it is given up on.
+  dialTimeoutMs?: number;
+}
+
+// Where frames for the attached app go. `send` answers false when the link is
+// over its high-water mark; the upstream then stops pushing and waits for
+// `resume()` — the buffer, not the socket's write queue, holds the backlog.
+export interface FrameSink {
+  send(frame: EngineToApp): boolean;
+}
+
+export interface AttachedPayload {
+  local: Endpoint;
+  remote: Endpoint;
+  replay: string[];
+  nick: string | null;
+  channels: string[];
+  detachedForMs: number;
+  unattended: boolean;
+}
+
+// Inbound IRC lines are at most 8191 bytes including tags. Anything past this
+// is not an IRC server, so the socket is dropped rather than buffered.
+const MAX_IRC_LINE = 16 * 1024;
+
+// The recorded registration burst stops growing here. Registration itself
+// (CAP, 001–005) is a few KiB; what pads a burst is a long MOTD, which a replay
+// does not need — irc-framework is registered at 001. A server that never sends
+// 376/422 would otherwise grow the burst forever.
+export const MAX_BURST_BYTES = 64 * 1024;
+
+// A dial that neither connects nor fails — a tarpit, a middlebox eating the
+// ClientHello, a wedged TLS listener — must end, or the network sits on
+// "Connecting…" until the engine restarts. irc-framework's own transport uses
+// 150 s; a minute is generous for a handshake.
+export const DEFAULT_DIAL_TIMEOUT_MS = 60_000;
+
+// After QUIT + FIN, how long to wait for the peer's FIN before destroying the
+// socket ourselves. A peer that ignores half-close would otherwise leave a
+// 'closing' zombie holding an fd, an ident entry, and its budget bytes forever.
+export const CLOSE_GRACE_MS = 10_000;
+
+const FALLBACK_USERHOST = '~lurker@engine.invalid';
+
+function prefixNick(prefix: string | undefined): string {
+  if (!prefix) return '';
+  const bang = prefix.indexOf('!');
+  return bang >= 0 ? prefix.slice(0, bang) : prefix;
+}
+
+export class EngineUpstream extends EventEmitter {
+  readonly id: string;
+  state: 'dialing' | 'open' | 'closed' = 'dialing';
+  // `close()`/`quit()` were called: the socket is on its way out. Not a state
+  // of its own because `open`-specific bookkeeping still applies until 'close'
+  // fires, but every entry point treats it as gone.
+  closing = false;
+  local: Endpoint | null = null;
+  remote: Endpoint | null = null;
+  readonly buffer: LineBuffer;
+  nick: string | null = null;
+  pingsAnsweredDetached = 0;
+
+  private socket: net.Socket | null = null;
+  private closeTimer: ReturnType<typeof setTimeout> | null = null;
+  private inbuf = '';
+  private lastError: string | null = null;
+  private identdId: number | null = null;
+  private burst: string[] = [];
+  private burstBytes = 0;
+  private burstDone = false;
+  // The seq of the last burst line; a replay covers everything up to it.
+  private burstEndSeq = 0;
+  // Registration finished with no app attached (see AttachedPayload.unattended).
+  private registeredUnattended = false;
+  private nickAtBurstEnd: string | null = null;
+  private hostmask: string | null = null;
+  // folded name → name as the server spelled it on JOIN
+  private channels = new Map<string, string>();
+
+  private sink: FrameSink | null = null;
+  // The app asked for this close. Its transport ends its own side the moment
+  // it asks (engineTransport.close()), so the eventual `closed` has nobody to
+  // go to — and MUST not go anywhere: on a fast loopback the FIN can round-trip
+  // between a `close` and the `connect` that reuses the id, and a `closed`
+  // routed by id would then hit the successor. Engine-initiated deaths (the
+  // server dropped us, a dial failed) are still reported.
+  private quietClose = false;
+  private stalled = false;
+  // Highest seq written to the current sink; everything pending above it is
+  // still owed.
+  private sentSeq = 0;
+  // `live` is owed once the backlog that existed at attach time has been sent.
+  private liveAfterSeq: number | null = null;
+  private detachedAt: number | null = null;
+
+  constructor(
+    readonly opts: UpstreamOptions,
+    bufferBytes: number,
+    budget: ByteBudget,
+  ) {
+    super();
+    this.id = opts.id;
+    this.buffer = new LineBuffer(bufferBytes, budget);
+  }
+
+  get attached(): boolean {
+    return this.sink !== null;
+  }
+
+  get registered(): boolean {
+    return this.burstDone;
+  }
+
+  // When the last link let go of this socket (null while attached).
+  get detachedSince(): number | null {
+    return this.detachedAt;
+  }
+
+  // Is this the same session a CONNECT with these parameters would open? A
+  // changed host/port/TLS/source address means the user edited the network and
+  // wants a fresh dial, not the old socket under new settings.
+  matchesDial(frame: { host: string; port: number; tls: boolean; outgoingAddr?: string }): boolean {
+    return (
+      this.opts.host === frame.host &&
+      this.opts.port === frame.port &&
+      this.opts.tls === !!frame.tls &&
+      (this.opts.outgoingAddr || '') === (frame.outgoingAddr || '')
+    );
+  }
+
+  // May throw synchronously (Node validates the port and the bind address
+  // before it ever touches the network); the caller owns that.
+  dial(): void {
+    const { host, port, outgoingAddr, rejectUnauthorized } = this.opts;
+    const onConnect = () => this.onOpen();
+    const base = {
+      host,
+      port,
+      localAddress: outgoingAddr || undefined,
+      // A bound source address fixes the family, or a dual-stack host whose
+      // lookup answers the other family first fails with `bind EINVAL` — the
+      // same pairing irc-framework's transport makes.
+      family: outgoingAddr ? net.isIP(outgoingAddr) || undefined : undefined,
+    };
+    const socket = this.opts.tls
+      ? tls.connect(
+          {
+            ...base,
+            // SNI only for a name — an IP literal is not a valid server name.
+            servername: net.isIP(host) ? undefined : host,
+            rejectUnauthorized,
+          },
+          onConnect,
+        )
+      : net.connect(base, onConnect);
+    this.socket = socket;
+    // utf8 with a StringDecoder underneath, so a multibyte character split across
+    // chunks reassembles correctly. Lurker never negotiates another encoding.
+    socket.setEncoding('utf8');
+    socket.setKeepAlive(true, 60_000);
+    // identd is answered the instant the ircd accepts our TCP connection —
+    // concurrently with the TLS handshake — so the 4-tuple must be registered on
+    // the raw 'connect', not on secureConnect. Same race the app path fixed.
+    socket.once('connect', () => this.onTcpConnect(socket));
+    socket.setTimeout(this.opts.dialTimeoutMs ?? DEFAULT_DIAL_TIMEOUT_MS);
+    socket.on('timeout', () => {
+      if (this.state === 'dialing') this.dropPeer('dial timed out');
+    });
+    socket.on('data', (chunk: string) => this.onData(chunk));
+    socket.on('error', (err: Error) => {
+      this.lastError = err.message;
+    });
+    socket.on('close', () => this.onClose());
+  }
+
+  // TCP is up (before any TLS handshake): the 4-tuple exists, so identd can be
+  // registered — this is the only place it can be, the app never sees the socket.
+  private onTcpConnect(s: net.Socket): void {
+    if (this.closing) return;
+    this.local = { address: s.localAddress || '', port: s.localPort || 0 };
+    this.remote = { address: s.remoteAddress || '', port: s.remotePort || 0 };
+    if (
+      this.opts.ident &&
+      this.identdId === null &&
+      (isIdentdEnabled() || isOidentdFileEnabled())
+    ) {
+      this.identdId = registerIdent({
+        localAddress: this.local.address,
+        localPort: this.local.port,
+        remoteAddress: this.remote.address,
+        remotePort: this.remote.port,
+        ident: this.opts.ident,
+      });
+    }
+  }
+
+  private onOpen(): void {
+    const s = this.socket;
+    if (!s || this.closing) return;
+    this.state = 'open';
+    s.setTimeout(0);
+    // Normally set on the raw 'connect' already; the fallback is for a socket
+    // whose 'connect' we somehow missed (it costs nothing to be sure).
+    if (!this.local || !this.remote) this.onTcpConnect(s);
+    const local = this.local ?? { address: s.localAddress || '', port: s.localPort || 0 };
+    const remote = this.remote ?? { address: s.remoteAddress || '', port: s.remotePort || 0 };
+    this.local = local;
+    this.remote = remote;
+    this.emit('open', local, remote);
+    this.sink?.send({ op: 'open', id: this.id, local, remote });
+  }
+
+  private onData(chunk: string): void {
+    this.inbuf += chunk;
+    let nl: number;
+    while ((nl = this.inbuf.indexOf('\n')) >= 0) {
+      const line = this.inbuf.slice(0, nl).replace(/\r$/, '');
+      this.inbuf = this.inbuf.slice(nl + 1);
+      if (line.length > MAX_IRC_LINE) return this.dropPeer('peer sent an over-long line');
+      if (line) this.onLine(line);
+    }
+    if (this.inbuf.length > MAX_IRC_LINE) this.dropPeer('peer sent an over-long line');
+  }
+
+  private dropPeer(why: string): void {
+    this.lastError = why;
+    this.socket?.destroy();
+  }
+
+  private onLine(line: string): void {
+    const msg = ircLineParser(line);
+    if (!msg) return;
+    const command = String(msg.command || '').toUpperCase();
+    if (command === 'PING') {
+      const token = msg.params[msg.params.length - 1];
+      this.rawWrite(token === undefined ? 'PONG' : `PONG :${token}`);
+      if (!this.sink) this.pingsAnsweredDetached++;
+      return;
+    }
+    if (command === '001') this.nick = msg.params[0] || null;
+    // Own state is tracked from the first line on — a NICK forced on us between
+    // 001 and 376, or a server that JOINs us to a channel during registration,
+    // must not be missed just because the burst is still open.
+    const ownState = this.nick ? this.track(command, msg.prefix, msg.params) : false;
+    if (!this.burstDone) {
+      // Own channel movement is state, replayed from the channel set; recording
+      // the line too would replay a JOIN the tracked set may since have undone.
+      if (!ownState) this.recordBurst(line);
+      if (command === '376' || command === '422') {
+        this.burstDone = true;
+        this.nickAtBurstEnd = this.nick;
+        this.registeredUnattended = this.sink === null;
+      }
+    }
+    const seq = this.buffer.push(line);
+    if (this.burstDone && this.burstEndSeq === 0) this.burstEndSeq = seq;
+    this.flush();
+  }
+
+  private recordBurst(line: string): void {
+    const bytes = Buffer.byteLength(line, 'utf8') + 2;
+    if (this.burstBytes + bytes > MAX_BURST_BYTES) return;
+    this.burst.push(line);
+    this.burstBytes += bytes;
+  }
+
+  private isSelf(nick: string): boolean {
+    return !!this.nick && nick.toLowerCase() === this.nick.toLowerCase();
+  }
+
+  // Apply an own-state line. Returns true when the line was own channel
+  // movement (JOIN/PART/KICK of us), which the burst must not record.
+  private track(command: string, prefix: string | undefined, params: string[]): boolean {
+    const from = prefixNick(prefix);
+    if (command === 'NICK' && this.isSelf(from)) {
+      this.nick = params[0] || this.nick;
+      this.noteHostmask(prefix);
+      return false;
+    }
+    if (command === 'JOIN' && this.isSelf(from)) {
+      const chan = params[0] || '';
+      if (chan) this.channels.set(chan.toLowerCase(), chan);
+      this.noteHostmask(prefix);
+      return true;
+    }
+    if (command === 'PART' && this.isSelf(from)) {
+      this.channels.delete((params[0] || '').toLowerCase());
+      return true;
+    }
+    if (command === 'KICK' && this.isSelf(params[1] || '')) {
+      this.channels.delete((params[0] || '').toLowerCase());
+      return true;
+    }
+    if (command === 'CHGHOST' && this.isSelf(from)) {
+      if (params[0] && params[1]) this.hostmask = `${params[0]}@${params[1]}`;
+    }
+    return false;
+  }
+
+  // Own user@host, learned from any line the server prefixes with our full
+  // mask (JOIN, NICK) and kept current by CHGHOST. The nick half is whatever
+  // the nick is now.
+  private noteHostmask(prefix: string | undefined): void {
+    if (!prefix) return;
+    const bang = prefix.indexOf('!');
+    if (bang >= 0) this.hostmask = prefix.slice(bang + 1);
+  }
+
+  private rawWrite(line: string): void {
+    if (this.state === 'open' && !this.closing) this.socket?.write(line + '\r\n');
+  }
+
+  write(line: string): void {
+    this.rawWrite(line);
+  }
+
+  // Send the unacked backlog to the current sink, in order, stopping when the
+  // sink is over its high-water mark. Called on every new line, on attach, and
+  // on drain.
+  private flush(): void {
+    const sink = this.sink;
+    if (!sink || this.stalled) return;
+    // A hole is only news to a sink that has not already been sent the lines
+    // that fell into it. One that has (it was attached, and simply hasn't acked
+    // yet) keeps them in hand; the gap stays recorded for whoever attaches
+    // next — and is forgotten if this sink acks past it (LineBuffer.ack).
+    const gap = this.buffer.peekGap();
+    if (gap && gap.lastDroppedSeq > this.sentSeq) {
+      // Taken BEFORE looking at the backpressure answer: `send` has queued the
+      // frame either way, and a stalled sink must not be told twice.
+      this.buffer.takeGap();
+      if (!sink.send({ op: 'gap', id: this.id, gap })) {
+        this.stalled = true;
+        return;
+      }
+    }
+    // Seqs are contiguous and only ever trimmed from the front, so the first
+    // owed line is at a computable index — no rescan of everything already sent.
+    const pending = this.buffer.pending();
+    const first =
+      pending.length && this.sentSeq >= pending[0].seq ? this.sentSeq - pending[0].seq + 1 : 0;
+    for (let i = first; i < pending.length; i++) {
+      const b = pending[i];
+      this.sentSeq = b.seq;
+      const ok = sink.send({ op: 'line', id: this.id, seq: b.seq, line: b.line });
+      if (this.liveAfterSeq !== null && b.seq >= this.liveAfterSeq) this.sendLive();
+      if (!ok) {
+        this.stalled = true;
+        return;
+      }
+    }
+    if (this.liveAfterSeq !== null) this.sendLive();
+  }
+
+  private sendLive(): void {
+    this.liveAfterSeq = null;
+    this.sink?.send({ op: 'live', id: this.id });
+  }
+
+  resume(): void {
+    this.stalled = false;
+    this.flush();
+  }
+
+  ack(seq: number): void {
+    this.buffer.ack(seq);
+  }
+
+  // Claim this socket for a sink. While still dialing there is nothing to replay:
+  // the sink simply becomes the one that hears `open`. Once open and registered,
+  // the caller sends the returned payload, then this flushes the backlog and
+  // `live`. 'unregistered' means the previous app died mid-registration; there
+  // is no session to hand over, so the caller should end the socket and let the
+  // app dial afresh.
+  attach(sink: FrameSink): AttachedPayload | 'dialing' | 'unregistered' {
+    this.sink = sink;
+    this.stalled = false;
+    const detachedForMs = this.detachedAt === null ? 0 : Date.now() - this.detachedAt;
+    this.detachedAt = null;
+    if (this.state !== 'open' || !this.local || !this.remote) {
+      this.sentSeq = 0;
+      return 'dialing';
+    }
+    if (!this.burstDone) return 'unregistered';
+    // The replay IS the delivery of the burst: the fresh Client walks it and
+    // registers. Sending those lines again as backlog would register it twice.
+    this.buffer.ack(this.burstEndSeq);
+    this.sentSeq = this.burstEndSeq;
+    // `live` is owed after the last line that exists right now — or immediately
+    // when there is nothing pending.
+    const pending = this.buffer.pending();
+    this.liveAfterSeq = pending.length ? pending[pending.length - 1].seq : 0;
+    return {
+      local: this.local,
+      remote: this.remote,
+      replay: this.replaySet(),
+      nick: this.nick,
+      channels: [...this.channels.values()],
+      detachedForMs,
+      unattended: this.registeredUnattended,
+    };
+  }
+
+  // Called by the server right after it has sent the `attached` frame.
+  flushAfterAttach(): void {
+    if (this.liveAfterSeq === 0) this.sendLive();
+    this.flush();
+  }
+
+  detach(): void {
+    if (!this.sink) return;
+    this.sink = null;
+    this.stalled = false;
+    this.liveAfterSeq = null;
+    this.detachedAt = Date.now();
+  }
+
+  // Nobody hears from this socket again — used when a fresh dial takes over its
+  // id. In particular the `closed` it will eventually produce must not reach a
+  // link that has moved on to the new socket under the same id.
+  silence(): void {
+    this.detach();
+    this.quietClose = true;
+  }
+
+  replaySet(): string[] {
+    const out = [...this.burst];
+    if (!this.nick) return out;
+    const userhost = this.hostmask || FALLBACK_USERHOST;
+    if (this.nickAtBurstEnd && this.nickAtBurstEnd !== this.nick) {
+      out.push(`:${this.nickAtBurstEnd}!${userhost} NICK :${this.nick}`);
+    }
+    for (const chan of this.channels.values()) out.push(`:${this.nick}!${userhost} JOIN ${chan}`);
+    return out;
+  }
+
+  // End the socket. The app asked (a QUIT went out first, or a user disconnected).
+  close(): void {
+    if (this.closing) return;
+    this.closing = true;
+    this.quietClose = true;
+    // Still dialing: end() would let the connect (and a TLS handshake) complete
+    // and only then FIN — a wasted registration attempt against the ircd's
+    // per-IP throttle, an ident entry for a socket nobody wanted, and an `open`
+    // the app has already given up on. Cut it off.
+    if (this.state !== 'open') return this.destroy();
+    this.socket?.end();
+    this.closeTimer = setTimeout(() => this.socket?.destroy(), CLOSE_GRACE_MS);
+    this.closeTimer.unref();
+  }
+
+  // Engine shutdown: say goodbye properly, then end. The server bounds the wait.
+  quit(message: string): void {
+    this.rawWrite(`QUIT :${message}`);
+    this.close();
+  }
+
+  destroy(): void {
+    this.closing = true;
+    this.socket?.destroy();
+  }
+
+  private onClose(): void {
+    if (this.state === 'closed') return;
+    this.state = 'closed';
+    if (this.closeTimer) {
+      clearTimeout(this.closeTimer);
+      this.closeTimer = null;
+    }
+    unregisterIdent(this.identdId);
+    this.identdId = null;
+    this.buffer.dispose();
+    const error = this.lastError ?? undefined;
+    if (!this.quietClose) {
+      this.sink?.send({ op: 'closed', id: this.id, ...(error ? { error } : {}) });
+    }
+    this.sink = null;
+    this.emit('closed', error);
+  }
+
+  info(): ConnectionInfo {
+    return {
+      id: this.id,
+      state: this.closing ? 'closing' : this.state === 'closed' ? 'closing' : this.state,
+      attached: this.attached,
+      nick: this.nick,
+      channelCount: this.channels.size,
+      bufferedLines: this.buffer.length,
+      bufferedBytes: this.buffer.bytes,
+      detachedForMs: this.detachedAt === null ? null : Date.now() - this.detachedAt,
+    };
+  }
+}

--- a/server/engine/upstream.ts
+++ b/server/engine/upstream.ts
@@ -72,8 +72,12 @@ export interface AttachedPayload {
   unattended: boolean;
 }
 
-// Inbound IRC lines are at most 8191 bytes including tags. Anything past this
-// is not an IRC server, so the socket is dropped rather than buffered.
+// IRCv3 caps a line at 8191 bytes including tags. This guard is deliberately
+// double that: the engine relays bytes rather than policing them, and a server
+// a little over the line is the app's problem to parse, not the engine's to
+// disconnect over. What it exists to stop is a peer that is not an IRC server
+// at all streaming an unbounded "line" into the buffer. Well under the 256 KiB
+// frame cap (MAX_FRAME_BYTES), so anything relayed here fits on the wire.
 const MAX_IRC_LINE = 16 * 1024;
 
 // The recorded registration burst stops growing here. Registration itself
@@ -121,6 +125,8 @@ export class EngineUpstream extends EventEmitter {
   private identdId: number | null = null;
   private burst: string[] = [];
   private burstBytes = 0;
+  // Latched once a line didn't fit, so the burst is a contiguous prefix.
+  private burstFull = false;
   private burstDone = false;
   // The seq of the last burst line; a replay covers everything up to it.
   private burstEndSeq = 0;
@@ -299,7 +305,7 @@ export class EngineUpstream extends EventEmitter {
     if (!this.burstDone) {
       // Own channel movement is state, replayed from the channel set; recording
       // the line too would replay a JOIN the tracked set may since have undone.
-      if (!ownState) this.recordBurst(line);
+      if (!ownState) this.recordBurst(line, command === '376' || command === '422');
       if (command === '376' || command === '422') {
         this.burstDone = true;
         this.nickAtBurstEnd = this.nick;
@@ -311,9 +317,23 @@ export class EngineUpstream extends EventEmitter {
     this.flush();
   }
 
-  private recordBurst(line: string): void {
+  // The cap LATCHES. Testing each line against the remaining headroom on its
+  // own would keep taking short lines after a long one was skipped, and the
+  // replay would be a subset of the registration with holes punched in it
+  // rather than a prefix of it. A truncated burst is a thing irc-framework can
+  // walk; a burst missing its middle is not.
+  //
+  // `force` is the single exception, for the line that ends the burst. Dropping
+  // that would replay a MOTD that starts and never finishes — irc-framework
+  // emits 'motd' only on 376/422, and that event is the one thing that renders
+  // the block, since 372/375/376 are on the app's numeric denylist. It is one
+  // short line, and it is what makes the truncation well-formed.
+  private recordBurst(line: string, force = false): void {
     const bytes = Buffer.byteLength(line, 'utf8') + 2;
-    if (this.burstBytes + bytes > MAX_BURST_BYTES) return;
+    if (this.burstFull || this.burstBytes + bytes > MAX_BURST_BYTES) {
+      this.burstFull = true;
+      if (!force) return;
+    }
     this.burst.push(line);
     this.burstBytes += bytes;
   }

--- a/server/test-utils/engineLink.ts
+++ b/server/test-utils/engineLink.ts
@@ -10,6 +10,8 @@ import { once } from 'node:events';
 import { FrameReader, PROTOCOL_MAJOR, encodeFrame } from '../engine/protocol.js';
 import type { AppToEngine, EngineToApp } from '../engine/protocol.js';
 
+export const TEST_INSTANCE = 'test-instance-a';
+
 export class TestLink {
   readonly frames: EngineToApp[] = [];
   hello: Extract<EngineToApp, { op: 'hello' }> | null = null;
@@ -47,13 +49,16 @@ export class TestLink {
   static async connect(
     port: number,
     secret: string,
-    opts: { protocol?: number; version?: string } = {},
+    opts: { protocol?: number; version?: string; instance?: string } = {},
   ): Promise<TestLink> {
     const link = await TestLink.open(port);
     link.send({
       op: 'hello',
       protocol: opts.protocol ?? PROTOCOL_MAJOR,
       secret,
+      // One default instance, so the ordinary tests all speak for the same
+      // "database"; the cross-instance cases pass their own.
+      instance: opts.instance ?? TEST_INSTANCE,
       app: { version: opts.version ?? 'test' },
     });
     await link.waitFor((f) => f.op === 'hello' || f.op === 'error');

--- a/server/test-utils/engineLink.ts
+++ b/server/test-utils/engineLink.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// A bare app-side link to the engine for tests: speaks the frame protocol and
+// nothing else, so engine behaviour can be asserted frame by frame without
+// irc-framework or the real transport in the loop.
+
+import net from 'node:net';
+import { once } from 'node:events';
+import { FrameReader, PROTOCOL_MAJOR, encodeFrame } from '../engine/protocol.js';
+import type { AppToEngine, EngineToApp } from '../engine/protocol.js';
+
+export class TestLink {
+  readonly frames: EngineToApp[] = [];
+  hello: Extract<EngineToApp, { op: 'hello' }> | null = null;
+  closed = false;
+  private readonly reader = new FrameReader();
+  private waiters: Array<{ pred: (f: EngineToApp) => boolean; resolve: (f: EngineToApp) => void }> =
+    [];
+
+  private constructor(readonly socket: net.Socket) {}
+
+  static async open(port: number, host = '127.0.0.1'): Promise<TestLink> {
+    const socket = net.connect(port, host);
+    await once(socket, 'connect');
+    socket.setEncoding('utf8');
+    const link = new TestLink(socket);
+    socket.on('data', (chunk: string) => {
+      for (const f of link.reader.push(chunk) as EngineToApp[]) {
+        link.frames.push(f);
+        if (f.op === 'hello') link.hello = f;
+        link.waiters = link.waiters.filter((w) => {
+          if (!w.pred(f)) return true;
+          w.resolve(f);
+          return false;
+        });
+      }
+    });
+    socket.on('error', () => {});
+    socket.on('close', () => {
+      link.closed = true;
+    });
+    return link;
+  }
+
+  // Open + hello in one go; resolves once the engine has answered.
+  static async connect(
+    port: number,
+    secret: string,
+    opts: { protocol?: number; version?: string } = {},
+  ): Promise<TestLink> {
+    const link = await TestLink.open(port);
+    link.send({
+      op: 'hello',
+      protocol: opts.protocol ?? PROTOCOL_MAJOR,
+      secret,
+      app: { version: opts.version ?? 'test' },
+    });
+    await link.waitFor((f) => f.op === 'hello' || f.op === 'error');
+    return link;
+  }
+
+  send(frame: AppToEngine): void {
+    this.socket.write(encodeFrame(frame));
+  }
+
+  // Lines received for `id`, in order.
+  lines(id: string): string[] {
+    return this.frames
+      .filter((f): f is Extract<EngineToApp, { op: 'line' }> => f.op === 'line' && f.id === id)
+      .map((f) => f.line);
+  }
+
+  waitFor<T extends EngineToApp = EngineToApp>(
+    pred: (f: EngineToApp) => boolean,
+    timeoutMs = 5000,
+  ): Promise<T> {
+    const hit = this.frames.find(pred);
+    if (hit) return Promise.resolve(hit as T);
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.waiters = this.waiters.filter((w) => w.resolve !== done);
+        reject(
+          new Error(
+            `TestLink: timed out waiting; last frames: ${JSON.stringify(this.frames.slice(-3))}`,
+          ),
+        );
+      }, timeoutMs);
+      const done = (f: EngineToApp) => {
+        clearTimeout(timer);
+        resolve(f as T);
+      };
+      this.waiters.push({ pred, resolve: done });
+    });
+  }
+
+  // Like waitFor, but only for frames that arrive AFTER this call — for a
+  // second `open` on an id that already had one.
+  waitForNew<T extends EngineToApp = EngineToApp>(
+    pred: (f: EngineToApp) => boolean,
+    timeoutMs = 5000,
+  ): Promise<T> {
+    const skip = this.frames.length;
+    return this.waitFor<T>((f) => this.frames.indexOf(f) >= skip && pred(f), timeoutMs);
+  }
+
+  // Wait for an inbound IRC line on `id` matching `re`.
+  waitForLine(id: string, re: RegExp, timeoutMs = 5000): Promise<string> {
+    return this.waitFor<Extract<EngineToApp, { op: 'line' }>>(
+      (f) => f.op === 'line' && f.id === id && re.test(f.line),
+      timeoutMs,
+    ).then((f) => f.line);
+  }
+
+  waitForClose(timeoutMs = 5000): Promise<void> {
+    if (this.closed) return Promise.resolve();
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error('TestLink: socket did not close')),
+        timeoutMs,
+      );
+      this.socket.once('close', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
+  // Simulate the app dying: no detach, no goodbye.
+  kill(): void {
+    this.socket.destroy();
+  }
+}

--- a/server/test-utils/fakeIrcd.ts
+++ b/server/test-utils/fakeIrcd.ts
@@ -30,6 +30,11 @@ export interface FakeIrcdOptions {
   caps?: string[];
   // false → 422 instead of a MOTD.
   motd?: boolean;
+  // Pad the MOTD with this many extra numbered 372 lines. Their lengths vary
+  // (every tenth is short), so a consumer that caps the MOTD by testing each
+  // line against its remaining headroom keeps the short ones after skipping a
+  // long one — which is how a truncated-with-holes bug shows itself.
+  motdPadLines?: number;
   // Rename every client to this DURING registration (between 005 and the MOTD),
   // the way nick enforcement or a SANICK would.
   burstNickTo?: string;
@@ -467,6 +472,13 @@ export class FakeIrcd extends EventEmitter {
     } else {
       this.num(c, '375', `- ${this.serverName} Message of the day -`);
       this.num(c, '372', '- welcome to the fake');
+      for (let i = 0; i < (this.opts.motdPadLines ?? 0); i++) {
+        this.num(
+          c,
+          '372',
+          `- ${String(i).padStart(4, '0')} ${'pad '.repeat(i % 10 === 9 ? 8 : 255)}`,
+        );
+      }
       this.num(c, '376', 'End of /MOTD command.');
     }
     this.emit('registered', c);

--- a/server/test-utils/fakeIrcd.ts
+++ b/server/test-utils/fakeIrcd.ts
@@ -1,0 +1,537 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// A small IRC server for tests that need a real socket on the far side —
+// enough of the protocol for a client to register, join, talk, and be watched.
+// Exists because the engine holds a TCP socket and nothing in-process can stand
+// in for that, and CI has no ircd. Deliberately not a faithful ircd: every reply
+// is the simplest form a real server sends, and anything unimplemented answers
+// 421 so a test that wanders off the map fails loudly.
+//
+// The things it gets deliberately right, because tests lean on them:
+//   - `registrations` records every completed registration, so a test can
+//     assert the server saw exactly one across an app restart.
+//   - server-time: when a client asks for it, every relayed line carries a
+//     leading `@time=` tag — the ergo behaviour that broke an early probe.
+//   - 317 (signon time) is reported only to the user asking about themself,
+//     as ergo does.
+//   - PING from the server is a method call, so tests decide when it happens.
+
+import net from 'node:net';
+import tls from 'node:tls';
+import { EventEmitter, once } from 'node:events';
+import { generate as generateSelfSigned } from 'selfsigned';
+import { ircLineParser } from 'irc-framework';
+import { CHANNEL_PREFIX_CHARS, isChannelTarget } from '../../shared/channels.js';
+
+export interface FakeIrcdOptions {
+  tls?: boolean;
+  // Advertise these in CAP LS (and ACK them when requested).
+  caps?: string[];
+  // false → 422 instead of a MOTD.
+  motd?: boolean;
+  // Rename every client to this DURING registration (between 005 and the MOTD),
+  // the way nick enforcement or a SANICK would.
+  burstNickTo?: string;
+  serverName?: string;
+  network?: string;
+}
+
+export interface FakeClient {
+  socket: net.Socket;
+  nick: string | null;
+  user: string | null;
+  registered: boolean;
+  signon: number;
+  caps: Set<string>;
+  capNegotiating: boolean;
+  channels: Set<string>;
+  // Every line this client sent, in order.
+  sent: string[];
+}
+
+const DEFAULT_CAPS = [
+  'server-time',
+  'message-tags',
+  'batch',
+  'multi-prefix',
+  'away-notify',
+  'account-notify',
+  'extended-join',
+  'chghost',
+  'cap-notify',
+  'userhost-in-names',
+  'echo-message',
+];
+
+export class FakeIrcd extends EventEmitter {
+  readonly clients: FakeClient[] = [];
+  readonly registrations: Array<{ nick: string; at: number }> = [];
+  readonly topics = new Map<string, string>();
+  private msgidCounter = 0;
+  private server!: net.Server;
+  port = 0;
+  private readonly caps: string[];
+  private readonly serverName: string;
+  private readonly network: string;
+
+  private constructor(private readonly opts: FakeIrcdOptions) {
+    super();
+    this.caps = opts.caps ?? DEFAULT_CAPS;
+    this.serverName = opts.serverName ?? 'fake.test';
+    this.network = opts.network ?? 'FakeNet';
+  }
+
+  static async start(opts: FakeIrcdOptions = {}): Promise<FakeIrcd> {
+    const ircd = new FakeIrcd(opts);
+    if (opts.tls) {
+      const pems = await generateSelfSigned([{ name: 'commonName', value: 'localhost' }], {
+        keySize: 2048,
+        algorithm: 'sha256',
+        extensions: [
+          {
+            name: 'subjectAltName',
+            altNames: [
+              { type: 2, value: 'localhost' },
+              { type: 7, ip: '127.0.0.1' },
+            ],
+          },
+        ],
+      });
+      ircd.server = tls.createServer({ key: pems.private, cert: pems.cert }, (s) => ircd.accept(s));
+    } else {
+      ircd.server = net.createServer((s) => ircd.accept(s));
+    }
+    await new Promise<void>((resolve) => ircd.server.listen(0, '127.0.0.1', resolve));
+    ircd.port = (ircd.server.address() as net.AddressInfo).port;
+    return ircd;
+  }
+
+  async close(): Promise<void> {
+    for (const c of this.clients) c.socket.destroy();
+    this.server.close();
+  }
+
+  client(nick: string): FakeClient | undefined {
+    const lower = nick.toLowerCase();
+    return this.clients.find((c) => c.nick?.toLowerCase() === lower && !c.socket.destroyed);
+  }
+
+  // Wait until a client with this nick has registered.
+  async waitForRegistration(nick: string, timeoutMs = 5000): Promise<FakeClient> {
+    const existing = this.client(nick);
+    if (existing?.registered) return existing;
+    return this.waitFor(() => {
+      const c = this.client(nick);
+      return c?.registered ? c : undefined;
+    }, timeoutMs);
+  }
+
+  // Wait until some client has sent a line matching `pred`.
+  async waitForLine(
+    pred: (line: string, client: FakeClient) => boolean,
+    timeoutMs = 5000,
+  ): Promise<string> {
+    return this.waitFor(() => {
+      for (const c of this.clients) {
+        const hit = c.sent.find((l) => pred(l, c));
+        if (hit) return hit;
+      }
+      return undefined;
+    }, timeoutMs);
+  }
+
+  private waitFor<T>(probe: () => T | undefined, timeoutMs: number): Promise<T> {
+    return new Promise((resolve, reject) => {
+      const deadline = Date.now() + timeoutMs;
+      const tick = () => {
+        const v = probe();
+        if (v !== undefined) return resolve(v);
+        if (Date.now() > deadline) return reject(new Error('fakeIrcd: timed out waiting'));
+        setTimeout(tick, 10);
+      };
+      tick();
+    });
+  }
+
+  // --- server-initiated traffic -------------------------------------------
+
+  ping(nick: string, token = 'fake'): void {
+    const c = this.client(nick);
+    if (c) this.raw(c, `PING :${token}`);
+  }
+
+  // Deliver a line from a synthetic peer to a nick or a channel.
+  say(from: string, target: string, text: string): string {
+    const msgid = `m${++this.msgidCounter}`;
+    const line = `:${from}!~${from}@peer.fake PRIVMSG ${target} :${text}`;
+    if (isChannelTarget(target)) {
+      for (const c of this.members(target)) this.tagged(c, line, msgid);
+    } else {
+      const c = this.client(target);
+      if (c) this.tagged(c, line, msgid);
+    }
+    return msgid;
+  }
+
+  setTopic(from: string, channel: string, topic: string): void {
+    this.topics.set(channel.toLowerCase(), topic);
+    for (const c of this.members(channel)) {
+      this.tagged(c, `:${from}!~${from}@peer.fake TOPIC ${channel} :${topic}`);
+    }
+  }
+
+  // Force-change a client's nick from the server side (a SANICK).
+  forceNick(nick: string, newNick: string): void {
+    const c = this.client(nick);
+    if (c) this.changeNick(c, newNick);
+  }
+
+  kick(channel: string, nick: string, by = 'oper'): void {
+    const victim = this.client(nick);
+    if (!victim) return;
+    for (const c of this.members(channel)) {
+      this.tagged(c, `:${by}!~${by}@peer.fake KICK ${channel} ${victim.nick} :out`);
+    }
+    victim.channels.delete(channel.toLowerCase());
+  }
+
+  // Inject an arbitrary server-side line to a client (CHGHOST, numerics, …).
+  sendRaw(nick: string, line: string): void {
+    const c = this.client(nick);
+    if (c) this.raw(c, line);
+  }
+
+  // Close a client's socket from the server side, optionally after ERROR.
+  drop(nick: string, withError = true): void {
+    const c = this.client(nick);
+    if (!c) return;
+    if (withError) this.raw(c, 'ERROR :Closing Link: dropped by test');
+    c.socket.end();
+  }
+
+  // --- internals -----------------------------------------------------------
+
+  private accept(socket: net.Socket): void {
+    const client: FakeClient = {
+      socket,
+      nick: null,
+      user: null,
+      registered: false,
+      signon: 0,
+      caps: new Set(),
+      capNegotiating: false,
+      channels: new Set(),
+      sent: [],
+    };
+    this.clients.push(client);
+    socket.setEncoding('utf8');
+    let buf = '';
+    socket.on('data', (chunk: string) => {
+      buf += chunk;
+      let nl: number;
+      while ((nl = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, nl).replace(/\r$/, '');
+        buf = buf.slice(nl + 1);
+        if (line) this.onLine(client, line);
+      }
+    });
+    socket.on('error', () => {});
+    socket.on('close', () => {
+      for (const ch of client.channels) this.partAll(client, ch);
+      client.channels.clear();
+    });
+  }
+
+  private hostmask(c: FakeClient): string {
+    return `${c.nick}!~${c.user ?? 'u'}@fake.host`;
+  }
+
+  private members(channel: string): FakeClient[] {
+    const lower = channel.toLowerCase();
+    return this.clients.filter((c) => c.channels.has(lower) && !c.socket.destroyed);
+  }
+
+  private raw(c: FakeClient, line: string): void {
+    if (!c.socket.destroyed) c.socket.write(line + '\r\n');
+  }
+
+  private num(c: FakeClient, code: string, ...params: string[]): void {
+    const nick = c.nick ?? '*';
+    const last = params.pop();
+    const head = params.length ? ' ' + params.join(' ') : '';
+    this.raw(
+      c,
+      `:${this.serverName} ${code} ${nick}${head}${last !== undefined ? ' :' + last : ''}`,
+    );
+  }
+
+  // Prefix a relayed line with tags the client negotiated.
+  private tagged(c: FakeClient, line: string, msgid?: string): void {
+    const tags: string[] = [];
+    if (c.caps.has('server-time')) tags.push(`time=${new Date().toISOString()}`);
+    if (c.caps.has('message-tags') && msgid) tags.push(`msgid=${msgid}`);
+    this.raw(c, tags.length ? `@${tags.join(';')} ${line}` : line);
+  }
+
+  private onLine(c: FakeClient, line: string): void {
+    c.sent.push(line);
+    this.emit('line', line, c);
+    const msg = ircLineParser(line);
+    if (!msg) return;
+    const cmd = String(msg.command || '').toUpperCase();
+    const p = msg.params;
+    switch (cmd) {
+      case 'CAP':
+        return this.onCap(c, p);
+      case 'NICK': {
+        if (!p[0]) return this.num(c, '431', 'No nickname given');
+        if (c.registered) return this.changeNick(c, p[0]);
+        c.nick = p[0];
+        return this.maybeRegister(c);
+      }
+      case 'USER':
+        c.user = p[0] ?? null;
+        return this.maybeRegister(c);
+      case 'PASS':
+        return;
+      case 'PING':
+        return this.raw(c, `:${this.serverName} PONG ${this.serverName} :${p[p.length - 1] ?? ''}`);
+      case 'PONG':
+        return;
+      case 'QUIT': {
+        const reason = p[0] ? `Quit: ${p[0]}` : 'Quit';
+        for (const ch of c.channels) {
+          for (const m of this.members(ch)) {
+            if (m !== c) this.tagged(m, `:${this.hostmask(c)} QUIT :${reason}`);
+          }
+        }
+        c.channels.clear();
+        this.raw(c, 'ERROR :Closing Link (Quit)');
+        c.socket.end();
+        return;
+      }
+    }
+    if (!c.registered) return this.num(c, '451', 'You have not registered');
+    switch (cmd) {
+      case 'JOIN': {
+        for (const chan of (p[0] ?? '').split(',').filter(Boolean)) {
+          const lower = chan.toLowerCase();
+          if (c.channels.has(lower)) continue;
+          c.channels.add(lower);
+          const joinLine = c.caps.has('extended-join')
+            ? `:${this.hostmask(c)} JOIN ${chan} * :${c.user ?? ''}`
+            : `:${this.hostmask(c)} JOIN ${chan}`;
+          for (const m of this.members(chan)) this.tagged(m, joinLine);
+          const topic = this.topics.get(lower);
+          if (topic) this.num(c, '332', chan, topic);
+          this.names(c, chan);
+        }
+        return;
+      }
+      case 'PART': {
+        const chan = p[0] ?? '';
+        if (!c.channels.has(chan.toLowerCase()))
+          return this.num(c, '442', chan, "You're not on that channel");
+        for (const m of this.members(chan))
+          this.tagged(m, `:${this.hostmask(c)} PART ${chan}${p[1] ? ' :' + p[1] : ''}`);
+        c.channels.delete(chan.toLowerCase());
+        return;
+      }
+      case 'NAMES':
+        return this.names(c, p[0] ?? '');
+      case 'PRIVMSG':
+      case 'NOTICE': {
+        const target = p[0] ?? '';
+        const text = p[1] ?? '';
+        const msgid = `m${++this.msgidCounter}`;
+        const out = `:${this.hostmask(c)} ${cmd} ${target} :${text}`;
+        if (isChannelTarget(target)) {
+          for (const m of this.members(target)) {
+            if (m !== c || c.caps.has('echo-message')) this.tagged(m, out, msgid);
+          }
+        } else {
+          const m = this.client(target);
+          if (!m) return this.num(c, '401', target, 'No such nick/channel');
+          this.tagged(m, out, msgid);
+          if (c.caps.has('echo-message')) this.tagged(c, out, msgid);
+        }
+        return;
+      }
+      case 'TOPIC': {
+        const chan = p[0] ?? '';
+        if (p.length < 2) {
+          const t = this.topics.get(chan.toLowerCase());
+          return t ? this.num(c, '332', chan, t) : this.num(c, '331', chan, 'No topic is set');
+        }
+        this.topics.set(chan.toLowerCase(), p[1]);
+        for (const m of this.members(chan))
+          this.tagged(m, `:${this.hostmask(c)} TOPIC ${chan} :${p[1]}`);
+        return;
+      }
+      case 'WHOIS': {
+        const target = this.client(p[p.length - 1] ?? '');
+        if (!target) return this.num(c, '401', p[0] ?? '', 'No such nick/channel');
+        this.num(c, '311', target.nick!, `~${target.user}`, 'fake.host', '*', target.user ?? '');
+        if (target === c) {
+          this.num(c, '317', target.nick!, '0', String(target.signon), 'seconds idle, signon time');
+        }
+        this.num(c, '318', target.nick!, 'End of /WHOIS list');
+        return;
+      }
+      case 'MODE': {
+        if (isChannelTarget(p[0]) && p.length === 1) return this.num(c, '324', p[0], '+nt');
+        return;
+      }
+      case 'WHO':
+        return this.num(c, '315', p[0] ?? '*', 'End of WHO list');
+      case 'AWAY':
+        return p[0]
+          ? this.num(c, '306', 'You have been marked as being away')
+          : this.num(c, '305', 'You are no longer marked as being away');
+      case 'MONITOR':
+        return;
+      case 'KICK': {
+        const chan = p[0] ?? '';
+        const victim = this.client(p[1] ?? '');
+        if (!victim || !victim.channels.has(chan.toLowerCase())) return;
+        for (const m of this.members(chan))
+          this.tagged(m, `:${this.hostmask(c)} KICK ${chan} ${victim.nick} :${p[2] ?? 'kicked'}`);
+        victim.channels.delete(chan.toLowerCase());
+        return;
+      }
+      default:
+        return this.num(c, '421', cmd, 'Unknown command');
+    }
+  }
+
+  private onCap(c: FakeClient, p: string[]): void {
+    const sub = (p[0] ?? '').toUpperCase();
+    if (sub === 'LS') {
+      c.capNegotiating = true;
+      // Two lines when asked for 302, to exercise multi-line LS handling.
+      if (p[1] === '302' && this.caps.length > 2) {
+        const half = Math.ceil(this.caps.length / 2);
+        this.raw(c, `:${this.serverName} CAP * LS * :${this.caps.slice(0, half).join(' ')}`);
+        this.raw(c, `:${this.serverName} CAP * LS :${this.caps.slice(half).join(' ')}`);
+      } else {
+        this.raw(c, `:${this.serverName} CAP * LS :${this.caps.join(' ')}`);
+      }
+    } else if (sub === 'REQ') {
+      const wanted = (p[1] ?? '').split(' ').filter(Boolean);
+      const ok = wanted.every((w) => this.caps.includes(w.replace(/^-/, '')));
+      if (ok) {
+        for (const w of wanted) {
+          if (w.startsWith('-')) c.caps.delete(w.slice(1));
+          else c.caps.add(w);
+        }
+        this.raw(c, `:${this.serverName} CAP ${c.nick ?? '*'} ACK :${wanted.join(' ')}`);
+      } else {
+        this.raw(c, `:${this.serverName} CAP ${c.nick ?? '*'} NAK :${wanted.join(' ')}`);
+      }
+    } else if (sub === 'END') {
+      c.capNegotiating = false;
+      this.maybeRegister(c);
+    }
+  }
+
+  private maybeRegister(c: FakeClient): void {
+    if (c.registered || !c.nick || !c.user || c.capNegotiating) return;
+    c.registered = true;
+    c.signon = Math.floor(Date.now() / 1000);
+    this.registrations.push({ nick: c.nick, at: Date.now() });
+    const n = c.nick;
+    this.num(c, '001', `Welcome to the ${this.network} IRC Network ${n}`);
+    this.num(c, '002', `Your host is ${this.serverName}, running version fake-1.0`);
+    this.num(c, '003', 'This server was created just now');
+    this.num(c, '004', this.serverName, 'fake-1.0', 'iow', 'ntk', 'k');
+    this.num(
+      c,
+      '005',
+      'CASEMAPPING=ascii',
+      `CHANTYPES=${CHANNEL_PREFIX_CHARS}`,
+      `NETWORK=${this.network}`,
+      'NICKLEN=32',
+      'PREFIX=(ov)@+',
+      'MONITOR=100',
+      'are supported by this server',
+    );
+    if (this.opts.burstNickTo) {
+      const to = this.opts.burstNickTo;
+      this.raw(c, `:${this.hostmask(c)} NICK :${to}`);
+      c.nick = to;
+    }
+    this.num(c, '251', 'There are 1 users on 1 servers');
+    if (this.opts.motd === false) {
+      this.num(c, '422', 'MOTD File is missing');
+    } else {
+      this.num(c, '375', `- ${this.serverName} Message of the day -`);
+      this.num(c, '372', '- welcome to the fake');
+      this.num(c, '376', 'End of /MOTD command.');
+    }
+    this.emit('registered', c);
+  }
+
+  private names(c: FakeClient, chan: string): void {
+    const nicks = this.members(chan).map((m) => m.nick!);
+    this.num(c, '353', '=', chan, nicks.join(' '));
+    this.num(c, '366', chan, 'End of /NAMES list.');
+  }
+
+  private changeNick(c: FakeClient, newNick: string): void {
+    if (this.client(newNick)) return this.num(c, '433', newNick, 'Nickname is already in use');
+    const line = `:${this.hostmask(c)} NICK :${newNick}`;
+    const seen = new Set<FakeClient>([c]);
+    for (const ch of c.channels) for (const m of this.members(ch)) seen.add(m);
+    for (const m of seen) this.tagged(m, line);
+    c.nick = newNick;
+  }
+
+  private partAll(c: FakeClient, lower: string): void {
+    for (const m of this.members(lower)) {
+      if (m !== c) this.tagged(m, `:${this.hostmask(c)} QUIT :Connection closed`);
+    }
+  }
+}
+
+// Convenience for tests: a raw client socket that speaks enough IRC to register
+// and observe, without irc-framework in the loop.
+export async function rawClient(
+  port: number,
+  nick: string,
+): Promise<{
+  socket: net.Socket;
+  lines: string[];
+  send: (l: string) => void;
+  waitFor: (re: RegExp, ms?: number) => Promise<string>;
+}> {
+  const socket = net.connect(port, '127.0.0.1');
+  await once(socket, 'connect');
+  socket.setEncoding('utf8');
+  const lines: string[] = [];
+  let buf = '';
+  socket.on('data', (chunk: string) => {
+    buf += chunk;
+    let nl: number;
+    while ((nl = buf.indexOf('\n')) >= 0) {
+      lines.push(buf.slice(0, nl).replace(/\r$/, ''));
+      buf = buf.slice(nl + 1);
+    }
+  });
+  const send = (l: string) => socket.write(l + '\r\n');
+  const waitFor = (re: RegExp, ms = 5000): Promise<string> =>
+    new Promise((resolve, reject) => {
+      const deadline = Date.now() + ms;
+      const tick = () => {
+        const hit = lines.find((l) => re.test(l));
+        if (hit) return resolve(hit);
+        if (Date.now() > deadline) return reject(new Error(`rawClient: no line matching ${re}`));
+        setTimeout(tick, 10);
+      };
+      tick();
+    });
+  send(`NICK ${nick}`);
+  send(`USER ${nick} 0 * :${nick}`);
+  await waitFor(/ 001 /);
+  return { socket, lines, send, waitFor };
+}


### PR DESCRIPTION
> **Draft — 2.1.3 has shipped; rebased onto it and ready for `/code-review high`.** Built overnight on 2026-08-25 as PR 1 of 3 (see `lurker-dev/IRC_ENGINE_PLAN.md`). Needs `/code-review high` before it leaves draft; two independent review passes have already run against it and their findings are folded in.

## What

A second entrypoint in the same image, `tsx server/engine.ts`, that dials and **holds the IRC sockets** so the app process can be redeployed without dropping them. Nothing in the app uses it yet — that is PR 2 (#829). This PR is the engine, its wire protocol, and its tests.

The engine is a *line-level* socket holder. It relays raw IRC both ways over one NDJSON-over-TCP link per app process, and understands exactly six IRC things: server `PING` (answered here, always, never forwarded — a detached or stalled app can't ping out), `001` (our nick), `376`/`422` (end of the registration burst it records), own `NICK`, own `JOIN`/`PART`/`KICK`, own `CHGHOST`. Everything else is bytes: numbered, buffered until the app acks, relayed. On re-attach it replays the recorded burst + NICK changes + one synthesised JOIN per channel into the app's fresh irc-framework Client, which comes up registered on the live nick with the live caps — without the network seeing a single extra command.

No database, no credentials (PASS/SASL ride the line stream as they do today), no tenant data — a connection is an opaque id the app chose.

## Files

- `server/engine/protocol.ts` — the contract (`PROTOCOL_MAJOR = 1`), framing, host:port parsing
- `server/engine/lineBuffer.ts` — bounded per-connection backlog + process-wide byte budget; oldest lines drop past the cap and the hole is reported as a `gap`
- `server/engine/upstream.ts` — one held socket: dial (TCP/TLS, source bind), identd registration on the 4-tuple, burst capture, own-state tracking, flush/ack/stall state machine, replay set
- `server/engine/server.ts` — the listener: hello + secret, connect-or-attach, newest-link-wins takeover, claim-checked writes, HTTP `/healthz` on the same port, QUIT-on-shutdown
- `server/engine/config.ts`, `server/engine.ts` — env + entrypoint (identd/oidentd modes run here; they belong to whoever holds the socket)
- `server/test-utils/fakeIrcd.ts` — the repo had no ircd to test sockets against; this is enough of one (CAP 302 multi-line LS, server-time tags, `317` only to yourself, PING on demand)
- `server/test-utils/engineLink.ts` — a bare frame-level link for tests

## Tests (26)

Framing and buffer units, plus the socket-level suite: dial/relay with increasing seqs, PING answered attached and detached and never forwarded, burst boundary on 376 and 422, NICK/JOIN/PART/KICK tracking and a server-forced nick, attach-after-kill with the ordered backlog then `live`, newest-link-wins (and the old link refused a `write`), acked lines not replayed, overflow → `gap`, TLS with and without `rejectUnauthorized`, identd registered on dial and released on close, secret/major refusal at hello, garbage frames dropped, the HTTP probe, QUIT on shutdown.

Also smoke-tested as the real entrypoint (boot → `/healthz` 200 → SIGTERM → exit 0), and the restore was run against the live ergo on von-braun with the real modules (PR 2's transport): identical signon time across the restart.

## Not in this PR

The app side (PR 2), the compose overlay/docs/`engine-1` tag (PR 3), the cell topology (control-plane, later).

