### PR TITLE
Lurker 2.1.4 — the IRC engine release

### DIFF
--- a/deploy/digitalocean-cloud-init.sh
+++ b/deploy/digitalocean-cloud-init.sh
@@ -14,6 +14,8 @@
 #     this works on both the Docker Marketplace image and vanilla Ubuntu)
 #   * fetch Lurker, front it with Caddy for automatic HTTPS (Let's Encrypt),
 #     and start everything under Docker Compose
+#   * run the IRC engine, so upgrading Lurker never drops your IRC connections
+#   * answer ident on :113, so networks see a verified ident for each user
 #   * configure passkeys and web push — HTTPS makes both possible, so the
 #     instance comes up feature-complete with no post-install server admin
 #   * add a small swapfile on low-RAM droplets and configure the firewall
@@ -40,28 +42,34 @@ LURKER_DOMAIN=""
 # Apple, Google, and Mozilla's push services require.
 ADMIN_EMAIL=""
 
-# ─── Optional: built-in identd (RFC 1413) ───────────────────────────────────
+# ─── Built-in identd (RFC 1413) — ON by default ─────────────────────────────
 #
-# Set to "true" to run Lurker's built-in identd on port 113. For a MULTI-USER
-# instance this lets IRC networks attribute each user individually behind the
-# shared server IP (and is what networks like Libera ask of a hosted service) —
-# users then appear with a verified ident rather than an unverified "~ident".
-# The script publishes :113 and opens it in the firewall. Leave blank for a
-# single-user instance that doesn't need it.
+# This is a public, domain-having instance, so it is set up the way a hosted
+# service is expected to be: identd answers on :113, and IRC networks attribute
+# each user individually behind the shared droplet IP (which is what networks
+# like Libera ask of a hosted service). Users appear with a verified ident
+# rather than an unverified "~ident". The script publishes :113 and opens it in
+# the firewall.
 #
-# Requires a Lurker image that includes identd (ghcr.io/amiantos/lurker:latest
-# once that lands). Docker note: the :113 callback is matched against the full
-# connection 4-tuple (both addresses + both ports), so the container has to see
-# the IRC server's real source IP and the outbound connection's source port.
-# Docker's default bridge (iptables DNAT) preserves both for external callbacks,
-# so this works as-is. If you ever see unverified idents — under heavy
-# concurrency (source-port reuse), or if your host routes :113 through the
-# userland proxy so callbacks appear to come from the docker gateway — run the
-# lurker service with `network_mode: host` instead, so the container shares the
-# host's addresses directly. The cell logs `[identd] <ports> matched a live
-# connection but query address <ip> did not` on every such mismatch, which is the
-# signal to switch.
-ENABLE_IDENTD=""
+# Set this to "" to turn it off — a single-user instance does not need it, and
+# a network that never asks will not notice either way.
+#
+# ⚠ identd runs on the ENGINE, not on `lurker`: it is the process holding the
+# IRC socket the network asks about, so it is the only one that can answer.
+# The script wires it there for you.
+#
+# Docker note: the :113 callback is matched against the full connection 4-tuple
+# (both addresses + both ports), so the container has to see the IRC server's
+# real source IP and the outbound connection's source port. Docker's default
+# bridge (iptables DNAT) preserves both for external callbacks, so this works
+# as-is. If you ever see unverified idents — under heavy concurrency (source-port
+# reuse), or if your host routes :113 through the userland proxy so callbacks
+# appear to come from the docker gateway — run the `lurker-engine` service with
+# `network_mode: host` instead, so the container shares the host's addresses
+# directly. The engine logs `[identd] <ports> matched a live connection but
+# query address <ip> did not` on every such mismatch, which is the signal to
+# switch.
+ENABLE_IDENTD="true"
 
 # ─── Optional: link previews & inline media ─────────────────────────────────
 #
@@ -88,6 +96,28 @@ ENABLE_IDENTD=""
 # ceiling when it decodes a poster. On the smallest (1 GB) droplet it will lean
 # on swap; 2 GB is the comfortable size once this is on.
 ENABLE_LINK_PREVIEWS=""
+
+# ─── The IRC engine — always on here, and not a knob ────────────────────────
+#
+# Lurker's IRC sockets live in a second container (`lurker-engine`) that an app
+# upgrade never recreates, so `docker compose pull && up -d` replaces Lurker
+# without re-registering, re-identifying, rejoining, or showing everyone in your
+# channels a Quit/Join. It holds no data — no database, no uploads, no volumes.
+#
+# This deploy uses it from the first boot, so there is nothing to migrate to
+# later. That is deliberately unlike the self-host quickstart, which stays a
+# two-command install and treats the engine as something you add when you want
+# it (docs/MIGRATION_ENGINE.md). Here the droplet is long-lived and public, and
+# not dropping IRC on every upgrade is worth a second container.
+#
+# The shared secret both containers authenticate with is generated below and
+# written to /opt/lurker/.env. It is preserved across a re-run of this script:
+# changing it would recreate the engine, which is the one thing it exists to
+# avoid. The engine publishes no port — :8016 exists only on the compose
+# network — so nothing here is reachable from outside the droplet.
+#
+# ⚠ An ENGINE upgrade still drops IRC. Its tag is `engine-1`, which moves only
+# when a release changes the engine; those releases say so in their notes.
 
 # ─── No edits needed below this line ────────────────────────────────────────
 
@@ -255,6 +285,43 @@ deploy() {
 
   local compose_files="docker-compose.yml:docker-compose.caddy.yml"
 
+  # ── Does the app we are about to run actually support the engine? ──────────
+  #
+  # `latest` is the most recent RELEASE, and the engine lands in the repo before
+  # it lands in a release. A droplet deployed in that window would otherwise get
+  # an app that ignores LURKER_ENGINE_URL entirely: no error, no log line, IRC
+  # dialled from the app container as always — and identd sitting on a
+  # `lurker-engine` that holds no sockets, which BREAKS ident instead of merely
+  # not helping it. Silent, and worse than the old behaviour.
+  #
+  # So ask the image. It is pulled here rather than at `up -d` and the answer
+  # picks the topology, which also means this script needs no edit when the
+  # engine reaches `latest` — the next deploy simply starts using it.
+  local app_image use_engine="false"
+  app_image="$(sed -n 's|^[[:space:]]*image:[[:space:]]*\(ghcr\.io/amiantos/lurker:.*\)$|\1|p' \
+    docker-compose.yml | head -1)"
+  log "Checking whether ${app_image} supports the IRC engine..."
+  docker pull -q "$app_image" >/dev/null 2>&1 || true
+  if docker run --rm --entrypoint sh "$app_image" \
+      -c 'test -f /app/server/services/engineLink.ts' >/dev/null 2>&1; then
+    use_engine="true"
+    log "It does — IRC will run in the engine container."
+  else
+    log "⚠ ${app_image} predates the IRC engine. Deploying WITHOUT it: the app"
+    log "  dials IRC itself, and identd stays on the app container where the"
+    log "  sockets are. Re-run this script after the next Lurker release to"
+    log "  switch over — nothing here needs editing."
+  fi
+
+  # Fetched (not generated) so a later `pull` + `up -d` keeps whatever the
+  # overlay grows, and layered before the identd overlay below, which adds a
+  # port to the service this one defines.
+  if [ "$use_engine" = "true" ]; then
+    log "Fetching the IRC engine overlay."
+    curl -fsSL -o docker-compose.engine.yml "$REPO_RAW/docker-compose.engine.yml"
+    compose_files="${compose_files}:docker-compose.engine.yml"
+  fi
+
   # The link-preview decoder: its own overlay (a second container on a private
   # bridge) plus the script that contains its egress. Both are fetched here so
   # that later `docker compose pull` + `up -d` updates keep the service, and so
@@ -267,11 +334,26 @@ deploy() {
     compose_files="${compose_files}:docker-compose.previews.yml"
   fi
 
-  # identd overlay, layered AFTER Caddy (which resets the lurker ports), so it
-  # re-publishes :113 and turns on the built-in identd while the web port stays
-  # internal to Caddy. Generated locally so `pull` + `up -d` updates keep it.
-  if [ "$ENABLE_IDENTD" = "true" ]; then
-    log "identd enabled — publishing :113 and turning on the built-in identd."
+  # identd, on the ENGINE — it holds the IRC socket the network asks about, so
+  # it is the only process that can answer the callback. Only the port mapping
+  # is generated here; LURKER_IDENTD_* go into .env below, which the engine
+  # overlay already forwards to `lurker-engine`. Caddy's `ports: !reset []`
+  # applies to `lurker` and never touches this service, so unlike the pre-engine
+  # version this overlay no longer has to be ordered after Caddy to survive.
+  if [ "$ENABLE_IDENTD" = "true" ] && [ "$use_engine" = "true" ]; then
+    log "identd enabled — publishing :113 on the engine."
+    cat > docker-compose.identd.yml <<'YAML'
+services:
+  lurker-engine:
+    ports:
+      - '113:113'
+YAML
+    compose_files="${compose_files}:docker-compose.identd.yml"
+  elif [ "$ENABLE_IDENTD" = "true" ]; then
+    # No engine: identd belongs on the app, which is holding the sockets. This
+    # overlay must stay ordered after Caddy, whose `ports: !reset []` on
+    # `lurker` would otherwise drop the mapping.
+    log "identd enabled — publishing :113 on the app (no engine on this image)."
     cat > docker-compose.identd.yml <<'YAML'
 services:
   lurker:
@@ -289,11 +371,49 @@ YAML
   # COMPOSE_FILE records the overlay stack so plain `docker compose` commands —
   # including future `pull` + `up -d` updates — pick up Caddy (and identd)
   # automatically.
+  # ⚠ Preserve an existing engine secret across a re-run of this script. A new
+  # value changes `lurker-engine`'s environment, which makes Compose recreate it
+  # — dropping every IRC connection, i.e. exactly what the engine is for. A
+  # first run has no .env and generates one.
+  # `.env` is rewritten from scratch below; keep the old one just long enough to
+  # read the engine secret back out of it.
+  [ -f .env ] && cp .env .env.bak
+
   cat > .env <<EOF
 LURKER_DOMAIN=${LURKER_DOMAIN}
 ADMIN_EMAIL=${ADMIN_EMAIL}
 COMPOSE_FILE=${compose_files}
 EOF
+
+  if [ "$use_engine" = "true" ]; then
+    # ⚠ Preserve an existing engine secret across a re-run of this script. A new
+    # value changes `lurker-engine`'s environment, which makes Compose recreate
+    # it — dropping every IRC connection, i.e. exactly what the engine is for.
+    local engine_secret=""
+    if [ -f .env.bak ]; then
+      engine_secret="$(sed -n 's/^LURKER_ENGINE_SECRET=//p' .env.bak | head -1)"
+    fi
+    if [ -z "$engine_secret" ]; then
+      engine_secret="$(openssl rand -hex 32 2>/dev/null ||
+        head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+      log "Generated a new engine secret."
+    else
+      log "Reusing the engine secret already in .env."
+    fi
+    cat >> .env <<EOF
+LURKER_ENGINE_SECRET=${engine_secret}
+EOF
+    # The engine overlay forwards these to `lurker-engine`; the overlay
+    # generated above publishes the port.
+    if [ "$ENABLE_IDENTD" = "true" ]; then
+      cat >> .env <<EOF
+LURKER_IDENTD_ENABLED=true
+LURKER_IDENTD_PORT=113
+EOF
+    fi
+  fi
+
+  rm -f .env.bak
 
   # ⚠ 0, not unset: the overlay defaults this to 1 (skip the self-test), which
   # is the right default for a self-host on a plain Docker network but the
@@ -374,6 +494,12 @@ log "${PUBLIC_IP} if you haven't already — Caddy retries Let's Encrypt"
 log "until it resolves, then https://${LURKER_DOMAIN} serves over HTTPS."
 log "Passkeys and web push are pre-configured; once you've created your"
 log "admin account, opt in per device from Lurker's settings."
+if [ -f "${INSTALL_DIR}/docker-compose.engine.yml" ]; then
+log "IRC runs through the engine container, so future upgrades —"
+log "  cd ${INSTALL_DIR} && docker compose pull && docker compose up -d"
+log "replace Lurker without dropping your IRC connections. Check what it holds:"
+log "  docker compose exec lurker node -e \"require('http').get('http://lurker-engine:8016/healthz',r=>r.pipe(process.stdout))\""
+fi
 if [ "$ENABLE_IDENTD" = "true" ]; then
   log "Built-in identd is running on :113 — connect to a network and check that"
   log "your ident shows up verified (no leading ~) via /whois on yourself."

--- a/deploy/digitalocean-cloud-init.sh
+++ b/deploy/digitalocean-cloud-init.sh
@@ -285,42 +285,17 @@ deploy() {
 
   local compose_files="docker-compose.yml:docker-compose.caddy.yml"
 
-  # ── Does the app we are about to run actually support the engine? ──────────
+  # The IRC engine, always — see the note at the top. Fetched (not generated) so
+  # a later `pull` + `up -d` keeps whatever the overlay grows, and layered before
+  # the identd overlay below, which adds a port to the service this one defines.
   #
-  # `latest` is the most recent RELEASE, and the engine lands in the repo before
-  # it lands in a release. A droplet deployed in that window would otherwise get
-  # an app that ignores LURKER_ENGINE_URL entirely: no error, no log line, IRC
-  # dialled from the app container as always — and identd sitting on a
-  # `lurker-engine` that holds no sockets, which BREAKS ident instead of merely
-  # not helping it. Silent, and worse than the old behaviour.
-  #
-  # So ask the image. It is pulled here rather than at `up -d` and the answer
-  # picks the topology, which also means this script needs no edit when the
-  # engine reaches `latest` — the next deploy simply starts using it.
-  local app_image use_engine="false"
-  app_image="$(sed -n 's|^[[:space:]]*image:[[:space:]]*\(ghcr\.io/amiantos/lurker:.*\)$|\1|p' \
-    docker-compose.yml | head -1)"
-  log "Checking whether ${app_image} supports the IRC engine..."
-  docker pull -q "$app_image" >/dev/null 2>&1 || true
-  if docker run --rm --entrypoint sh "$app_image" \
-      -c 'test -f /app/server/services/engineLink.ts' >/dev/null 2>&1; then
-    use_engine="true"
-    log "It does — IRC will run in the engine container."
-  else
-    log "⚠ ${app_image} predates the IRC engine. Deploying WITHOUT it: the app"
-    log "  dials IRC itself, and identd stays on the app container where the"
-    log "  sockets are. Re-run this script after the next Lurker release to"
-    log "  switch over — nothing here needs editing."
-  fi
-
-  # Fetched (not generated) so a later `pull` + `up -d` keeps whatever the
-  # overlay grows, and layered before the identd overlay below, which adds a
-  # port to the service this one defines.
-  if [ "$use_engine" = "true" ]; then
-    log "Fetching the IRC engine overlay."
-    curl -fsSL -o docker-compose.engine.yml "$REPO_RAW/docker-compose.engine.yml"
-    compose_files="${compose_files}:docker-compose.engine.yml"
-  fi
+  # ⚠ This assumes the app image has engine support, i.e. Lurker >= 2.1.4. It
+  # does not check: an older image would ignore LURKER_ENGINE_URL silently and
+  # leave identd answering from a container holding no sockets. `latest` is
+  # 2.1.4+, so the only way to land there is to pin an older image on purpose.
+  log "Fetching the IRC engine overlay."
+  curl -fsSL -o docker-compose.engine.yml "$REPO_RAW/docker-compose.engine.yml"
+  compose_files="${compose_files}:docker-compose.engine.yml"
 
   # The link-preview decoder: its own overlay (a second container on a private
   # bridge) plus the script that contains its egress. Both are fetched here so
@@ -340,28 +315,13 @@ deploy() {
   # overlay already forwards to `lurker-engine`. Caddy's `ports: !reset []`
   # applies to `lurker` and never touches this service, so unlike the pre-engine
   # version this overlay no longer has to be ordered after Caddy to survive.
-  if [ "$ENABLE_IDENTD" = "true" ] && [ "$use_engine" = "true" ]; then
+  if [ "$ENABLE_IDENTD" = "true" ]; then
     log "identd enabled — publishing :113 on the engine."
     cat > docker-compose.identd.yml <<'YAML'
 services:
   lurker-engine:
     ports:
       - '113:113'
-YAML
-    compose_files="${compose_files}:docker-compose.identd.yml"
-  elif [ "$ENABLE_IDENTD" = "true" ]; then
-    # No engine: identd belongs on the app, which is holding the sockets. This
-    # overlay must stay ordered after Caddy, whose `ports: !reset []` on
-    # `lurker` would otherwise drop the mapping.
-    log "identd enabled — publishing :113 on the app (no engine on this image)."
-    cat > docker-compose.identd.yml <<'YAML'
-services:
-  lurker:
-    ports:
-      - '113:113'
-    environment:
-      - LURKER_IDENTD_ENABLED=true
-      - LURKER_IDENTD_PORT=113
 YAML
     compose_files="${compose_files}:docker-compose.identd.yml"
   fi
@@ -385,32 +345,31 @@ ADMIN_EMAIL=${ADMIN_EMAIL}
 COMPOSE_FILE=${compose_files}
 EOF
 
-  if [ "$use_engine" = "true" ]; then
-    # ⚠ Preserve an existing engine secret across a re-run of this script. A new
-    # value changes `lurker-engine`'s environment, which makes Compose recreate
-    # it — dropping every IRC connection, i.e. exactly what the engine is for.
-    local engine_secret=""
-    if [ -f .env.bak ]; then
-      engine_secret="$(sed -n 's/^LURKER_ENGINE_SECRET=//p' .env.bak | head -1)"
-    fi
-    if [ -z "$engine_secret" ]; then
-      engine_secret="$(openssl rand -hex 32 2>/dev/null ||
-        head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')"
-      log "Generated a new engine secret."
-    else
-      log "Reusing the engine secret already in .env."
-    fi
-    cat >> .env <<EOF
+  # ⚠ Preserve an existing engine secret across a re-run of this script. A new
+  # value changes `lurker-engine`'s environment, which makes Compose recreate it
+  # — dropping every IRC connection, i.e. exactly what the engine is for.
+  local engine_secret=""
+  if [ -f .env.bak ]; then
+    engine_secret="$(sed -n 's/^LURKER_ENGINE_SECRET=//p' .env.bak | head -1)"
+  fi
+  if [ -z "$engine_secret" ]; then
+    engine_secret="$(openssl rand -hex 32 2>/dev/null ||
+      head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+    log "Generated a new engine secret."
+  else
+    log "Reusing the engine secret already in .env."
+  fi
+  cat >> .env <<EOF
 LURKER_ENGINE_SECRET=${engine_secret}
 EOF
-    # The engine overlay forwards these to `lurker-engine`; the overlay
-    # generated above publishes the port.
-    if [ "$ENABLE_IDENTD" = "true" ]; then
-      cat >> .env <<EOF
+
+  # The engine overlay forwards these to `lurker-engine`; the overlay generated
+  # above publishes the port.
+  if [ "$ENABLE_IDENTD" = "true" ]; then
+    cat >> .env <<EOF
 LURKER_IDENTD_ENABLED=true
 LURKER_IDENTD_PORT=113
 EOF
-    fi
   fi
 
   rm -f .env.bak
@@ -494,12 +453,10 @@ log "${PUBLIC_IP} if you haven't already — Caddy retries Let's Encrypt"
 log "until it resolves, then https://${LURKER_DOMAIN} serves over HTTPS."
 log "Passkeys and web push are pre-configured; once you've created your"
 log "admin account, opt in per device from Lurker's settings."
-if [ -f "${INSTALL_DIR}/docker-compose.engine.yml" ]; then
 log "IRC runs through the engine container, so future upgrades —"
 log "  cd ${INSTALL_DIR} && docker compose pull && docker compose up -d"
 log "replace Lurker without dropping your IRC connections. Check what it holds:"
 log "  docker compose exec lurker node -e \"require('http').get('http://lurker-engine:8016/healthz',r=>r.pipe(process.stdout))\""
-fi
 if [ "$ENABLE_IDENTD" = "true" ]; then
   log "Built-in identd is running on :113 — connect to a network and check that"
   log "your ident shows up verified (no leading ~) via /whois on yourself."

--- a/docs/digitalocean.md
+++ b/docs/digitalocean.md
@@ -15,14 +15,28 @@ You don't need the droplet's IP before creating it: the droplet boots and starts
 
 Passkeys and web push notifications are configured automatically — the deploy derives the WebAuthn and push settings from your domain and email — so you can enable them per device from Lurker's in-app settings without touching the server.
 
+**IRC runs in the engine, and ident is answered.** Both are on from the first boot here, and neither is a knob you have to find:
+
+- The **IRC engine** (`lurker-engine`) holds the IRC sockets in a container that an app upgrade never recreates, so `docker compose pull && up -d` replaces Lurker without re-registering, re-identifying, rejoining, or showing everyone in your channels a `Quit`/`Join`. It holds no data. There is nothing to migrate to later — unlike a plain self-host, which stays a two-command install and [adds the engine when it wants it](/MIGRATION_ENGINE). An **engine** upgrade does still drop IRC; those releases say so in their notes.
+- **identd** answers on `:113` from the engine — it is the process holding the socket the network asks about, so it is the only one that can. Users get a verified ident instead of a shared `~ident`, which is what networks like Libera ask of a hosted service. Set `ENABLE_IDENTD=""` in the script if you would rather not run it.
+
+Check what the engine is holding at any time:
+
+```bash
+cd /opt/lurker
+docker compose exec lurker \
+  node -e "require('http').get('http://lurker-engine:8016/healthz',r=>r.pipe(process.stdout))"
+```
+
 Deploy progress is logged to `/var/log/lurker-deploy.log` on the droplet.
 
 ## Optional extras
 
-Two features are off unless you switch them on in the script, next to the two required values:
+One feature is off unless you switch it on in the script, next to the two required values:
 
-- **`ENABLE_IDENTD="true"`** — runs Lurker's built-in identd on port 113, so a multi-user instance can give each user a verified ident on IRC instead of a shared `~ident`.
 - **`ENABLE_LINK_PREVIEWS="true"`** — runs [`lurker-previews`](https://github.com/amiantos/lurker-previews), the second container that turns pasted links into preview cards, renders images inline, and gives videos a poster frame.
+
+(The engine and identd are covered above — both are on by default here, and identd is the one you turn _off_, with `ENABLE_IDENTD=""`.)
 
 Link previews are worth a word on what the script does for you, because it is the part that is fiddly by hand. All the fetching and media parsing happens in that second container, never in the one holding your database and sessions — and the script gives it the same treatment the hosted fleet gets: its own private bridge, firewall rules that let it reach the public internet and nothing private (not this droplet, not your VPC, not your other containers), and a systemd unit that re-applies them on every boot. The decoder's own boot self-test is left on, so it re-proves that containment every time it starts and refuses to serve rather than quietly parse hostile bytes with a route to your infrastructure — the one lapse it can't catch by itself is a firewall reload while it's running, which is why the note below the update command exists.
 
@@ -39,7 +53,7 @@ cd /opt/lurker
 docker compose pull && docker compose up -d
 ```
 
-The deploy script records the Caddy overlay in `.env`, so `docker compose` picks it up automatically — no `-f` flags needed. Your `data/` directory is left untouched.
+The deploy script records every overlay it used — Caddy, the engine, identd — in `COMPOSE_FILE` in `.env`, so `docker compose` picks them all up automatically and no `-f` flags are needed. Your `data/` directory is left untouched, and this upgrade replaces only the app: **your IRC connections stay up.**
 
 If you enabled link previews, follow that with:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "2.1.3",
+  "version": "2.1.4",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Version bump to **2.1.4**, shipping the IRC engine, plus the DigitalOcean deploy going engine-first with identd on.

## What ships

**The engine.** IRC sockets live in a separate `lurker-engine` process that an app upgrade never recreates — so upgrading no longer re-registers, re-identifies, rejoins, or shows everyone in your channels a `Quit`/`Join`.

**Off by default for a plain self-host.** `LURKER_ENGINE_URL`'s presence is the whole gate, the quickstart stays a two-command install, and `docs/MIGRATION_ENGINE.md` is the walkthrough for adding it to an existing instance.

**On by default for DigitalOcean**, with identd. That droplet is long-lived, public and domain-having — the case where a second container earns its keep and where networks expect a hosted service to answer ident. identd moves to `lurker-engine`, because it holds the socket the network asks about and is the only process that can answer the callback.

## ⚠ Publish the release before deploying a droplet

The DO script is fetched from `main` at deploy time, so it goes live **on merge**. `latest` only becomes 2.1.4 when the release is **published** — a separate step afterwards.

In that window a fresh droplet gets engine containers + identd on the engine + a 2.1.3 app that ignores `LURKER_ENGINE_URL` entirely: no error, no log line, and identd answering from a container holding no sockets. That *breaks* ident rather than merely not helping, and it does so silently.

The earlier image-probe commit handled this; publishing 2.1.4 removes the condition instead. So: **merge → publish the release → then deploy.**

## Verification

`npm run check` and the full suite green (292 files, 4193 tests). Docs build clean.

The deploy script was run end to end in `docker:dind` against an image that really contains engine code:

- engine container healthy; `:113` and the identd env on `lurker-engine` and nowhere else
- the app logs `engine mode: attached to lurker-engine:8016` — the line whose absence was the whole bug
- a re-run leaves both the engine secret and the container id untouched, so it would not have dropped IRC

## Docs

`docs/digitalocean.md` now says the engine and identd are on, how to check what the engine holds, and that the upgrade command leaves IRC up. Deeper engine docs (`SELF_HOSTING.md`, `MIGRATION_ENGINE.md`) already landed in #837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
