### PR TITLE
Bump Lurker version to 2.1.5 — engine restore flood/stall fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "2.1.4",
+  "version": "2.1.5",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
## 2.1.5 — bug-fix release for the IRC engine

The first fix release since the engine shipped in 2.1.4. Rolls up #840.

**What it fixes.** On a re-attach, the per-channel state re-sync (NAMES/TOPIC/MODE, plus the WHO the NAMES reply triggers) went out as a fixed 400 ms burst:
- On solanum networks (Libera) it flood-killed the client — "Excess Flood" at about the seventh channel on every container restart.
- Across many networks re-attaching at once, the burst's reply processing stalled the event loop for several seconds and tripped ping timeouts on other connections.

**The fix (#840):** requests are now paced by the server's own replies — one channel in flight, the next released when the previous one's numerics land, with a step deadline as the only fallback. The server's queue never holds more than a few of our lines on any ircd. The eager away-sync WHO is additionally size-gated on restore (`LURKER_RESTORE_WHO_MAX_MEMBERS`, default 500) since its per-member reply is the heaviest part of the burst; away-notify keeps active members' state live regardless. Validated against real `solanum-1.0-dev`.

**Scope.** Version bump only (both `package.json`s + lockfiles), matching the 2.1.4 bump. App-side change only — nothing in `server/engine` moved, so the `engine-1` tag stays put and `docker compose pull && up -d` recreates the app while the engine keeps every held IRC connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
