### PR TITLE
Engine restore: pace channel state requests by the server's replies

### DIFF
--- a/server/services/engineRestorePacing.test.ts
+++ b/server/services/engineRestorePacing.test.ts
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The restore's per-channel state requests are paced by the server's replies,
+// not by a timer: one channel in flight, the next released by the previous
+// one's 366 / 331|332 / 324 / 315, with a deadline as the only fallback. Read
+// off the wire against the fake ircd — the same shape an ircd's flood control
+// judges (see drainRestoreQueue in ircConnection.ts).
+
+// MUST be first: redirects DATABASE_PATH before anything opens the db.
+import '../test-utils/isolateDb.js';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createUser } from '../db/users.js';
+import { createNetwork } from '../db/networks.js';
+import type { Network } from '../db/networks.js';
+import { IrcConnection } from './ircConnection.js';
+import ircManager from './ircManager.js';
+import { EngineServer } from '../engine/server.js';
+import { FakeIrcd } from '../test-utils/fakeIrcd.js';
+import { EngineLink, engineConfigured } from './engineLink.js';
+
+const SECRET = 'restore-pacing-secret';
+const CHANNELS = ['#p1', '#p2', '#p3', '#p4', '#p5', '#p6'];
+// This channel's TOPIC is never answered: its step can only end by the deadline.
+// (TOPIC, not WHO: irc-framework serialises WHO requests behind their 315, so a
+// WHO held back would also wedge every later channel's auto-WHO — a test of the
+// framework's queue, not of the pacing.)
+const HELD = '#p3';
+const DEADLINE_MS = 1500;
+
+let ircd: FakeIrcd;
+let engine: EngineServer;
+let network: Network;
+let userId: number;
+
+// Every line on the wire, in the order it happened: '>' client → server (the
+// fake ircd's 'line' event), '<' server → client (the Client's 'raw').
+interface Wire {
+  t: number;
+  dir: '>' | '<';
+  line: string;
+}
+const wire: Wire[] = [];
+
+function until(pred: () => boolean, ms = 5000, what = 'condition'): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + ms;
+    const tick = () => {
+      if (pred()) return resolve();
+      if (Date.now() > deadline) {
+        const tail = wire
+          .slice(-60)
+          .map((w) => `${w.dir} ${w.line}`)
+          .join('\n');
+        return reject(new Error(`timed out waiting for ${what}; last wire lines:\n${tail}`));
+      }
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+beforeAll(async () => {
+  ircd = await FakeIrcd.start();
+  ircd.on('line', (line: string) => wire.push({ t: Date.now(), dir: '>', line }));
+  engine = new EngineServer({
+    secret: SECRET,
+    bufferBytes: 64 * 1024,
+    bufferTotalBytes: 1024 * 1024,
+    version: 'test',
+    log: () => {},
+  });
+  const { port } = await engine.listen(0, '127.0.0.1');
+  process.env.LURKER_ENGINE_URL = `tcp://127.0.0.1:${port}`;
+  process.env.LURKER_ENGINE_SECRET = SECRET;
+  process.env.LURKER_ENGINE_RETRY_BASE_MS = '100';
+  // A full-suite CI run starves the event loop; keep the link's heartbeat well
+  // clear of the run so it can't drop a healthy idle link mid-test.
+  process.env.LURKER_ENGINE_HEARTBEAT_MS = '600000';
+  process.env.LURKER_RESTORE_STEP_DEADLINE_MS = String(DEADLINE_MS);
+  EngineLink.resetForTests();
+  if (!engineConfigured()) throw new Error('engine mode did not switch on');
+  const user = createUser('restore-pacing');
+  userId = user.id;
+  network = createNetwork(user.id, {
+    name: 'restore-pacing',
+    host: '127.0.0.1',
+    port: ircd.port,
+    tls: 0,
+    nick: 'pace',
+    autoconnect: 0,
+  })!;
+});
+
+afterAll(async () => {
+  ircManager.shutdown();
+  EngineLink.resetForTests();
+  await engine.shutdown('tests done', 500);
+  await ircd.close();
+  delete process.env.LURKER_ENGINE_URL;
+  delete process.env.LURKER_ENGINE_SECRET;
+  delete process.env.LURKER_ENGINE_RETRY_BASE_MS;
+  delete process.env.LURKER_ENGINE_HEARTBEAT_MS;
+  delete process.env.LURKER_RESTORE_STEP_DEADLINE_MS;
+});
+
+describe('engine restore pacing', () => {
+  it("releases each channel on the previous one's replies, and by the deadline when one never comes", async () => {
+    // A session with six channels, then the app "restarts".
+    const conn = new IrcConnection({ network, onEvent: () => {} });
+    conn.connect();
+    await until(() => conn.state === 'connected', 5000, 'connected');
+    for (const ch of CHANNELS) conn.join(ch);
+    await until(() => CHANNELS.every((ch) => conn.isChannelJoined(ch)), 5000, 'joins');
+    conn.detach();
+    await until(() => conn.state === 'disconnected', 5000, 'detached');
+
+    ircd.hold = (cmd, p) => cmd === 'TOPIC' && (p[0] ?? '').toLowerCase() === HELD;
+    const restoreStart = wire.length;
+    const conn2 = ircManager.startNetwork(userId, network.id)!;
+    conn2.client.on('raw', (ev: { line: string; from_server: boolean }) => {
+      if (ev.from_server) wire.push({ t: Date.now(), dir: '<', line: ev.line });
+    });
+    await until(() => conn2.state === 'connected', 5000, 'reattached');
+    const last = CHANNELS[CHANNELS.length - 1];
+    await until(
+      () => wire.slice(restoreStart).some((w) => w.dir === '<' && numericFor(w.line, '315', last)),
+      DEADLINE_MS + 5000,
+      "the last channel's WHO answered",
+    );
+
+    const since = wire.slice(restoreStart);
+    const sentIdx = (line: string) => since.findIndex((w) => w.dir === '>' && w.line === line);
+    const sentAt = (line: string) => since[sentIdx(line)].t;
+    const gotIdx = (numeric: string, chan: string) =>
+      since.findIndex((w) => w.dir === '<' && numericFor(w.line, numeric, chan));
+
+    // Every channel was asked all four things.
+    for (const ch of CHANNELS) {
+      for (const cmd of ['NAMES', 'TOPIC', 'MODE']) {
+        expect(sentIdx(`${cmd} ${ch}`), `${cmd} ${ch}`).toBeGreaterThanOrEqual(0);
+      }
+      expect(
+        since.some((w) => w.dir === '>' && w.line.startsWith(`WHO ${ch}`)),
+        `WHO ${ch}`,
+      ).toBe(true);
+    }
+
+    // The gate: a channel's first request goes out only after the previous
+    // channel's last reply came in — all four of them.
+    for (let i = 1; i < CHANNELS.length; i++) {
+      const prev = CHANNELS[i - 1];
+      if (prev === HELD) continue;
+      const next = sentIdx(`NAMES ${CHANNELS[i]}`);
+      for (const numeric of ['366', '324', '315']) {
+        const got = gotIdx(numeric, prev);
+        expect(got, `${numeric} ${prev}`).toBeGreaterThanOrEqual(0);
+        expect(got, `${numeric} ${prev} before NAMES ${CHANNELS[i]}`).toBeLessThan(next);
+      }
+      const topic = Math.max(gotIdx('331', prev), gotIdx('332', prev));
+      expect(topic, `topic reply ${prev}`).toBeGreaterThanOrEqual(0);
+      expect(topic).toBeLessThan(next);
+    }
+
+    // The fallback: the held channel's step ends at the deadline, not before —
+    // and the steps that were answered did not wait for it.
+    const afterHeld = CHANNELS[CHANNELS.indexOf(HELD) + 1];
+    expect(Math.max(gotIdx('331', HELD), gotIdx('332', HELD))).toBe(-1);
+    const heldWait = sentAt(`NAMES ${afterHeld}`) - sentAt(`NAMES ${HELD}`);
+    expect(heldWait).toBeGreaterThanOrEqual(DEADLINE_MS - 50);
+    expect(heldWait).toBeLessThan(DEADLINE_MS + 1000);
+    for (let i = 1; i < CHANNELS.length; i++) {
+      if (CHANNELS[i - 1] === HELD) continue;
+      const gap = sentAt(`NAMES ${CHANNELS[i]}`) - sentAt(`NAMES ${CHANNELS[i - 1]}`);
+      expect(gap, `gap before ${CHANNELS[i]}`).toBeLessThan(DEADLINE_MS / 2);
+    }
+
+    // The invariant an ircd's flood control judges: never more than one
+    // channel's four requests unanswered at the server. (The held channel's
+    // TOPIC is unanswered by construction, so that channel is left out.)
+    let outstanding = 0;
+    let peak = 0;
+    for (const w of since) {
+      const m = /^(?:\S+ (?:366|331|332|324|315) \S+ |(?:NAMES|TOPIC|MODE|WHO) )(#p\d)\b/.exec(
+        w.line,
+      );
+      if (!m || m[1] === HELD) continue;
+      outstanding += w.dir === '>' ? 1 : -1;
+      peak = Math.max(peak, outstanding);
+    }
+    expect(peak).toBeLessThanOrEqual(4);
+  }, 20000);
+});
+
+function numericFor(line: string, numeric: string, chan: string): boolean {
+  return new RegExp(`^\\S+ ${numeric} \\S+ ${chan}\\b`).test(line);
+}

--- a/server/services/engineRestorePacing.test.ts
+++ b/server/services/engineRestorePacing.test.ts
@@ -3,9 +3,9 @@
 
 // The restore's per-channel state requests are paced by the server's replies,
 // not by a timer: one channel in flight, the next released by the previous
-// one's 366 / 331|332 / 324 / 315, with a deadline as the only fallback. Read
-// off the wire against the fake ircd — the same shape an ircd's flood control
-// judges (see drainRestoreQueue in ircConnection.ts).
+// one's 366 / 331|332 / 324, with a deadline as the only fallback. Read off the
+// wire against the fake ircd — the same shape an ircd's flood control judges
+// (see drainRestoreQueue in ircConnection.ts).
 
 // MUST be first: redirects DATABASE_PATH before anything opens the db.
 import '../test-utils/isolateDb.js';
@@ -22,9 +22,9 @@ import { EngineLink, engineConfigured } from './engineLink.js';
 const SECRET = 'restore-pacing-secret';
 const CHANNELS = ['#p1', '#p2', '#p3', '#p4', '#p5', '#p6'];
 // This channel's TOPIC is never answered: its step can only end by the deadline.
-// (TOPIC, not WHO: irc-framework serialises WHO requests behind their 315, so a
-// WHO held back would also wedge every later channel's auto-WHO — a test of the
-// framework's queue, not of the pacing.)
+// (TOPIC rather than WHO: the WHO is not part of the gate, and irc-framework
+// serialises WHO requests behind their 315, so a WHO held back would also wedge
+// every later channel's auto-WHO — the framework's queue, not the pacing.)
 const HELD = '#p3';
 const DEADLINE_MS = 1500;
 
@@ -33,8 +33,12 @@ let engine: EngineServer;
 let network: Network;
 let userId: number;
 
-// Every line on the wire, in the order it happened: '>' client → server (the
-// fake ircd's 'line' event), '<' server → client (the Client's 'raw').
+// Every line on the wire, in causal order: '>' is stamped as the Client writes
+// it — the same synchronous chain that arms the step deadline, so the timing
+// assertions read one clock — and '<' as the fake ircd sends it, which is
+// before the relay hop, so a reply is always logged ahead of the request it
+// releases. (Recording both at the Client would log them the other way round:
+// Lurker's own 'raw' handler runs first and writes the next request inside it.)
 interface Wire {
   t: number;
   dir: '>' | '<';
@@ -62,7 +66,6 @@ function until(pred: () => boolean, ms = 5000, what = 'condition'): Promise<void
 
 beforeAll(async () => {
   ircd = await FakeIrcd.start();
-  ircd.on('line', (line: string) => wire.push({ t: Date.now(), dir: '>', line }));
   engine = new EngineServer({
     secret: SECRET,
     bufferBytes: 64 * 1024,
@@ -110,30 +113,45 @@ describe('engine restore pacing', () => {
     const conn = new IrcConnection({ network, onEvent: () => {} });
     conn.connect();
     await until(() => conn.state === 'connected', 5000, 'connected');
+    // Let the first session's join-time WHOs finish before it lets go: a WHO
+    // still in flight at detach has its 315 land in the engine's backlog and
+    // replay to the next session, where it would pass for that session's own.
+    const whoAnswered = new Set<string>();
+    conn.client.on('raw', (ev: { line: string; from_server: boolean }) => {
+      const m = ev.from_server ? /^\S+ 315 \S+ (#p\d)\b/.exec(ev.line) : null;
+      if (m) whoAnswered.add(m[1]);
+    });
     for (const ch of CHANNELS) conn.join(ch);
     await until(() => CHANNELS.every((ch) => conn.isChannelJoined(ch)), 5000, 'joins');
+    await until(() => whoAnswered.size === CHANNELS.length, 5000, "first session's WHOs answered");
     conn.detach();
     await until(() => conn.state === 'disconnected', 5000, 'detached');
 
     ircd.hold = (cmd, p) => cmd === 'TOPIC' && (p[0] ?? '').toLowerCase() === HELD;
-    const restoreStart = wire.length;
     const conn2 = ircManager.startNetwork(userId, network.id)!;
+    ircd.on('sent', (line: string) => wire.push({ t: Date.now(), dir: '<', line }));
     conn2.client.on('raw', (ev: { line: string; from_server: boolean }) => {
-      if (ev.from_server) wire.push({ t: Date.now(), dir: '<', line: ev.line });
+      if (!ev.from_server) wire.push({ t: Date.now(), dir: '>', line: ev.line });
     });
     await until(() => conn2.state === 'connected', 5000, 'reattached');
+    // Done when the last channel's own WHO — the one this session sent — is
+    // answered.
     const last = CHANNELS[CHANNELS.length - 1];
     await until(
-      () => wire.slice(restoreStart).some((w) => w.dir === '<' && numericFor(w.line, '315', last)),
+      () => {
+        const who = wire.findIndex((w) => w.dir === '>' && w.line.startsWith(`WHO ${last}`));
+        return (
+          who >= 0 && wire.slice(who).some((w) => w.dir === '<' && numericFor(w.line, '315', last))
+        );
+      },
       DEADLINE_MS + 5000,
       "the last channel's WHO answered",
     );
 
-    const since = wire.slice(restoreStart);
-    const sentIdx = (line: string) => since.findIndex((w) => w.dir === '>' && w.line === line);
-    const sentAt = (line: string) => since[sentIdx(line)].t;
+    const sentIdx = (line: string) => wire.findIndex((w) => w.dir === '>' && w.line === line);
+    const sentAt = (line: string) => wire[sentIdx(line)].t;
     const gotIdx = (numeric: string, chan: string) =>
-      since.findIndex((w) => w.dir === '<' && numericFor(w.line, numeric, chan));
+      wire.findIndex((w) => w.dir === '<' && numericFor(w.line, numeric, chan));
 
     // Every channel was asked all four things.
     for (const ch of CHANNELS) {
@@ -141,18 +159,18 @@ describe('engine restore pacing', () => {
         expect(sentIdx(`${cmd} ${ch}`), `${cmd} ${ch}`).toBeGreaterThanOrEqual(0);
       }
       expect(
-        since.some((w) => w.dir === '>' && w.line.startsWith(`WHO ${ch}`)),
+        wire.some((w) => w.dir === '>' && w.line.startsWith(`WHO ${ch}`)),
         `WHO ${ch}`,
       ).toBe(true);
     }
 
     // The gate: a channel's first request goes out only after the previous
-    // channel's last reply came in — all four of them.
+    // channel's last gated reply came in — all three of them.
     for (let i = 1; i < CHANNELS.length; i++) {
       const prev = CHANNELS[i - 1];
       if (prev === HELD) continue;
       const next = sentIdx(`NAMES ${CHANNELS[i]}`);
-      for (const numeric of ['366', '324', '315']) {
+      for (const numeric of ['366', '324']) {
         const got = gotIdx(numeric, prev);
         expect(got, `${numeric} ${prev}`).toBeGreaterThanOrEqual(0);
         expect(got, `${numeric} ${prev} before NAMES ${CHANNELS[i]}`).toBeLessThan(next);
@@ -163,11 +181,12 @@ describe('engine restore pacing', () => {
     }
 
     // The fallback: the held channel's step ends at the deadline, not before —
-    // and the steps that were answered did not wait for it.
+    // and the steps that were answered did not wait for it. One clock on both
+    // sides, and a timer never fires early, so the lower bound is exact.
     const afterHeld = CHANNELS[CHANNELS.indexOf(HELD) + 1];
     expect(Math.max(gotIdx('331', HELD), gotIdx('332', HELD))).toBe(-1);
     const heldWait = sentAt(`NAMES ${afterHeld}`) - sentAt(`NAMES ${HELD}`);
-    expect(heldWait).toBeGreaterThanOrEqual(DEADLINE_MS - 50);
+    expect(heldWait).toBeGreaterThanOrEqual(DEADLINE_MS - 5);
     expect(heldWait).toBeLessThan(DEADLINE_MS + 1000);
     for (let i = 1; i < CHANNELS.length; i++) {
       if (CHANNELS[i - 1] === HELD) continue;
@@ -175,12 +194,14 @@ describe('engine restore pacing', () => {
       expect(gap, `gap before ${CHANNELS[i]}`).toBeLessThan(DEADLINE_MS / 2);
     }
 
-    // The invariant an ircd's flood control judges: never more than one
-    // channel's four requests unanswered at the server. (The held channel's
-    // TOPIC is unanswered by construction, so that channel is left out.)
+    // The invariant an ircd's flood control judges: never more than four of
+    // our restore lines unanswered at the server. Not implied by the gate
+    // above — the WHO is outside it, held to one in flight by irc-framework's
+    // own queue — so it is pinned here. (The held channel's TOPIC is unanswered
+    // by construction, so that channel is left out.)
     let outstanding = 0;
     let peak = 0;
-    for (const w of since) {
+    for (const w of wire) {
       const m = /^(?:\S+ (?:366|331|332|324|315) \S+ |(?:NAMES|TOPIC|MODE|WHO) )(#p\d)\b/.exec(
         w.line,
       );

--- a/server/services/engineRestoreWhoGate.test.ts
+++ b/server/services/engineRestoreWhoGate.test.ts
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The restore's eager away-sync WHO is size-gated: on a re-attach, a channel
+// over RESTORE_WHO_MAX_MEMBERS is not WHO'd (its 352-per-member reply is the
+// heaviest part of the reconnect burst), while a fresh interactive join still
+// WHOs at any size. Driven with the threshold pinned to 0, so every restored
+// channel is "over" it and the gate is exercised deterministically without
+// seeding hundreds of members.
+
+// MUST be first: redirects DATABASE_PATH before anything opens the db.
+import '../test-utils/isolateDb.js';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createUser } from '../db/users.js';
+import { createNetwork } from '../db/networks.js';
+import type { Network } from '../db/networks.js';
+import { IrcConnection } from './ircConnection.js';
+import ircManager from './ircManager.js';
+import { EngineServer } from '../engine/server.js';
+import { FakeIrcd } from '../test-utils/fakeIrcd.js';
+import { EngineLink, engineConfigured } from './engineLink.js';
+
+const SECRET = 'who-gate-secret';
+const CHANNELS = ['#wa', '#wb', '#wc'];
+let ircd: FakeIrcd;
+let engine: EngineServer;
+let network: Network;
+let userId: number;
+
+const sentBy = (nick: string) => ircd.client(nick)?.sent ?? [];
+
+function until(pred: () => boolean, ms = 5000, what = 'condition'): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + ms;
+    const tick = () => {
+      if (pred()) return resolve();
+      if (Date.now() > deadline) return reject(new Error(`timed out waiting for ${what}`));
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+beforeAll(async () => {
+  ircd = await FakeIrcd.start();
+  engine = new EngineServer({
+    secret: SECRET,
+    bufferBytes: 64 * 1024,
+    bufferTotalBytes: 1024 * 1024,
+    version: 'test',
+    log: () => {},
+  });
+  const { port } = await engine.listen(0, '127.0.0.1');
+  process.env.LURKER_ENGINE_URL = `tcp://127.0.0.1:${port}`;
+  process.env.LURKER_ENGINE_SECRET = SECRET;
+  process.env.LURKER_ENGINE_RETRY_BASE_MS = '100';
+  process.env.LURKER_ENGINE_HEARTBEAT_MS = '600000';
+  process.env.LURKER_RESTORE_STEP_DEADLINE_MS = '1500';
+  // 0 → every restored channel (>= 1 member: us) is over the threshold.
+  process.env.LURKER_RESTORE_WHO_MAX_MEMBERS = '0';
+  EngineLink.resetForTests();
+  if (!engineConfigured()) throw new Error('engine mode did not switch on');
+  const user = createUser('who-gate');
+  userId = user.id;
+  network = createNetwork(user.id, {
+    name: 'who-gate',
+    host: '127.0.0.1',
+    port: ircd.port,
+    tls: 0,
+    nick: 'gate',
+    autoconnect: 0,
+  })!;
+});
+
+afterAll(async () => {
+  ircManager.shutdown();
+  EngineLink.resetForTests();
+  await engine.shutdown('tests done', 500);
+  await ircd.close();
+  delete process.env.LURKER_ENGINE_URL;
+  delete process.env.LURKER_ENGINE_SECRET;
+  delete process.env.LURKER_ENGINE_RETRY_BASE_MS;
+  delete process.env.LURKER_ENGINE_HEARTBEAT_MS;
+  delete process.env.LURKER_RESTORE_STEP_DEADLINE_MS;
+  delete process.env.LURKER_RESTORE_WHO_MAX_MEMBERS;
+});
+
+describe('engine restore WHO size-gate', () => {
+  it('skips the away-sync WHO for restored channels over the threshold, but not a fresh join', async () => {
+    const conn = new IrcConnection({ network, onEvent: () => {} });
+    conn.connect();
+    await until(() => conn.state === 'connected', 5000, 'connected');
+    for (const ch of CHANNELS) conn.join(ch);
+    await until(() => CHANNELS.every((ch) => conn.isChannelJoined(ch)), 5000, 'joins');
+    // A normal join DID WHO (the gate is restore-only) — proves the ircd/route work.
+    for (const ch of CHANNELS) {
+      expect(
+        sentBy('gate').some((l) => l === `WHO ${ch}`),
+        `initial WHO ${ch}`,
+      ).toBe(true);
+    }
+
+    const sentBefore = sentBy('gate').length;
+    conn.detach();
+    await until(() => conn.state === 'disconnected', 5000, 'detached');
+
+    const conn2 = ircManager.startNetwork(userId, network.id)!;
+    await until(() => conn2.state === 'connected', 5000, 'reattached');
+    // Restore runs one channel at a time; wait until the last channel's MODE
+    // request (the final line of the final step) has gone out.
+    const last = CHANNELS[CHANNELS.length - 1];
+    await until(
+      () => sentBy('gate').slice(sentBefore).includes(`MODE ${last}`),
+      5000,
+      'restore reached the last channel',
+    );
+    // Give any (skipped) WHO a beat to NOT appear.
+    await new Promise((r) => setTimeout(r, 100));
+
+    const since = sentBy('gate').slice(sentBefore);
+    for (const ch of CHANNELS) {
+      // The state requests still went out — the gate only drops the WHO.
+      expect(since, `NAMES ${ch}`).toContain(`NAMES ${ch}`);
+      expect(since, `TOPIC ${ch}`).toContain(`TOPIC ${ch}`);
+      expect(since, `MODE ${ch}`).toContain(`MODE ${ch}`);
+      // ...but the away-sync WHO was skipped for this restored channel.
+      expect(
+        since.some((l) => l === `WHO ${ch}`),
+        `WHO ${ch} skipped`,
+      ).toBe(false);
+    }
+
+    // A fresh interactive join still WHOs, at any size and threshold — the gate
+    // is restore-scoped (restoreQuiet marks only the restored channels).
+    const beforeFresh = sentBy('gate').length;
+    conn2.join('#fresh');
+    await until(() => conn2.isChannelJoined('#fresh'), 5000, 'fresh join');
+    await until(
+      () => sentBy('gate').slice(beforeFresh).includes('WHO #fresh'),
+      5000,
+      'fresh-join WHO',
+    );
+  }, 25000);
+});

--- a/server/services/engineRestoreWhoGate.test.ts
+++ b/server/services/engineRestoreWhoGate.test.ts
@@ -92,13 +92,15 @@ describe('engine restore WHO size-gate', () => {
     await until(() => conn.state === 'connected', 5000, 'connected');
     for (const ch of CHANNELS) conn.join(ch);
     await until(() => CHANNELS.every((ch) => conn.isChannelJoined(ch)), 5000, 'joins');
-    // A normal join DID WHO (the gate is restore-only) — proves the ircd/route work.
-    for (const ch of CHANNELS) {
-      expect(
-        sentBy('gate').some((l) => l === `WHO ${ch}`),
-        `initial WHO ${ch}`,
-      ).toBe(true);
-    }
+    // A normal join DID WHO (the gate is restore-only) — proves the ircd/route
+    // work. Waited, not asserted immediately: irc-framework serialises WHO
+    // behind each 315, so later channels' WHOs trail the joins (and this also
+    // ensures no initial WHO is still queued when we snapshot below).
+    await until(
+      () => CHANNELS.every((ch) => sentBy('gate').includes(`WHO ${ch}`)),
+      5000,
+      'initial WHOs',
+    );
 
     const sentBefore = sentBy('gate').length;
     conn.detach();

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -171,9 +171,12 @@ const RESTORE_QUIET_MS = 10_000;
 // LURKER_RESTORE_STEP_DEADLINE_MS overrides it, read per step, so a test of the
 // fallback does not have to sit through it.
 const RESTORE_STEP_DEADLINE_MS = 10_000;
-// The terminal reply of each request a restore step makes.
+// The terminal reply of each request a restore step makes. Indexed by an
+// arbitrary numeric, so the value is `| undefined` — that is what makes the
+// `if (!reply) return` guard in noteRestoreReply type-honest for the numerics
+// that are not in the map (e.g. the 329 that follows 324).
 type RestoreReply = 'names' | 'topic' | 'mode';
-const RESTORE_REPLY_OF: Record<string, RestoreReply> = {
+const RESTORE_REPLY_OF: Record<string, RestoreReply | undefined> = {
   '366': 'names', // RPL_ENDOFNAMES
   '331': 'topic', // RPL_NOTOPIC
   '332': 'topic', // RPL_TOPIC
@@ -4135,9 +4138,11 @@ export class IrcConnection {
   // turn that one lost reply into a deadline wait for every channel after it.
   private drainRestoreQueue(): void {
     this.endRestoreStep();
-    // Skip what we are no longer in (a backlog KICK may have arrived in between).
+    // Skip what we are no longer in (a backlog KICK may have arrived in
+    // between). isChannelJoined, not a raw toLowerCase probe — membership folds
+    // through the network's CASEMAPPING (this file's #707 rule).
     let name = this.restoreQueue.shift();
-    while (name !== undefined && !this.channels.has(name.toLowerCase())) {
+    while (name !== undefined && !this.isChannelJoined(name)) {
       name = this.restoreQueue.shift();
     }
     if (name === undefined) return;

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -163,10 +163,29 @@ const MAX_CONSECUTIVE_SASL_FAILURES = 3;
 // short window after the restore — see RESTORE_QUIET_MS.
 const RESTORE_QUIET_NUMERICS = new Set(['221', '324', '329', '331', '332', '333']);
 const RESTORE_QUIET_MS = 10_000;
-// The per-channel state requests after a restore go out paced, not as one
-// burst: three lines per channel for forty channels in one tick is exactly
-// the flood the JOIN coalescing elsewhere exists to avoid.
-const RESTORE_REQUEST_INTERVAL_MS = 400;
+// The per-channel state requests after a restore go out one channel at a time,
+// and the next channel waits for this one's replies (drainRestoreQueue). This
+// deadline is the fallback for a reply that never comes — a server that skips
+// a numeric, or a channel the engine still counts us in and the server does
+// not — so one silent channel costs one wait, not the whole restore.
+// Overridable so a test of the fallback does not have to sit through it.
+const RESTORE_STEP_DEADLINE_MS = 10_000;
+function restoreStepDeadlineMs(): number {
+  const n = Number(process.env.LURKER_RESTORE_STEP_DEADLINE_MS);
+  return Number.isFinite(n) && n > 0 ? n : RESTORE_STEP_DEADLINE_MS;
+}
+// The terminal reply of each request a restore step makes, and the errors
+// that say no reply is coming for the channel at all.
+type RestoreReply = 'names' | 'topic' | 'mode' | 'who';
+const RESTORE_REPLY_OF: Record<string, RestoreReply | 'all'> = {
+  '366': 'names', // RPL_ENDOFNAMES
+  '331': 'topic', // RPL_NOTOPIC
+  '332': 'topic', // RPL_TOPIC
+  '324': 'mode', // RPL_CHANNELMODEIS
+  '315': 'who', // RPL_ENDOFWHO — the WHO the NAMES reply triggers (see 'userlist')
+  '403': 'all', // ERR_NOSUCHCHANNEL
+  '442': 'all', // ERR_NOTONCHANNEL
+};
 // How long a link-loss re-attach waits for the engine to say what it holds
 // before treating the session as gone and taking the ordinary reconnect ladder.
 const ENGINE_REATTACH_WAIT_MS = 10_000;
@@ -694,6 +713,9 @@ export class IrcConnection {
   private restoredCallbacks: Array<() => void>;
   private restoreQueue: string[];
   private restoreTimer: ReturnType<typeof setTimeout> | null;
+  // The restore step in flight: the folded channel and which of its replies
+  // are still owed. Null between steps and outside a restore.
+  private restoreStep: { key: string; owed: Set<RestoreReply> } | null;
   private engineTransport: EngineTransport | null;
   private engineSocketAlive: boolean;
   // folded channel → the state replies still owed from the restore's own
@@ -809,6 +831,7 @@ export class IrcConnection {
     this.restoredCallbacks = [];
     this.restoreQueue = [];
     this.restoreTimer = null;
+    this.restoreStep = null;
     this.engineTransport = null;
     this.engineSocketAlive = false;
     this.restoreQuiet = new Map();
@@ -1124,6 +1147,10 @@ export class IrcConnection {
           raw: { command: rawCommand, params: msg?.params ?? [] },
         });
       }
+      // A reply to the restore step in flight is what releases the next
+      // channel's requests. Before the denylist: 366 and 315 are exactly the
+      // kind of line the server buffer never shows.
+      if (this.restoreStep) this.noteRestoreReply(rawCommand, msg?.params?.[1]);
       if (isServerBufferDeniedNumeric(rawCommand)) return;
       if (
         RESTORE_QUIET_NUMERICS.has(rawCommand) &&
@@ -3996,8 +4023,9 @@ export class IrcConnection {
         this.restoring = false;
         // A synthesised JOIN gets none of what a real one is volunteered — no
         // 353/366, no 332, and the join handler's MODE is skipped on a restore —
-        // so ask, one channel at a time (RESTORE_REQUEST_INTERVAL_MS), keeping
-        // each channel's replies out of the server buffer until they arrive.
+        // so ask, one channel at a time, each waiting for the last one's
+        // replies (drainRestoreQueue), keeping each channel's replies out of
+        // the server buffer until they arrive.
         // Our umodes were set after the burst ended (the post-MOTD `MODE nick
         // +i`), so they are not in the replay either.
         this.restoreQuiet.set('*', {
@@ -4061,27 +4089,62 @@ export class IrcConnection {
       this.restoreTimer = null;
     }
     this.restoreQuiet.clear();
+    this.restoreStep = null;
   }
 
+  // One channel in flight. The next channel's three requests go out when this
+  // one's replies are all in — NAMES → 366, TOPIC → 331/332, MODE → 324, and
+  // the WHO the NAMES reply triggers ('userlist') → 315 — or when the step
+  // deadline passes. Closed-loop rather than a fixed interval because the
+  // interval was a guess at one ircd's flood budget, and wrong: solanum
+  // (Libera) lets a registered client past its grace period send 5 lines and
+  // then 2 per second, and kills at 20 unprocessed — so 4 lines per channel
+  // every 400 ms was "Excess Flood" by the seventh channel on every restart.
+  // Gated on replies, the server's queue never holds more than these four
+  // lines of ours, on any ircd, and a server that throttles simply sets the
+  // pace. (irc-framework already serialises WHO behind its 315, so one channel
+  // at a time is also the only order the WHOs could go out in.)
   private drainRestoreQueue(): void {
-    const name = this.restoreQueue.shift();
-    if (name === undefined) return;
-    // Still in it? (A backlog KICK may have arrived in between.)
-    if (this.channels.has(name.toLowerCase())) {
-      this.restoreQuiet.set(name.toLowerCase(), {
-        until: Date.now() + RESTORE_QUIET_MS,
-        mode: true,
-        topic: true,
-      });
-      this.rawQuiet('NAMES', name);
-      this.rawQuiet('TOPIC', name);
-      this.rawQuiet('MODE', name);
+    if (this.restoreTimer) {
+      clearTimeout(this.restoreTimer);
+      this.restoreTimer = null;
     }
-    if (this.restoreQueue.length === 0) return;
+    this.restoreStep = null;
+    // Skip what we are no longer in (a backlog KICK may have arrived in between).
+    let name = this.restoreQueue.shift();
+    while (name !== undefined && !this.channels.has(name.toLowerCase())) {
+      name = this.restoreQueue.shift();
+    }
+    if (name === undefined) return;
+    const key = name.toLowerCase();
+    this.restoreQuiet.set(key, {
+      until: Date.now() + RESTORE_QUIET_MS,
+      mode: true,
+      topic: true,
+    });
+    this.restoreStep = { key, owed: new Set(['names', 'topic', 'mode', 'who']) };
+    this.rawQuiet('NAMES', name);
+    this.rawQuiet('TOPIC', name);
+    this.rawQuiet('MODE', name);
     this.restoreTimer = setTimeout(() => {
       this.restoreTimer = null;
       if (!this.disposed && this.state === 'connected') this.drainRestoreQueue();
-    }, RESTORE_REQUEST_INTERVAL_MS);
+    }, restoreStepDeadlineMs());
+  }
+
+  // A server line naming the in-flight step's channel: retire the reply it is,
+  // and when nothing is owed, move on. 403/442 mean the channel will answer
+  // nothing at all.
+  private noteRestoreReply(numeric: string, channel: unknown): void {
+    const step = this.restoreStep;
+    if (!step || typeof channel !== 'string' || channel.toLowerCase() !== step.key) return;
+    const reply = RESTORE_REPLY_OF[numeric];
+    if (!reply) return;
+    if (reply === 'all') step.owed.clear();
+    else step.owed.delete(reply);
+    if (step.owed.size === 0 && !this.disposed && this.state === 'connected') {
+      this.drainRestoreQueue();
+    }
   }
 
   private rawQuiet(command: string, arg: string): void {

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -168,23 +168,16 @@ const RESTORE_QUIET_MS = 10_000;
 // deadline is the fallback for a reply that never comes — a server that skips
 // a numeric, or a channel the engine still counts us in and the server does
 // not — so one silent channel costs one wait, not the whole restore.
-// Overridable so a test of the fallback does not have to sit through it.
+// LURKER_RESTORE_STEP_DEADLINE_MS overrides it, read per step, so a test of the
+// fallback does not have to sit through it.
 const RESTORE_STEP_DEADLINE_MS = 10_000;
-function restoreStepDeadlineMs(): number {
-  const n = Number(process.env.LURKER_RESTORE_STEP_DEADLINE_MS);
-  return Number.isFinite(n) && n > 0 ? n : RESTORE_STEP_DEADLINE_MS;
-}
-// The terminal reply of each request a restore step makes, and the errors
-// that say no reply is coming for the channel at all.
-type RestoreReply = 'names' | 'topic' | 'mode' | 'who';
-const RESTORE_REPLY_OF: Record<string, RestoreReply | 'all'> = {
+// The terminal reply of each request a restore step makes.
+type RestoreReply = 'names' | 'topic' | 'mode';
+const RESTORE_REPLY_OF: Record<string, RestoreReply> = {
   '366': 'names', // RPL_ENDOFNAMES
   '331': 'topic', // RPL_NOTOPIC
   '332': 'topic', // RPL_TOPIC
   '324': 'mode', // RPL_CHANNELMODEIS
-  '315': 'who', // RPL_ENDOFWHO — the WHO the NAMES reply triggers (see 'userlist')
-  '403': 'all', // ERR_NOSUCHCHANNEL
-  '442': 'all', // ERR_NOTONCHANNEL
 };
 // How long a link-loss re-attach waits for the engine to say what it holds
 // before treating the session as gone and taking the ordinary reconnect ladder.
@@ -1148,9 +1141,9 @@ export class IrcConnection {
         });
       }
       // A reply to the restore step in flight is what releases the next
-      // channel's requests. Before the denylist: 366 and 315 are exactly the
-      // kind of line the server buffer never shows.
-      if (this.restoreStep) this.noteRestoreReply(rawCommand, msg?.params?.[1]);
+      // channel's requests. Before the denylist: 366 is exactly the kind of
+      // line the server buffer never shows.
+      this.noteRestoreReply(rawCommand, msg?.params?.[1]);
       if (isServerBufferDeniedNumeric(rawCommand)) return;
       if (
         RESTORE_QUIET_NUMERICS.has(rawCommand) &&
@@ -4084,52 +4077,61 @@ export class IrcConnection {
     this.restoreUnattended = false;
     this.restoredCallbacks = [];
     this.restoreQueue = [];
+    this.endRestoreStep();
+    this.restoreQuiet.clear();
+  }
+
+  private endRestoreStep(): void {
     if (this.restoreTimer) {
       clearTimeout(this.restoreTimer);
       this.restoreTimer = null;
     }
-    this.restoreQuiet.clear();
     this.restoreStep = null;
   }
 
   // One channel in flight. The next channel's three requests go out when this
-  // one's replies are all in — NAMES → 366, TOPIC → 331/332, MODE → 324, and
-  // the WHO the NAMES reply triggers ('userlist') → 315 — or when the step
-  // deadline passes. Closed-loop rather than a fixed interval because the
-  // interval was a guess at one ircd's flood budget, and wrong: solanum
-  // (Libera) lets a registered client past its grace period send 5 lines and
-  // then 2 per second, and kills at 20 unprocessed — so 4 lines per channel
-  // every 400 ms was "Excess Flood" by the seventh channel on every restart.
-  // Gated on replies, the server's queue never holds more than these four
-  // lines of ours, on any ircd, and a server that throttles simply sets the
-  // pace. (irc-framework already serialises WHO behind its 315, so one channel
-  // at a time is also the only order the WHOs could go out in.)
+  // one's replies are all in — NAMES → 366, TOPIC → 331/332, MODE → 324 — or
+  // when the step deadline passes. Closed-loop rather than a fixed interval
+  // because the interval was a guess at one ircd's flood budget, and wrong:
+  // solanum (Libera) lets a registered client past its grace period send 5
+  // lines and then 2 per second, and kills at 20 unprocessed — so 4 lines per
+  // channel every 400 ms was "Excess Flood" by the seventh channel on every
+  // restart. Gated on replies, the server's queue never holds more than four
+  // lines of ours on any ircd — these three plus the WHO the NAMES reply
+  // triggers ('userlist'), which irc-framework already serialises behind its
+  // 315 (`who_queue`) — and a server that throttles simply sets the pace. The
+  // WHO is deliberately NOT part of the gate: irc-framework's queue never
+  // recovers from a 315 that does not come, and a step waiting on it would
+  // turn that one lost reply into a deadline wait for every channel after it.
   private drainRestoreQueue(): void {
-    if (this.restoreTimer) {
-      clearTimeout(this.restoreTimer);
-      this.restoreTimer = null;
-    }
-    this.restoreStep = null;
+    this.endRestoreStep();
     // Skip what we are no longer in (a backlog KICK may have arrived in between).
     let name = this.restoreQueue.shift();
     while (name !== undefined && !this.channels.has(name.toLowerCase())) {
       name = this.restoreQueue.shift();
     }
     if (name === undefined) return;
-    const key = name.toLowerCase();
-    this.restoreQuiet.set(key, {
+    this.restoreQuiet.set(name.toLowerCase(), {
       until: Date.now() + RESTORE_QUIET_MS,
       mode: true,
       topic: true,
     });
-    this.restoreStep = { key, owed: new Set(['names', 'topic', 'mode', 'who']) };
+    // Keyed by the network's own fold: the replies echo the channel as the
+    // server spells it, which on an rfc1459 network is not a toLowerCase away.
+    this.restoreStep = {
+      key: foldTargetFor(this.network.id, name),
+      owed: new Set(['names', 'topic', 'mode']),
+    };
     this.rawQuiet('NAMES', name);
     this.rawQuiet('TOPIC', name);
     this.rawQuiet('MODE', name);
-    this.restoreTimer = setTimeout(() => {
-      this.restoreTimer = null;
-      if (!this.disposed && this.state === 'connected') this.drainRestoreQueue();
-    }, restoreStepDeadlineMs());
+    this.restoreTimer = setTimeout(
+      () => {
+        this.restoreTimer = null;
+        if (!this.disposed && this.state === 'connected') this.drainRestoreQueue();
+      },
+      Math.max(1, reconnectEnvInt('LURKER_RESTORE_STEP_DEADLINE_MS', RESTORE_STEP_DEADLINE_MS)),
+    );
   }
 
   // A server line naming the in-flight step's channel: retire the reply it is,
@@ -4137,11 +4139,15 @@ export class IrcConnection {
   // nothing at all.
   private noteRestoreReply(numeric: string, channel: unknown): void {
     const step = this.restoreStep;
-    if (!step || typeof channel !== 'string' || channel.toLowerCase() !== step.key) return;
-    const reply = RESTORE_REPLY_OF[numeric];
-    if (!reply) return;
-    if (reply === 'all') step.owed.clear();
-    else step.owed.delete(reply);
+    if (!step || typeof channel !== 'string') return;
+    if (foldTargetFor(this.network.id, channel) !== step.key) return;
+    if (numeric === '403' || numeric === '442') {
+      step.owed.clear();
+    } else {
+      const reply = RESTORE_REPLY_OF[numeric];
+      if (!reply) return;
+      step.owed.delete(reply);
+    }
     if (step.owed.size === 0 && !this.disposed && this.state === 'connected') {
       this.drainRestoreQueue();
     }

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -179,6 +179,18 @@ const RESTORE_REPLY_OF: Record<string, RestoreReply> = {
   '332': 'topic', // RPL_TOPIC
   '324': 'mode', // RPL_CHANNELMODEIS
 };
+// On a restore, a channel with MORE than this many members does not get the
+// eager away-sync WHO (see the 'userlist' handler). That WHO's reply is one
+// verbose 352 line PER MEMBER — the heaviest thing a restore does, and what a
+// big-channel reconnect turns into an [event-loop] stall — while NAMES packs
+// many nicks per 353 line. In a channel this large per-member away dots matter
+// least, and away-notify keeps active members' state live regardless; the only
+// loss is that a member who was silently away before the reconnect reads as
+// present until they next move. Read live (LURKER_RESTORE_WHO_MAX_MEMBERS; 0
+// disables the restore WHO entirely). NOT a functional cap — a user /who and
+// every fresh interactive join still WHO in full; this only trims the eager
+// sync on the reconnect burst.
+const RESTORE_WHO_MAX_MEMBERS = 500;
 // How long a link-loss re-attach waits for the engine to say what it holds
 // before treating the session as gone and taking the ordinary reconnect ladder.
 const ENGINE_REATTACH_WAIT_MS = 10_000;
@@ -2730,13 +2742,31 @@ export class IrcConnection {
       // channel. away-notify keeps it live after this initial sync. Mark it so
       // the 'wholist' handler consumes the reply silently instead of echoing
       // every member to the server buffer (#342).
-      try {
-        c.who(eventChannel);
-        // Mark only after a successful send: if c.who() throws, a stale flag
-        // would silently suppress a later user-typed /who for this channel.
-        this.autoWhoTargets.add(eventChannel.toLowerCase());
-      } catch (_) {
-        /* ignore */
+      //
+      // Exception: on a RESTORE, a very large channel's away-sync WHO is skipped
+      // (RESTORE_WHO_MAX_MEMBERS) — its 352-per-member reply is the heaviest part
+      // of the reconnect burst. restoreQuiet marks exactly the channels
+      // drainRestoreQueue just requested, so this never touches a fresh
+      // interactive join (which WHOs in full, any size).
+      const rq = this.restoreQuiet.get(eventChannel.toLowerCase());
+      const inRestore = !!rq && Date.now() < rq.until;
+      const whoMax = reconnectEnvInt('LURKER_RESTORE_WHO_MAX_MEMBERS', RESTORE_WHO_MAX_MEMBERS);
+      if (inRestore && ch.members.size > whoMax) {
+        // Diagnostic only (docker logs), never a server-buffer row: on a big
+        // multi-network restore this can fire per channel.
+        console.log(
+          `[irc] restore: skipped away-sync WHO for ${eventChannel} (${ch.members.size} members > ${whoMax}) ` +
+            `on network ${this.network.id}; away-notify keeps it live`,
+        );
+      } else {
+        try {
+          c.who(eventChannel);
+          // Mark only after a successful send: if c.who() throws, a stale flag
+          // would silently suppress a later user-typed /who for this channel.
+          this.autoWhoTargets.add(eventChannel.toLowerCase());
+        } catch (_) {
+          /* ignore */
+        }
       }
       const ms = Date.now() - tHandler;
       if (IRC_HANDLER_WARN_MS > 0 && ms >= IRC_HANDLER_WARN_MS) {

--- a/server/test-utils/fakeIrcd.ts
+++ b/server/test-utils/fakeIrcd.ts
@@ -73,6 +73,9 @@ export class FakeIrcd extends EventEmitter {
   readonly clients: FakeClient[] = [];
   readonly registrations: Array<{ nick: string; at: number }> = [];
   readonly topics = new Map<string, string>();
+  // Test hook: return true to swallow a client command — no reply of any kind —
+  // so a test can hold a specific reply back and release it with answer().
+  hold: ((cmd: string, params: string[], c: FakeClient) => boolean) | null = null;
   private msgidCounter = 0;
   private server!: net.Server;
   port = 0;
@@ -271,6 +274,12 @@ export class FakeIrcd extends EventEmitter {
     );
   }
 
+  // Send a numeric to a client by nick — for a reply a test held back.
+  answer(nick: string, code: string, ...params: string[]): void {
+    const c = this.client(nick);
+    if (c) this.num(c, code, ...params);
+  }
+
   // Prefix a relayed line with tags the client negotiated.
   private tagged(c: FakeClient, line: string, msgid?: string): void {
     const tags: string[] = [];
@@ -286,6 +295,7 @@ export class FakeIrcd extends EventEmitter {
     if (!msg) return;
     const cmd = String(msg.command || '').toUpperCase();
     const p = msg.params;
+    if (this.hold?.(cmd, p, c)) return;
     switch (cmd) {
       case 'CAP':
         return this.onCap(c, p);

--- a/server/test-utils/fakeIrcd.ts
+++ b/server/test-utils/fakeIrcd.ts
@@ -260,10 +260,13 @@ export class FakeIrcd extends EventEmitter {
     return this.clients.filter((c) => c.channels.has(lower) && !c.socket.destroyed);
   }
 
-  // Every line this server sends is also emitted as 'sent' (line, client), so a
-  // test can log both directions of a conversation in causal order.
+  // Every line this server actually writes is also emitted as 'sent' (line,
+  // client), so a test can log both directions of a conversation in causal
+  // order. Only on a real write — a line dropped to a destroyed socket never
+  // went on the wire and must not show up in a wire log.
   private raw(c: FakeClient, line: string): void {
-    if (!c.socket.destroyed) c.socket.write(line + '\r\n');
+    if (c.socket.destroyed) return;
+    c.socket.write(line + '\r\n');
     this.emit('sent', line, c);
   }
 

--- a/server/test-utils/fakeIrcd.ts
+++ b/server/test-utils/fakeIrcd.ts
@@ -74,7 +74,7 @@ export class FakeIrcd extends EventEmitter {
   readonly registrations: Array<{ nick: string; at: number }> = [];
   readonly topics = new Map<string, string>();
   // Test hook: return true to swallow a client command — no reply of any kind —
-  // so a test can hold a specific reply back and release it with answer().
+  // for a test of what the client does when a reply never comes.
   hold: ((cmd: string, params: string[], c: FakeClient) => boolean) | null = null;
   private msgidCounter = 0;
   private server!: net.Server;
@@ -260,8 +260,11 @@ export class FakeIrcd extends EventEmitter {
     return this.clients.filter((c) => c.channels.has(lower) && !c.socket.destroyed);
   }
 
+  // Every line this server sends is also emitted as 'sent' (line, client), so a
+  // test can log both directions of a conversation in causal order.
   private raw(c: FakeClient, line: string): void {
     if (!c.socket.destroyed) c.socket.write(line + '\r\n');
+    this.emit('sent', line, c);
   }
 
   private num(c: FakeClient, code: string, ...params: string[]): void {
@@ -272,12 +275,6 @@ export class FakeIrcd extends EventEmitter {
       c,
       `:${this.serverName} ${code} ${nick}${head}${last !== undefined ? ' :' + last : ''}`,
     );
-  }
-
-  // Send a numeric to a client by nick — for a reply a test held back.
-  answer(nick: string, code: string, ...params: string[]): void {
-    const c = this.client(nick);
-    if (c) this.num(c, code, ...params);
   }
 
   // Prefix a relayed line with tags the client negotiated.


### PR DESCRIPTION
## What

A re-attached session asks NAMES/TOPIC/MODE per channel (and the NAMES reply triggers a WHO). Until now those went out every 400 ms — 4 lines per channel, ~10 lines/s sustained. Solanum (Libera) allows a registered client past its grace period 5 lines and then 2 per second, and kills at 20 unprocessed, so a 10-channel restore was **Excess Flood at about the seventh channel on every container restart** (reported the day after 2.1.4). Fresh connects never saw it because their burst lands inside the post-registration grace.

Now one channel is in flight at a time. The next channel's requests go out when the previous one's replies are all in (366, 331/332, 324), 403/442 end a step early, and a 10 s step deadline is the only fallback (`LURKER_RESTORE_STEP_DEADLINE_MS`, a test seam). The server's queue never holds more than four of our lines on any ircd — three gated plus the one WHO irc-framework itself keeps in flight — and a throttling server simply sets the pace.

The WHO is deliberately outside the gate: irc-framework serialises WHO behind its 315 (`who_queue`) and never recovers from one that does not come, so gating on 315 would turn a single lost reply into a deadline wait for every channel after it.

## Test

`engineRestorePacing.test.ts` reads the gate and the deadline fallback off the wire against the fake ircd (which grows a `hold` hook and a `'sent'` event). Inbound lines are stamped where the ircd sends them and outbound where the Client writes them, so replies are logged in causal order and the timing assertions read one clock. Removing the gate makes the test fail.

Measured before/after with 10 channels: 42 lines in 3.6 s → never more than 4 unanswered.

## Not in this PR

- The fresh-connect JOIN + MODE×N + WHO×N burst is unpaced (in-grace on solanum up to ~30 channels); the same loop could take it later.
- A server that never answers a WHO wedges every later auto-WHO on the Client (pre-existing irc-framework behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
