### PR TITLE
Bump Lurker version to 2.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "2.1.2",
+  "version": "2.1.3",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
The four package files, nothing else — the same shape as the 2.1.1 (#771) and 2.1.2 (#783)
bumps, done with `npm version --no-git-tag-version` in the root and in `vue_client` so the
lockfiles stay in step.

`npm run check` and `npm test` green.

---

# Changelog since 2.1.2

25 pull requests, all merged through review; nothing landed on `main` outside one.

## ⚠ Read before releasing

- **`chat.smart_filter_mode` defaults on.** Existing smart-filter users will see op/voice
  churn start collapsing away on upgrade. Intentional — the rung is called "smart filter" and
  had never filtered modes — but it is a visible behaviour change, not a silent one.
- **Op/voice changes now fold into consolidation summaries** for everyone on the default
  `chat.consolidate_joins`, and the summary names who a mode was done *to* rather than who
  did it.
- **lurker-ios#127 requires this release deployed.** Once the phone folds op/voice churn, a
  server older than #827 hands back a page unit finer than what the phone draws and its
  top-up paging is unbounded. The iOS beta note should say it wants a server on 2.1.3+.
- **A security fix is included** — see #822 under Fixes.

## Event noise: MODE joins the filters

The headline of this release. `mode` had never taken part in the event-noise tier, so anyone
running the smart filter still ate every ChanServ op burst, and a netsplit rejoin on an
auto-op channel came out chopped into fragments.

- **#825** — the server now classifies every mode change (`prefix` / `list` / `chan`) and
  stamps it on the row, because no client is sent the ISUPPORT it would need to work that out
  (and the obvious shortcut is wrong: on solanum `+q` is a *quiet*, not an owner grant). On
  the back of that, the smart rung gained `chat.smart_filter_mode`, hiding op/voice churn
  aimed at nicks nobody was talking to. Judged on the nicks a mode acted *on*, never its
  author — the author is nearly always a service that never speaks. One ban, key or channel
  flag anywhere in the message and the whole row still shows.
- **#826** — mode lines are narrated instead of printed raw: `ChanServ gave op to alice`
  rather than `mode by ChanServ: +o alice`, with the target rendered as a real nick you can
  click. Bans, keys, limits and flags each read as English too, and the channel key is no
  longer printed into scrollback.
- **#827** — op/voice churn folds into the consolidation summary, classified the same way
  presence is, so a granted-then-revoked pair reads "was briefly opped" rather than
  disappearing. `renderable` stopped spending page budget on rows that fold away, which was a
  short-page bug in exactly the netsplit case the feature targets.

## Search

- **#798** — the `from:` / `in:` / `on:` filters are indexed, and FTS results stream
  newest-first.
- **#800** — search moved to a REST endpoint; the WS command is deprecated.

## Features

- **#791** — MCP agent-control verbs: connection, presence, channels, whois, raw. *(thanks
  @JawshTheDark)*
- **#806** — relay bots follow a chain of marked bridges, so a message crossing two hops is
  attributed correctly (#801).
- **#808** — uploads name their text dialect and state the charset, fixing pastes that
  arrived looking corrupted when the bytes were fine all along (#788).

## Fixes

- **#822** — **a deleted user's invite could let a stranger in** (#590).
- **#810** — sends are refused on a connection that can't reach the wire, instead of silently
  vanishing (#809).
- **#811** — Disconnect is reachable while a network is reconnecting (#785).
- **#814** — filter and gate inputs no longer freeze mid-word on Android keyboards (#622).
- **#815** — a failed channel command is surfaced in the channel it was run in (#434).
- **#819** — the user is told when a nick isn't there (#817, #818).
- **#823** — a failed `/ctcp` is reported where it was issued (#821).
- **#812** — a URL's span is measured past its sentence punctuation (#774).
- **#813** — the ignore GUI can express a NOHIGHLIGHT-only rule (#775).

## Docs, infra and dependencies

- **#786** — the link-preview decoder's deployment story.
- **#824** — an export test bought its page crossings with pages rather than rows, removing a
  flake (#820).
- **#802, #803, #804, #805, #807, #794** — Dependabot batches and wrangler bumps.
