### PR TITLE
Stop asserting a principle nobody decided

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -810,10 +810,11 @@ ask for the unit your tier would otherwise use and accept the occasional short
 page.
 
 - **What counts is the complement of the set you hide**, not "messages". Under
-  `'renderable'` a `kick`, `mode`, `topic`, `error`, or `invite` each renders
-  standalone, so each is worth one slot; under `'chat'` the same holds minus
-  `mode`. Kicks, topics and invites are never free under either — they are
-  things that happened, not churn.
+  `'renderable'` a `kick`, `topic`, `error`, or `invite` each renders standalone,
+  so each is worth one slot — as does a `mode` row that isn't pure member-status
+  churn. Under `'chat'` no `mode` row counts at all. Kicks, topics and invites
+  are never free under either; that they aren't in the noise set is an
+  undocumented default rather than a decision, so don't reason from it.
 - **The slice is still a contiguous id range**, exactly like an event-counted
   one. `hasMoreOlder`, prepend-and-dedupe, and the `before: <oldest returned
 id>` cursor are unchanged. This cannot open a hole.

--- a/shared/eventFilter.ts
+++ b/shared/eventFilter.ts
@@ -79,10 +79,13 @@ export function asEventMode(value: unknown): EventMode {
  * foldsIntoRun); it just does so without being a member of the set that sizes
  * pages. Don't "fix" the divergence by merging them.
  *
- * Deliberately NOT included, because they are content rather than churn:
- * `kick` (someone was removed, and by whom), `topic`, `invite`, `error`,
- * `motd` and the various status lines. Hiding those would make the buffer lie
- * about what happened rather than merely quieter.
+ * ⚠ `kick`, `topic`, `invite`, `error`, `motd` and the various status lines are
+ * absent here, and that is an UNDOCUMENTED DEFAULT rather than a decision
+ * anyone made — they were simply never brought into the filters, and nobody has
+ * revisited it. Earlier revisions of this comment asserted a principle ("things
+ * that happened, not churn") as though it were settled; it wasn't. Don't cite it
+ * as a reason for anything. If someone asks for these to be hidden, that is a
+ * live question rather than a closed one.
  */
 export const NOISE_TYPES: ReadonlySet<string> = new Set([...CONSOLIDATABLE_TYPES, 'mode']);
 

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -838,7 +838,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'consolidation is on. "Smart filter" shows events only for nicks who have recently ' +
       'spoken, so silent lurkers cycling on and off stay invisible. "Hide all" removes ' +
       'event rows entirely, leaving conversation only. Kicks, topic changes and ' +
-      'invites are never hidden — they are things that happened, not churn.',
+      'invites are never hidden at any setting.',
   },
   {
     key: 'chat.events.mobile',

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -1121,8 +1121,8 @@ const renderRows = computed((): RenderRow[] => {
     // and including mode changes. Unconditional on purpose: a reader who asked
     // for no event noise on this device wants none of it, not
     // none-except-mine. Kicks, topic changes and invites sit outside
-    // NOISE_TYPES and still render, because they are things that happened
-    // rather than churn. Placed with the other hard hides so the rows never
+    // NOISE_TYPES and still render — see the warning there before treating that
+    // as a principle. Placed with the other hard hides so the rows never
     // reach the ignore/highlight evaluation below, and so dividers anchor to
     // the first row the reader can actually see.
     if (hideAllEvents && isNoiseType(m.type)) continue;


### PR DESCRIPTION
Comment-only. This is the tail of #827 — the merge landed at `a494def`, one commit before
this was pushed, so it was stranded on the branch.

Three places said kick/topic/invite are excluded from `NOISE_TYPES` **because they are things
that happened rather than churn**, phrased as settled reasoning:

- `shared/eventFilter.ts` — on `NOISE_TYPES` itself, as the stated reason the two sets differ
- `vue_client/src/components/MessageList.vue` — on the `none`-tier hard hide
- `shared/settingsRegistry.ts` — in the user-facing `chat.events` description

It was never decided. Those types were simply never brought into the filters and nobody has
revisited it. Leaving the claim in place means the next person to touch this inherits a
rationale nobody owns — and either defends it or, worse, reasons from it.

So the code comments now record it as the undocumented default it is, with an explicit
warning not to cite it and a note that hiding these is a live question rather than a closed
one. The user-facing string just says what happens ("Kicks, topic changes and invites are
never hidden at any setting") instead of explaining why.

No behaviour change. `npm run check` and `npm test` green.
