### PR TITLE
Self-host topology for the engine: compose overlay, docs, engine-1 tag (#386, 3/3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -203,6 +203,11 @@ VAPID_SUBJECT=mailto:you@example.com
 #
 # Engine-side only (server/engine.ts):
 #   Where to listen. Keep it off the public internet: a docker network or VPC.
+#   LURKER_ENGINE_SECRET is the ONLY thing between a reachable engine and every
+#   connection it holds, so treat this like a database port, not a web port.
+#   (Sessions are partitioned by the Lurker database that opened them, so two
+#   Lurker instances on one engine cannot reach each other's connections — but
+#   that is isolation between honest instances, not a substitute for the bind.)
 # LURKER_ENGINE_LISTEN=0.0.0.0:8016
 #   How much of what arrives while the app is away to keep, per connection and
 #   in total (bytes, digits only, at least 65536 — below that the engine refuses

--- a/.env.example
+++ b/.env.example
@@ -174,6 +174,47 @@ VAPID_SUBJECT=mailto:you@example.com
 # LURKER_OIDENTD_FILE=~/.oidentd.conf
 
 # ---------------------------------------------------------------------------
+# IRC engine — keep IRC connected across Lurker upgrades. Off by default: the
+# app dials IRC itself. Set LURKER_ENGINE_URL and the IRC sockets live in a
+# separate `lurker-engine` process (same image, `tsx server/engine.ts`) that an
+# app upgrade never restarts — same nick, same channels, nothing re-registers,
+# and what was said while the app was down is delivered when it returns.
+# The Docker way is the docker-compose.engine.yml overlay, which sets all of
+# this; see "IRC engine" in docs/SELF_HOSTING.md.
+#
+# The presence of LURKER_ENGINE_URL IS the switch. Both processes must share
+# LURKER_ENGINE_SECRET (`openssl rand -hex 32`). An app the engine REFUSES
+# (wrong secret, incompatible engine version) logs why and falls back to
+# dialing IRC directly for that run — though ident is not answered until the
+# secret is fixed, since :113 is the engine's. An engine that is merely
+# UNREACHABLE (down, or a typo in the host) is a different thing: the app stays
+# in engine mode and its connections wait for it, retrying, because the sockets
+# may well still be alive in there; it logs that it is waiting.
+#
+# ⚠ identd (LURKER_IDENTD_ENABLED / LURKER_OIDENTD_FILE) belongs to whichever
+# process holds the socket — in engine mode, the ENGINE. Set it on the engine
+# (and give the engine the :113 port mapping and, for oidentd, the file's bind
+# mount); the app ignores those two while an engine is configured.
+# LURKER_OUTGOING_ADDR stays on the APP: it reads the variable and tells the
+# engine which address to bind.
+# ---------------------------------------------------------------------------
+# LURKER_ENGINE_URL=tcp://lurker-engine:8016
+# LURKER_ENGINE_SECRET=replace-me-with-a-long-random-string
+#
+# Engine-side only (server/engine.ts):
+#   Where to listen. Keep it off the public internet: a docker network or VPC.
+# LURKER_ENGINE_LISTEN=0.0.0.0:8016
+#   How much of what arrives while the app is away to keep, per connection and
+#   in total (bytes, digits only, at least 65536 — below that the engine refuses
+#   to start). Past the cap the OLDEST lines are dropped and the app is told
+#   where the hole is.
+# LURKER_ENGINE_BUFFER_BYTES=4194304
+# LURKER_ENGINE_BUFFER_TOTAL_BYTES=268435456
+#   A session no app has claimed for this long (ms) is ended — the backstop for
+#   an app that never comes back (or one an older engine refuses).
+# LURKER_ENGINE_ORPHAN_MS=3600000
+
+# ---------------------------------------------------------------------------
 # Outbound connect throttle. On (re)start Lurker auto-connects every user's
 # autoconnect networks; on a busy multi-user instance many land on the SAME IRC
 # network from one IP in the same instant, tripping registration-flood limits.

--- a/.env.example
+++ b/.env.example
@@ -202,13 +202,20 @@ VAPID_SUBJECT=mailto:you@example.com
 # LURKER_ENGINE_SECRET=replace-me-with-a-long-random-string
 #
 # Engine-side only (server/engine.ts):
-#   Where to listen. Keep it off the public internet: a docker network or VPC.
-#   LURKER_ENGINE_SECRET is the ONLY thing between a reachable engine and every
-#   connection it holds, so treat this like a database port, not a web port.
-#   (Sessions are partitioned by the Lurker database that opened them, so two
-#   Lurker instances on one engine cannot reach each other's connections — but
-#   that is isolation between honest instances, not a substitute for the bind.)
-# LURKER_ENGINE_LISTEN=0.0.0.0:8016
+#   Where to listen. DEFAULTS TO 127.0.0.1:8016 — the engine beside the app on
+#   one host, which is the ordinary self-host. LURKER_ENGINE_SECRET is the ONLY
+#   thing between a reachable engine and every connection it holds, so treat
+#   this like a database port, not a web port. (Sessions are partitioned by the
+#   Lurker database that opened them, so two Lurker instances on one engine
+#   cannot reach each other's connections — but that is isolation between
+#   honest instances, not a substitute for the bind.)
+#   ⚠ In Docker you must widen it: containers do not share a network namespace,
+#   so a loopback bind is unreachable from the app's container. The compose
+#   overlay sets 0.0.0.0:8016 and publishes no port, which is why :8016 exists
+#   only on the compose network.
+#   ⚠ On one host, point LURKER_ENGINE_URL at 127.0.0.1, not `localhost` —
+#   `localhost` can resolve to ::1 first, which a 127.0.0.1 bind will refuse.
+# LURKER_ENGINE_LISTEN=127.0.0.1:8016
 #   How much of what arrives while the app is away to keep, per connection and
 #   in total (bytes, digits only, at least 65536 — below that the engine refuses
 #   to start). Past the cap the OLDEST lines are dropped and the app is told

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      publish_engine:
+        description: 'Also move the engine-1 tag (normally automatic on releases that touch the engine)'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -32,6 +37,55 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The engine step diffs against the previous release tag; a plain
+          # push build needs no history.
+          fetch-depth: ${{ github.event_name == 'release' && 0 || 1 }}
+
+      # The IRC engine (server/engine.ts) ships in this same image under its
+      # own tag lineage, `engine-<protocol major>`, that moves ONLY when a
+      # release changes the engine. Self-hosters run the engine from that tag so
+      # `docker compose pull && up -d` recreates the app and leaves the engine —
+      # and their IRC connections — alone (docker-compose.engine.yml). On a
+      # release: diff the engine's files against the previous release tag; on a
+      # manual run: the publish_engine input. Never on a push (staging).
+      #
+      # The major is read from the source of truth, server/engine/protocol.ts,
+      # so a PROTOCOL_MAJOR bump cannot publish a v2 engine under `engine-1`.
+      # package.json / package-lock.json are deliberately NOT in the path list:
+      # every release bumps the version field, which would move the tag on
+      # every release. The one dependency the engine runs on (irc-framework's
+      # line parser) is compared by its resolved version instead.
+      - name: Decide whether the engine tag moves
+        id: engine
+        shell: bash
+        run: |
+          set -euo pipefail
+          MAJOR="$(sed -nE 's/^export const PROTOCOL_MAJOR = ([0-9]+);/\1/p' server/engine/protocol.ts)"
+          [ -n "$MAJOR" ] || { echo "could not read PROTOCOL_MAJOR from server/engine/protocol.ts" >&2; exit 1; }
+          version="${GITHUB_REF_NAME#v}"
+          changed=false
+          if [ "${{ github.event_name }}" = "release" ]; then
+            prev="$(git describe --tags --abbrev=0 "${GITHUB_REF_NAME}^" 2>/dev/null || true)"
+            if [ -z "$prev" ]; then
+              changed=true
+            elif ! git diff --quiet "$prev" "$GITHUB_REF_NAME" -- \
+                server/engine server/engine.ts server/services/identd.ts \
+                server/utils/processGuards.ts server/utils/userAgent.ts \
+                Dockerfile 'tsconfig*.json'; then
+              changed=true
+            else
+              dep() { git show "$1:package-lock.json" | jq -r '.packages["node_modules/irc-framework"].version // empty'; }
+              [ "$(dep "$prev")" = "$(dep "$GITHUB_REF_NAME")" ] || changed=true
+            fi
+            echo "engine files changed since ${prev:-<none>}: $changed"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish_engine }}" = "true" ]; then
+            changed=true
+            version="manual-$(git rev-parse --short HEAD)"
+          fi
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -54,6 +108,8 @@ jobs:
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
             type=sha,prefix=
+            type=raw,value=engine-${{ steps.engine.outputs.major }},enable=${{ steps.engine.outputs.changed == 'true' }}
+            type=raw,value=engine-${{ steps.engine.outputs.major }}-${{ steps.engine.outputs.version }},enable=${{ steps.engine.outputs.changed == 'true' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,7 +40,12 @@ jobs:
         with:
           # The engine step diffs against the previous release tag; a plain
           # push build needs no history.
-          fetch-depth: ${{ github.event_name == 'release' && 0 || 1 }}
+          #
+          # The values are QUOTED on purpose. `cond && 0 || 1` always evaluates
+          # to 1 in a GitHub Actions expression, because 0 is falsy and the
+          # `|| 1` branch wins — which would silently make every release a
+          # shallow checkout, and every release move the engine tag.
+          fetch-depth: ${{ github.event_name == 'release' && '0' || '1' }}
 
       # The IRC engine (server/engine.ts) ships in this same image under its
       # own tag lineage, `engine-<protocol major>`, that moves ONLY when a
@@ -66,6 +71,14 @@ jobs:
           version="${GITHUB_REF_NAME#v}"
           changed=false
           if [ "${{ github.event_name }}" = "release" ]; then
+            # Without history there is nothing to diff, and the fallback below
+            # is "publish" — so a shallow checkout here would quietly move the
+            # engine tag on every release, which is the one thing this step
+            # exists to prevent. Fail loudly instead.
+            if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+              echo "shallow clone: cannot decide the engine tag (fetch-depth must be 0 on releases)" >&2
+              exit 1
+            fi
             prev="$(git describe --tags --abbrev=0 "${GITHUB_REF_NAME}^" 2>/dev/null || true)"
             if [ -z "$prev" ]; then
               changed=true

--- a/docker-compose.engine.yml
+++ b/docker-compose.engine.yml
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 Brad Root
+# SPDX-License-Identifier: MPL-2.0
+#
+# IRC engine — keep IRC connected across Lurker upgrades. Available from 2.1.4.
+#
+# Layer it on top of the base compose file:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.engine.yml up -d
+#
+# (Combine with -f docker-compose.caddy.yml / -f docker-compose.previews.yml
+# freely — the overlays touch different things.)
+#
+# What it does: the IRC sockets move into a SECOND container, `lurker-engine`,
+# that the ordinary upgrade never recreates. `docker compose pull && docker
+# compose up -d` then replaces only `lurker` — the app, the web UI, the database
+# writer — and your IRC connections stay up: same nick, same channels, nothing
+# re-registers, and whatever was said while the app was down is delivered when
+# it comes back. Pointing Lurker at the engine (LURKER_ENGINE_URL) is the
+# entire switch; without this overlay the app dials IRC itself exactly as
+# before.
+#
+# ⚠ The one upgrade that still drops IRC is the ENGINE's. Its image tag is
+# `engine-1` (see `image:` below), which only moves when a release changes the
+# engine itself — the changelog says so when one does. Everything else moves
+# `latest` and leaves the engine running. A release that needs `engine-2`
+# says so too, and for that one: STOP THE ENGINE FIRST, then upgrade — the
+# old engine would otherwise keep every session alive while the new app,
+# refused by it, dials its own and collides with its own ghosts (the engine
+# does reap sessions nobody has claimed for an hour, but that is a backstop).
+#
+# ⚠ Opting in drops IRC once: the `up -d` that adds the engine recreates
+# `lurker` with the new setting. Opting back out: STOP THE ENGINE FIRST, then
+# bring the stack up WITHOUT this file — and if you put the overlay in a
+# COMPOSE_FILE line in .env, take it out of there first, or the plain command
+# still loads it:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.engine.yml stop lurker-engine
+#   COMPOSE_FILE=docker-compose.yml docker compose up -d --remove-orphans
+#
+# ⚠ The secret is shared: set LURKER_ENGINE_SECRET once, in a .env file beside
+# this compose (`openssl rand -hex 32` makes a good one). The app authenticates
+# to the engine with it; both sides read the same variable.
+#
+# identd moves WITH the socket. If you run the built-in identd or the oidentd
+# file (LURKER_IDENTD_ENABLED / LURKER_OIDENTD_FILE), those now belong on the
+# engine — it is the process holding the connection the network asks about.
+# This file forwards them from .env; if yours live in an `environment:` block
+# on `lurker` in a docker-compose.override.yml instead, move that block to
+# `lurker-engine` there. The host :113 mapping and, for oidentd, the bind
+# mount are yours to add on `lurker-engine` too (they were yours to add on
+# `lurker` before) — they are deliberately NOT published here, because a host
+# that already runs its own identd owns :113. See "IRC engine" in
+# docs/SELF_HOSTING.md for the snippet. LURKER_OUTGOING_ADDR stays on
+# `lurker`: the app tells the engine which address to bind.
+
+services:
+  lurker:
+    environment:
+      # The presence of this variable IS the feature gate.
+      - LURKER_ENGINE_URL=tcp://lurker-engine:8016
+      - LURKER_ENGINE_SECRET=${LURKER_ENGINE_SECRET:?set LURKER_ENGINE_SECRET in .env (openssl rand -hex 32)}
+    depends_on:
+      lurker-engine:
+        condition: service_healthy
+
+  lurker-engine:
+    # ⚠ NOT `latest`. Compose recreates every service whose image changed on
+    # `up -d`; on `latest` every app release would restart the engine too and
+    # drop IRC — the thing this overlay exists to prevent. `engine-1` moves only
+    # with engine releases. The `1` is the engine protocol major: a `lurker`
+    # release that needs `engine-2` will say so, and refuses to talk to an
+    # `engine-1` (it falls back to dialing IRC directly rather than hang).
+    # LURKER_ENGINE_IMAGE overrides the whole reference — for a locally built
+    # image, or to pin a release.
+    image: ${LURKER_ENGINE_IMAGE:-ghcr.io/amiantos/lurker:engine-1}
+    container_name: lurker-engine
+    restart: unless-stopped
+    command: ['node_modules/.bin/tsx', 'server/engine.ts']
+    # No volumes: the engine holds no data. The database, uploads and sessions
+    # stay with `lurker`. (oidentd file mode is the one thing that wants a mount
+    # here — see above.)
+    environment:
+      - LURKER_ENGINE_SECRET=${LURKER_ENGINE_SECRET:?set LURKER_ENGINE_SECRET in .env (openssl rand -hex 32)}
+      # Ident — see the note above. Empty is the same as unset, so declaring
+      # them costs nothing; the engine logs which mode it resolved at boot.
+      - LURKER_IDENTD_ENABLED=${LURKER_IDENTD_ENABLED:-}
+      - LURKER_IDENTD_PORT=${LURKER_IDENTD_PORT:-}
+      - LURKER_IDENTD_BIND=${LURKER_IDENTD_BIND:-}
+      - LURKER_OIDENTD_FILE=${LURKER_OIDENTD_FILE:-}
+      # How much of what arrives while the app is down the engine keeps, per
+      # connection and in total (bytes, digits only, at least 65536). Past the
+      # cap the OLDEST lines go and the app is told where the hole is.
+      # Defaults: 4 MiB / 256 MiB.
+      - LURKER_ENGINE_BUFFER_BYTES=${LURKER_ENGINE_BUFFER_BYTES:-}
+      - LURKER_ENGINE_BUFFER_TOTAL_BYTES=${LURKER_ENGINE_BUFFER_TOTAL_BYTES:-}
+    # The engine answers a plain HTTP probe on its own port; `lurker` waits for
+    # it so the first connect attempts don't race the engine's own start.
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "require('http').get('http://127.0.0.1:8016/healthz',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    logging:
+      options:
+        max-size: 20m
+        max-file: '3'

--- a/docker-compose.engine.yml
+++ b/docker-compose.engine.yml
@@ -81,6 +81,14 @@ services:
     # here — see above.)
     environment:
       - LURKER_ENGINE_SECRET=${LURKER_ENGINE_SECRET:?set LURKER_ENGINE_SECRET in .env (openssl rand -hex 32)}
+      # ⚠ REQUIRED here, and not a stray default. The engine binds 127.0.0.1
+      # unless told otherwise, which is right for an engine running beside the
+      # app on a host but wrong in a container: containers do not share a
+      # network namespace, so a loopback bind here is unreachable from the
+      # `lurker` container and every connection fails. Nothing is exposed by
+      # this — the service publishes no ports, so :8016 exists only on the
+      # compose network. Remove this line and the stack stops working.
+      - LURKER_ENGINE_LISTEN=${LURKER_ENGINE_LISTEN:-0.0.0.0:8016}
       # Ident — see the note above. Empty is the same as unset, so declaring
       # them costs nothing; the engine logs which mode it resolved at boot.
       - LURKER_IDENTD_ENABLED=${LURKER_IDENTD_ENABLED:-}

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -526,6 +526,61 @@ Playback replays the last 50 lines per joined channel (plus your 20 most recentl
 
 Known limitations (shared-connection bouncer semantics): replies to one attached client's WHOIS/LIST are visible to all attached clients on that network; Lurker-side ignore rules don't filter the live relay; and on end-to-end encrypted channels an attached client sees the wire ciphertext for incoming messages.
 
+### IRC engine (upgrade without dropping IRC)
+
+_Available from 2.1.4._ Every Lurker upgrade restarts the container, and the container holds your IRC connections — so every upgrade has meant a reconnect: re-register, re-identify, rejoin, and a `Quit`/`Join` for everyone in your channels. The **engine** ends that. It is a second container that holds the IRC sockets and nothing else, and the ordinary upgrade never recreates it.
+
+Enable it with the overlay:
+
+```bash
+echo "LURKER_ENGINE_SECRET=$(openssl rand -hex 32)" >> .env
+docker compose -f docker-compose.yml -f docker-compose.engine.yml up -d
+```
+
+That first `up -d` recreates `lurker` with the new setting and drops IRC one last time. From then on:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.engine.yml pull
+docker compose -f docker-compose.yml -f docker-compose.engine.yml up -d
+```
+
+replaces only the app. Your connections stay up — same nick, same channels, nothing re-registers — and whatever was said while the app was down is delivered when it comes back. The web UI reconnects on its own, as it does after any restart. (Tip: put `COMPOSE_FILE=docker-compose.yml:docker-compose.engine.yml` in `.env` and the commands go back to plain `pull` / `up -d`; remember that line when you turn the engine off again, below.)
+
+Without the overlay nothing changes: the app dials IRC itself exactly as before. `LURKER_ENGINE_URL` is the whole switch.
+
+**What still drops IRC:** an upgrade of the engine itself. Its image tag is `engine-1`, which only moves when a release changes the engine — rare, and called out in that release's notes. `pull` fetches nothing new for it otherwise, and `up -d` leaves it running. A release that needs `engine-2` is called out too, and for that one **stop the engine first** (`docker compose … stop lurker-engine`), then upgrade both: an old engine that refuses the new app would otherwise keep every session alive while the app dials its own and collides with its own ghosts. (The engine ends any session no app has claimed for an hour — `LURKER_ENGINE_ORPHAN_MS` — but that is a backstop, not a procedure.)
+
+**identd moves with the socket.** If you run the built-in identd (`LURKER_IDENTD_ENABLED`, and `LURKER_IDENTD_PORT`/`LURKER_IDENTD_BIND` if set) or the oidentd file (`LURKER_OIDENTD_FILE`), they now belong on the engine — it is the process holding the connection the network asks about; the app ignores them while an engine is configured, and the engine logs which mode it resolved at boot. Where they live decides what to do:
+
+- In `.env`: nothing to edit — the overlay forwards them to `lurker-engine`.
+- In an `environment:` block on `lurker` in your `docker-compose.override.yml` (how most people set them): move that block to `lurker-engine`. The overlay cannot see values set there.
+
+The host `:113` mapping is yours to add on `lurker-engine`, as it was yours to add on `lurker` — the overlay deliberately does not publish it, because a host that already runs its own ident daemon owns that port (that is what `LURKER_OIDENTD_FILE` mode is for). For oidentd, the file's bind mount moves too. In `docker-compose.override.yml`:
+
+```yaml
+services:
+  lurker-engine:
+    ports:
+      - '113:113' # built-in identd
+    volumes:
+      - ./oidentd:/oidentd # oidentd file mode: LURKER_OIDENTD_FILE=/oidentd/lurker.conf
+```
+
+…and remove the same from `lurker` (if you used the DigitalOcean deploy's identd overlay, that is where its `113:113` lives). `LURKER_OUTGOING_ADDR` is the exception: it **stays on `lurker`** — the app reads it and tells the engine which address to bind — but the address must of course exist on the engine's host.
+
+**Turning it off again.** Stop the engine first, or the network briefly sees two of you; then bring the stack up _without_ the overlay — and if you added the `COMPOSE_FILE` line to `.env`, take the overlay out of it first, otherwise the plain command still loads it and simply restarts the engine you just stopped:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.engine.yml stop lurker-engine
+COMPOSE_FILE=docker-compose.yml docker compose up -d --remove-orphans
+```
+
+**If the engine refuses the app** — wrong `LURKER_ENGINE_SECRET`, or an app that needs a newer engine — the app logs exactly that at startup and falls back to dialing IRC directly for that run: IRC works, but ident is not answered until you fix it (the engine owns `:113` now). **If the engine is merely unreachable** — it is down, or `LURKER_ENGINE_URL` has a typo — that is _not_ a fallback: the app stays in engine mode and its connections wait for it, retrying and logging that they are waiting, because the sockets may well still be alive in there. `docker compose logs lurker` says which of the two you are looking at.
+
+**Buffering while the app is down.** The engine keeps what arrives per connection (4 MiB by default, 256 MiB in total; `LURKER_ENGINE_BUFFER_BYTES` / `LURKER_ENGINE_BUFFER_TOTAL_BYTES`, digits, at least 65536). Past that the oldest lines go, and the app notes where the hole is in the network's server buffer when it comes back. Deploys take seconds; the buffer covers hours of normal traffic.
+
+**Health.** `curl http://lurker-engine:8016/healthz` from inside the compose network answers `{"ok":true,"held":N}` with the number of connections it is holding; the overlay uses the same probe as the service's healthcheck. `LURKER_ENGINE_IMAGE` overrides the image reference — a locally built image, or a pinned release.
+
 ---
 
 ## Troubleshooting

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -579,6 +579,10 @@ COMPOSE_FILE=docker-compose.yml docker compose up -d --remove-orphans
 
 **Buffering while the app is down.** The engine keeps what arrives per connection (4 MiB by default, 256 MiB in total; `LURKER_ENGINE_BUFFER_BYTES` / `LURKER_ENGINE_BUFFER_TOTAL_BYTES`, digits, at least 65536). Past that the oldest lines go, and the app notes where the hole is in the network's server buffer when it comes back. Deploys take seconds; the buffer covers hours of normal traffic.
 
+**One engine, more than one Lurker.** Sessions are keyed to the Lurker database that opened them, not just to a user and network number — those are row ids, and two separate Lurker databases both number their first user and first network `1`. Each Lurker generates an identity for itself the first time it talks to an engine and keeps it in its own database, so two of them on one engine cannot see, attach to, drive or close each other's connections, and neither is told the other's exist. The engine refuses an app that does not identify itself at all rather than letting it share an id space with everyone else.
+
+That makes the arrangement safe, not tuned: the buffer budget (`LURKER_ENGINE_BUFFER_TOTAL_BYTES`) is shared across everything the engine holds, and so is `:113` — one identd answers for every connection on that host, which is fine when the connections are yours and not what you want between strangers. **Keep the engine on a private network either way.** `LURKER_ENGINE_SECRET` is the only thing standing between the internet and every connection the engine holds, and the overlay deliberately publishes no port.
+
 **Health.** `curl http://lurker-engine:8016/healthz` from inside the compose network answers `{"ok":true,"held":N}` with the number of connections it is holding; the overlay uses the same probe as the service's healthcheck. `LURKER_ENGINE_IMAGE` overrides the image reference — a locally built image, or a pinned release.
 
 ---

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -583,6 +583,8 @@ COMPOSE_FILE=docker-compose.yml docker compose up -d --remove-orphans
 
 That makes the arrangement safe, not tuned: the buffer budget (`LURKER_ENGINE_BUFFER_TOTAL_BYTES`) is shared across everything the engine holds, and so is `:113` — one identd answers for every connection on that host, which is fine when the connections are yours and not what you want between strangers. **Keep the engine on a private network either way.** `LURKER_ENGINE_SECRET` is the only thing standing between the internet and every connection the engine holds, and the overlay deliberately publishes no port.
 
+**Where the engine listens.** It binds `127.0.0.1:8016` unless told otherwise, so an engine nobody configured is not reachable from another machine. The overlay sets `LURKER_ENGINE_LISTEN=0.0.0.0:8016` because containers do not share a network namespace — a loopback bind inside `lurker-engine` is unreachable from `lurker` — and that is safe there precisely because no port is published: `:8016` exists only on the compose network. **Running without Docker**, app and engine on one host, the default already works; point `LURKER_ENGINE_URL` at `tcp://127.0.0.1:8016` rather than `localhost`, which can resolve to `::1` first and be refused. Putting the engine on a _different_ host means widening the bind yourself, and then the secret is doing real work over a real network — give it a private network or a tunnel, not the open internet.
+
 **Health.** `curl http://lurker-engine:8016/healthz` from inside the compose network answers `{"ok":true,"held":N}` with the number of connections it is holding; the overlay uses the same probe as the service's healthcheck. `LURKER_ENGINE_IMAGE` overrides the image reference — a locally built image, or a pinned release.
 
 ---

--- a/server/engine/topology.test.ts
+++ b/server/engine/topology.test.ts
@@ -32,6 +32,24 @@ describe('engine topology artefacts', () => {
     expect(wf).not.toMatch(/git diff --quiet[^\n]*package\.json/);
   });
 
+  // The engine binds loopback unless told otherwise (server/engine/config.ts),
+  // which is the safe default for an engine beside the app on a host — and
+  // fatal in a container, where loopback is that container's own namespace and
+  // the `lurker` container cannot reach it. The overlay must therefore set the
+  // bind, and this pins the coupling from the other end: nothing else would
+  // fail if that line were dropped, until every connection did.
+  it('the compose overlay gives the engine a reachable bind', () => {
+    const overlay = fs.readFileSync(path.join(root, 'docker-compose.engine.yml'), 'utf8');
+    const m = /LURKER_ENGINE_LISTEN=\$\{LURKER_ENGINE_LISTEN:-([^}]+)\}/.exec(overlay);
+    expect(
+      m,
+      'the overlay should set LURKER_ENGINE_LISTEN for the engine container',
+    ).not.toBeNull();
+    expect(m![1]).not.toMatch(/^(127\.|::1|localhost)/);
+    // …and it still must not publish the port; the compose network is the boundary.
+    expect(overlay).not.toMatch(/^\s*ports:/m);
+  });
+
   // `${{ cond && 0 || 1 }}` always evaluates to 1 in a GitHub Actions
   // expression: 0 is falsy, so the `|| 1` branch wins. In the checkout step
   // that silently turns every release into a shallow clone, `git describe`

--- a/server/engine/topology.test.ts
+++ b/server/engine/topology.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The engine's protocol major is copied into two artefacts that CI and
+// self-hosters read: the image tag the compose overlay pins, and the tag the
+// publish workflow derives. The workflow reads the constant from source; this
+// pins the overlay to it, so a PROTOCOL_MAJOR bump cannot ship a v2 engine to
+// people pulling `engine-1`.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { PROTOCOL_MAJOR } from './protocol.js';
+
+const root = path.join(import.meta.dirname, '..', '..');
+
+describe('engine topology artefacts', () => {
+  it('docker-compose.engine.yml pins the image tag for this PROTOCOL_MAJOR', () => {
+    const overlay = fs.readFileSync(path.join(root, 'docker-compose.engine.yml'), 'utf8');
+    const m = /image:\s*\$\{LURKER_ENGINE_IMAGE:-ghcr\.io\/amiantos\/lurker:engine-(\d+)\}/.exec(
+      overlay,
+    );
+    expect(m, 'the overlay should pin ghcr.io/amiantos/lurker:engine-<major>').not.toBeNull();
+    expect(Number(m![1])).toBe(PROTOCOL_MAJOR);
+  });
+
+  it('the publish workflow reads the major from protocol.ts rather than hardcoding it', () => {
+    const wf = fs.readFileSync(path.join(root, '.github/workflows/docker-publish.yml'), 'utf8');
+    expect(wf).toMatch(/PROTOCOL_MAJOR = \(\[0-9\]\+\);/);
+    expect(wf).not.toMatch(/^\s*MAJOR=\d+\s*$/m);
+    // And it never trips on the version bump every release makes.
+    expect(wf).not.toMatch(/git diff --quiet[^\n]*package\.json/);
+  });
+});

--- a/server/engine/topology.test.ts
+++ b/server/engine/topology.test.ts
@@ -31,4 +31,24 @@ describe('engine topology artefacts', () => {
     // And it never trips on the version bump every release makes.
     expect(wf).not.toMatch(/git diff --quiet[^\n]*package\.json/);
   });
+
+  // `${{ cond && 0 || 1 }}` always evaluates to 1 in a GitHub Actions
+  // expression: 0 is falsy, so the `|| 1` branch wins. In the checkout step
+  // that silently turns every release into a shallow clone, `git describe`
+  // finds no previous tag, the step falls back to "the engine changed", and
+  // `engine-<major>` moves on EVERY release — recreating the engine container,
+  // and dropping the IRC connections the whole overlay exists to keep. It
+  // fails in the direction that looks like success, and nothing but a
+  // self-hoster noticing their connections drop would report it.
+  it('the publish workflow cannot land a falsy value in a GitHub Actions ternary', () => {
+    const wf = fs.readFileSync(path.join(root, '.github/workflows/docker-publish.yml'), 'utf8');
+    const ternaries = [...wf.matchAll(/\$\{\{[^}]*?&&([^}]*?)\|\|[^}]*?\}\}/g)];
+    expect(ternaries.length, 'expected at least the fetch-depth ternary').toBeGreaterThan(0);
+    for (const t of ternaries) {
+      expect(t[1].trim(), `falsy true-branch in ${t[0]}`).not.toMatch(/^(0|false|'')$/);
+    }
+    // The release path must also refuse to decide from a clone that cannot see
+    // history, rather than falling through to "publish".
+    expect(wf).toMatch(/is-shallow-repository/);
+  });
 });


### PR DESCRIPTION
> **Draft — 2.1.3 has shipped; rebased onto it and reviewed.** PR 3 of 3, stacked on #829 (PR 2). Docs, compose and CI only. Design: `lurker-dev/IRC_ENGINE_PLAN.md` §5.9.

## What a self-hoster sees

**Nothing, unless they opt in.** `LURKER_ENGINE_URL` is the switch, the same contract as `LURKER_PREVIEWS_URL`. `docker compose pull && up -d` keeps working exactly as today.

Opting in is `docker-compose.engine.yml` in the previews-overlay style: adds `lurker-engine` (with a healthcheck on its own `/healthz`, and `LURKER_ENGINE_IMAGE` to override the image), sets the URL + shared secret on `lurker`, and forwards the identd/oidentd variables from `.env` to the engine (they belong to whoever holds the socket). It deliberately does **not** publish host `:113` — a host already running its own ident daemon owns that port — so identd users add the mapping (and, for oidentd, the bind mount) on `lurker-engine` in their override; the docs carry the snippet. `LURKER_OUTGOING_ADDR` stays on `lurker` (the app reads it and tells the engine what to bind).

## The compose trap, and the `engine-1` tag

`docker compose up -d` recreates every service whose image changed. On `latest`, every app release would restart the engine too and drop IRC — defeating the overlay for exactly the people it's for. So the engine service pins **`ghcr.io/amiantos/lurker:engine-1`** (the `1` is `PROTOCOL_MAJOR`), and `docker-publish.yml` moves that tag (plus a pinned `engine-1-<version>`) **only on releases whose diff against the previous release tag touches the engine's files**, or on a manual run that asks. A docs-only release leaves the tag's digest where it was — the gate reads `PROTOCOL_MAJOR` from source, ignores the per-release version bump, and compares irc-framework's resolved version instead of the lockfile as a whole (a test pins the overlay's tag to the constant).

**Post-merge step:** the `engine-1` tag does not exist until a release (or a manual run) publishes it, and the docs/overlay go live on merge. Right after merging: `gh workflow run docker-publish.yml -f publish_engine=true`, then `docker manifest inspect ghcr.io/amiantos/lurker:engine-1`. The docs say "available from 2.1.4".

## Docs

`docs/SELF_HOSTING.md` → "IRC engine (upgrade without dropping IRC)": enabling, the one upgrade that still drops IRC, what moves to the engine, opting out in the safe order (stop the engine first), what a refusal looks like, buffering, health. `.env.example` documents the variables.
