### PR TITLE
Attach the app to the engine: transport, restore gates, and the flag (#386, 2/3)

### DIFF
--- a/server/db/instanceId.ts
+++ b/server/db/instanceId.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// A stable identity for THIS Lurker database.
+//
+// Engine connection ids are `<instance>:<userId>:<networkId>`, and userId and
+// networkId are rowids — unique in one database and meaningless outside it. Two
+// Lurker instances pointed at one engine would otherwise both mint `1:1` for
+// unrelated people, and the engine's dial check cannot tell them apart because
+// two users on the same popular network dial the identical host/port/tls. That
+// is how IRCCloud exposed logs across accounts in July 2020: two connection
+// servers issuing ids in one id space.
+//
+// It lives in the DATABASE, not in an env var or a file beside it, because the
+// thing it namespaces IS the database's rowid sequence. Restore this database
+// somewhere else and the identity travels with the rows it describes — which is
+// what you want: those really are the same connections. Point a second, DIFFERENT
+// database at the same engine and it gets its own.
+//
+// Generated once, then never changes. It is not a secret: it names a namespace,
+// it does not protect one (LURKER_ENGINE_SECRET does that).
+
+import { randomBytes } from 'node:crypto';
+import db from './index.js';
+
+const KEY = 'engine_instance_id';
+
+let cached: string | null = null;
+
+function read(): string | null {
+  const row = db.prepare('SELECT value FROM app_meta WHERE key = ?').get(KEY) as
+    | { value: string }
+    | undefined;
+  return row?.value || null;
+}
+
+export function instanceId(): string {
+  if (cached) return cached;
+  const existing = read();
+  if (existing) return (cached = existing);
+  // DO NOTHING + re-read rather than a bare INSERT: a deploy can briefly run two
+  // processes against this file, and both would generate. The one that loses the
+  // insert must adopt the winner's value, not its own — two ids for one database
+  // is the very collision this exists to prevent.
+  db.prepare('INSERT INTO app_meta (key, value) VALUES (?, ?) ON CONFLICT (key) DO NOTHING').run(
+    KEY,
+    randomBytes(16).toString('hex'),
+  );
+  const settled = read();
+  if (!settled) throw new Error('could not establish an instance id');
+  return (cached = settled);
+}
+
+// Tests only: forget the memoised value so a fresh scratch database is picked up.
+export function resetInstanceIdForTests(): void {
+  cached = null;
+}

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -748,6 +748,45 @@ export function hasMessageForTarget(networkId: number, target: string): boolean 
   return !!db.prepare('SELECT 1 FROM messages WHERE buffer_id = ? LIMIT 1').get(bufferId);
 }
 
+// Whether a row with this server-assigned msgid already exists on the network.
+// Used by the engine-mode catch-up window (ircConnection.catchingUp): a line the
+// previous process persisted but had not yet acked when it died is delivered
+// again to its successor, and the msgid is the only thing that says so. Index
+// seek on idx_messages_msgid.
+const hasMsgidStmt = db.prepare(
+  'SELECT 1 FROM messages WHERE network_id = ? AND msgid = ? LIMIT 1',
+);
+export function hasMessageWithMsgid(networkId: number, msgid: string): boolean {
+  if (!networkId || !msgid) return false;
+  return !!hasMsgidStmt.get(networkId, msgid);
+}
+
+// The msgid-less version of the same question, for networks that don't tag
+// messages (Libera, OFTC, ZNC…): the same target, sender, kind and text within
+// a short window of the same time. Only ever consulted in the catch-up window,
+// where a repeat means a re-delivery, not a user saying the same thing twice.
+const hasLikeStmt = db.prepare(
+  `SELECT 1 FROM messages
+   WHERE network_id = ? AND target = ? AND type = ? AND nick IS ? AND text IS ?
+     AND time BETWEEN ? AND ? LIMIT 1`,
+);
+export function hasRecentMessageLike(
+  networkId: number,
+  target: string,
+  type: string,
+  nick: string | null,
+  text: string | null,
+  time: string,
+  toleranceMs = 5000,
+): boolean {
+  if (!networkId || !target) return false;
+  const t = Date.parse(time);
+  if (!Number.isFinite(t)) return false;
+  const lo = new Date(t - toleranceMs).toISOString();
+  const hi = new Date(t + toleranceMs).toISOString();
+  return !!hasLikeStmt.get(networkId, target, type, nick, text, lo, hi);
+}
+
 // Whether a target has a real (non-notice) conversation — at least one PRIVMSG or
 // ACTION. NOTICE-only buffers (services like NickServ/ChanServ, which now get a
 // buffer of their own, #439) are NOT conversations: presence-tracking keys off

--- a/server/server.ts
+++ b/server/server.ts
@@ -13,6 +13,12 @@ import http from 'http';
 
 import { buildApp } from './app.js';
 import ircManager from './services/ircManager.js';
+import {
+  EngineLink,
+  engineConfigured,
+  startEngineLink,
+  stopEngineLink,
+} from './services/engineLink.js';
 import { attachWsHub } from './services/wsHub.js';
 import './services/verbs/index.js';
 import { getNodeSecret } from './middleware/nodeAuth.js';
@@ -106,7 +112,22 @@ if (isNodeMode() && !nodeUploadConfigured()) {
     '[lurker] node edition is active but LURKER_NODE_UPLOAD_URL / LURKER_NODE_UPLOAD_API_KEY are unset — image and text uploads will fail (400) until they are configured',
   );
 }
-if (isNodeMode() && !isIdentdEnabled() && !isOidentdFileEnabled()) {
+// Engine mode (LURKER_ENGINE_URL): the IRC sockets live in a separate process
+// that survives this one. Start the link now; NOT awaited, so a down engine
+// can't hold the HTTP listener hostage — connections simply wait for it. A
+// refusal (wrong secret, protocol major) turns engine mode off for this run,
+// loudly, whenever it happens; identd then has to start here after all.
+if (engineConfigured()) {
+  void startEngineLink();
+  EngineLink.shared().once('refused', () => {
+    console.warn(
+      '[lurker] engine refused — starting the ident services in this process instead. Note that :113 is normally published on the engine container, so they may not be reachable until the engine is fixed.',
+    );
+    startIdentServices();
+  });
+}
+
+if (isNodeMode() && !engineConfigured() && !isIdentdEnabled() && !isOidentdFileEnabled()) {
   console.warn(
     '[lurker] node edition is active but neither LURKER_IDENTD_ENABLED nor LURKER_OIDENTD_FILE is set — IRC networks cannot attribute individual users; they will appear with an unverified ~ident behind the cell IP',
   );
@@ -145,23 +166,22 @@ startEventLoopMonitor();
 // Built-in identd (opt-in via LURKER_IDENTD_ENABLED). A multi-user gateway
 // needs it so IRC networks can attribute each user behind the shared IP; bind
 // it before connections register their idents.
-if (isIdentdEnabled()) {
-  startIdentd(identdPort(), identdBindHost());
-}
-
-// Alternative ident delivery: instead of binding :113 ourselves, maintain an
-// oidentd config file for a host-installed ident daemon (opt-in via
-// LURKER_OIDENTD_FILE). Write the initial (empty) file before initAll connects
-// networks, so a stale file from a prior run can't serve dead mappings. The two
-// modes are independent; running both is usually a misconfiguration, so warn.
-if (isOidentdFileEnabled()) {
-  if (isIdentdEnabled()) {
-    console.warn(
-      '[lurker] both LURKER_IDENTD_ENABLED and LURKER_OIDENTD_FILE are set — Lurker will bind :113 AND maintain the oidentd file; running both is usually unintended, pick one',
-    );
+// In engine mode the engine answers :113 (the socket 4-tuples are its), so
+// both ident modes are its to run; the same variables on this process are
+// ignored rather than fought over — unless the engine refuses us later, in
+// which case they start here then (see the 'refused' hook above).
+function startIdentServices(): void {
+  if (isIdentdEnabled()) startIdentd(identdPort(), identdBindHost());
+  if (isOidentdFileEnabled()) {
+    if (isIdentdEnabled()) {
+      console.warn(
+        '[lurker] both LURKER_IDENTD_ENABLED and LURKER_OIDENTD_FILE are set — Lurker will bind :113 AND maintain the oidentd file; running both is usually unintended, pick one',
+      );
+    }
+    initOidentdFile();
   }
-  initOidentdFile();
 }
+if (!engineConfigured()) startIdentServices();
 
 // Parse any native push credentials now, so a misconfiguration is a failed boot
 // with a name attached rather than a silent non-delivery. Unset is normal and
@@ -247,6 +267,7 @@ function shutdown(signal: string): void {
   stopIgnoreSweeper();
   stopEventLoopMonitor();
   ircManager.shutdown();
+  stopEngineLink();
   server.close(() => process.exit(0));
   setTimeout(() => process.exit(1), 5000).unref();
 }

--- a/server/services/engineIntegration.test.ts
+++ b/server/services/engineIntegration.test.ts
@@ -29,7 +29,12 @@ import { IrcConnection } from './ircConnection.js';
 import ircManager from './ircManager.js';
 import { EngineServer } from '../engine/server.js';
 import { FakeIrcd } from '../test-utils/fakeIrcd.js';
-import { EngineLink, engineConfigured } from './engineLink.js';
+import {
+  EngineLink,
+  engineConfigured,
+  engineConnectionId,
+  isOurConnectionId,
+} from './engineLink.js';
 
 const SECRET = 'integration-secret';
 
@@ -105,7 +110,7 @@ beforeAll(async () => {
     // the client sent — so "the connect commands ran" is a wire fact.
     connect_commands: 'PING connectcmd',
   })!;
-  engineId = `${userId}:${network.id}`;
+  engineId = engineConnectionId(userId, network.id);
   ircManager.on('event', (e: Ev) => managerEvents.push(e));
 });
 
@@ -439,6 +444,37 @@ describe('IrcConnection through the engine', () => {
     const fresh = ircManager.startNetwork(userId, network.id)!;
     await until(() => fresh.state === 'connected', 8000, 'fresh connection for the next test');
   }, 30000);
+
+  // The app half of the instance partition. The engine refuses cross-instance
+  // work (server/engine/engine.test.ts), but the id has to carry the namespace
+  // in the first place, and reconciliation has to refuse to parse a foreign one
+  // into this database's rowids.
+  it('namespaces connection ids by instance and never adopts a foreign one', async () => {
+    // Not `1:1` — the bare rowid pair every other Lurker would also mint.
+    expect(engineId).toMatch(/^[0-9a-f]{32}:\d+:\d+$/);
+    expect(engineId.endsWith(`:${userId}:${network.id}`)).toBe(true);
+    expect(isOurConnectionId(engineId)).toBe(true);
+
+    // Same rowids, different database.
+    const foreign = `${'f'.repeat(32)}:${userId}:${network.id}`;
+    expect(isOurConnectionId(foreign)).toBe(false);
+
+    // A foreign id in the held list must not be parsed into our rowids and
+    // adopted (or closed) as though it named one of our networks.
+    const link = EngineLink.shared();
+    const heldSet = (link as unknown as { heldSet: Set<string> }).heldSet;
+    heldSet.add(foreign);
+    try {
+      const before = ircManager.getConnection(userId, network.id);
+      ircManager.reconcileEngine();
+      // Untouched: not adopted, and still on the engine's books as far as we
+      // are concerned — we simply have no business with it.
+      expect(ircManager.getConnection(userId, network.id)).toBe(before);
+      expect(heldSet.has(foreign)).toBe(true);
+    } finally {
+      heldSet.delete(foreign);
+    }
+  });
 
   it('ircManager.shutdown() detaches; dispose still QUITs', async () => {
     ircManager.shutdown();

--- a/server/services/engineIntegration.test.ts
+++ b/server/services/engineIntegration.test.ts
@@ -1,0 +1,417 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The whole stack in one process: a real IrcConnection with a real (scratch)
+// database, through the engine, against the fake ircd — then a SECOND
+// IrcConnection attached to the socket the first one left behind. This is the
+// test the plan calls the killer: a redeploy is, to the engine, exactly "dispose
+// one IrcConnection, build another".
+//
+// What must be true afterwards, and is asserted here:
+//   - the network saw one registration, and no NICK/USER/CAP after the restart;
+//   - the restore wrote NO history (no "Connecting…", no MOTD, no own-join row,
+//     no "Connected as"), while everything that happened during the gap did
+//     land — once, in order, with a KICK from the gap honoured;
+//   - the connect commands did not run again and the autojoin list was not
+//     re-JOINed (a channel we were kicked from stays left);
+//   - losing the link to the engine re-attaches without a 'disconnected' state
+//     or an error row; shutdown detaches; dispose still QUITs.
+
+// MUST be first: redirects DATABASE_PATH before anything opens the db.
+import '../test-utils/isolateDb.js';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import db from '../db/index.js';
+import { createUser } from '../db/users.js';
+import { createNetwork } from '../db/networks.js';
+import { setUserPaused } from '../db/users.js';
+import type { Network } from '../db/networks.js';
+import { IrcConnection } from './ircConnection.js';
+import ircManager from './ircManager.js';
+import { EngineServer } from '../engine/server.js';
+import { FakeIrcd } from '../test-utils/fakeIrcd.js';
+import { EngineLink, engineConfigured } from './engineLink.js';
+
+const SECRET = 'integration-secret';
+
+let ircd: FakeIrcd;
+let engine: EngineServer;
+let network: Network;
+let userId: number;
+let engineId: string;
+
+type Ev = Record<string, unknown>;
+const managerEvents: Ev[] = [];
+
+interface Row {
+  id: number;
+  type: string;
+  target: string;
+  text: string | null;
+  nick: string | null;
+}
+const rows = (): Row[] =>
+  db
+    .prepare('SELECT id, type, target, text, nick FROM messages WHERE network_id = ? ORDER BY id')
+    .all(network.id) as Row[];
+
+function until(pred: () => boolean, ms = 5000, what = 'condition'): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + ms;
+    const tick = () => {
+      if (pred()) return resolve();
+      if (Date.now() > deadline) {
+        const conn = ircManager.getConnection(userId, network.id);
+        return reject(
+          new Error(
+            `timed out waiting for ${what}; conn.state=${conn?.state} link=${EngineLink.shared().state} states=${JSON.stringify(stateEvents(managerEvents))} held=${engine.held()}`,
+          ),
+        );
+      }
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+beforeAll(async () => {
+  ircd = await FakeIrcd.start();
+  engine = new EngineServer({
+    secret: SECRET,
+    bufferBytes: 64 * 1024,
+    bufferTotalBytes: 1024 * 1024,
+    version: 'test',
+    log: () => {},
+  });
+  const { port } = await engine.listen(0, '127.0.0.1');
+  process.env.LURKER_ENGINE_URL = `tcp://127.0.0.1:${port}`;
+  process.env.LURKER_ENGINE_SECRET = SECRET;
+  process.env.LURKER_ENGINE_RETRY_BASE_MS = '100';
+  // A full-suite CI run starves the event loop; keep the link's heartbeat well
+  // clear of the run so it can't drop a healthy idle link mid-test.
+  process.env.LURKER_ENGINE_HEARTBEAT_MS = '600000';
+  EngineLink.resetForTests();
+  if (!engineConfigured()) throw new Error('engine mode did not switch on');
+
+  const user = createUser('engine-int');
+  userId = user.id;
+  network = createNetwork(user.id, {
+    name: 'engine-int',
+    host: '127.0.0.1',
+    port: ircd.port,
+    tls: 0,
+    nick: 'lurk',
+    autoconnect: 0,
+    // A raw line the fake ircd answers harmlessly, and that is visible in what
+    // the client sent — so "the connect commands ran" is a wire fact.
+    connect_commands: 'PING connectcmd',
+  })!;
+  engineId = `${userId}:${network.id}`;
+  ircManager.on('event', (e: Ev) => managerEvents.push(e));
+});
+
+afterAll(async () => {
+  ircManager.shutdown();
+  EngineLink.resetForTests();
+  await engine.shutdown('tests done', 500);
+  await ircd.close();
+  delete process.env.LURKER_ENGINE_URL;
+  delete process.env.LURKER_ENGINE_SECRET;
+  delete process.env.LURKER_ENGINE_RETRY_BASE_MS;
+  delete process.env.LURKER_ENGINE_HEARTBEAT_MS;
+});
+
+const sentBy = (nick: string) => ircd.client(nick)?.sent ?? [];
+const stateEvents = (events: Ev[]) =>
+  events.filter((e) => e.type === 'state').map((e) => e.state as string);
+
+describe('IrcConnection through the engine', () => {
+  let rowsBeforeDetach = 0;
+  let sentBeforeDetach = 0;
+
+  it('connects, persists, joins and runs its connect commands like a socket would', async () => {
+    const events: Ev[] = [];
+    const conn = new IrcConnection({ network, onEvent: (e) => events.push(e as Ev) });
+    conn.connect();
+    await until(() => conn.state === 'connected', 5000, 'connected');
+    await until(() => sentBy('lurk').includes('PING connectcmd'), 5000, 'connect command');
+    conn.join('#stay');
+    conn.join('#gone');
+    await until(
+      () => conn.isChannelJoined('#stay') && conn.isChannelJoined('#gone'),
+      5000,
+      'joins',
+    );
+    // Normal history: the connecting notice, the MOTD, our own joins.
+    const types = rows().map((r) => r.type);
+    expect(types).toContain('notice');
+    expect(types).toContain('motd');
+    expect(rows().filter((r) => r.type === 'join' && r.nick === 'lurk')).toHaveLength(2);
+    expect(
+      rows().some((r) => r.type === 'notice' && (r.text ?? '').startsWith('Connecting to ')),
+    ).toBe(true);
+    expect(ircd.registrations.filter((r) => r.nick === 'lurk')).toHaveLength(1);
+    expect(stateEvents(events)).toContain('connected');
+
+    // The app "shuts down": detach, never QUIT.
+    rowsBeforeDetach = rows().length;
+    sentBeforeDetach = sentBy('lurk').length;
+    conn.detach();
+    await until(() => conn.state === 'disconnected', 5000, 'detached');
+    expect(engine.held()).toContain(engineId);
+    expect(ircd.client('lurk')).toBeDefined();
+    // Nothing more went to the wire from the dead process — in particular no QUIT.
+    expect(sentBy('lurk').slice(sentBeforeDetach)).toEqual([]);
+  }, 20000);
+
+  it('a new IrcConnection re-attaches with no new history and no re-registration', async () => {
+    // Life while the app is away.
+    ircd.kick('#gone', 'lurk');
+    ircd.say('peer', '#stay', 'while away');
+    ircd.say('peer', 'lurk', 'dm while away');
+    await new Promise((r) => setTimeout(r, 30));
+    managerEvents.length = 0;
+
+    // Through ircManager this time, so the autojoin listener is on.
+    const conn = ircManager.startNetwork(userId, network.id)!;
+    expect(conn).toBeTruthy();
+    await until(() => conn.state === 'connected', 5000, 'reattached');
+    await until(() => rows().length >= rowsBeforeDetach + 3, 5000, 'backlog persisted');
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The gap's messages — the deterministic part — persisted once each, in
+    // order, with no re-registration and no duplication. (Two things here are
+    // deliberately NOT pinned, because they race on a sub-second window and are
+    // covered elsewhere: whether the restore re-requests channel state and
+    // surfaces transient MODE/WHO `motd` rows, exactly as a normal reconnect
+    // does; and whether the self-KICK for #gone persists a row, which depends on
+    // whether the engine had already reconciled #gone out of the replay when the
+    // app attached. What must never happen — the #829 property — is a duplicate.)
+    const added = rows().slice(rowsBeforeDetach);
+    const messages = added.filter((r) => r.type === 'message');
+    expect(messages.map((r) => [r.target, r.text])).toEqual([
+      ['#stay', 'while away'],
+      ['peer', 'dm while away'],
+    ]);
+    // No substantive line delivered twice by an at-least-once hand-over.
+    const keys = added
+      .filter((r) => r.type === 'message' || r.type === 'kick')
+      .map((r) => `${r.type}:${r.target}:${r.text}`);
+    expect(new Set(keys).size).toBe(keys.length);
+    // If a kick row landed at all, it is #gone's — never a stray.
+    expect(added.filter((r) => r.type === 'kick').every((r) => r.target === '#gone')).toBe(true);
+
+    // Live state came from the replay.
+    expect(conn.currentNick).toBe('lurk');
+    expect(conn.isChannelJoined('#stay')).toBe(true);
+    expect(conn.isChannelJoined('#gone')).toBe(false);
+    expect(stateEvents(managerEvents)).toContain('connected');
+    expect(stateEvents(managerEvents)).not.toContain('disconnected');
+
+    // The network saw: MODE/NAMES/TOPIC for the synthesised join, nothing else.
+    // No registration, no connect command, no JOIN of the autojoin list.
+    expect(ircd.registrations.filter((r) => r.nick === 'lurk')).toHaveLength(1);
+    const since = sentBy('lurk').slice(sentBeforeDetach);
+    expect(since.some((l) => /^(NICK|USER|CAP|JOIN) /.test(l))).toBe(false);
+    expect(since.filter((l) => /^(MODE|NAMES|TOPIC) #stay$/.test(l))).toHaveLength(3);
+    expect(since.filter((l) => l === 'PING connectcmd')).toHaveLength(0);
+    expect(ircd.client('lurk')!.channels.has('#gone')).toBe(false);
+
+    // And it is a working connection.
+    conn.say('#stay', 'back');
+    await ircd.waitForLine((l) => /^PRIVMSG #stay :?back$/.test(l));
+  }, 20000);
+
+  it('losing the link to the engine re-attaches without a disconnect', async () => {
+    const conn = ircManager.getConnection(userId, network.id)!;
+    managerEvents.length = 0;
+    const rowsBefore = rows().length;
+    const sentBefore = sentBy('lurk').length;
+    EngineLink.shared().simulateLoss();
+    // The whole cycle can finish inside one poll interval, so read the trail of
+    // state events rather than sampling conn.state.
+    await until(
+      () => {
+        const trail = stateEvents(managerEvents);
+        return (
+          trail.includes('reconnecting') &&
+          trail.lastIndexOf('connected') > trail.indexOf('reconnecting')
+        );
+      },
+      5000,
+      'reconnecting → connected',
+    );
+    expect(conn.state).toBe('connected');
+    await new Promise((r) => setTimeout(r, 50));
+    expect(stateEvents(managerEvents)).not.toContain('disconnected');
+    expect(
+      rows()
+        .slice(rowsBefore)
+        .filter((r) => r.type === 'error' || r.type === 'notice'),
+    ).toEqual([]);
+    expect(ircd.registrations.filter((r) => r.nick === 'lurk')).toHaveLength(1);
+    expect(
+      sentBy('lurk')
+        .slice(sentBefore)
+        .some((l) => /^(NICK|USER|CAP|QUIT) /.test(l)),
+    ).toBe(false);
+    ircd.say('peer', '#stay', 'after link loss');
+    await until(
+      () => rows().some((r) => r.text === 'after link loss'),
+      5000,
+      'message after re-attach',
+    );
+  }, 20000);
+
+  it('skips a msgid it already has during catch-up, and only then', async () => {
+    const conn = ircManager.getConnection(userId, network.id)!;
+    expect(conn.state).toBe('connected');
+    const feed = (msgid: string, text: string) =>
+      conn.client.connection.addReadBuffer(
+        `@msgid=${msgid} :peer!~peer@peer.fake PRIVMSG #stay :${text}`,
+      );
+    const count = (text: string) => rows().filter((r) => r.text === text).length;
+    // The hand-over window: the same line twice is one row.
+    conn.catchingUp = true;
+    feed('dup-1', 'seen twice in catch-up');
+    feed('dup-1', 'seen twice in catch-up');
+    expect(count('seen twice in catch-up')).toBe(1);
+    // Steady state: no lookup, a server never repeats a msgid anyway.
+    conn.catchingUp = false;
+    feed('dup-2', 'steady state');
+    feed('dup-2', 'steady state');
+    expect(count('steady state')).toBe(2);
+    // And catch-up never drops a line it has NOT seen.
+    conn.catchingUp = true;
+    feed('fresh-1', 'new in catch-up');
+    expect(count('new in catch-up')).toBe(1);
+    conn.catchingUp = false;
+  });
+
+  it('restartNetwork dials afresh: no restore of the quitting session, no reconnect row', async () => {
+    const before = ircManager.getConnection(userId, network.id)!;
+    expect(before.state).toBe('connected');
+    const rowsBefore = rows().length;
+    managerEvents.length = 0;
+    const conn = ircManager.restartNetwork(userId, network.id, 'restart in test')!;
+    expect(conn).not.toBe(before);
+    await until(() => conn.state === 'connected', 5000, 'reconnected after restart');
+    await until(
+      () => ircd.registrations.filter((r) => r.nick === 'lurk').length === 2,
+      5000,
+      'second registration',
+    );
+    const trail = stateEvents(managerEvents);
+    expect(trail).not.toContain('reconnecting');
+    const since = rows().slice(rowsBefore);
+    // A fresh dial announces itself and reads the MOTD; nothing says "Reconnecting".
+    expect(
+      since.some((r) => r.type === 'notice' && (r.text ?? '').startsWith('Connecting to ')),
+    ).toBe(true);
+    expect(since.some((r) => (r.text ?? '').startsWith('Reconnecting in '))).toBe(false);
+    expect(since.some((r) => r.type === 'error')).toBe(false);
+    conn.join('#stay');
+    await until(() => conn.isChannelJoined('#stay'), 5000, 'rejoined #stay');
+  }, 20000);
+
+  it('a disconnect during a link outage ends our side and does not come back when the link does', async () => {
+    const conn = ircManager.getConnection(userId, network.id)!;
+    expect(conn.state).toBe('connected');
+    EngineLink.shared().simulateLoss();
+    await until(() => conn.state !== 'connected', 5000, 'noticed the loss');
+    ircManager.stopNetwork(userId, network.id, 'user clicked disconnect');
+    expect(ircManager.getConnection(userId, network.id)).toBeNull();
+    expect(conn.state).toBe('disconnected');
+    await until(() => EngineLink.shared().state === 'ready', 5000, 'link back');
+    // The close that could not leave during the outage goes out the moment the
+    // link is back — before reconcile could adopt the socket — so nothing
+    // resurrects it, and the next start is a fresh dial.
+    await until(() => !engine.held().includes(engineId), 5000, 'deferred close delivered');
+    expect(ircManager.getConnection(userId, network.id)).toBeNull();
+    const registrationsBefore = ircd.registrations.length;
+    const again = ircManager.startNetwork(userId, network.id)!;
+    await until(() => again.state === 'connected', 5000, 'redialed after user disconnect');
+    expect(ircd.registrations.length).toBe(registrationsBefore + 1);
+    again.join('#stay');
+    await until(() => again.isChannelJoined('#stay'), 5000, 'back in #stay');
+  }, 20000);
+
+  it('a held connection nobody autoconnects is adopted on boot; a paused account gets closed', async () => {
+    const conn = ircManager.getConnection(userId, network.id)!;
+    expect(conn.state).toBe('connected');
+    // "Deploy": shutdown detaches, and a fresh process boots with a fresh link.
+    ircManager.shutdown();
+    expect(engine.held()).toContain(engineId);
+    EngineLink.resetForTests();
+    EngineLink.shared().start();
+    await until(() => EngineLink.shared().state === 'ready', 5000, 'new link ready');
+    managerEvents.length = 0;
+    const rowsBefore = rows().length;
+    // autoconnect is 0 on this network, so initAll starts nothing itself…
+    ircManager.initAll();
+    // …and reconcile adopts what the engine kept.
+    const adopted = ircManager.getConnection(userId, network.id);
+    expect(adopted).not.toBeNull();
+    await until(() => adopted!.state === 'connected', 5000, 'adopted connection attached');
+    expect(
+      rows()
+        .slice(rowsBefore)
+        .some((r) => (r.text ?? '').startsWith('Connecting to ')),
+    ).toBe(false);
+
+    // Same again, but the account is paused now: policy says close, not adopt.
+    ircManager.shutdown();
+    expect(engine.held()).toContain(engineId);
+    setUserPaused(userId, true);
+    try {
+      EngineLink.resetForTests();
+      EngineLink.shared().start();
+      await until(() => EngineLink.shared().state === 'ready', 5000, 'link ready again');
+      ircManager.initAll();
+      expect(ircManager.getConnection(userId, network.id)).toBeNull();
+      await until(
+        () => !engine.held().includes(engineId),
+        5000,
+        "engine closed the paused account's socket",
+      );
+      await until(() => ircd.client('lurk') === undefined, 5000, 'ircd saw it go');
+    } finally {
+      setUserPaused(userId, false);
+    }
+    // Leave a live connection behind for the last test.
+    const fresh = ircManager.startNetwork(userId, network.id)!;
+    await until(() => fresh.state === 'connected', 5000, 'fresh connection for the next test');
+  }, 30000);
+
+  it('a buffer closed while the link was down is PARTed on re-attach, not re-armed', async () => {
+    const conn = ircManager.getConnection(userId, network.id)!;
+    expect(conn.state).toBe('connected');
+    conn.join('#leaving');
+    await until(() => conn.isChannelJoined('#leaving'), 5000, 'joined #leaving');
+    EngineLink.shared().simulateLoss();
+    await until(() => conn.state !== 'connected', 5000, 'noticed the loss');
+    // The user closes the buffer while cut off: autojoin drops, the PART is
+    // silently lost by irc-framework's disconnected write().
+    ircManager.partChannel(userId, network.id, '#leaving');
+    await until(() => conn.state === 'connected', 8000, 'reattached');
+    await until(() => !ircd.client('lurk')!.channels.has('#leaving'), 5000, 'the late PART landed');
+    expect(conn.isChannelJoined('#leaving')).toBe(false);
+    expect(conn.isChannelJoined('#stay')).toBe(true);
+  }, 20000);
+
+  it('ircManager.shutdown() detaches; dispose still QUITs', async () => {
+    ircManager.shutdown();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(engine.held()).toContain(engineId);
+    expect(ircd.client('lurk')).toBeDefined();
+    expect(sentBy('lurk').some((l) => l.startsWith('QUIT'))).toBe(false);
+
+    const conn = ircManager.startNetwork(userId, network.id)!;
+    await until(() => conn.state === 'connected', 5000, 'reattached after shutdown');
+    // Hold the record: once the socket is gone, client() no longer finds it.
+    const record = ircd.client('lurk')!;
+    ircManager.disposeNetwork(userId, network.id, 'removed in test');
+    await until(() => !engine.held().includes(engineId), 5000, 'engine released the socket');
+    expect(record.sent.some((l) => l === 'QUIT :removed in test')).toBe(true);
+    await until(() => ircd.client('lurk') === undefined, 5000, 'ircd saw the quit');
+  }, 20000);
+});

--- a/server/services/engineIntegration.test.ts
+++ b/server/services/engineIntegration.test.ts
@@ -398,6 +398,48 @@ describe('IrcConnection through the engine', () => {
     expect(conn.isChannelJoined('#stay')).toBe(true);
   }, 20000);
 
+  // The window Copilot's review on #829 pointed at: reconcileEngine checks the
+  // link is ready at the top of its loop, but the link can die inside it. A
+  // bare send() would drop the close on the floor and the paused account would
+  // stay on IRC until something else happened to reconcile again.
+  //
+  // simulateLoss() destroys the socket synchronously while `state` is still
+  // 'ready', which is exactly that window, and nothing here calls initAll(), so
+  // no second reconcile on the next 'ready' can paper over a lost close.
+  it('a reconcile close issued as the link dies is queued, not lost', async () => {
+    const conn = ircManager.getConnection(userId, network.id)!;
+    expect(conn.state).toBe('connected');
+    // Detach, so the engine holds the socket with no live transport in the way.
+    ircManager.shutdown();
+    await until(() => engine.held().includes(engineId), 5000, 'engine holds the detached socket');
+
+    setUserPaused(userId, true);
+    try {
+      EngineLink.resetForTests();
+      const link = EngineLink.shared();
+      link.start();
+      await until(() => link.state === 'ready', 5000, 'link ready');
+      expect(link.held).toContain(engineId);
+
+      link.simulateLoss();
+      expect(link.state).toBe('ready'); // the control: still inside the window
+      ircManager.reconcileEngine();
+
+      await until(() => link.state === 'ready', 8000, 'link back');
+      await until(
+        () => !engine.held().includes(engineId),
+        8000,
+        'the queued close reached the engine',
+      );
+      await until(() => ircd.client('lurk') === undefined, 5000, 'ircd saw it go');
+    } finally {
+      setUserPaused(userId, false);
+    }
+    // Leave a live connection behind for the last test.
+    const fresh = ircManager.startNetwork(userId, network.id)!;
+    await until(() => fresh.state === 'connected', 8000, 'fresh connection for the next test');
+  }, 30000);
+
   it('ircManager.shutdown() detaches; dispose still QUITs', async () => {
     ircManager.shutdown();
     await new Promise((r) => setTimeout(r, 50));

--- a/server/services/engineLink.ts
+++ b/server/services/engineLink.ts
@@ -21,6 +21,7 @@
 import net from 'node:net';
 import { EventEmitter } from 'node:events';
 import { FrameReader, PROTOCOL_MAJOR, encodeFrame, parseHostPort } from '../engine/protocol.js';
+import { instanceId } from '../db/instanceId.js';
 import type { AppToEngine, EngineToApp } from '../engine/protocol.js';
 import { APP_VERSION } from '../utils/userAgent.js';
 
@@ -29,8 +30,19 @@ const PROCESS_STARTED_AT = Date.now();
 
 // The id the engine knows a network's socket by. One definition, so the two
 // sides of every comparison agree.
+// `<instance>:<userId>:<networkId>`. The instance prefix is not decoration: the
+// two rowids are unique within ONE Lurker database and collide freely across
+// two, so without it a second Lurker on the same engine mints the same id for a
+// different person's connection. Every caller goes through this function, which
+// is the point — none of them can forget the prefix.
 export function engineConnectionId(userId: number, networkId: number): string {
-  return `${userId}:${networkId}`;
+  return `${instanceId()}:${userId}:${networkId}`;
+}
+
+// Does this id belong to us? Used where an id comes back FROM the engine rather
+// than being minted here.
+export function isOurConnectionId(id: string): boolean {
+  return id.startsWith(`${instanceId()}:`);
 }
 
 let urlWarned = false;
@@ -311,6 +323,7 @@ export class EngineLink extends EventEmitter {
           op: 'hello',
           protocol: PROTOCOL_MAJOR,
           secret: this.opts.secret,
+          instance: instanceId(),
           app: { version: APP_VERSION, startedAt: PROCESS_STARTED_AT },
         }),
       );

--- a/server/services/engineLink.ts
+++ b/server/services/engineLink.ts
@@ -1,0 +1,468 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The app's one link to the IRC engine (server/engine.ts). Engine mode is
+// switched on by LURKER_ENGINE_URL, the same way LURKER_PREVIEWS_URL switches on
+// the preview decoder: unset, nothing here runs and the app dials IRC itself.
+//
+// One TCP link per process carries every connection's frames, routed by id to
+// the EngineTransport that claimed it. The link reconnects on its own with a
+// short backoff — the engine being briefly unreachable is not the same as the
+// IRC sockets being gone, and the transports get a chance to re-attach. It also
+// heartbeats: a half-open link (a NAT entry expired under an engine on another
+// host) is noticed in seconds, not when irc-framework's 120 s ping timeout
+// misreads the silence as an IRC disconnect.
+//
+// Two failures are terminal and turn engine mode OFF for the life of the
+// process: a bad secret and a protocol-major mismatch. Both mean the operator
+// has to change something, and a cell with a misconfigured engine must not sit
+// with no IRC at all — it falls back to dialing directly, loudly.
+
+import net from 'node:net';
+import { EventEmitter } from 'node:events';
+import { FrameReader, PROTOCOL_MAJOR, encodeFrame, parseHostPort } from '../engine/protocol.js';
+import type { AppToEngine, EngineToApp } from '../engine/protocol.js';
+import { APP_VERSION } from '../utils/userAgent.js';
+
+// This process's generation, for the engine's newest-wins rule (protocol.ts).
+const PROCESS_STARTED_AT = Date.now();
+
+// The id the engine knows a network's socket by. One definition, so the two
+// sides of every comparison agree.
+export function engineConnectionId(userId: number, networkId: number): string {
+  return `${userId}:${networkId}`;
+}
+
+let urlWarned = false;
+
+// `tcp://host:port`, `host:port`, or the same with a scheme/path an operator
+// might habitually add. Garbage is a null (and one warning), never a throw —
+// this is read at module top level in server.ts.
+export function parseEngineUrl(raw: string | undefined): { host: string; port: number } | null {
+  const s = (raw || '').trim();
+  if (!s) return null;
+  const authority = s
+    .replace(/^[a-z][a-z0-9+.-]*:\/\//i, '')
+    .replace(/[/?#].*$/, '')
+    .trim();
+  try {
+    return parseHostPort(authority, { host: '127.0.0.1', port: 8016 });
+  } catch (err) {
+    if (!urlWarned) {
+      urlWarned = true;
+      console.error(
+        `[lurker] LURKER_ENGINE_URL is not usable (${(err as Error).message}) — engine mode is off; expected tcp://host:port`,
+      );
+    }
+    return null;
+  }
+}
+
+let disabledReason: string | null = null;
+
+export function engineConfigured(): boolean {
+  return disabledReason === null && parseEngineUrl(process.env.LURKER_ENGINE_URL) !== null;
+}
+
+// Fall back to direct dialing for the rest of this process. See the header.
+export function disableEngineMode(reason: string): void {
+  disabledReason = reason;
+}
+
+export function engineDisabledReason(): string | null {
+  return disabledReason;
+}
+
+export type LinkState = 'idle' | 'connecting' | 'ready' | 'down' | 'refused';
+
+export interface FrameHandler {
+  onFrame(frame: EngineToApp): void;
+  // The link itself dropped (not the IRC socket). Handlers are unregistered
+  // before this fires; a transport that wants to come back re-registers.
+  onLost(): void;
+}
+
+function envInt(name: string, fallback: number): number {
+  const n = Number((process.env[name] || '').trim());
+  return Number.isInteger(n) && n > 0 ? n : fallback;
+}
+
+export interface EngineLinkOptions {
+  host: string;
+  port: number;
+  secret: string;
+  retryBaseMs?: number;
+  retryMaxMs?: number;
+  heartbeatMs?: number;
+  log?: (line: string, level?: 'info' | 'warn' | 'error') => void;
+}
+
+const DEFAULT_HEARTBEAT_MS = 15_000;
+
+export class EngineLink extends EventEmitter {
+  state: LinkState = 'idle';
+  engineVersion: string | null = null;
+  refusedReason: string | null = null;
+
+  private socket: net.Socket | null = null;
+  private reader = new FrameReader();
+  private readonly handlers = new Map<string, FrameHandler>();
+  // What the engine holds for us, kept current: seeded by hello, then
+  // maintained from the frames that change it. The labels ("Attaching…" vs
+  // "Starting connection…") and the re-attach decision both read it.
+  private readonly heldSet = new Set<string>();
+  // Closes requested while the link was down. A QUIT that never left is not a
+  // reason to keep the session: they are sent the moment the link is back,
+  // before anyone gets to adopt those sockets.
+  private readonly pendingCloses = new Set<string>();
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private lastFrameAt = 0;
+  private attempt = 0;
+  private stopped = false;
+  private everReady = false;
+  private readonly retryBaseMs: number;
+  private readonly retryMaxMs: number;
+  private readonly heartbeatMs: number;
+  private readonly log: (line: string, level?: 'info' | 'warn' | 'error') => void;
+
+  constructor(readonly opts: EngineLinkOptions) {
+    super();
+    // One waiter per network on whenReady()/awaitSettled(); the default cap
+    // of 10 would warn on the 11th.
+    this.setMaxListeners(0);
+    this.retryBaseMs = opts.retryBaseMs ?? envInt('LURKER_ENGINE_RETRY_BASE_MS', 1000);
+    this.retryMaxMs = opts.retryMaxMs ?? 15_000;
+    this.heartbeatMs =
+      opts.heartbeatMs ?? envInt('LURKER_ENGINE_HEARTBEAT_MS', DEFAULT_HEARTBEAT_MS);
+    this.log =
+      opts.log ??
+      ((line, level = 'info') => {
+        const fn =
+          level === 'error' ? console.error : level === 'warn' ? console.warn : console.log;
+        fn(`[lurker] engine: ${line}`);
+      });
+  }
+
+  private static instance: EngineLink | null = null;
+
+  static shared(): EngineLink {
+    if (!EngineLink.instance) {
+      const url = parseEngineUrl(process.env.LURKER_ENGINE_URL);
+      EngineLink.instance = new EngineLink({
+        host: url?.host ?? '127.0.0.1',
+        port: url?.port ?? 8016,
+        secret: (process.env.LURKER_ENGINE_SECRET || '').trim(),
+      });
+    }
+    return EngineLink.instance;
+  }
+
+  // Tests build engines on ephemeral ports and need a fresh singleton each time.
+  static resetForTests(): void {
+    EngineLink.instance?.stop();
+    EngineLink.instance = null;
+    disabledReason = null;
+  }
+
+  get address(): string {
+    return `${this.opts.host}:${this.opts.port}`;
+  }
+
+  get held(): string[] {
+    return [...this.heldSet];
+  }
+
+  holds(id: string): boolean {
+    return this.heldSet.has(id);
+  }
+
+  start(): void {
+    if (this.stopped || this.state !== 'idle') return;
+    this.connectOnce();
+  }
+
+  // Resolves once the first attempt has an answer (ready / refused / down) or
+  // the timeout passes with it still connecting.
+  awaitSettled(timeoutMs: number): Promise<LinkState> {
+    if (this.state !== 'idle' && this.state !== 'connecting') return Promise.resolve(this.state);
+    return new Promise((resolve) => {
+      const done = () => {
+        clearTimeout(timer);
+        this.off('ready', done);
+        this.off('refused', done);
+        this.off('down', done);
+        resolve(this.state);
+      };
+      const timer = setTimeout(done, timeoutMs);
+      this.on('ready', done);
+      this.on('refused', done);
+      this.on('down', done);
+    });
+  }
+
+  // Wait for the link to be usable. 'refused' is terminal; 'timeout' means the
+  // engine stayed unreachable for the whole window.
+  whenReady(timeoutMs: number): Promise<'ready' | 'refused' | 'timeout'> {
+    if (this.state === 'ready') return Promise.resolve('ready');
+    if (this.state === 'refused') return Promise.resolve('refused');
+    this.start();
+    return new Promise((resolve) => {
+      const finish = (r: 'ready' | 'refused' | 'timeout') => {
+        clearTimeout(timer);
+        this.off('ready', onReady);
+        this.off('refused', onRefused);
+        resolve(r);
+      };
+      const onReady = () => finish('ready');
+      const onRefused = () => finish('refused');
+      const timer = setTimeout(() => finish('timeout'), timeoutMs);
+      this.on('ready', onReady);
+      this.on('refused', onRefused);
+    });
+  }
+
+  register(id: string, handler: FrameHandler): void {
+    this.handlers.set(id, handler);
+  }
+
+  unregister(id: string, handler?: FrameHandler): void {
+    if (!handler || this.handlers.get(id) === handler) this.handlers.delete(id);
+  }
+
+  send(frame: AppToEngine): boolean {
+    if (this.state !== 'ready' || !this.socket || this.socket.destroyed) return false;
+    this.socket.write(encodeFrame(frame));
+    return true;
+  }
+
+  // End an engine-held socket. Sent now if the link is up; otherwise remembered
+  // and sent the moment it is — a user's Disconnect (or a settings change that
+  // needs a fresh dial) during an outage must not quietly become "kept".
+  requestClose(id: string): void {
+    this.heldSet.delete(id);
+    if (!this.send({ op: 'close', id })) this.pendingCloses.add(id);
+  }
+
+  noteDetached(id: string): void {
+    this.heldSet.delete(id);
+  }
+
+  // Test seam: the link dies under a live app.
+  simulateLoss(): void {
+    this.socket?.destroy();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+    this.stopHeartbeat();
+    this.socket?.destroy();
+    this.socket = null;
+  }
+
+  private startHeartbeat(socket: net.Socket): void {
+    this.stopHeartbeat();
+    this.lastFrameAt = Date.now();
+    let lastBeat = Date.now();
+    this.heartbeatTimer = setInterval(() => {
+      if (this.socket !== socket) return this.stopHeartbeat();
+      const now = Date.now();
+      const overran = now - lastBeat > this.heartbeatMs * 2;
+      lastBeat = now;
+      // A beat that fired far later than scheduled means the event loop was
+      // starved, not the link — a stale lastFrameAt would then be OUR fault. Send
+      // a fresh ping and give the peer another interval to answer it, rather than
+      // drop a link that may be perfectly healthy.
+      if (!overran && now - this.lastFrameAt > this.heartbeatMs * 3) {
+        this.log(
+          `no answer from ${this.address} for ${now - this.lastFrameAt}ms — dropping the link`,
+          'warn',
+        );
+        socket.destroy();
+        return;
+      }
+      this.send({ op: 'ping' });
+    }, this.heartbeatMs);
+    this.heartbeatTimer.unref();
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  private connectOnce(): void {
+    this.state = 'connecting';
+    this.reader = new FrameReader();
+    const socket = net.connect(this.opts.port, this.opts.host);
+    this.socket = socket;
+    let sawHello = false;
+    socket.setEncoding('utf8');
+    socket.setKeepAlive(true, 10_000);
+    socket.on('connect', () => {
+      socket.write(
+        encodeFrame({
+          op: 'hello',
+          protocol: PROTOCOL_MAJOR,
+          secret: this.opts.secret,
+          app: { version: APP_VERSION, startedAt: PROCESS_STARTED_AT },
+        }),
+      );
+    });
+    socket.on('data', (chunk: string) => {
+      this.lastFrameAt = Date.now();
+      let frames: EngineToApp[];
+      try {
+        frames = this.reader.push(chunk) as EngineToApp[];
+      } catch (err) {
+        this.log(`dropping link: ${(err as Error).message}`, 'warn');
+        socket.destroy();
+        return;
+      }
+      for (const frame of frames) {
+        if (!sawHello) {
+          if (frame.op === 'hello') {
+            sawHello = true;
+            this.state = 'ready';
+            this.heldSet.clear();
+            for (const id of frame.held) this.heldSet.add(id);
+            this.engineVersion = frame.engine.version;
+            if (this.everReady) {
+              this.log(`link restored to ${this.address} after ${this.attempt} attempt(s)`);
+            }
+            this.everReady = true;
+            this.attempt = 0;
+            this.startHeartbeat(socket);
+            // Closes that never left go out before anyone hears 'ready' and
+            // decides those sockets are worth adopting.
+            for (const id of this.pendingCloses) {
+              this.heldSet.delete(id);
+              this.send({ op: 'close', id });
+            }
+            this.pendingCloses.clear();
+            this.emit('ready');
+            continue;
+          }
+          if (frame.op === 'error') {
+            // Nothing a retry can fix. Engine mode is over for this process:
+            // every connection that fails from here dials IRC directly on its
+            // next attempt, instead of collecting a refusal per backoff tick.
+            this.refusedReason = frame.message;
+            this.state = 'refused';
+            this.stopped = true;
+            disableEngineMode(frame.message);
+            this.log(
+              `refused by ${this.address}: ${frame.message} — falling back to dialing IRC directly`,
+              'error',
+            );
+            this.emit('refused', frame.message);
+            socket.destroy();
+            return;
+          }
+          continue;
+        }
+        this.route(frame);
+      }
+    });
+    socket.on('error', () => {});
+    socket.on('close', () => {
+      if (this.socket !== socket) return;
+      this.socket = null;
+      this.stopHeartbeat();
+      const wasReady = this.state === 'ready';
+      if (this.state !== 'refused') this.state = 'down';
+      if (wasReady) {
+        this.log(
+          `link to ${this.address} lost — holding IRC connections in the engine, re-attaching`,
+          'warn',
+        );
+        const lost = [...this.handlers.values()];
+        this.handlers.clear();
+        this.emit('lost');
+        for (const h of lost) h.onLost();
+      } else if (this.attempt === 0 && this.state === 'down') {
+        this.log(`unreachable at ${this.address} — retrying`, 'warn');
+        this.emit('down');
+      }
+      this.scheduleRetry();
+    });
+  }
+
+  private route(frame: EngineToApp): void {
+    switch (frame.op) {
+      case 'ping':
+        this.send({ op: 'pong' });
+        return;
+      case 'pong':
+        return;
+      case 'attached':
+      case 'open':
+        this.heldSet.add(frame.id);
+        break;
+      case 'closed':
+      case 'detached':
+        this.heldSet.delete(frame.id);
+        break;
+      default:
+        break;
+    }
+    if ('id' in frame && typeof frame.id === 'string') {
+      const h = this.handlers.get(frame.id);
+      if (h) h.onFrame(frame);
+      else if (frame.op !== 'closed' && frame.op !== 'detached') {
+        // A frame for a connection this process never claimed (or has since
+        // released) — the engine's answer to an orphan close, typically.
+        this.emit('unrouted', frame);
+      }
+      return;
+    }
+    this.emit('frame', frame);
+  }
+
+  private scheduleRetry(): void {
+    if (this.stopped || this.retryTimer) return;
+    const delay = Math.min(this.retryBaseMs * 2 ** this.attempt, this.retryMaxMs);
+    this.attempt++;
+    this.retryTimer = setTimeout(
+      () => {
+        this.retryTimer = null;
+        if (!this.stopped) this.connectOnce();
+      },
+      delay + Math.floor(Math.random() * 250),
+    );
+  }
+}
+
+// Boot-time entry point for server.ts: start connecting and log the verdict
+// when it comes. Deliberately not awaited by the caller — a down engine must
+// not hold up the HTTP listener; connections simply wait for the link.
+export function startEngineLink(timeoutMs = 5000): Promise<LinkState> {
+  const link = EngineLink.shared();
+  link.start();
+  return link.awaitSettled(timeoutMs).then((state) => {
+    if (state === 'ready') {
+      console.log(
+        `[lurker] engine mode: attached to ${link.address} (engine ${link.engineVersion}, holding ${link.held.length} connection(s))`,
+      );
+    } else if (state === 'refused') {
+      console.error(
+        `[lurker] engine at ${link.address} refused this app (${link.refusedReason}) — falling back to dialing IRC directly for this run. Fix LURKER_ENGINE_SECRET or update the engine, then restart.`,
+      );
+    } else {
+      console.warn(
+        `[lurker] engine at ${link.address} did not answer within ${timeoutMs}ms — staying in engine mode; IRC connections will open once it is reachable`,
+      );
+    }
+    return state;
+  });
+}
+
+export function stopEngineLink(): void {
+  EngineLink.shared().stop();
+}

--- a/server/services/engineTransport.test.ts
+++ b/server/services/engineTransport.test.ts
@@ -7,6 +7,9 @@
 // registered comes up on the live nick with the live caps, in the live channels,
 // with the backlog delivered after the replay, and the network sees nothing.
 
+// MUST be first: the engine link reads this instance's id from the database
+// (it namespaces every connection id), so importing it opens one.
+import '../test-utils/isolateDb.js';
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import IRC from 'irc-framework';
 import type { Client, ConnectOptions } from 'irc-framework';

--- a/server/services/engineTransport.test.ts
+++ b/server/services/engineTransport.test.ts
@@ -1,0 +1,419 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The engine-backed transport under a real irc-framework Client, against a real
+// engine and a real (fake) ircd — no IrcConnection, no database. What this pins
+// is the RESTORE: a brand-new Client attached to a socket some other Client
+// registered comes up on the live nick with the live caps, in the live channels,
+// with the backlog delivered after the replay, and the network sees nothing.
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import IRC from 'irc-framework';
+import type { Client, ConnectOptions } from 'irc-framework';
+import { EngineServer } from '../engine/server.js';
+import { FakeIrcd } from '../test-utils/fakeIrcd.js';
+import { EngineLink } from './engineLink.js';
+import {
+  ENGINE_CLOSE,
+  EngineTransport,
+  engineCloseCode,
+  sanitizeReplay,
+} from './engineTransport.js';
+import type { EnginePhase, EnginePhaseInfo } from './engineTransport.js';
+
+const SECRET = 'transport-secret';
+
+let ircd: FakeIrcd;
+let engine: EngineServer;
+let enginePort: number;
+const links: EngineLink[] = [];
+const clients: Client[] = [];
+
+beforeAll(async () => {
+  ircd = await FakeIrcd.start();
+  engine = new EngineServer({
+    secret: SECRET,
+    bufferBytes: 4096,
+    bufferTotalBytes: 64 * 1024,
+    version: 'test',
+    log: () => {},
+  });
+  enginePort = (await engine.listen(0, '127.0.0.1')).port;
+});
+
+afterAll(async () => {
+  await engine.shutdown('tests done', 500);
+  await ircd.close();
+});
+
+afterEach(() => {
+  for (const c of clients.splice(0)) {
+    try {
+      c.connection.end();
+    } catch {
+      /* already gone */
+    }
+  }
+  for (const l of links.splice(0)) l.stop();
+});
+
+function newLink(secret = SECRET, port = enginePort): EngineLink {
+  // Long heartbeat: a full-suite CI run starves the event loop enough that a
+  // 15 s beat could otherwise drop a healthy idle link mid-test.
+  const l = new EngineLink({
+    host: '127.0.0.1',
+    port,
+    secret,
+    retryBaseMs: 100,
+    heartbeatMs: 600_000,
+    log: () => {},
+  });
+  links.push(l);
+  return l;
+}
+
+interface Timeline {
+  events: string[];
+  phases: Array<{ phase: EnginePhase; info: EnginePhaseInfo }>;
+  closes: unknown[];
+  transport: EngineTransport | null;
+}
+
+let counter = 0;
+
+// A Client through the engine, with everything it sees written to a timeline.
+function makeClient(link: EngineLink, id: string, nick: string, opts: { timeoutMs?: number } = {}) {
+  const t: Timeline = { events: [], phases: [], closes: [], transport: null };
+  const client = new IRC.Client();
+  clients.push(client);
+  client.requestCap('message-tags');
+  client.requestCap('batch');
+  client.on('registered', (e) => t.events.push(`registered:${e.nick}`));
+  client.on('join', (e) => t.events.push(`join:${e.nick}:${e.channel}`));
+  client.on('nick', (e) => t.events.push(`nick:${e.nick}>${e.new_nick}`));
+  client.on('privmsg', (e) => t.events.push(`privmsg:${e.target}:${e.message}`));
+  client.on('topic', (e) => t.events.push(`topic:${e.channel}:${e.topic}`));
+  client.on('socket close', (err) => {
+    t.events.push(`socket close:${engineCloseCode(err) ?? (err ? 'error' : 'clean')}`);
+    t.closes.push(err);
+  });
+  client.connect({
+    host: '127.0.0.1',
+    port: ircd.port,
+    tls: false,
+    nick,
+    username: nick,
+    gecos: 'transport test',
+    auto_reconnect: false,
+    version: false,
+    transport: EngineTransport,
+    engineConnId: id,
+    engineLink: link,
+    engineConnectTimeoutMs: opts.timeoutMs ?? 3000,
+    engineHooks: {
+      onTransport: (tr: unknown) => {
+        t.transport = tr as EngineTransport;
+      },
+      onPhase: (phase: string, info: Record<string, unknown>) => {
+        t.events.push(`phase:${phase}`);
+        t.phases.push({ phase: phase as EnginePhase, info: info as EnginePhaseInfo });
+      },
+    },
+  } as ConnectOptions);
+  return { client, t };
+}
+
+// Poll for a condition; on timeout, say which one and show the timeline so a
+// failure reads as "never saw X after [...]" rather than a bare 5000ms.
+function until(pred: () => boolean, what: string, dump?: () => unknown, ms = 4000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + ms;
+    const tick = () => {
+      if (pred()) return resolve();
+      if (Date.now() > deadline) {
+        return reject(
+          new Error(`timed out waiting for ${what}; timeline: ${JSON.stringify(dump?.() ?? null)}`),
+        );
+      }
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+describe('EngineTransport', () => {
+  it('dials fresh through the engine and registers like a socket would', async () => {
+    const link = newLink();
+    const id = `t:${++counter}`;
+    const { client, t } = makeClient(link, id, 'fresh');
+    await until(
+      () => t.events.includes('registered:fresh'),
+      't.events.includes("registered:fresh")',
+      () => t.events,
+    );
+    expect(t.phases.map((p) => p.phase)).toEqual(['dialing']);
+    // ISUPPORT (005) lands between 001 and end-of-registration; poll rather than
+    // read synchronously, so a slow run doesn't catch it pre-005.
+    await until(
+      () => client.network.options.NETWORK === 'FakeNet',
+      'NETWORK from ISUPPORT',
+      () => client.network.options,
+    );
+    expect(ircd.registrations.filter((r) => r.nick === 'fresh')).toHaveLength(1);
+  });
+
+  it('restores a new Client onto a socket a dead process registered', async () => {
+    const id = `t:${++counter}`;
+    const linkA = newLink();
+    const a = makeClient(linkA, id, 'orig');
+    await until(
+      () => a.t.events.includes('registered:orig'),
+      'a.t.events.includes("registered:orig")',
+      () => a.t.events,
+    );
+    a.client.join('#one');
+    a.client.join('#two');
+    await until(
+      () => a.t.events.includes('join:orig:#two'),
+      'a.t.events.includes("join:orig:#two")',
+      () => a.t.events,
+    );
+    a.client.changeNick('moved');
+    await until(
+      () => a.t.events.includes('nick:orig>moved'),
+      'a.t.events.includes("nick:orig>moved")',
+      () => a.t.events,
+    );
+    a.client.part('#one');
+    await until(
+      () => ircd.client('moved')!.channels.size === 1,
+      'ircd.client("moved")!.channels.size === 1',
+      undefined,
+    );
+    const capsA = [...a.client.network.cap.enabled].toSorted();
+    expect(capsA.length).toBeGreaterThan(0);
+    const sentBefore = ircd.client('moved')!.sent.length;
+
+    // Process A dies: link destroyed, no detach, no QUIT.
+    linkA.simulateLoss();
+    await until(
+      () => a.t.events.some((e) => e.startsWith('socket close:')),
+      'a.t.events.some((e) => e.startsWith("socket close:"))',
+      () => a.t.events,
+    );
+    expect(a.t.events.at(-1)).toBe(`socket close:${ENGINE_CLOSE.LINK_LOST}`);
+    linkA.stop();
+
+    ircd.say('peer', '#two', 'while away 1');
+    ircd.say('peer', 'moved', 'dm while away');
+    ircd.setTopic('peer', '#two', 'set while away');
+    ircd.say('peer', '#two', 'while away 2');
+
+    // Process B: a fresh Client, configured with the STALE nick.
+    const linkB = newLink();
+    const b = makeClient(linkB, id, 'orig');
+    await until(
+      () => b.t.events.includes('phase:live'),
+      'b.t.events.includes("phase:live")',
+      () => b.t.events,
+    );
+
+    // Registered from the replay, on the live nick, same caps, same ISUPPORT.
+    expect(b.client.user.nick).toBe('moved');
+    expect([...b.client.network.cap.enabled].toSorted()).toEqual(capsA);
+    expect(b.client.network.options.NETWORK).toBe('FakeNet');
+    expect(b.client.network.options.CASEMAPPING).toBe('ascii');
+
+    const attached = b.t.phases.find((p) => p.phase === 'attached')!;
+    expect(attached.info.nick).toBe('moved');
+    expect(attached.info.channels).toEqual(['#two']);
+    const restored = b.t.phases.find((p) => p.phase === 'restored')!;
+    expect(restored.info.swallowed!.map((l) => l.split(' ')[0])).toEqual([
+      'CAP',
+      'NICK',
+      'USER',
+      'CAP',
+      'CAP',
+    ]);
+
+    // Timeline: the replay (registered, nick, join) inside attached..restored;
+    // the backlog after restored, in order; then live.
+    const ev = b.t.events;
+    const idx = (s: string) => ev.indexOf(s);
+    expect(idx('phase:attached')).toBeLessThan(idx('registered:orig'));
+    expect(idx('registered:orig')).toBeLessThan(idx('nick:orig>moved'));
+    expect(idx('nick:orig>moved')).toBeLessThan(idx('join:moved:#two'));
+    expect(idx('join:moved:#two')).toBeLessThan(idx('phase:restored'));
+    const backlog = ev.filter((e) => e.startsWith('privmsg:') || e.startsWith('topic:'));
+    expect(backlog).toEqual([
+      'privmsg:#two:while away 1',
+      'privmsg:moved:dm while away',
+      'topic:#two:set while away',
+      'privmsg:#two:while away 2',
+    ]);
+    expect(idx('phase:restored')).toBeLessThan(idx(backlog[0]));
+    expect(idx(backlog.at(-1)!)).toBeLessThan(idx('phase:live'));
+    expect(ev.filter((e) => e === 'phase:dialing')).toHaveLength(0);
+
+    // The network saw one registration and, since the kill, nothing but the
+    // NAMES/MODE the new Client asked for on its synthesised JOIN — no NICK,
+    // no USER, no CAP.
+    expect(ircd.registrations.filter((r) => r.nick === 'orig')).toHaveLength(1);
+    const since = ircd.client('moved')!.sent.slice(sentBefore);
+    expect(since.some((l) => /^(NICK|USER|CAP) /.test(l))).toBe(false);
+
+    // And it still works as a client: outbound goes to the wire.
+    b.client.say('#two', 'back');
+    // (irc-framework omits the colon when the text has no spaces.)
+    await ircd.waitForLine((l) => /^PRIVMSG #two :?back$/.test(l));
+  }, 20000);
+
+  it('reports a takeover to the old process without a socket close', async () => {
+    const id = `t:${++counter}`;
+    const a = makeClient(newLink(), id, 'shared');
+    await until(
+      () => a.t.events.includes('registered:shared'),
+      'a registered',
+      () => a.t.events,
+    );
+    // Wait until the engine actually holds a's session before contesting it, so
+    // b takes it over rather than fresh-dialing a socket a hasn't finished — or,
+    // under load, has momentarily lost.
+    await until(
+      () => engine.held().includes(id),
+      'engine holds a',
+      () => engine.held(),
+    );
+    const b = makeClient(newLink(), id, 'shared');
+    await until(
+      () => a.t.events.some((e) => e.startsWith('socket close:')),
+      'a hears the takeover',
+      () => ({ a: a.t.events, b: b.t.events }),
+    );
+    expect(a.t.events.at(-1)).toBe(`socket close:${ENGINE_CLOSE.TAKEN_OVER}`);
+    expect(ircd.client('shared')).toBeDefined();
+    expect(engine.held()).toContain(id);
+  });
+
+  it('detach() leaves the socket in the engine and ends cleanly for irc-framework', async () => {
+    const id = `t:${++counter}`;
+    const a = makeClient(newLink(), id, 'leaver');
+    await until(
+      () => a.t.events.includes('registered:leaver'),
+      'a.t.events.includes("registered:leaver")',
+      () => a.t.events,
+    );
+    a.t.transport!.detach();
+    await until(
+      () => a.t.events.some((e) => e.startsWith('socket close:')),
+      'a.t.events.some((e) => e.startsWith("socket close:"))',
+      () => a.t.events,
+    );
+    expect(a.t.events.at(-1)).toBe(`socket close:${ENGINE_CLOSE.DETACHED}`);
+    // The engine processes {op:'detach'} async over the link, so poll rather
+    // than read synchronously right after the local close event.
+    await until(
+      () => engine.held().includes(id),
+      'engine holds after detach',
+      () => engine.held(),
+    );
+    expect(ircd.client('leaver')).toBeDefined();
+    // close() after detach must not reach the engine.
+    a.client.connection.end();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(engine.held()).toContain(id);
+    // The next process finds it.
+    const b = makeClient(newLink(), id, 'leaver');
+    await until(
+      () => b.t.events.includes('phase:live'),
+      'b.t.events.includes("phase:live")',
+      () => b.t.events,
+    );
+    expect(b.client.user.nick).toBe('leaver');
+  });
+
+  it('a gap arrives after the replay and before the surviving backlog', async () => {
+    const id = `t:${++counter}`;
+    const linkA = newLink();
+    const a = makeClient(linkA, id, 'gapper');
+    await until(
+      () => a.t.events.includes('registered:gapper'),
+      'a.t.events.includes("registered:gapper")',
+      () => a.t.events,
+    );
+    linkA.simulateLoss();
+    await new Promise((r) => setTimeout(r, 30));
+    for (let i = 0; i < 100; i++) ircd.say('peer', 'gapper', `line ${i} ${'x'.repeat(50)}`);
+    await new Promise((r) => setTimeout(r, 50));
+    const b = makeClient(newLink(), id, 'gapper');
+    await until(
+      () => b.t.events.includes('phase:live'),
+      'b.t.events.includes("phase:live")',
+      () => b.t.events,
+    );
+    const ev = b.t.events;
+    expect(ev.indexOf('phase:restored')).toBeLessThan(ev.indexOf('phase:gap'));
+    expect(ev.indexOf('phase:gap')).toBeLessThan(ev.findIndex((e) => e.startsWith('privmsg:')));
+    expect(ev.filter((e) => e.startsWith('privmsg:')).at(-1)).toMatch(/line 99 /);
+  }, 20000);
+
+  it('fails with UNREACHABLE when no engine answers, and REFUSED on a bad secret', async () => {
+    const dead = newLink(SECRET, 1);
+    const a = makeClient(dead, `t:${++counter}`, 'nobody', { timeoutMs: 300 });
+    await until(
+      () => a.t.events.some((e) => e.startsWith('socket close:')),
+      'a.t.events.some((e) => e.startsWith("socket close:"))',
+      () => a.t.events,
+      3000,
+    );
+    expect(a.t.events.at(-1)).toBe(`socket close:${ENGINE_CLOSE.UNREACHABLE}`);
+
+    const wrong = newLink('not-the-secret');
+    const b = makeClient(wrong, `t:${++counter}`, 'nobody2', { timeoutMs: 2000 });
+    await until(
+      () => b.t.events.some((e) => e.startsWith('socket close:')),
+      'b.t.events.some((e) => e.startsWith("socket close:"))',
+      () => b.t.events,
+      3000,
+    );
+    expect(b.t.events.at(-1)).toBe(`socket close:${ENGINE_CLOSE.REFUSED}`);
+    expect(wrong.state).toBe('refused');
+  }, 20000);
+});
+
+describe('sanitizeReplay', () => {
+  it('drops the SASL exchange and the sasl cap, keeps everything else verbatim', () => {
+    const replay = [
+      ':irc.x CAP * LS * :sasl=PLAIN,EXTERNAL multi-prefix',
+      ':irc.x CAP * LS :server-time',
+      ':irc.x CAP me ACK :sasl multi-prefix server-time',
+      'AUTHENTICATE +',
+      ':irc.x 900 me me!u@h acct :You are now logged in as acct',
+      ':irc.x 903 me :SASL authentication successful',
+      ':irc.x 001 me :Welcome',
+      ':irc.x CAP me ACK :sasl',
+    ];
+    expect(sanitizeReplay(replay)).toEqual([
+      ':irc.x CAP * LS * :multi-prefix',
+      ':irc.x CAP * LS :server-time',
+      ':irc.x CAP me ACK :multi-prefix server-time',
+      ':irc.x 001 me :Welcome',
+    ]);
+  });
+});
+
+describe('engine answers to a bad CONNECT', () => {
+  it('surface as a failed dial, not a Client stuck in connecting', async () => {
+    const l = newLink();
+    const id = `t:${++counter}`;
+    const { t } = makeClient(l, id, 'badport');
+    // Reach in and make the next CONNECT invalid.
+    (t.transport as unknown as { options: { port: number } }).options.port = 70000;
+    await until(
+      () => t.events.some((e) => e.startsWith('socket close:')),
+      'a failed dial',
+      () => t.events,
+    );
+    expect(String((t.closes[0] as Error)?.message)).toMatch(/invalid port/);
+  });
+});

--- a/server/services/engineTransport.ts
+++ b/server/services/engineTransport.ts
@@ -1,0 +1,429 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// An irc-framework transport backed by the engine (server/engine.ts) instead of
+// a socket of its own. Same contract as irc-framework's src/transports/net.js
+// — `connect / writeLine / close / disposeSocket / setEncoding / isConnected`,
+// events `open / line / close / debug / extra` — so ircConnection.ts keeps a
+// real, live Client and none of its handlers know the socket is elsewhere.
+//
+// The one thing this does that a socket never would is RESTORE. When the engine
+// answers CONNECT with `attached`, the socket is already registered and this
+// Client is brand new, so the transport feeds it the engine's replay (the
+// recorded registration burst, our NICK, one JOIN per channel) and swallows the
+// registration commands the Client sends in response. The end-of-restore marker
+// is a PING the transport makes up: when the Client's PONG for it comes back
+// through writeLine(), everything before it has been processed. irc-framework's
+// read path is synchronous today; the marker means nothing here depends on that.
+
+import { EventEmitter } from 'node:events';
+import type { ConnectOptions } from 'irc-framework';
+import { ircLineParser } from 'irc-framework';
+import { EngineLink } from './engineLink.js';
+import type { FrameHandler } from './engineLink.js';
+import type { EngineToApp, Gap } from '../engine/protocol.js';
+
+export const ENGINE_CLOSE = {
+  // The app↔engine link dropped; the IRC socket is (probably) still held.
+  LINK_LOST: 'ENGINE_LINK_LOST',
+  // The engine never became reachable (or never answered) within the window.
+  UNREACHABLE: 'ENGINE_UNREACHABLE',
+  // A newer app process claimed this connection.
+  TAKEN_OVER: 'ENGINE_TAKEN_OVER',
+  // The engine refused this app outright (secret / protocol major).
+  REFUSED: 'ENGINE_REFUSED',
+  // This process let go on purpose (shutdown); the socket stays in the engine.
+  DETACHED: 'ENGINE_DETACHED',
+} as const;
+
+export class EngineCloseError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+// irc-framework hands the close error through as-is ('socket close' event arg).
+export function engineCloseCode(err: unknown): string | null {
+  if (err instanceof EngineCloseError) return err.code;
+  const code = (err as { code?: unknown } | null)?.code;
+  return typeof code === 'string' && code.startsWith('ENGINE_') ? code : null;
+}
+
+export type EnginePhase = 'dialing' | 'attached' | 'restored' | 'live' | 'gap';
+
+export interface EnginePhaseInfo {
+  detachedForMs?: number;
+  nick?: string | null;
+  channels?: string[];
+  replay?: number;
+  unattended?: boolean;
+  swallowed?: string[];
+  gap?: Gap;
+}
+
+export interface EngineHooks {
+  onTransport?(transport: EngineTransport): void;
+  onPhase?(phase: EnginePhase, info: EnginePhaseInfo): void;
+}
+
+const RESTORE_MARK = '__lurker_restore__';
+// Outbound lines that belong to registration. While restoring they are answered
+// by the replay, never by the network.
+const SWALLOW = /^(CAP|NICK|USER|PASS|AUTHENTICATE)(\s|$)/;
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+// After CONNECT goes out on a ready link, how long the engine has to say
+// dialing / attached / closed / error before the attempt is called off.
+const CONNECT_REPLY_TIMEOUT_MS = Number(process.env.LURKER_ENGINE_REPLY_TIMEOUT_MS) || 30_000;
+
+// The replay is the OLD registration, verbatim — including its SASL exchange.
+// The fresh Client would answer a replayed `AUTHENTICATE +` from the network
+// row as it is NOW (and irc-framework dereferences a missing account without
+// checking), so the exchange is taken out: SASL already happened on this
+// socket, and nothing in the replay needs it to happen again.
+const SASL_NUMERICS = new Set(['900', '901', '902', '903', '904', '905', '906', '907', '908']);
+export function sanitizeReplay(lines: string[]): string[] {
+  const out: string[] = [];
+  for (const line of lines) {
+    const msg = ircLineParser(line);
+    if (!msg) continue;
+    const command = String(msg.command || '').toUpperCase();
+    if (command === 'AUTHENTICATE' || SASL_NUMERICS.has(command)) continue;
+    if (command === 'CAP' && /^(LS|ACK|NEW)$/i.test(msg.params[1] ?? '')) {
+      const caps = (msg.params[msg.params.length - 1] ?? '')
+        .split(' ')
+        .filter((c) => c && c.split('=')[0] !== 'sasl');
+      if (caps.length === 0) continue;
+      const head = msg.params.slice(0, -1);
+      const prefix = msg.prefix ? `:${msg.prefix} ` : '';
+      out.push(`${prefix}CAP ${head.join(' ')} :${caps.join(' ')}`);
+      continue;
+    }
+    out.push(line);
+  }
+  return out;
+}
+
+export interface EngineConnectOptions extends ConnectOptions {
+  engineConnId: string;
+  engineIdent?: string;
+  engineHooks?: EngineHooks;
+  // Test seams.
+  engineLink?: EngineLink;
+  engineConnectTimeoutMs?: number;
+}
+
+export class EngineTransport extends EventEmitter implements FrameHandler {
+  readonly id: string;
+  restoring = false;
+  requested_disconnect = false;
+  private connected = false;
+  private ended = false;
+  private detachedByApp = false;
+  // A newer process owns the socket now; nothing we send may touch it.
+  private lostToPeer = false;
+  private closeSent = false;
+  private readonly link: EngineLink;
+  private readonly hooks: EngineHooks | undefined;
+  private pending: EngineToApp[] = [];
+  private swallowed: string[] = [];
+  private replyTimer: ReturnType<typeof setTimeout> | null = null;
+  // Acks are coalesced per synchronous batch (one microtask), so a chunk of a
+  // hundred lines is one frame, not a hundred.
+  private ackSeq = 0;
+  private ackQueued = false;
+
+  constructor(readonly options: EngineConnectOptions) {
+    super();
+    this.id = options.engineConnId;
+    this.link = options.engineLink ?? EngineLink.shared();
+    this.hooks = options.engineHooks;
+    this.hooks?.onTransport?.(this);
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  private debugOut(s: string): void {
+    this.emit('debug', 'EngineTransport ' + s);
+  }
+
+  connect(): void {
+    this.ended = false;
+    this.requested_disconnect = false;
+    this.detachedByApp = false;
+    this.link.register(this.id, this);
+    const go = () => {
+      const o = this.options;
+      this.link.send({
+        op: 'connect',
+        id: this.id,
+        host: o.host,
+        port: o.port,
+        tls: !!o.tls,
+        rejectUnauthorized: o.rejectUnauthorized !== false,
+        ...(o.outgoing_addr ? { outgoingAddr: o.outgoing_addr } : {}),
+        ...(o.engineIdent ? { ident: o.engineIdent } : {}),
+      });
+      this.armReplyTimer();
+    };
+    if (this.link.state === 'ready') return go();
+    void this.link
+      .whenReady(this.options.engineConnectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS)
+      .then((r) => {
+        if (this.ended) return;
+        if (r === 'ready') {
+          // The link may have come and gone in between; register again so a
+          // restart of the link didn't drop us.
+          this.link.register(this.id, this);
+          return go();
+        }
+        if (r === 'refused') {
+          this.fail(
+            ENGINE_CLOSE.REFUSED,
+            `the Lurker engine at ${this.link.address} refused this app (${this.link.refusedReason})`,
+          );
+        } else {
+          this.fail(
+            ENGINE_CLOSE.UNREACHABLE,
+            `the Lurker engine at ${this.link.address} is unreachable`,
+          );
+        }
+      });
+  }
+
+  private armReplyTimer(): void {
+    this.clearReplyTimer();
+    this.replyTimer = setTimeout(() => {
+      this.replyTimer = null;
+      if (this.ended || this.connected) return;
+      this.fail(
+        ENGINE_CLOSE.UNREACHABLE,
+        `the Lurker engine at ${this.link.address} did not answer the connect request`,
+      );
+    }, CONNECT_REPLY_TIMEOUT_MS);
+    this.replyTimer.unref();
+  }
+
+  private clearReplyTimer(): void {
+    if (this.replyTimer) {
+      clearTimeout(this.replyTimer);
+      this.replyTimer = null;
+    }
+  }
+
+  private fail(code: string, message: string): void {
+    this.end(new EngineCloseError(code, message));
+  }
+
+  // This transport is finished: no more frames in either direction, and
+  // irc-framework hears a close so it tears the Client's timers down. A fresh
+  // connect() builds a fresh transport.
+  private end(err: Error | false): void {
+    this.clearReplyTimer();
+    this.ended = true;
+    this.link.unregister(this.id, this);
+    this.connected = false;
+    this.restoring = false;
+    this.pending = [];
+    this.emit('close', err);
+  }
+
+  // --- FrameHandler ---------------------------------------------------------
+
+  onLost(): void {
+    if (this.ended || this.detachedByApp) return;
+    const wasConnected = this.connected;
+    this.connected = false;
+    this.restoring = false;
+    this.pending = [];
+    if (wasConnected) {
+      this.end(
+        new EngineCloseError(
+          ENGINE_CLOSE.LINK_LOST,
+          `lost the link to the Lurker engine at ${this.link.address}`,
+        ),
+      );
+    } else {
+      // Mid-connect: wait for the link like a fresh connect would.
+      this.clearReplyTimer();
+      this.connect();
+    }
+  }
+
+  onFrame(frame: EngineToApp): void {
+    if (this.ended) return;
+    switch (frame.op) {
+      case 'dialing':
+        this.clearReplyTimer();
+        this.hooks?.onPhase?.('dialing', {});
+        return;
+      case 'open':
+        this.clearReplyTimer();
+        this.connected = true;
+        this.emit('extra', 'raw socket connected', {
+          localAddress: frame.local.address,
+          localPort: frame.local.port,
+          remoteAddress: frame.remote.address,
+          remotePort: frame.remote.port,
+        });
+        this.emit('open');
+        return;
+      case 'attached':
+        this.clearReplyTimer();
+        this.restore(frame);
+        return;
+      case 'line':
+        if (this.restoring) this.pending.push(frame);
+        else this.deliver(frame);
+        return;
+      case 'gap':
+        if (this.restoring) this.pending.push(frame);
+        else this.hooks?.onPhase?.('gap', { gap: frame.gap });
+        return;
+      case 'live':
+        if (this.restoring) this.pending.push(frame);
+        else this.hooks?.onPhase?.('live', {});
+        return;
+      case 'detached':
+        this.lostToPeer = true;
+        this.fail(ENGINE_CLOSE.TAKEN_OVER, 'another Lurker process took over this connection');
+        return;
+      case 'closed':
+        this.end(frame.error ? new Error(frame.error) : false);
+        return;
+      case 'error':
+        // Before the socket is up, an error naming our id is the engine's
+        // answer to the CONNECT (a bad port, a non-IP bind address): the dial
+        // failed. irc-framework has no connect timeout of its own, so this is
+        // where the Client learns it. After that it is informational.
+        if (!this.connected) this.end(new Error(frame.message));
+        else this.debugOut(`engine error: ${frame.message}`);
+        return;
+      default:
+        return;
+    }
+  }
+
+  private restore(frame: Extract<EngineToApp, { op: 'attached' }>): void {
+    this.connected = true;
+    this.restoring = true;
+    this.swallowed = [];
+    this.hooks?.onPhase?.('attached', {
+      detachedForMs: frame.detachedForMs,
+      nick: frame.nick,
+      channels: frame.channels,
+      replay: frame.replay.length,
+      unattended: frame.unattended,
+    });
+    this.emit('extra', 'raw socket connected', {
+      localAddress: frame.local.address,
+      localPort: frame.local.port,
+      remoteAddress: frame.remote.address,
+      remotePort: frame.remote.port,
+    });
+    try {
+      // irc-framework answers 'open' by sending CAP LS / NICK / USER — swallowed.
+      this.emit('open');
+      for (const line of sanitizeReplay(frame.replay)) this.emit('line', line);
+      this.emit('line', `PING :${RESTORE_MARK}`);
+    } catch (err) {
+      // A handler threw mid-replay. The Client is in no state to continue on
+      // this socket, and attaching again would throw again: end the socket so
+      // the next attempt is a fresh dial, and report why.
+      this.link.requestClose(this.id);
+      this.closeSent = true;
+      this.end(new Error(`restore failed: ${(err as Error).message}`));
+    }
+  }
+
+  private finishRestore(): void {
+    this.restoring = false;
+    this.hooks?.onPhase?.('restored', { swallowed: this.swallowed.slice() });
+    const queued = this.pending.splice(0);
+    for (const f of queued) this.onFrame(f);
+  }
+
+  private deliver(frame: Extract<EngineToApp, { op: 'line' }>): void {
+    this.emit('line', frame.line);
+    // By the time emit() returns, irc-framework and every ircConnection handler
+    // have run — persistence included, better-sqlite3 being synchronous — so
+    // the ack can never get ahead of the row. Coalesced: one frame per batch.
+    this.ackSeq = frame.seq;
+    if (!this.ackQueued) {
+      this.ackQueued = true;
+      queueMicrotask(() => {
+        this.ackQueued = false;
+        if (!this.ended && this.connected)
+          this.link.send({ op: 'ack', id: this.id, seq: this.ackSeq });
+      });
+    }
+  }
+
+  // --- irc-framework transport contract ---------------------------------------
+
+  // irc-framework passes a callback only from Connection.end(), to close the
+  // socket once the last line (a QUIT) is out. It is called SYNCHRONOUSLY here
+  // so the `close` frame follows the QUIT on the link immediately — ahead of
+  // anything the app does next, such as restartNetwork's fresh CONNECT for the
+  // same id, which must find the old socket closing rather than attach to it.
+  writeLine(line: string, cb?: () => void): void {
+    if (this.restoring) {
+      if (line === `PONG ${RESTORE_MARK}` || line === `PONG :${RESTORE_MARK}`) {
+        this.finishRestore();
+        cb?.();
+        return;
+      }
+      if (SWALLOW.test(line)) {
+        this.swallowed.push(line);
+        cb?.();
+        return;
+      }
+    }
+    if (this.connected) this.link.send({ op: 'write', id: this.id, line });
+    else this.debugOut('writeLine() called when not connected');
+    cb?.();
+  }
+
+  // End the IRC socket. This is what QUIT ends in. A no-op after detach() (the
+  // socket is meant to outlive us) and after a takeover (it is someone else's).
+  // Otherwise the close is delivered now, or the moment the link is back — a
+  // Disconnect during an outage is still a Disconnect.
+  close(): void {
+    this.requested_disconnect = true;
+    if (this.detachedByApp || this.lostToPeer || this.closeSent) return;
+    this.closeSent = true;
+    this.link.requestClose(this.id);
+    // End our side NOW rather than on the engine's `closed`: irc-framework must
+    // tear this Client's timers down before a successor claims the same id, or
+    // a zombie PING (or ping-timeout QUIT) from the old Client would land on the
+    // successor's socket. The engine's later `closed` for the old socket goes
+    // unrouted, by design.
+    if (!this.ended) this.end(false);
+  }
+
+  // Leave the IRC socket alive in the engine for the next app process, and end
+  // only our side. Tagged, so ircConnection knows nothing about the network
+  // changed — no presence sweep, no "Disconnected" row.
+  detach(): void {
+    if (this.detachedByApp || this.ended) return;
+    this.detachedByApp = true;
+    this.requested_disconnect = true;
+    this.link.send({ op: 'detach', id: this.id });
+    this.link.noteDetached(this.id);
+    this.end(new EngineCloseError(ENGINE_CLOSE.DETACHED, 'detached; the engine keeps the socket'));
+  }
+
+  disposeSocket(): void {
+    this.clearReplyTimer();
+    this.ended = true;
+    this.link.unregister(this.id, this);
+  }
+
+  setEncoding(encoding: string): boolean {
+    return encoding === 'utf8';
+  }
+}

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2,8 +2,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import IRC, { ircLineParser } from 'irc-framework';
-import type { Client as IrcClient } from 'irc-framework';
-import { insertMessage, hasMessageForTarget, hasConversationForTarget } from '../db/messages.js';
+import type { Client as IrcClient, ConnectOptions } from 'irc-framework';
+import {
+  insertMessage,
+  hasMessageForTarget,
+  hasConversationForTarget,
+  hasMessageWithMsgid,
+  hasRecentMessageLike,
+} from '../db/messages.js';
 import { renameBuffer as renameDmBuffer } from '../db/renameBuffer.js';
 import { refoldNetworkBuffers } from '../db/refoldBuffers.js';
 import { normalizeCasemapping } from '../db/casemapping.js';
@@ -43,6 +49,9 @@ import { deriveIdent } from '../../shared/ident.js';
 import { classifyModeChange, modeLetter } from '../../shared/modes.js';
 import type { ModeChange } from '../../shared/modes.js';
 import { registerIdent, unregisterIdent, isIdentdEnabled, isOidentdFileEnabled } from './identd.js';
+import { EngineLink, engineConfigured, engineConnectionId } from './engineLink.js';
+import { ENGINE_CLOSE, EngineTransport, engineCloseCode } from './engineTransport.js';
+import type { EnginePhase, EnginePhaseInfo } from './engineTransport.js';
 import { MESSAGE_MAX_BYTES, partitionMultiline, reassembleMultiline } from './messageSplit.js';
 import type { MultilineLimits } from './messageSplit.js';
 import { e2eManager } from './e2e/manager.js';
@@ -146,6 +155,24 @@ export type ReconnectGate = () => { ok: true } | { ok: false; reason: string };
 // nothing ever registers and the count runs out. Worst case is a bounded 3
 // attempts spread over the backoff ladder, which is not a hammer.
 const MAX_CONSECUTIVE_SASL_FAILURES = 3;
+
+// Replies to the state requests a restore makes for each channel (MODE → 324
+// (+329), TOPIC → 331 or 332 (+333)). A real join is volunteered these; a
+// synthesised one has to ask, and the server-buffer renderer would print each
+// answer as a line of history on every app restart. Kept quiet per channel for a
+// short window after the restore — see RESTORE_QUIET_MS.
+const RESTORE_QUIET_NUMERICS = new Set(['221', '324', '329', '331', '332', '333']);
+const RESTORE_QUIET_MS = 10_000;
+// The per-channel state requests after a restore go out paced, not as one
+// burst: three lines per channel for forty channels in one tick is exactly
+// the flood the JOIN coalescing elsewhere exists to avoid.
+const RESTORE_REQUEST_INTERVAL_MS = 400;
+// How long a link-loss re-attach waits for the engine to say what it holds
+// before treating the session as gone and taking the ordinary reconnect ladder.
+const ENGINE_REATTACH_WAIT_MS = 10_000;
+// System-buffer line for a shutdown detach, in place of "Disconnected" — which
+// is exactly what did not happen.
+const DETACHED_LOG = 'Detached — the engine is keeping this connection open for the next start';
 
 const NON_PERSISTED_TYPES = new Set([
   'state',
@@ -639,19 +666,56 @@ export class IrcConnection {
   // it could never run out. Only 'registered' clears it.
   private saslFailureStreak: number;
   private readonly reconnectGate: ReconnectGate | undefined;
+  // Engine mode: a newer process took this connection over. The manager drops
+  // us from its map so a later /connect builds a fresh IrcConnection instead of
+  // finding this corpse and doing nothing.
+  private readonly onTakenOver: (() => void) | undefined;
+  // Engine mode (services/engineTransport.ts): the IRC socket lives in the
+  // engine process and this Client is attached to it over a link.
+  //
+  // restoring: true while a re-attach replays the recorded session into this
+  //   fresh Client. publish() drops anything that would persist (the burst's
+  //   MOTD, the "Connected as" notice, the synthesised own-JOIN rows), and the
+  //   'registered' handler skips the side effects only a real connect wants.
+  // engineTransport: the live transport, for detach() at shutdown.
+  // engineSocketAlive: set by 'socket close' when what closed was the LINK
+  //   (or a takeover), not the IRC socket — 'close' then re-attaches instead of
+  //   running the disconnect path.
+  restoring: boolean;
+  // True from the engine's `attached` until its `live`: the backlog it held
+  // while we were away is being delivered. Hand-over is at-least-once — a line
+  // the previous process persisted but had not acked comes again — so in this
+  // window a msgid we already have is skipped rather than written twice.
+  catchingUp: boolean;
+  // The engine finished registering this socket with no app attached (the
+  // previous one died between NICK/USER and 001): nothing ever ran the
+  // post-registration steps, so the restore runs them.
+  restoreUnattended: boolean;
+  private restoredCallbacks: Array<() => void>;
+  private restoreQueue: string[];
+  private restoreTimer: ReturnType<typeof setTimeout> | null;
+  private engineTransport: EngineTransport | null;
+  private engineSocketAlive: boolean;
+  // folded channel → the state replies still owed from the restore's own
+  // requests (MODE → 324/329, TOPIC → 331/332/333; '*' → our umode 221), kept
+  // out of the server buffer until they arrive or the deadline passes.
+  private restoreQuiet: Map<string, { until: number; mode: boolean; topic: boolean }>;
 
   constructor({
     network,
     onEvent,
     reconnectGate,
+    onTakenOver,
   }: {
     network: Network;
     onEvent: (event: EnrichedEvent) => void;
     reconnectGate?: ReconnectGate;
+    onTakenOver?: () => void;
   }) {
     this.network = network;
     this.onEvent = onEvent;
     this.reconnectGate = reconnectGate;
+    this.onTakenOver = onTakenOver;
     // ALL CTCP handling lives in our 'ctcp request' handler (VERSION/PING/TIME/
     // SOURCE/CLIENTINFO, rate-limited + surfaced), so irc-framework's built-in
     // VERSION auto-reply is disabled with `version: false`. That MUST go in the
@@ -739,6 +803,15 @@ export class IrcConnection {
     this.pendingSaslFailure = null;
     this.pendingServerBan = null;
     this.saslFailureStreak = 0;
+    this.restoring = false;
+    this.catchingUp = false;
+    this.restoreUnattended = false;
+    this.restoredCallbacks = [];
+    this.restoreQueue = [];
+    this.restoreTimer = null;
+    this.engineTransport = null;
+    this.engineSocketAlive = false;
+    this.restoreQuiet = new Map();
     this.bind();
   }
 
@@ -802,6 +875,11 @@ export class IrcConnection {
   // that stand in for publish stay assignable.
   publish(event: IrcEvent): EnrichedEvent | void {
     if (this.disposed) return;
+    // A replayed session is not new history: nothing it would persist is
+    // wanted, while the control events (state, channel-joined, own-nick) are
+    // exactly what a re-attached process needs.
+    if (this.restoring && this.shouldPersist(event)) return;
+    if (this.catchingUp && this.shouldPersist(event) && this.alreadyPersisted(event)) return;
     event = this.normalizeChannelTarget(event);
     const time = normalizeEventTime(event.time);
     const enriched: EnrichedEvent = {
@@ -882,10 +960,22 @@ export class IrcConnection {
     });
   }
 
-  setState(state: string, extra: Record<string, unknown> = {}): void {
+  // `opts.log`: false skips the system-buffer line for this transition (the
+  // state event still goes to clients); a string replaces its text. Neither
+  // reaches the wire.
+  setState(
+    state: string,
+    extra: Record<string, unknown> = {},
+    opts: { log?: boolean | string } = {},
+  ): void {
     const changed = this.state !== state;
     this.state = state;
     this.publish({ type: 'state', state, ...extra });
+    if (opts.log === false) return;
+    if (typeof opts.log === 'string') {
+      if (changed) this.logNet(opts.log, 'info');
+      return;
+    }
     // Only log on a real transition. A disconnect fires both 'socket close' and
     // 'close', each calling setState('disconnected'); without this guard the
     // system buffer gets two "Disconnected" lines per network (#355). The state
@@ -1035,6 +1125,12 @@ export class IrcConnection {
         });
       }
       if (isServerBufferDeniedNumeric(rawCommand)) return;
+      if (
+        RESTORE_QUIET_NUMERICS.has(rawCommand) &&
+        this.isRestoreQuiet(rawCommand, rawCommand === '221' ? '*' : msg?.params?.[1])
+      ) {
+        return;
+      }
       // formatUnknownNumeric only renders 3-digit numerics (it strips the
       // leading recipient-nick param), so PRIVMSG/JOIN/NOTICE/etc. naturally
       // fall through and never pollute the server buffer.
@@ -1187,7 +1283,11 @@ export class IrcConnection {
       } catch (e) {
         console.warn('[presence] hydrate failed:', (e as Error)?.message || e);
       }
-      this.setState('connected', { nick: registeredNick });
+      // On a restore the 001 being replayed carries the nick the socket
+      // REGISTERED with, which the NICK line right behind it may change; the
+      // engine hook already logged "Re-attached … as <live nick>", so this
+      // transition goes to clients only.
+      this.setState('connected', { nick: registeredNick }, { log: !this.restoring });
       // Defer the MONITOR + handshake until ISUPPORT tells us the server
       // supports it (same pattern the nick-regain watch uses). 005 always
       // follows 001, so the 'server options' handler trips shortly after.
@@ -1237,7 +1337,10 @@ export class IrcConnection {
       // after, the socket-reconnect path runs clearAwayAll({autoSet:true}) and
       // clears it cleanly; if not, staying away across an IRC blip is the
       // correct behavior.
-      if (this.awayState.active && this.awayState.message) {
+      // Not on a restore: the socket already carries the away state (this
+      // process set it before it went away), and the 306 the re-assert draws
+      // would land as a server-buffer row on every restart.
+      if (this.awayState.active && this.awayState.message && !this.restoring) {
         try {
           this.client.raw('AWAY :' + this.awayState.message);
         } catch (_) {
@@ -1248,7 +1351,9 @@ export class IrcConnection {
       // IRC lines fired after 001. `WAIT <seconds>` pauses before the next
       // command (e.g. waiting for NickServ identify to take effect before
       // joining +r channels). Re-runs on every reconnect by design.
-      this.runConnectCommands();
+      // Not on a re-attach: the socket already ran them (NickServ is already
+      // satisfied, and a WAIT-delayed JOIN would join what we are in).
+      if (!this.restoring) this.runConnectCommands();
     });
     c.on('close', () => {
       // Final safety net (clean disconnect/dispose may not always emit
@@ -1270,6 +1375,7 @@ export class IrcConnection {
       this.ctcpLimiter = new RateLimiter();
       this.stopLagPinger();
       this.cancelPendingConnectCommands();
+      this.resetRestoreState();
       this.lagMs = null;
       // Next socket starts a fresh fallback ladder from the configured nick.
       this.preRegistered = true;
@@ -1292,6 +1398,15 @@ export class IrcConnection {
       // fires. This covers any clean-close path that somehow skipped it;
       // markAllPeersOffline is idempotent and disposed-guarded, so the double
       // call is a no-op.
+      if (this.engineSocketAlive) {
+        // The IRC socket is alive in the engine; only our side ended. Go
+        // straight back to CONNECT (the engine answers ATTACH if it still holds
+        // the socket, and dials if it doesn't — the normal handlers take either)
+        // unless this was a takeover, which is someone else's connection now.
+        this.engineSocketAlive = false;
+        this.reattachSoon();
+        return;
+      }
       this.markAllPeersOffline();
       this.setState('disconnected');
       // Decide, now that we know WHEN the socket died, whether a SASL rejection
@@ -1364,7 +1479,9 @@ export class IrcConnection {
       if (limit === 0 || this.useMonitor) return;
       this.useMonitor = true;
       this.monitorLimit = limit;
-      this.logNet(`MONITOR (IRCv3 presence) supported, watch limit ${limit}`);
+      if (!this.restoring) {
+        this.logNet(`MONITOR (IRCv3 presence) supported, watch limit ${limit}`);
+      }
       if (this.pendingRegainSetup && this.regainNick) {
         this.pendingRegainSetup = false;
         try {
@@ -1443,6 +1560,31 @@ export class IrcConnection {
     // surfacing it to the server buffer the user just sees a red dot and no
     // log line.
     c.on('socket close', (err: Record<string, unknown>) => {
+      const engineCode = engineCloseCode(err);
+      if (
+        engineCode === ENGINE_CLOSE.LINK_LOST ||
+        engineCode === ENGINE_CLOSE.TAKEN_OVER ||
+        engineCode === ENGINE_CLOSE.DETACHED
+      ) {
+        // Not the IRC socket. Our link to the engine dropped (the socket is
+        // still held; 'close' re-attaches), a newer app process claimed the
+        // connection (it lives on, elsewhere), or we let go on purpose at
+        // shutdown (the next process picks it up). Nothing about the network
+        // changed: no presence sweep — which would fire a "came online" push
+        // for every favorited peer on the next attach — and no error row.
+        this.engineSocketAlive = true;
+        if (engineCode === ENGINE_CLOSE.TAKEN_OVER) {
+          this.intentionalDisconnect = true;
+          this.setState('disconnected');
+          this.logNet('Another Lurker process took over this connection', 'warn');
+          this.onTakenOver?.();
+        } else if (engineCode === ENGINE_CLOSE.DETACHED) {
+          this.setState('disconnected', {}, { log: DETACHED_LOG });
+        } else {
+          this.setState('reconnecting');
+        }
+        return;
+      }
       this.setState('disconnected');
       // Our socket to this network just dropped — from our vantage point every
       // peer we track here is now unreachable, so mark them all offline. This is
@@ -1481,7 +1623,11 @@ export class IrcConnection {
     // The 'reconnecting' state + notice are now emitted by our own controller
     // (scheduleReconnectIfWarranted), not the library: irc-framework's
     // auto_reconnect is disabled, so it never fires a 'reconnecting' event.
-    c.on('connecting', () => this.setState('connecting'));
+    // On an attach the state still transitions (clients need the dot), but
+    // "Connecting…" in the system buffer would describe a connect that isn't
+    // happening; the manager already said "Attaching…" and the engine hook
+    // says "Re-attached" when it lands.
+    c.on('connecting', () => this.setState('connecting', {}, { log: !this.engineHoldsUs() }));
 
     // Diagnostic: irc-framework fires 'ping timeout' when it hasn't seen data
     // from the server for `ping_timeout` seconds (120s default) — then it QUITs
@@ -1533,6 +1679,9 @@ export class IrcConnection {
         // answers :113 from this map, and the oidentd shared-daemon mode renders
         // the same map to a config file. Skip only when neither is on.
         if (!isIdentdEnabled() && !isOidentdFileEnabled()) return;
+        // In engine mode the engine holds the socket and registered the ident
+        // when it dialed; this process serves no identd.
+        if (engineConfigured()) return;
         // The full 4-tuple identifies the connection to the identd server; the
         // ports alone are ambiguous (see identd.ts). Both addresses and ports
         // are already populated at TCP connect.
@@ -2010,6 +2159,29 @@ export class IrcConnection {
         // already 'online'. (It WILL fire if state is 'offline' or null.)
         // The away-notify 'back' event is the authoritative back signal.
         this.markPeerEvent(eventNick, 'online');
+      }
+      if (eventNick === c.user.nick && this.restoring) {
+        // A synthesised JOIN from the engine's replay. autojoin is lowered only
+        // by a part, a kick or a close (db/buffers.ts) — so a channel the socket
+        // is still in whose row says autojoin=0 means the user left it while
+        // the app (or its link) was away and the PART never went out. This is
+        // that PART, late. Otherwise it is state, not intent: the row's flag
+        // stays whatever it was.
+        const row = getBuffer(this.network.user_id, this.network.id, eventChannel);
+        if (
+          row &&
+          (!row.autojoin || isBufferClosed(this.network.user_id, this.network.id, eventChannel))
+        ) {
+          this.channels.delete(eventChannel.toLowerCase());
+          try {
+            c.raw('PART', eventChannel);
+          } catch (_) {
+            /* ignore */
+          }
+          return;
+        }
+        this.publish({ type: 'channel-joined', target: eventChannel });
+        return;
       }
       if (eventNick === c.user.nick) {
         // The ECHO is the only signal the join actually landed on the channel
@@ -3699,20 +3871,10 @@ export class IrcConnection {
     const account = sasl_password
       ? { account: sasl_account || nick, password: sasl_password }
       : undefined;
-    const proto = this.network.tls ? ' (TLS)' : '';
-    const connectingNotice: IrcEvent = {
-      type: 'notice',
-      target: this.serverTarget(),
-      nick: 'lurker',
-      notable: false, // #470: status line — not counted as unread (see MessageInput.notable)
-      text: `Connecting to ${this.network.host}:${this.network.port}${proto}…`,
-    };
-    // On an auto-reconnect attempt (reconnectAttempt has advanced past 0), don't
-    // persist this per-attempt status line — a long outage would otherwise write
-    // one row per retry forever (see scheduleReconnectIfWarranted). The initial
-    // and manual connects (attempt 0) still persist their one "Connecting…" line.
-    if (this.reconnectAttempt > 0) this.publishEphemeral(connectingNotice);
-    else this.publish(connectingNotice);
+    // In engine mode the notice waits for the engine to say it is dialing — a
+    // CONNECT it answers with ATTACH connects nothing (see onEnginePhase).
+    if (!engineConfigured()) this.announceConnecting();
+    this.resetRestoreState();
     this.client.connect({
       host: this.network.host,
       port: this.network.port,
@@ -3754,6 +3916,262 @@ export class IrcConnection {
       // network's RFC 1413 callback lands on the built-in identd rather than the
       // host's (outgoingAddr → irc-framework outgoing_addr → socket localAddress).
       outgoing_addr: outgoingAddr(),
+      ...this.engineConnectOptions(),
+    });
+  }
+
+  private announceConnecting(): void {
+    const proto = this.network.tls ? ' (TLS)' : '';
+    const connectingNotice: IrcEvent = {
+      type: 'notice',
+      target: this.serverTarget(),
+      nick: 'lurker',
+      notable: false, // #470: status line — not counted as unread (see MessageInput.notable)
+      text: `Connecting to ${this.network.host}:${this.network.port}${proto}…`,
+    };
+    // On an auto-reconnect attempt (reconnectAttempt has advanced past 0), don't
+    // persist this per-attempt status line — a long outage would otherwise write
+    // one row per retry forever (see scheduleReconnectIfWarranted). The initial
+    // and manual connects (attempt 0) still persist their one "Connecting…" line.
+    if (this.reconnectAttempt > 0) this.publishEphemeral(connectingNotice);
+    else this.publish(connectingNotice);
+  }
+
+  // Engine mode: route this Client through the engine-backed transport. The id
+  // is what the engine knows the socket by across app restarts; the ident rides
+  // along because identd is answered where the socket is, and the ident comes
+  // from the account (#643), which the engine never sees.
+  private engineConnectOptions(): Partial<ConnectOptions> {
+    if (!engineConfigured()) return {};
+    const account = findUserById(this.network.user_id);
+    return {
+      transport: EngineTransport,
+      engineConnId: engineConnectionId(this.network.user_id, this.network.id),
+      engineIdent: deriveIdent({
+        nodeMode: isNodeMode(),
+        accountUsername: account?.username || '',
+        accountIdent: account?.ident || null,
+      }),
+      engineHooks: {
+        onTransport: (t) => {
+          this.engineTransport = t as EngineTransport;
+        },
+        onPhase: (phase, info) => this.onEnginePhase(phase as EnginePhase, info as EnginePhaseInfo),
+      },
+    };
+  }
+
+  private onEnginePhase(phase: EnginePhase, info: EnginePhaseInfo): void {
+    switch (phase) {
+      case 'dialing':
+        this.resetRestoreState();
+        this.announceConnecting();
+        break;
+      case 'attached': {
+        this.resetRestoreState();
+        this.restoring = true;
+        this.catchingUp = true;
+        this.restoreUnattended = !!info.unattended;
+        // The engine's channel set is the truth about the socket. Anything we
+        // still think we are in but the engine doesn't (kicked or parted while
+        // this process was cut off) is gone — and must not get NAMES/TOPIC
+        // requests whose replies would resurrect it.
+        const live = new Set((info.channels ?? []).map((c) => c.toLowerCase()));
+        for (const [key, ch] of this.channels) {
+          if (live.has(key)) continue;
+          this.channels.delete(key);
+          this.joinedFoldedCache = null;
+          this.publish({ type: 'channel-parted', target: ch.name });
+        }
+        const away = info.detachedForMs
+          ? ` (app was away ${Math.round(info.detachedForMs / 1000)}s)`
+          : '';
+        const how = info.unattended ? ' — it registered on its own while no app was attached' : '';
+        this.logNet(
+          `Re-attached to the engine-held connection as ${info.nick ?? '?'}${away}${how}`,
+        );
+        break;
+      }
+      case 'restored': {
+        this.restoring = false;
+        // A synthesised JOIN gets none of what a real one is volunteered — no
+        // 353/366, no 332, and the join handler's MODE is skipped on a restore —
+        // so ask, one channel at a time (RESTORE_REQUEST_INTERVAL_MS), keeping
+        // each channel's replies out of the server buffer until they arrive.
+        // Our umodes were set after the burst ended (the post-MOTD `MODE nick
+        // +i`), so they are not in the replay either.
+        this.restoreQuiet.set('*', {
+          until: Date.now() + RESTORE_QUIET_MS,
+          mode: true,
+          topic: false,
+        });
+        this.rawQuiet('MODE', this.currentNick);
+        this.restoreQueue = [...this.channels.values()].map((ch) => ch.name);
+        this.drainRestoreQueue();
+        // A socket the engine registered on its own never had its
+        // post-registration steps: the connect commands run now, and the
+        // manager's rejoin (onceRestored, at `live`) covers the autojoin list.
+        if (this.restoreUnattended) this.runConnectCommands();
+        break;
+      }
+      case 'gap': {
+        const g = info.gap;
+        if (!g) break;
+        const dropped = g.lastDroppedSeq - g.firstDroppedSeq + 1;
+        this.publish({
+          type: 'notice',
+          target: this.serverTarget(),
+          nick: 'lurker',
+          notable: false, // status line, like the reconnect notices
+          text: `Lurker was away longer than the engine's buffer covers — ${dropped} line${dropped === 1 ? '' : 's'} received before ${new Date(g.at).toISOString()} could not be kept.`,
+        });
+        break;
+      }
+      case 'live':
+        this.catchingUp = false;
+        // Only now is the picture complete: the replay said which channels the
+        // socket is in, and the backlog said why (a KICK from one of them is a
+        // backlog line, and it is what lowers that channel's autojoin).
+        for (const cb of this.restoredCallbacks.splice(0)) {
+          try {
+            cb();
+          } catch (e) {
+            console.warn('[engine] restored callback failed:', (e as Error)?.message || e);
+          }
+        }
+        break;
+    }
+  }
+
+  // Run once the current restore has finished — replay AND backlog — or at
+  // once if none is in progress. The manager's rejoin pass hangs off this.
+  onceRestored(cb: () => void): void {
+    if (this.restoring || this.catchingUp) this.restoredCallbacks.push(cb);
+    else cb();
+  }
+
+  private resetRestoreState(): void {
+    this.restoring = false;
+    this.catchingUp = false;
+    this.restoreUnattended = false;
+    this.restoredCallbacks = [];
+    this.restoreQueue = [];
+    if (this.restoreTimer) {
+      clearTimeout(this.restoreTimer);
+      this.restoreTimer = null;
+    }
+    this.restoreQuiet.clear();
+  }
+
+  private drainRestoreQueue(): void {
+    const name = this.restoreQueue.shift();
+    if (name === undefined) return;
+    // Still in it? (A backlog KICK may have arrived in between.)
+    if (this.channels.has(name.toLowerCase())) {
+      this.restoreQuiet.set(name.toLowerCase(), {
+        until: Date.now() + RESTORE_QUIET_MS,
+        mode: true,
+        topic: true,
+      });
+      this.rawQuiet('NAMES', name);
+      this.rawQuiet('TOPIC', name);
+      this.rawQuiet('MODE', name);
+    }
+    if (this.restoreQueue.length === 0) return;
+    this.restoreTimer = setTimeout(() => {
+      this.restoreTimer = null;
+      if (!this.disposed && this.state === 'connected') this.drainRestoreQueue();
+    }, RESTORE_REQUEST_INTERVAL_MS);
+  }
+
+  private rawQuiet(command: string, arg: string): void {
+    try {
+      this.client.raw(command, arg);
+    } catch (_) {
+      /* ignore */
+    }
+  }
+
+  // Is this numeric the reply to a request the restore made for this channel
+  // (or, for 221, for us)? If so it is not history. Each reply retires its
+  // half of the entry, so a user's own /topic or /mode a moment later renders.
+  private isRestoreQuiet(numeric: string, channel: unknown): boolean {
+    if (typeof channel !== 'string' || this.restoreQuiet.size === 0) return false;
+    const key = channel.toLowerCase();
+    const entry = this.restoreQuiet.get(key);
+    if (!entry) return false;
+    if (Date.now() >= entry.until) {
+      this.restoreQuiet.delete(key);
+      return false;
+    }
+    const isMode = numeric === '324' || numeric === '329' || numeric === '221';
+    const isTopic = numeric === '331' || numeric === '332' || numeric === '333';
+    if (isMode && entry.mode) {
+      // 324 is followed by 329 on most servers; 221 stands alone.
+      if (numeric === '329' || numeric === '221') entry.mode = false;
+      return true;
+    }
+    if (isTopic && entry.topic) {
+      // 332 is followed by 333; 331 stands alone.
+      if (numeric === '331' || numeric === '333') entry.topic = false;
+      return true;
+    }
+    if (!entry.mode && !entry.topic) this.restoreQuiet.delete(key);
+    return false;
+  }
+
+  // Catch-up dedupe: has this line already been written by the process that
+  // was attached before us? By msgid where the network provides one; otherwise
+  // by the same target/kind/sender/text within a few seconds of the same time.
+  private alreadyPersisted(event: IrcEvent): boolean {
+    if (typeof event.msgid === 'string') {
+      return hasMessageWithMsgid(this.network.id, event.msgid);
+    }
+    const target = event.target as string;
+    const type = event.type;
+    if (!target || !type) return false;
+    const time = normalizeEventTime(event.time);
+    return hasRecentMessageLike(
+      this.network.id,
+      target,
+      type,
+      (event.nick as string | undefined) ?? null,
+      (event.text as string | undefined) ?? null,
+      time,
+    );
+  }
+
+  // Engine mode shutdown: leave the IRC socket in the engine for the next app
+  // process and end only our side. QUIT is deliberately NOT sent.
+  detach(): void {
+    this.intentionalDisconnect = true;
+    this.clearReconnectTimer();
+    const t = this.engineTransport;
+    if (t && t.isConnected()) t.detach();
+    else this.setState('disconnected', {}, { log: DETACHED_LOG });
+  }
+
+  // Engine mode: does the engine currently report holding this connection? True
+  // means a CONNECT will be an attach, not a dial.
+  private engineHoldsUs(): boolean {
+    if (!engineConfigured()) return false;
+    return EngineLink.shared().holds(engineConnectionId(this.network.user_id, this.network.id));
+  }
+
+  // After an engine-link loss. Wait for the link to say what it holds: held →
+  // CONNECT now, which the engine answers with ATTACH (not a dial, so not
+  // throttled). Not held — the engine itself restarted and the session really is
+  // gone — → this is a real reconnect and takes the ordinary ladder: backoff,
+  // the per-host stagger (#236), the policy gate (#616), and its persisted
+  // "Reconnecting…" row. A link that never comes back ends up there too.
+  private reattachSoon(): void {
+    if (this.disposed || this.intentionalDisconnect || this.reconnectTimer != null) return;
+    const link = EngineLink.shared();
+    const id = engineConnectionId(this.network.user_id, this.network.id);
+    void link.whenReady(ENGINE_REATTACH_WAIT_MS).then((r) => {
+      if (this.disposed || this.intentionalDisconnect || this.reconnectTimer != null) return;
+      if (r === 'ready' && link.holds(id)) this.connect();
+      else this.scheduleReconnectIfWarranted();
     });
   }
 

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -3,6 +3,7 @@
 
 import { EventEmitter } from 'events';
 import { IrcConnection } from './ircConnection.js';
+import { EngineLink, engineConfigured, engineConnectionId } from './engineLink.js';
 import * as systemLog from './systemLog.js';
 import connectScheduler from './connectScheduler.js';
 import { listNetworksForUser, getNetwork } from '../db/networks.js';
@@ -131,8 +132,13 @@ export function planChannelRejoins(
   return ops;
 }
 
+function engineHolds(userId: number, networkId: number): boolean {
+  return engineConfigured() && EngineLink.shared().holds(engineConnectionId(userId, networkId));
+}
+
 class IrcManager extends EventEmitter {
   byUser: Map<number, Map<number, IrcConnection>>;
+  private engineReconcileHooked = false;
 
   constructor() {
     super();
@@ -191,6 +197,46 @@ class IrcManager extends EventEmitter {
       .all()
       .map((r) => (r as { id: number }).id);
     for (const id of userIds) this.initForUser(id);
+    if (engineConfigured()) {
+      this.reconcileEngine();
+      // Again whenever the link (re)connects: an engine that answered after the
+      // boot-time wait, or came back from an outage, reports a fresh held list.
+      if (!this.engineReconcileHooked) {
+        this.engineReconcileHooked = true;
+        EngineLink.shared().on('ready', () => this.reconcileEngine());
+      }
+    }
+  }
+
+  // Engine mode: every socket the engine holds that no connection here speaks
+  // for. The previous process had it open — manually, or before the network was
+  // deleted or the account paused — and a held socket is a stronger statement
+  // of intent than the autoconnect flag, so it is ADOPTED (startNetwork, which
+  // attaches) whenever policy still allows, and closed when it doesn't: a
+  // paused account must not stay on IRC because the engine held the door.
+  reconcileEngine(): void {
+    const link = EngineLink.shared();
+    if (link.state !== 'ready') return;
+    for (const id of link.held) {
+      const m = /^(\d+):(\d+)$/.exec(id);
+      if (!m) continue;
+      const userId = Number(m[1]);
+      const networkId = Number(m[2]);
+      if (this.getConnection(userId, networkId)) continue;
+      const gate = this.connectGate(userId, networkId);
+      if (gate.ok) {
+        systemLog.log({
+          userId,
+          scope: `net:${gate.network.name}`,
+          fields: { networkId },
+          text: 'Adopting the connection the engine kept open',
+        });
+        this.startNetwork(userId, networkId);
+      } else {
+        console.warn(`[lurker] engine holds ${id} but ${gate.reason} — closing it`);
+        link.send({ op: 'close', id });
+      }
+    }
   }
 
   /**
@@ -280,6 +326,20 @@ class IrcManager extends EventEmitter {
       // so a reconnect re-clears the same gates the initial connect did. Read
       // live (not captured), because pause/lockdown can change mid-backoff.
       reconnectGate: () => this.gateReconnect(userId, networkId),
+      // Engine mode: a newer process claimed this connection. Drop the corpse
+      // (and tear its timers down — the transport is already dead, so the QUIT
+      // dispose() sends goes nowhere) so the next /connect builds afresh
+      // instead of finding it and doing nothing.
+      onTakenOver: () => {
+        if (this.connectionsForUser(userId).get(networkId) === conn) {
+          this.connectionsForUser(userId).delete(networkId);
+          try {
+            conn?.dispose('taken over by a newer process');
+          } catch (_) {
+            /* ignore */
+          }
+        }
+      },
     });
     this.connectionsForUser(userId).set(networkId, conn);
     // Seed self-presence from the per-user truth before the IRC handshake. The
@@ -298,29 +358,38 @@ class IrcManager extends EventEmitter {
     // object, so we bail instead of opening an orphan socket.
     const launch = (): void => {
       if (this.getConnection(userId, networkId) !== connRef || connRef.disposed) return;
+      // Engine mode: if the engine reports holding this connection, the CONNECT
+      // about to go out is an attach — say so, rather than announce a dial.
+      const held = engineHolds(userId, networkId);
       systemLog.log({
         userId,
         scope: `net:${network.name}`,
         fields: { networkId },
-        text: `Starting connection to ${network.host}:${network.port}${network.tls ? ' (TLS)' : ''}`,
+        text: held
+          ? `Attaching to the connection the engine kept open to ${network.host}`
+          : `Starting connection to ${network.host}:${network.port}${network.tls ? ' (TLS)' : ''}`,
       });
       connRef.connect();
     };
-    if (opts.deferrable) {
+    // An attach registers nothing on the ircd, so the per-host dial stagger
+    // has nothing to protect: engine-held sessions come back at once.
+    if (opts.deferrable && !engineHolds(userId, networkId)) {
       // Stagger bulk (re)connects per destination host so a fleet-wide restart
       // doesn't flood one IRC network from our IP. See connectScheduler / #236.
       connectScheduler.schedule(network.host, launch);
     } else {
       launch();
     }
-    conn.client.on('registered', () => {
-      // The rejoin list is where the user actually WAS (autojoin is written on
-      // the join echo, never the request), so a forwarded/failed join can't
-      // replay itself here.
-      const joined = listAutojoinChannels(networkId).map((b) => ({
-        name: b.target,
-        key: b.key,
-      }));
+    // The rejoin list is where the user actually WAS (autojoin is written on
+    // the join echo, never the request), so a forwarded/failed join can't
+    // replay itself here. On a re-attach the pass waits for the replay to walk
+    // the synthesised JOINs (onceRestored) and then joins only what the socket
+    // is NOT in — a socket the engine registered on its own (no channels), or
+    // one whose autojoin list grew while this process was away.
+    const rejoin = (onlyMissing: boolean): void => {
+      const joined = listAutojoinChannels(networkId)
+        .filter((b) => !onlyMissing || !connRef.isChannelJoined(b.target))
+        .map((b) => ({ name: b.target, key: b.key }));
       const names = joined.map((c) => c.name);
       if (names.length > 0) {
         systemLog.log({
@@ -331,6 +400,10 @@ class IrcManager extends EventEmitter {
         });
       }
       for (const op of planChannelRejoins(joined)) connRef.join(op.channels, op.keys);
+    };
+    conn.client.on('registered', () => {
+      if (connRef.restoring) connRef.onceRestored(() => rejoin(true));
+      else rejoin(false);
     });
 
     return conn;
@@ -872,7 +945,10 @@ class IrcManager extends EventEmitter {
     for (const userMap of this.byUser.values()) {
       for (const conn of userMap.values()) {
         try {
-          conn.disconnect();
+          // Engine mode: leave the sockets in the engine for the next process —
+          // that is the whole point. Otherwise QUIT as before.
+          if (engineConfigured()) conn.detach();
+          else conn.disconnect();
         } catch (_) {
           /* ignore */
         }

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -234,7 +234,13 @@ class IrcManager extends EventEmitter {
         this.startNetwork(userId, networkId);
       } else {
         console.warn(`[lurker] engine holds ${id} but ${gate.reason} — closing it`);
-        link.send({ op: 'close', id });
+        // requestClose, not a bare send: the link can drop between the check at
+        // the top of this loop and here, and a policy close that silently
+        // evaporates leaves a paused account on IRC. The queue is also what
+        // makes this decision stick — EngineLink flushes pending closes before
+        // it emits 'ready', i.e. before anything can decide those sockets are
+        // worth adopting.
+        link.requestClose(id);
       }
     }
   }

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -3,7 +3,12 @@
 
 import { EventEmitter } from 'events';
 import { IrcConnection } from './ircConnection.js';
-import { EngineLink, engineConfigured, engineConnectionId } from './engineLink.js';
+import {
+  EngineLink,
+  engineConfigured,
+  engineConnectionId,
+  isOurConnectionId,
+} from './engineLink.js';
 import * as systemLog from './systemLog.js';
 import connectScheduler from './connectScheduler.js';
 import { listNetworksForUser, getNetwork } from '../db/networks.js';
@@ -218,7 +223,15 @@ class IrcManager extends EventEmitter {
     const link = EngineLink.shared();
     if (link.state !== 'ready') return;
     for (const id of link.held) {
-      const m = /^(\d+):(\d+)$/.exec(id);
+      // The engine only offers us our own instance's sessions, but this is
+      // where a foreign id would do its damage — parsed into someone else's
+      // rowids and adopted as ours — so check the prefix here too rather than
+      // trusting the other side to have filtered.
+      if (!isOurConnectionId(id)) {
+        console.warn(`[lurker] engine offered ${id}, which is not this instance's — ignoring`);
+        continue;
+      }
+      const m = /^[0-9a-f]+:(\d+):(\d+)$/.exec(id);
       if (!m) continue;
       const userId = Number(m[1]);
       const networkId = Number(m[2]);

--- a/server/types/irc-framework.d.ts
+++ b/server/types/irc-framework.d.ts
@@ -37,6 +37,22 @@ declare module 'irc-framework' {
      * — and therefore which identd — a connection appears to originate from.
      */
     outgoing_addr?: string;
+    /**
+     * Pluggable transport (irc-framework `options.transport`): a class the
+     * Connection instantiates with these options and drives through
+     * connect/writeLine/close. Lurker supplies services/engineTransport.ts in
+     * engine mode; unset means the built-in TCP/TLS transport.
+     */
+    transport?: new (options: never) => object;
+    /** Engine mode: the connection id the engine knows this socket by. */
+    engineConnId?: string;
+    /** Engine mode: the RFC 1413 ident the engine answers for this socket. */
+    engineIdent?: string;
+    /** Engine mode: callbacks the transport reports phases through. */
+    engineHooks?: {
+      onTransport?(transport: unknown): void;
+      onPhase?(phase: string, info: Record<string, unknown>): void;
+    };
   }
 
   /** Options passed to the Client constructor. */
@@ -100,6 +116,17 @@ declare module 'irc-framework' {
      * survives a socket drop until the next 'connecting' event.
      */
     readonly connected: boolean;
+
+    /**
+     * The underlying Connection: `end()` closes the transport cleanly (what
+     * quit() ends in); `connected` mirrors the socket state.
+     */
+    connection: {
+      end(): void;
+      connected: boolean;
+      /** Feed one raw inbound line through the parser and handlers (tests). */
+      addReadBuffer(line: string): void;
+    };
 
     /** Request an IRCv3 capability during CAP negotiation. */
     requestCap(cap: string): void;


### PR DESCRIPTION
> **Draft — 2.1.3 has shipped; rebased onto it and ready for `/code-review high`.** PR 2 of 3, stacked on #828 (PR 1). Needs `/code-review high` before it leaves draft; two independent review passes have already run against it and their findings are folded in. Design: `lurker-dev/IRC_ENGINE_PLAN.md` §5.3–5.6.

## What

`LURKER_ENGINE_URL` puts the app into engine mode. **Unset — the default everywhere — nothing here runs** and the app dials IRC itself exactly as before; that is the path the whole existing suite still exercises (4155 tests green).

Set, `IrcConnection` routes its irc-framework Client through an engine-backed transport — the pluggable `options.transport` seam irc-framework already has — so the 6,000 lines of handlers keep a real, live Client and never learn the socket is elsewhere. CONNECT is connect-or-attach: for a socket the engine already holds, the transport replays the recorded session into the fresh Client and swallows the registration it sends back.

## What a restore deliberately does not do (each pinned by `engineIntegration.test.ts`)

- persist any of the replay — `publish()` drops anything that would persist while `restoring` (one line; covers the MOTD, "Connected as", "Negotiated capabilities", own-join rows, per-channel nick rows)
- run the connect commands again, or re-JOIN the autojoin list (a channel you were kicked from while the app was away stays left)
- announce "Connecting…" — that notice now waits for the engine's `dialing` phase
- render the replies to its own MODE/NAMES/TOPIC requests as history (`324/329/331/332/333` are quieted for those channels for 10 s — a synthesised JOIN gets nothing volunteered, so the restore has to ask, and today's renderer would print each answer on every restart)

## Failure modes

- **Link to the engine lost, socket still held** → `reconnecting` → immediate re-CONNECT → ATTACH. No `disconnected` state, no presence sweep, no error row (pinned).
- **A newer process took the connection** → terminal and quiet for the old one.
- **Engine unreachable** → the ordinary backoff ladder, with the reason in the error row.
- **Engine refuses the app** (wrong secret, protocol major) → engine mode off for this run, direct dialing, a loud log line. A misconfigured engine can never leave a cell with no IRC.

`ircManager.shutdown()` detaches instead of QUITting; a user's disconnect, a deleted network and a paused account still close the socket. Anything the engine holds that boot doesn't claim is closed rather than left as a ghost on the network.

## Files

`server/services/engineLink.ts` (one link per process, reconnects with backoff, terminal refusal), `server/services/engineTransport.ts` (the transport + restore procedure), gates in `ircConnection.ts` / `ircManager.ts` / `server.ts` (top-level `await` settles the link before identd is decided), `types/irc-framework.d.ts`.

## Tests

`engineTransport.test.ts` (6): the restore under a real irc-framework Client — timeline order (attached → registered → nick → join → restored → backlog → live), caps identical, exactly `CAP/NICK/USER/CAP/CAP` swallowed, takeover, detach, gap ordering, unreachable/refused codes.
`engineIntegration.test.ts` (4): a real `IrcConnection` + scratch DB + `ircManager`: first connect persists like a socket would; detach; a new `IrcConnection` re-attaches with **exactly** the gap's rows (a KICK honoured, two messages, in order) and nothing else, one registration on the ircd, no NICK/USER/CAP/JOIN, no connect command; link loss re-attaches silently; shutdown detaches; dispose still QUITs.

Also run with the real modules against the live ergo on von-braun: identical `317` signon before and after the restart.

