### PR TITLE
Retention: per-buffer history line cap (plan PR 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,6 +131,16 @@ VAPID_SUBJECT=mailto:you@example.com
 # LURKER_MAX_UPLOAD_MB=100
 
 # ---------------------------------------------------------------------------
+# History retention ceiling: the most stored lines any buffer may keep. Unset
+# (or 0) = no ceiling, the self-host default — history is kept forever. Users
+# may set a LOWER per-buffer limit in Settings → Data, never a higher one, so
+# on a multi-user instance this is also the default for users who set nothing.
+# Pruning is permanent and runs in the background; bookmarked messages are
+# always kept. A value that won't parse is ignored WITH a warning — a typo
+# must never mass-delete history.
+# LURKER_MAX_RETENTION_LINES=100000
+
+# ---------------------------------------------------------------------------
 # Built-in identd (RFC 1413). For MULTI-USER deployments connecting many users
 # to a network from one IP, so the network can attribute each user. Off by
 # default (binding :113 is privileged; single-user self-hosts don't need it).

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -770,6 +770,16 @@ connection-independent — offline networks still serve it.
 pipeline requests: keep a monotonically increasing token and drop any reply
 whose token you've superseded.
 
+**Stored history is NOT append-only.** Instances can enforce a retention
+policy (an operator ceiling and/or a per-user setting) that permanently
+deletes a buffer's oldest rows in the background. Do not treat a message id
+you once fetched as permanently fetchable: an `around` jump to it can come
+back `anchorMissing`, a `before` page can return fewer rows with
+`hasMoreOlder:false` earlier than history "should" end, and on the IRC
+bouncer surface an empty CHATHISTORY batch can mean pruned as well as
+never-existed. None of these are distinguishable from history that never
+existed — cache accordingly.
+
 ### `countBy` — what `limit` counts
 
 `limit` counts **stored rows**. If you consolidate presence noise — the web

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -7,6 +7,7 @@ import {
   resolveBufferIdByNetwork,
   resolveOrMintForInsert,
 } from './bufferResolve.js';
+import { markBufferDirty } from './retention.js';
 import { countsTowardPage } from '../../shared/eventFilter.js';
 import type { PageUnit } from '../../shared/eventFilter.js';
 import type { ModeChange } from '../../shared/modes.js';
@@ -180,6 +181,8 @@ export function insertMessage(row: MessageInput): {
     msgid: row.msgid || null,
   });
   const id = result.lastInsertRowid;
+  // Retention prunes lazily: the sweep only ever looks at buffers that grew.
+  markBufferDirty(bufferId);
   const altRow = altByIdStmt.get(id) as { alt: number } | undefined;
   // bufferId returned so the live publish path can stamp it onto the enriched
   // event without a second resolve — the wire's `irc` frames carry it.

--- a/server/db/messagesEqp.test.ts
+++ b/server/db/messagesEqp.test.ts
@@ -152,3 +152,38 @@ describe('search filter paths', () => {
     expect(detail).not.toMatch(/TEMP B-TREE/);
   });
 });
+
+// The retention sweep's two statements (db/retention.ts). Count-based
+// retention was chosen partly BECAUSE these ride idx_messages_buf_unread with
+// no new index; these pins are what make that a property rather than a hope.
+// The bookmark-exemption probe must stay a seek on the (user_id, message_id)
+// primary key — dropping the user_id term demotes it to a scan of the whole
+// bookmarks table per candidate row.
+describe('retention prune paths', () => {
+  it('the boundary probe walks the covering per-buffer index', () => {
+    const detail = plan(
+      `SELECT id FROM messages WHERE buffer_id = 1 ORDER BY id DESC LIMIT 1 OFFSET 999`,
+    );
+    expect(detail).toMatch(/USING COVERING INDEX idx_messages_buf_unread/);
+  });
+
+  it('the delete subselect stays covered, with a seekable bookmark probe', () => {
+    const detail = plan(
+      `DELETE FROM messages WHERE id IN (
+         SELECT m.id FROM messages m
+          WHERE m.buffer_id = 1 AND m.id < 500
+            AND NOT EXISTS (
+              SELECT 1 FROM user_bookmarks ub
+               WHERE ub.user_id = 1 AND ub.message_id = m.id
+            )
+          LIMIT 500
+       )`,
+    );
+    expect(detail).toMatch(
+      /USING COVERING INDEX idx_messages_buf_unread \(buffer_id=\? AND id<\?\)/,
+    );
+    expect(detail).toMatch(
+      /USING COVERING INDEX sqlite_autoindex_user_bookmarks_1 \(user_id=\? AND message_id=\?\)/,
+    );
+  });
+});

--- a/server/db/retention.ts
+++ b/server/db/retention.ts
@@ -32,9 +32,19 @@ export function takeDirtyBuffers(): number[] {
   return out;
 }
 
-/** Boot seeding: every buffer is suspect until the sweeper has looked once. */
+/** Boot seeding: every buffer is suspect until the sweeper has looked once.
+ *  Also the after-import catch-all — imported rows bypass insertMessage, so
+ *  nothing else would ever mark their buffers. */
 export function seedAllBuffersDirty(): void {
   const rows = db.prepare(`SELECT id FROM buffers`).all() as Array<{ id: number }>;
+  for (const row of rows) dirtyBuffers.add(row.id);
+}
+
+/** Re-examine one user's buffers — their retention setting changed. */
+export function seedUserBuffersDirty(userId: number): void {
+  const rows = db.prepare(`SELECT id FROM buffers WHERE user_id = ?`).all(userId) as Array<{
+    id: number;
+  }>;
   for (const row of rows) dirtyBuffers.add(row.id);
 }
 

--- a/server/db/retention.ts
+++ b/server/db/retention.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// Storage side of history retention (RETENTION_PLAN.md): the dirty-buffer set
+// Storage side of history retention (lurker-dev/RETENTION_PLAN.md): the dirty-buffer set
 // that tells the sweeper where to look, and the two statements it runs. The
 // scheduling lives in services/retentionSweeper.ts; this module owns the SQL
 // so the statements sit next to the schema they depend on.
@@ -71,9 +71,10 @@ export function retentionBoundaryId(bufferId: number, capLines: number): number 
   return row?.id;
 }
 
-// One bounded bite of the over-cap tail, oldest rows first by construction
-// (everything below the boundary goes eventually; order within doesn't
-// matter). The NOT EXISTS is the bookmark exemption — a bookmarked row below
+// One bounded bite of the over-cap tail. Deliberately no ORDER BY in the
+// subselect: everything below the boundary goes eventually, so any qualifying
+// rows do, and ordering would only add sort work. The NOT EXISTS is the
+// bookmark exemption — a bookmarked row below
 // the boundary survives as an extra ABOVE the cap (later boundary probes walk
 // past it and it never becomes deletable). It is scoped by user_id, not just
 // message_id: user_bookmarks has no index on message_id alone, and a buffer

--- a/server/db/retention.ts
+++ b/server/db/retention.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Storage side of history retention (RETENTION_PLAN.md): the dirty-buffer set
+// that tells the sweeper where to look, and the two statements it runs. The
+// scheduling lives in services/retentionSweeper.ts; this module owns the SQL
+// so the statements sit next to the schema they depend on.
+//
+// Both statements ride idx_messages_buf_unread (buffer_id, id DESC, …) —
+// count-based retention needs no new index, which is half the reason it won
+// over age-based (the other half is in the plan). The messages_ad trigger
+// keeps messages_fts in sync through these deletes, so search never sees a
+// pruned row.
+
+import db from './index.js';
+
+// Buffers that took an insert since the sweeper last looked. In-memory on
+// purpose: a restart just means the next boot seeds every buffer dirty and
+// re-verifies, which is also what makes the steady sweeper double as the
+// backfill when retention is first enabled on an existing database.
+const dirtyBuffers = new Set<number>();
+
+export function markBufferDirty(bufferId: number): void {
+  dirtyBuffers.add(bufferId);
+}
+
+/** Drain the dirty set. The caller owns the snapshot; new inserts during a
+ *  sweep land in a fresh set and are picked up next tick. */
+export function takeDirtyBuffers(): number[] {
+  const out = [...dirtyBuffers];
+  dirtyBuffers.clear();
+  return out;
+}
+
+/** Boot seeding: every buffer is suspect until the sweeper has looked once. */
+export function seedAllBuffersDirty(): void {
+  const rows = db.prepare(`SELECT id FROM buffers`).all() as Array<{ id: number }>;
+  for (const row of rows) dirtyBuffers.add(row.id);
+}
+
+const ownerStmt = db.prepare(`SELECT user_id AS userId FROM buffers WHERE id = ?`);
+
+/** The buffer's owning user, or undefined for a buffer deleted since it was
+ *  marked dirty (the cascade already took its messages with it). */
+export function bufferOwnerId(bufferId: number): number | undefined {
+  const row = ownerStmt.get(bufferId) as { userId: number } | undefined;
+  return row?.userId;
+}
+
+// The newest `capLines`-th row's id: everything strictly below it is over the
+// cap. OFFSET walks the buffer's own rows inside the covering index — message
+// ids are a single global sequence, so id arithmetic can never answer this
+// (see hasMoreThan in db/messages.ts). No row at that offset = the buffer is
+// within its cap.
+const boundaryStmt = db.prepare(`
+  SELECT id FROM messages WHERE buffer_id = ? ORDER BY id DESC LIMIT 1 OFFSET ?
+`);
+
+export function retentionBoundaryId(bufferId: number, capLines: number): number | undefined {
+  const row = boundaryStmt.get(bufferId, capLines - 1) as { id: number } | undefined;
+  return row?.id;
+}
+
+// One bounded bite of the over-cap tail, oldest rows first by construction
+// (everything below the boundary goes eventually; order within doesn't
+// matter). The NOT EXISTS is the bookmark exemption — a bookmarked row below
+// the boundary survives as an extra ABOVE the cap (later boundary probes walk
+// past it and it never becomes deletable). It is scoped by user_id, not just
+// message_id: user_bookmarks has no index on message_id alone, and a buffer
+// has exactly one owner who is the only user able to bookmark its rows, so
+// the (user_id, message_id) primary key answers the probe as a seek.
+const deleteBatchStmt = db.prepare(`
+  DELETE FROM messages WHERE id IN (
+    SELECT m.id FROM messages m
+     WHERE m.buffer_id = ? AND m.id < ?
+       AND NOT EXISTS (
+         SELECT 1 FROM user_bookmarks ub
+          WHERE ub.user_id = ? AND ub.message_id = m.id
+       )
+     LIMIT ?
+  )
+`);
+
+/** Delete up to `limit` over-cap rows. Returns the number deleted; a return
+ *  below `limit` means this buffer's tail is done. */
+export function deleteRetentionBatch(
+  bufferId: number,
+  boundaryId: number,
+  ownerUserId: number,
+  limit: number,
+): number {
+  return deleteBatchStmt.run(bufferId, boundaryId, ownerUserId, limit).changes;
+}

--- a/server/server.ts
+++ b/server/server.ts
@@ -27,6 +27,7 @@ import * as systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
 import { sweepExpiredPreviews } from './db/linkPreviews.js';
 import { sweepPreviewCache } from './services/previewCache/index.js';
+import { startRetentionSweeper } from './services/retentionSweeper.js';
 import { listGrandfatheredUsernames } from './db/users.js';
 import { backfillEncryptColumns } from './db/secretBackfill.js';
 import { assertPushCredentials } from './services/push/credentials.js';
@@ -155,6 +156,12 @@ setInterval(sweepExpiredPreviews, 60 * 60 * 1000).unref();
 // it swallows its own failures, like every other path in that module.
 void sweepPreviewCache();
 setInterval(() => void sweepPreviewCache(), 60 * 60 * 1000).unref();
+
+// History retention (RETENTION_PLAN.md). Self-scheduling rather than a fixed
+// interval — a tick that found a backlog comes back in seconds — and started
+// unconditionally: with no ceiling and no user opt-in every tick is a no-op
+// over an empty dirty set, which costs nothing.
+startRetentionSweeper();
 
 systemLog.log({ scope: 'server', text: `Lurker server starting up (edition: ${EDITION})` });
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -157,7 +157,7 @@ setInterval(sweepExpiredPreviews, 60 * 60 * 1000).unref();
 void sweepPreviewCache();
 setInterval(() => void sweepPreviewCache(), 60 * 60 * 1000).unref();
 
-// History retention (RETENTION_PLAN.md). Self-scheduling rather than a fixed
+// History retention (lurker-dev/RETENTION_PLAN.md). Self-scheduling rather than a fixed
 // interval — a tick that found a backlog comes back in seconds — and started
 // unconditionally: with no ceiling and no user opt-in every tick is a no-op
 // over an empty dirty set, which costs nothing.

--- a/server/server.ts
+++ b/server/server.ts
@@ -159,8 +159,9 @@ setInterval(() => void sweepPreviewCache(), 60 * 60 * 1000).unref();
 
 // History retention (lurker-dev/RETENTION_PLAN.md). Self-scheduling rather than a fixed
 // interval — a tick that found a backlog comes back in seconds — and started
-// unconditionally: with no ceiling and no user opt-in every tick is a no-op
-// over an empty dirty set, which costs nothing.
+// unconditionally: with no ceiling and no user opt-in, the boot-seeded first
+// pass is one budgeted, yielding walk of owner/cap lookups that drains to
+// nothing, and every tick after it is a no-op over an empty dirty set.
 startRetentionSweeper();
 
 systemLog.log({ scope: 'server', text: `Lurker server starting up (edition: ${EDITION})` });

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -30,6 +30,7 @@ import { setImmediate as yieldToEventLoop } from 'node:timers/promises';
 import type { Statement, RunResult } from 'better-sqlite3';
 import db from '../db/index.js';
 import { EXPORT_TABLES, EXPORT_FORMAT_VERSION, IMPORT_ORDER } from '../db/exportSchema.js';
+import { seedAllBuffersDirty } from '../db/retention.js';
 import { isBuiltinThemeId, THEME_POINTER_KEYS } from '../../shared/themePresets.js';
 import themesService from './themesService.js';
 import { encryptSecret } from '../utils/secretCrypto.js';
@@ -754,6 +755,12 @@ export async function importFromZipFile(
       if (err instanceof ImportError) throw err;
       throw new ImportError('insert_failed', `import failed: ${(err as Error).message}`);
     }
+
+    // The message stream above bypasses insertMessage, so nothing marked the
+    // imported buffers for the retention sweeper — without this, an over-cap
+    // archive sits unexamined until the next restart or a live line lands in
+    // each buffer.
+    seedAllBuffersDirty();
 
     return { manifest, counts, thumbnailsAttached };
   } finally {

--- a/server/services/retentionLimits.test.ts
+++ b/server/services/retentionLimits.test.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The clamp matrix for effectiveRetentionLines: user setting × operator
+// ceiling, with 0 meaning "unlimited" at both layers, and the fail-open
+// handling of an unparseable ceiling (a typo must never mass-delete history).
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let createUser: typeof import('../db/users.js').createUser;
+let setUserSetting: typeof import('../db/settings.js').setUserSetting;
+let deleteUserSetting: typeof import('../db/settings.js').deleteUserSetting;
+let effectiveRetentionLines: typeof import('./retentionLimits.js').effectiveRetentionLines;
+let declaredRetentionCeilingLines: typeof import('./retentionLimits.js').declaredRetentionCeilingLines;
+
+let userId: number;
+
+beforeAll(async () => {
+  ({ createUser } = await import('../db/users.js'));
+  ({ setUserSetting, deleteUserSetting } = await import('../db/settings.js'));
+  ({ effectiveRetentionLines, declaredRetentionCeilingLines } =
+    await import('./retentionLimits.js'));
+  userId = createUser('retention-alice').id;
+});
+
+afterEach(() => {
+  delete process.env.LURKER_MAX_RETENTION_LINES;
+  deleteUserSetting(userId, 'data.retention.lines');
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('declaredRetentionCeilingLines', () => {
+  it('unset means no ceiling', () => {
+    expect(declaredRetentionCeilingLines()).toBeNull();
+  });
+
+  it('0 is an explicit no-ceiling spelling, not a misconfiguration', () => {
+    process.env.LURKER_MAX_RETENTION_LINES = '0';
+    expect(declaredRetentionCeilingLines()).toBeNull();
+  });
+
+  it('a bare integer is the ceiling', () => {
+    process.env.LURKER_MAX_RETENTION_LINES = '100000';
+    expect(declaredRetentionCeilingLines()).toBe(100000);
+  });
+
+  it('garbage fails open to no ceiling', () => {
+    process.env.LURKER_MAX_RETENTION_LINES = '100k';
+    expect(declaredRetentionCeilingLines()).toBeNull();
+  });
+
+  it('a negative value fails open to no ceiling', () => {
+    process.env.LURKER_MAX_RETENTION_LINES = '-5';
+    expect(declaredRetentionCeilingLines()).toBeNull();
+  });
+});
+
+describe('effectiveRetentionLines', () => {
+  it('nothing set anywhere = unlimited (0)', () => {
+    expect(effectiveRetentionLines(userId)).toBe(0);
+  });
+
+  it('a user setting alone governs', () => {
+    setUserSetting(userId, 'data.retention.lines', 5000);
+    expect(effectiveRetentionLines(userId)).toBe(5000);
+  });
+
+  it('the ceiling alone IS the default for an untouched user', () => {
+    process.env.LURKER_MAX_RETENTION_LINES = '10000';
+    expect(effectiveRetentionLines(userId)).toBe(10000);
+  });
+
+  it('a user above the ceiling is clamped down to it', () => {
+    process.env.LURKER_MAX_RETENTION_LINES = '10000';
+    setUserSetting(userId, 'data.retention.lines', 20000);
+    expect(effectiveRetentionLines(userId)).toBe(10000);
+  });
+
+  it('a user below the ceiling keeps their own tighter cap', () => {
+    process.env.LURKER_MAX_RETENTION_LINES = '10000';
+    setUserSetting(userId, 'data.retention.lines', 5000);
+    expect(effectiveRetentionLines(userId)).toBe(5000);
+  });
+
+  it('an explicit user 0 (unlimited) still clamps to the ceiling', () => {
+    process.env.LURKER_MAX_RETENTION_LINES = '10000';
+    setUserSetting(userId, 'data.retention.lines', 0);
+    expect(effectiveRetentionLines(userId)).toBe(10000);
+  });
+
+  it('an unparseable ceiling leaves the user cap governing', () => {
+    process.env.LURKER_MAX_RETENTION_LINES = 'lots';
+    setUserSetting(userId, 'data.retention.lines', 5000);
+    expect(effectiveRetentionLines(userId)).toBe(5000);
+  });
+});

--- a/server/services/retentionLimits.test.ts
+++ b/server/services/retentionLimits.test.ts
@@ -62,6 +62,15 @@ describe('declaredRetentionCeilingLines', () => {
     process.env.LURKER_MAX_RETENTION_LINES = '-5';
     expect(declaredRetentionCeilingLines()).toBeNull();
   });
+
+  it('Number() coercions are NOT accepted — bare decimal integers only', () => {
+    // "1.9" → 1 or "1e5" → 100000 would enable pruning with a ceiling the
+    // operator never wrote; both must fail open instead.
+    process.env.LURKER_MAX_RETENTION_LINES = '1.9';
+    expect(declaredRetentionCeilingLines()).toBeNull();
+    process.env.LURKER_MAX_RETENTION_LINES = '1e5';
+    expect(declaredRetentionCeilingLines()).toBeNull();
+  });
 });
 
 describe('effectiveRetentionLines', () => {
@@ -101,5 +110,15 @@ describe('effectiveRetentionLines', () => {
     process.env.LURKER_MAX_RETENTION_LINES = 'lots';
     setUserSetting(userId, 'data.retention.lines', 5000);
     expect(effectiveRetentionLines(userId)).toBe(5000);
+  });
+
+  it('the 1000-line floor is write-time only — a stored value enforces as stored', () => {
+    // minNonzero lives in validate(), the sole surface a user can write
+    // through. The resolver deliberately does NOT re-floor: no legacy rows
+    // can predate the floor (it shipped with the feature), and keeping the
+    // resolver literal lets tests inject tiny caps instead of looping
+    // thousands of rows per case.
+    setUserSetting(userId, 'data.retention.lines', 50);
+    expect(effectiveRetentionLines(userId)).toBe(50);
   });
 });

--- a/server/services/retentionLimits.ts
+++ b/server/services/retentionLimits.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// THE per-buffer history cap, in one place (RETENTION_PLAN.md).
+//
+// Two values stack, and the effective cap is the smaller of the ones actually
+// set:
+//
+//   1. the operator ceiling  LURKER_MAX_RETENTION_LINES. An env var rather
+//                            than a tenant setting for the same reason
+//                            LURKER_MAX_UPLOAD_MB is: it describes the
+//                            deployment, and a tenant must not be able to
+//                            raise it. There is deliberately no separate
+//                            operator *default* — an untouched user setting
+//                            resolves to unlimited and then clamps to the
+//                            ceiling, so the ceiling IS the default.
+//   2. the user's own        `data.retention.lines` (0 = unlimited).
+//
+// 0 (or unset) means "keep everything" at every layer. Every path that
+// enforces or advertises a retention cap goes through effectiveRetentionLines
+// so the sweeper and whatever a client is told can never disagree.
+
+import { getUserSettings } from '../db/settings.js';
+import { defaultsAsObject } from './settingsRegistry.js';
+
+// Warn once per process, not per sweep tick: a misconfiguration that repeats
+// every minute is noise rather than a signal.
+let warnedBadCeiling = false;
+
+/**
+ * What the operator DECLARED, in lines per buffer, or null when they declared
+ * no ceiling. `0` is accepted as an explicit "no ceiling" spelling and is not
+ * a misconfiguration.
+ *
+ * Anything unparseable falls back to NO ceiling, loudly. Fail-open is the only
+ * safe direction for this particular knob: a typo that resolved to some small
+ * number would quietly mass-delete history that cannot be restored.
+ */
+export function declaredRetentionCeilingLines(): number | null {
+  const raw = (process.env.LURKER_MAX_RETENTION_LINES || '').trim();
+  if (!raw) return null;
+  const lines = Math.floor(Number(raw));
+  if (!Number.isFinite(lines) || lines < 0) {
+    if (!warnedBadCeiling) {
+      warnedBadCeiling = true;
+      console.warn(
+        `[lurker] LURKER_MAX_RETENTION_LINES="${raw}" is not a whole number of ` +
+          'lines; ignoring it. History is NOT bounded by an instance ceiling. ' +
+          'Use a bare integer, e.g. LURKER_MAX_RETENTION_LINES=100000.',
+      );
+    }
+    return null;
+  }
+  return lines === 0 ? null : lines;
+}
+
+/**
+ * The effective per-buffer cap for this user, in lines — the number the
+ * sweeper actually prunes to. 0 = unlimited. The user's stored value is read
+ * with the registry default merged in (the uploadLimits pattern), so a second
+ * hardcoded default here can't drift from the registry.
+ */
+export function effectiveRetentionLines(userId: number): number {
+  const settings = { ...defaultsAsObject(), ...getUserSettings(userId) };
+  const n = Number(settings['data.retention.lines']);
+  const userCap = Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
+  const ceiling = declaredRetentionCeilingLines();
+  if (ceiling == null) return userCap;
+  return userCap === 0 ? ceiling : Math.min(userCap, ceiling);
+}

--- a/server/services/retentionLimits.ts
+++ b/server/services/retentionLimits.ts
@@ -22,6 +22,7 @@
 
 import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject } from './settingsRegistry.js';
+import * as systemLog from './systemLog.js';
 
 // Warn once per process, not per sweep tick: a misconfiguration that repeats
 // every minute is noise rather than a signal.
@@ -43,11 +44,14 @@ export function declaredRetentionCeilingLines(): number | null {
   if (!Number.isFinite(lines) || lines < 0) {
     if (!warnedBadCeiling) {
       warnedBadCeiling = true;
-      console.warn(
-        `[lurker] LURKER_MAX_RETENTION_LINES="${raw}" is not a whole number of ` +
-          'lines; ignoring it. History is NOT bounded by an instance ceiling. ' +
-          'Use a bare integer, e.g. LURKER_MAX_RETENTION_LINES=100000.',
-      );
+      const text =
+        `LURKER_MAX_RETENTION_LINES="${raw}" is not a whole number of ` +
+        'lines; ignoring it. History is NOT bounded by an instance ceiling. ' +
+        'Use a bare integer, e.g. LURKER_MAX_RETENTION_LINES=100000.';
+      console.warn(`[lurker] ${text}`);
+      // Also into the system buffer: "the ceiling never took effect" is an
+      // operator-facing condition, and stdout is not an operator surface.
+      systemLog.log({ level: 'warn', scope: 'server', text });
     }
     return null;
   }

--- a/server/services/retentionLimits.ts
+++ b/server/services/retentionLimits.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// THE per-buffer history cap, in one place (RETENTION_PLAN.md).
+// THE per-buffer history cap, in one place (lurker-dev/RETENTION_PLAN.md).
 //
 // Two values stack, and the effective cap is the smaller of the ones actually
 // set:
@@ -40,8 +40,11 @@ let warnedBadCeiling = false;
 export function declaredRetentionCeilingLines(): number | null {
   const raw = (process.env.LURKER_MAX_RETENTION_LINES || '').trim();
   if (!raw) return null;
-  const lines = Math.floor(Number(raw));
-  if (!Number.isFinite(lines) || lines < 0) {
+  // Strictly a bare decimal integer. Number() coercions like "1.9" → 1 or
+  // "1e5" → 100000 would silently enable pruning with a ceiling the operator
+  // never wrote, which is exactly what fail-open exists to prevent.
+  const lines = /^\d+$/.test(raw) ? Number(raw) : NaN;
+  if (!Number.isFinite(lines)) {
     if (!warnedBadCeiling) {
       warnedBadCeiling = true;
       const text =

--- a/server/services/retentionSweeper.test.ts
+++ b/server/services/retentionSweeper.test.ts
@@ -157,22 +157,23 @@ describe('runRetentionTick', () => {
     expect(result.buffersExamined).toBe(0);
   });
 
-  it('lowering the cap in settings prunes without waiting for a new insert', async () => {
+  it('changing the cap in settings re-marks the user’s buffers without new traffic', async () => {
     const { wireRetentionSettingsListener } = await import('./retentionSweeper.js');
     const settingsService = (await import('./settingsService.js')).default;
-    const { userId, ids, bufferId } = seedBuffer('ret-setting', 12);
+    const { userId, bufferId } = seedBuffer('ret-setting', 12);
 
-    // Drain the seeding inserts and verify the buffer is clean and uncapped.
+    // Drain the seeding inserts so only the settings write can re-mark.
     await runRetentionTick(OPTS);
     expect(rowIds(bufferId)).toHaveLength(12);
 
     // The settings write alone must re-mark the user's buffers — the copy
     // promises deletion, not "deletion once the buffer next sees traffic".
+    // 1000 is the smallest nonzero value validate() accepts (minNonzero);
+    // the prune math itself is covered above with injected tiny caps.
     wireRetentionSettingsListener();
-    const updated = settingsService.update(userId, { 'data.retention.lines': 3 });
+    const updated = settingsService.update(userId, { 'data.retention.lines': 1000 });
     expect(updated.ok).toBe(true);
-    await runRetentionTick(OPTS);
-    expect(rowIds(bufferId)).toEqual(ids.slice(9));
+    expect(takeDirtyBuffers()).toContain(bufferId);
   });
 
   it('an in-flight export pauses the sweep without losing the dirty set', async () => {

--- a/server/services/retentionSweeper.test.ts
+++ b/server/services/retentionSweeper.test.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Integration tests for the retention sweep: real inserts through
+// insertMessage (which feeds the dirty set), real deletes through
+// runRetentionTick, assertions against the real messages + messages_fts
+// tables. Batch/budget constants are INJECTED tiny — test cost must never
+// scale with the production constants.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: typeof import('../db/index.js').default;
+let createUser: typeof import('../db/users.js').createUser;
+let createNetwork: typeof import('../db/networks.js').createNetwork;
+let insertMessage: typeof import('../db/messages.js').insertMessage;
+let addBookmark: typeof import('../db/bookmarks.js').addBookmark;
+let setUserSetting: typeof import('../db/settings.js').setUserSetting;
+let runRetentionTick: typeof import('./retentionSweeper.js').runRetentionTick;
+let takeDirtyBuffers: typeof import('../db/retention.js').takeDirtyBuffers;
+
+beforeAll(async () => {
+  ({ default: db } = await import('../db/index.js'));
+  ({ createUser } = await import('../db/users.js'));
+  ({ createNetwork } = await import('../db/networks.js'));
+  ({ insertMessage } = await import('../db/messages.js'));
+  ({ addBookmark } = await import('../db/bookmarks.js'));
+  ({ setUserSetting } = await import('../db/settings.js'));
+  ({ runRetentionTick } = await import('./retentionSweeper.js'));
+  ({ takeDirtyBuffers } = await import('../db/retention.js'));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// Tiny knobs so the budget/backlog behavior is exercised with dozens of rows,
+// not hundreds of thousands.
+const OPTS = { batchRows: 4, maxBatchesPerTick: 100, idleDelayMs: 0, busyDelayMs: 0 };
+
+const BASE = Date.parse('2026-08-26T00:00:00Z');
+
+/** A user with their own network and `count` chat lines in #chan. Returns the
+ *  ascending message ids and the buffer id they landed in. Each line's first
+ *  word is `<name-sans-punctuation><i>` — unique across the whole test file,
+ *  so an FTS hit count can never bleed in from another test's buffer. */
+function seedBuffer(
+  name: string,
+  count: number,
+): { userId: number; ids: number[]; bufferId: number } {
+  const user = createUser(name);
+  const net = createNetwork(user.id, { name, host: 'h', port: 6697, tls: true, nick: name });
+  const word = name.replace(/[^a-z0-9]/g, '');
+  const ids: number[] = [];
+  let bufferId = 0;
+  for (let i = 0; i < count; i++) {
+    const r = insertMessage({
+      networkId: net!.id,
+      target: '#chan',
+      time: new Date(BASE + i * 1000).toISOString(),
+      type: 'message',
+      nick: 'someone',
+      text: `${word}${i} filler`,
+      self: false,
+    });
+    ids.push(Number(r.id));
+    bufferId = r.bufferId;
+  }
+  return { userId: user.id, ids, bufferId };
+}
+
+function rowIds(bufferId: number): number[] {
+  return (
+    db
+      .prepare(`SELECT id FROM messages WHERE buffer_id = ? ORDER BY id ASC`)
+      .all(bufferId) as Array<{ id: number }>
+  ).map((r) => r.id);
+}
+
+function ftsHits(word: string): number {
+  return db
+    .prepare(`SELECT COUNT(*) AS n FROM messages_fts WHERE messages_fts MATCH ?`)
+    .pluck()
+    .get(word) as number;
+}
+
+describe('runRetentionTick', () => {
+  it('leaves an uncapped buffer alone', async () => {
+    const { bufferId } = seedBuffer('ret-uncapped', 8);
+    const result = await runRetentionTick(OPTS);
+    expect(rowIds(bufferId)).toHaveLength(8);
+    expect(result.backlog).toBe(false);
+  });
+
+  it('prunes to exactly the cap, keeping the newest rows, FTS included', async () => {
+    const { userId, ids, bufferId } = seedBuffer('ret-capped', 30);
+    setUserSetting(userId, 'data.retention.lines', 10);
+    expect(ftsHits('retcapped3')).toBe(1);
+
+    const result = await runRetentionTick(OPTS);
+
+    expect(result.rowsDeleted).toBe(20);
+    expect(rowIds(bufferId)).toEqual(ids.slice(20));
+    // The delete trigger kept the external-content FTS table in step: a word
+    // that only ever appeared in a pruned row is unfindable, a retained one
+    // still hits.
+    expect(ftsHits('retcapped3')).toBe(0);
+    expect(ftsHits('retcapped29')).toBe(1);
+  });
+
+  it('a bookmarked row survives pruning as an extra above the cap', async () => {
+    const { userId, ids, bufferId } = seedBuffer('ret-bookmark', 30);
+    setUserSetting(userId, 'data.retention.lines', 10);
+    expect(addBookmark(userId, ids[2])).toBe(true);
+
+    await runRetentionTick(OPTS);
+
+    expect(rowIds(bufferId)).toEqual([ids[2], ...ids.slice(20)]);
+
+    // Steady state: with no new inserts the saved row is never deletable and
+    // repeat ticks change nothing.
+    const { markBufferDirty } = await import('../db/retention.js');
+    markBufferDirty(bufferId);
+    const again = await runRetentionTick(OPTS);
+    expect(again.rowsDeleted).toBe(0);
+    expect(rowIds(bufferId)).toEqual([ids[2], ...ids.slice(20)]);
+  });
+
+  it('a budget-exhausted tick reports backlog and later ticks finish the job', async () => {
+    const { userId, ids, bufferId } = seedBuffer('ret-budget', 30);
+    setUserSetting(userId, 'data.retention.lines', 5);
+
+    const first = await runRetentionTick({ ...OPTS, maxBatchesPerTick: 2 });
+    expect(first.backlog).toBe(true);
+    expect(first.rowsDeleted).toBe(8); // 2 budgeted batches of 4
+
+    let guard = 0;
+    let backlog = true;
+    while (backlog) {
+      if (++guard > 10) throw new Error('sweep never converged');
+      backlog = (await runRetentionTick({ ...OPTS, maxBatchesPerTick: 2 })).backlog;
+    }
+    expect(rowIds(bufferId)).toEqual(ids.slice(25));
+  });
+
+  it('a tick drains the dirty set; only inserts refill it', async () => {
+    const { bufferId } = seedBuffer('ret-dirty', 3);
+    // Everything seeded above (and here) is pending until a tick runs…
+    expect(takeDirtyBuffers()).toContain(bufferId);
+    // …and takeDirtyBuffers drained it, so a tick now examines nothing.
+    const result = await runRetentionTick(OPTS);
+    expect(result.buffersExamined).toBe(0);
+  });
+});

--- a/server/services/retentionSweeper.test.ts
+++ b/server/services/retentionSweeper.test.ts
@@ -137,7 +137,7 @@ describe('runRetentionTick', () => {
 
     const first = await runRetentionTick({ ...OPTS, maxBatchesPerTick: 2 });
     expect(first.backlog).toBe(true);
-    expect(first.rowsDeleted).toBe(8); // 2 budgeted batches of 4
+    expect(first.rowsDeleted).toBe(4); // the boundary probe spends 1, one batch of 4 spends the other
 
     let guard = 0;
     let backlog = true;
@@ -155,5 +155,40 @@ describe('runRetentionTick', () => {
     // …and takeDirtyBuffers drained it, so a tick now examines nothing.
     const result = await runRetentionTick(OPTS);
     expect(result.buffersExamined).toBe(0);
+  });
+
+  it('lowering the cap in settings prunes without waiting for a new insert', async () => {
+    const { wireRetentionSettingsListener } = await import('./retentionSweeper.js');
+    const settingsService = (await import('./settingsService.js')).default;
+    const { userId, ids, bufferId } = seedBuffer('ret-setting', 12);
+
+    // Drain the seeding inserts and verify the buffer is clean and uncapped.
+    await runRetentionTick(OPTS);
+    expect(rowIds(bufferId)).toHaveLength(12);
+
+    // The settings write alone must re-mark the user's buffers — the copy
+    // promises deletion, not "deletion once the buffer next sees traffic".
+    wireRetentionSettingsListener();
+    const updated = settingsService.update(userId, { 'data.retention.lines': 3 });
+    expect(updated.ok).toBe(true);
+    await runRetentionTick(OPTS);
+    expect(rowIds(bufferId)).toEqual(ids.slice(9));
+  });
+
+  it('an in-flight export pauses the sweep without losing the dirty set', async () => {
+    const { createExportJob, deleteJob } = await import('../db/dataExports.js');
+    const { userId, ids, bufferId } = seedBuffer('ret-export', 12);
+    setUserSetting(userId, 'data.retention.lines', 5);
+
+    const job = createExportJob(userId, true);
+    const paused = await runRetentionTick(OPTS);
+    expect(paused.buffersExamined).toBe(0);
+    expect(paused.rowsDeleted).toBe(0);
+    expect(rowIds(bufferId)).toHaveLength(12);
+
+    // Job gone → the untouched dirty set prunes on the very next tick.
+    deleteJob(job.id);
+    await runRetentionTick(OPTS);
+    expect(rowIds(bufferId)).toEqual(ids.slice(7));
   });
 });

--- a/server/services/retentionSweeper.ts
+++ b/server/services/retentionSweeper.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// The background prune loop for history retention (RETENTION_PLAN.md §3.3).
+// The background prune loop for history retention (lurker-dev/RETENTION_PLAN.md §3.3).
 //
 // Shape: a self-rescheduling setTimeout chain (not setInterval — a tick that
 // found work reschedules itself sooner than one that didn't, TheLounge's

--- a/server/services/retentionSweeper.ts
+++ b/server/services/retentionSweeper.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The background prune loop for history retention (RETENTION_PLAN.md §3.3).
+//
+// Shape: a self-rescheduling setTimeout chain (not setInterval — a tick that
+// found work reschedules itself sooner than one that didn't, TheLounge's
+// cadence). Each tick drains the dirty-buffer set fed by insertMessage,
+// resolves each buffer owner's effective cap once, and deletes the over-cap
+// tail in small discrete batches with a setImmediate yield between them — the
+// shared better-sqlite3 connection is synchronous, so the yield is what keeps
+// WS fan-out and IRC sockets breathing while a large backlog is chewed down.
+// A tick that hits its work budget re-marks the unfinished buffer and comes
+// back in seconds rather than minutes; that budget, not a one-shot migration,
+// is how first enablement on a big database backfills (and what keeps the
+// Litestream WAL churn on hosted cells paced).
+//
+// Errors: warn and keep going, but stop the loop entirely after three
+// consecutive failing ticks (TheLounge's circuit breaker) — a persistent SQL
+// error repeating every few seconds forever is worse than pruning stopping,
+// which only ever costs disk, never data.
+
+import {
+  takeDirtyBuffers,
+  markBufferDirty,
+  seedAllBuffersDirty,
+  bufferOwnerId,
+  retentionBoundaryId,
+  deleteRetentionBatch,
+} from '../db/retention.js';
+import { effectiveRetentionLines } from './retentionLimits.js';
+
+export interface RetentionSweepOptions {
+  /** Rows per DELETE statement. */
+  batchRows: number;
+  /** Total batches a single tick may spend before yielding to the next one. */
+  maxBatchesPerTick: number;
+  /** Delay before the next tick when this one finished its whole backlog. */
+  idleDelayMs: number;
+  /** Delay when the tick ran out of budget with work left. */
+  busyDelayMs: number;
+}
+
+export const RETENTION_SWEEP_DEFAULTS: RetentionSweepOptions = {
+  batchRows: 500,
+  maxBatchesPerTick: 20,
+  idleDelayMs: 60 * 1000,
+  busyDelayMs: 5 * 1000,
+};
+
+export interface RetentionTickResult {
+  buffersExamined: number;
+  rowsDeleted: number;
+  /** Work remained when the tick's budget ran out. */
+  backlog: boolean;
+}
+
+const yieldToLoop = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+/**
+ * One sweep pass over the currently-dirty buffers. Exported for tests; the
+ * production loop below is just this on a timer.
+ */
+export async function runRetentionTick(
+  opts: RetentionSweepOptions = RETENTION_SWEEP_DEFAULTS,
+): Promise<RetentionTickResult> {
+  const result: RetentionTickResult = { buffersExamined: 0, rowsDeleted: 0, backlog: false };
+  // Per-tick cap cache: one settings read per owner, not per buffer.
+  const capByUser = new Map<number, number>();
+  let batchesSpent = 0;
+
+  for (const bufferId of takeDirtyBuffers()) {
+    if (batchesSpent >= opts.maxBatchesPerTick) {
+      // Out of budget — put the rest back for the (soon) next tick.
+      markBufferDirty(bufferId);
+      result.backlog = true;
+      continue;
+    }
+    const ownerId = bufferOwnerId(bufferId);
+    if (ownerId === undefined) continue; // buffer deleted; cascade got the rows
+    let cap = capByUser.get(ownerId);
+    if (cap === undefined) {
+      cap = effectiveRetentionLines(ownerId);
+      capByUser.set(ownerId, cap);
+    }
+    result.buffersExamined++;
+    if (cap <= 0) continue; // unlimited
+
+    const boundaryId = retentionBoundaryId(bufferId, cap);
+    if (boundaryId === undefined) continue; // within cap
+
+    while (batchesSpent < opts.maxBatchesPerTick) {
+      const deleted = deleteRetentionBatch(bufferId, boundaryId, ownerId, opts.batchRows);
+      batchesSpent++;
+      result.rowsDeleted += deleted;
+      if (deleted < opts.batchRows) break; // tail done (or only bookmarks left)
+      await yieldToLoop();
+    }
+    if (batchesSpent >= opts.maxBatchesPerTick) {
+      // The last batch came back full — assume more tail and re-check soon.
+      markBufferDirty(bufferId);
+      result.backlog = true;
+    }
+    await yieldToLoop();
+  }
+  return result;
+}
+
+let started = false;
+
+export function startRetentionSweeper(
+  opts: RetentionSweepOptions = RETENTION_SWEEP_DEFAULTS,
+): void {
+  if (started) return;
+  started = true;
+  seedAllBuffersDirty();
+  let consecutiveFailures = 0;
+  const schedule = (delayMs: number) => {
+    setTimeout(() => void tick(), delayMs).unref();
+  };
+  const tick = async () => {
+    try {
+      const r = await runRetentionTick(opts);
+      consecutiveFailures = 0;
+      schedule(r.backlog ? opts.busyDelayMs : opts.idleDelayMs);
+    } catch (err) {
+      consecutiveFailures++;
+      console.warn('[lurker] retention sweep failed:', (err as Error).message);
+      if (consecutiveFailures >= 3) {
+        console.error(
+          '[lurker] retention sweeping STOPPED after 3 consecutive failures; ' +
+            'history is no longer being pruned. Restart the server to resume.',
+        );
+        return;
+      }
+      schedule(opts.idleDelayMs);
+    }
+  };
+  schedule(opts.idleDelayMs);
+}

--- a/server/services/retentionSweeper.ts
+++ b/server/services/retentionSweeper.ts
@@ -6,34 +6,44 @@
 // Shape: a self-rescheduling setTimeout chain (not setInterval — a tick that
 // found work reschedules itself sooner than one that didn't, TheLounge's
 // cadence). Each tick drains the dirty-buffer set fed by insertMessage,
-// resolves each buffer owner's effective cap once, and deletes the over-cap
-// tail in small discrete batches with a setImmediate yield between them — the
-// shared better-sqlite3 connection is synchronous, so the yield is what keeps
-// WS fan-out and IRC sockets breathing while a large backlog is chewed down.
-// A tick that hits its work budget re-marks the unfinished buffer and comes
-// back in seconds rather than minutes; that budget, not a one-shot migration,
-// is how first enablement on a big database backfills (and what keeps the
-// Litestream WAL churn on hosted cells paced).
+// resolves each buffer owner's effective cap once, and works in small
+// discrete statements with a setImmediate yield between them — the shared
+// better-sqlite3 connection is synchronous, so the yields are what keep WS
+// fan-out and IRC sockets breathing while a large backlog is chewed down.
+// The tick budget counts EVERY bounded statement, boundary probes included:
+// boot seeds every buffer dirty, so the first tick after start would
+// otherwise chain hundreds of O(cap) index walks back-to-back — the exact
+// event-loop-starvation class the connect snapshot already had an incident
+// with. A tick that runs out of budget re-marks what it didn't finish and
+// comes back in seconds rather than minutes; that budget, not a one-shot
+// migration, is how first enablement on a big database backfills (and what
+// keeps the Litestream WAL churn on hosted cells paced).
 //
 // Errors: warn and keep going, but stop the loop entirely after three
 // consecutive failing ticks (TheLounge's circuit breaker) — a persistent SQL
 // error repeating every few seconds forever is worse than pruning stopping,
-// which only ever costs disk, never data.
+// which only ever costs disk, never data. The stop is posted to the system
+// buffer, not just stdout: an operator has to be able to notice it.
 
 import {
   takeDirtyBuffers,
   markBufferDirty,
   seedAllBuffersDirty,
+  seedUserBuffersDirty,
   bufferOwnerId,
   retentionBoundaryId,
   deleteRetentionBatch,
 } from '../db/retention.js';
+import { listInflightJobs } from '../db/dataExports.js';
 import { effectiveRetentionLines } from './retentionLimits.js';
+import settingsService from './settingsService.js';
+import * as systemLog from './systemLog.js';
 
 export interface RetentionSweepOptions {
   /** Rows per DELETE statement. */
   batchRows: number;
-  /** Total batches a single tick may spend before yielding to the next one. */
+  /** Bounded statements (boundary probes + delete batches) a single tick may
+   *  spend before handing the rest to the next one. */
   maxBatchesPerTick: number;
   /** Delay before the next tick when this one finished its whole backlog. */
   idleDelayMs: number;
@@ -65,45 +75,96 @@ export async function runRetentionTick(
   opts: RetentionSweepOptions = RETENTION_SWEEP_DEFAULTS,
 ): Promise<RetentionTickResult> {
   const result: RetentionTickResult = { buffersExamined: 0, rowsDeleted: 0, backlog: false };
+
+  // A with-history export pages the messages table by ascending id with no
+  // snapshot isolation (services/exportService.ts) — deleting rows ahead of
+  // its cursor would silently hole the archive, and "export your data first"
+  // is exactly what the retention setting's own copy tells a user about to
+  // lower their cap. Skip the whole tick; the dirty set is untouched, so
+  // nothing is forgotten. A crashed job can't wedge this: boot fails orphaned
+  // in-flight rows (recoverInterruptedExports).
+  if (listInflightJobs().length > 0) return result;
+
   // Per-tick cap cache: one settings read per owner, not per buffer.
   const capByUser = new Map<number, number>();
   let batchesSpent = 0;
 
-  for (const bufferId of takeDirtyBuffers()) {
-    if (batchesSpent >= opts.maxBatchesPerTick) {
-      // Out of budget — put the rest back for the (soon) next tick.
-      markBufferDirty(bufferId);
-      result.backlog = true;
-      continue;
-    }
-    const ownerId = bufferOwnerId(bufferId);
-    if (ownerId === undefined) continue; // buffer deleted; cascade got the rows
-    let cap = capByUser.get(ownerId);
-    if (cap === undefined) {
-      cap = effectiveRetentionLines(ownerId);
-      capByUser.set(ownerId, cap);
-    }
-    result.buffersExamined++;
-    if (cap <= 0) continue; // unlimited
-
-    const boundaryId = retentionBoundaryId(bufferId, cap);
-    if (boundaryId === undefined) continue; // within cap
-
-    while (batchesSpent < opts.maxBatchesPerTick) {
-      const deleted = deleteRetentionBatch(bufferId, boundaryId, ownerId, opts.batchRows);
-      batchesSpent++;
-      result.rowsDeleted += deleted;
-      if (deleted < opts.batchRows) break; // tail done (or only bookmarks left)
+  const pending = takeDirtyBuffers();
+  for (let i = 0; i < pending.length; i++) {
+    const bufferId = pending[i];
+    try {
+      if (batchesSpent >= opts.maxBatchesPerTick) {
+        // Out of budget — put the rest back for the (soon) next tick.
+        markBufferDirty(bufferId);
+        result.backlog = true;
+        continue;
+      }
+      // Yield BEFORE the buffer's first statement so no skip path below can
+      // chain synchronous work across buffers.
       await yieldToLoop();
+      const ownerId = bufferOwnerId(bufferId);
+      if (ownerId === undefined) continue; // buffer deleted; cascade got the rows
+      let cap = capByUser.get(ownerId);
+      if (cap === undefined) {
+        cap = effectiveRetentionLines(ownerId);
+        capByUser.set(ownerId, cap);
+      }
+      result.buffersExamined++;
+      if (cap <= 0) continue; // unlimited
+
+      // The OFFSET walk is O(cap) index entries — real work, charged like a
+      // delete batch.
+      const boundaryId = retentionBoundaryId(bufferId, cap);
+      batchesSpent++;
+      if (boundaryId === undefined) continue; // within cap
+
+      // "Done" is a short delete batch, NOT an exhausted budget: keying the
+      // re-mark on the budget livelocks — with a small budget every capped
+      // buffer ends its visit at the limit and reports a backlog forever.
+      let tailDone = false;
+      while (batchesSpent < opts.maxBatchesPerTick) {
+        const deleted = deleteRetentionBatch(bufferId, boundaryId, ownerId, opts.batchRows);
+        batchesSpent++;
+        result.rowsDeleted += deleted;
+        if (deleted < opts.batchRows) {
+          tailDone = true; // (or only bookmarks left below the boundary)
+          break;
+        }
+        await yieldToLoop();
+      }
+      if (!tailDone) {
+        // Budget died mid-buffer — re-check soon.
+        markBufferDirty(bufferId);
+        result.backlog = true;
+      }
+    } catch (err) {
+      // Put the in-flight buffer and the undrained remainder back before the
+      // throw reaches the caller — a transient error (e.g. SQLITE_BUSY) must
+      // not silently drop quiet over-cap buffers from tracking until the
+      // next restart.
+      for (let j = i; j < pending.length; j++) markBufferDirty(pending[j]);
+      throw err;
     }
-    if (batchesSpent >= opts.maxBatchesPerTick) {
-      // The last batch came back full — assume more tail and re-check soon.
-      markBufferDirty(bufferId);
-      result.backlog = true;
-    }
-    await yieldToLoop();
   }
   return result;
+}
+
+let settingsListenerWired = false;
+
+/**
+ * Re-examine a user's buffers when their retention setting changes. Without
+ * this, a lowered cap only takes effect per-buffer on the next insert or the
+ * next restart — and the setting's copy promises deletion, not "deletion,
+ * eventually, if the buffer stays active". Exported for tests; idempotent.
+ */
+export function wireRetentionSettingsListener(): void {
+  if (settingsListenerWired) return;
+  settingsListenerWired = true;
+  settingsService.on('event', ({ userId, changes }) => {
+    if (Object.prototype.hasOwnProperty.call(changes, 'data.retention.lines')) {
+      seedUserBuffersDirty(userId);
+    }
+  });
 }
 
 let started = false;
@@ -114,6 +175,7 @@ export function startRetentionSweeper(
   if (started) return;
   started = true;
   seedAllBuffersDirty();
+  wireRetentionSettingsListener();
   let consecutiveFailures = 0;
   const schedule = (delayMs: number) => {
     setTimeout(() => void tick(), delayMs).unref();
@@ -127,10 +189,13 @@ export function startRetentionSweeper(
       consecutiveFailures++;
       console.warn('[lurker] retention sweep failed:', (err as Error).message);
       if (consecutiveFailures >= 3) {
-        console.error(
-          '[lurker] retention sweeping STOPPED after 3 consecutive failures; ' +
-            'history is no longer being pruned. Restart the server to resume.',
-        );
+        systemLog.log({
+          level: 'error',
+          scope: 'server',
+          text:
+            'Retention sweeping stopped after 3 consecutive failures; history is ' +
+            'no longer being pruned. Restart the server to resume.',
+        });
         return;
       }
       schedule(opts.idleDelayMs);

--- a/server/services/settingsRegistry.test.ts
+++ b/server/services/settingsRegistry.test.ts
@@ -65,7 +65,7 @@ describe('validate', () => {
     it('rejects the hole between 0 and the floor', () => {
       const out = validate(KEY, 50);
       expect(out.ok).toBe(false);
-      expect(!out.ok && out.error).toMatch(/0 \(off\) or >= 1000/);
+      expect(!out.ok && out.error).toMatch(/0 or >= 1000/);
     });
   });
 

--- a/server/services/settingsRegistry.test.ts
+++ b/server/services/settingsRegistry.test.ts
@@ -50,6 +50,25 @@ describe('validate', () => {
     });
   });
 
+  describe('int minNonzero', () => {
+    // Retention is the live carrier of the field: 0 = unlimited is valid, a
+    // small live cap is a guarded footgun (pruning is irreversible).
+    const KEY = 'data.retention.lines';
+    it('the registry actually carries the field under test', () => {
+      const opt = getOption(KEY);
+      expect(opt?.type === 'int' ? opt.minNonzero : undefined).toBe(1000);
+    });
+    it('accepts 0 (off) and the floor itself', () => {
+      expect(validate(KEY, 0).ok).toBe(true);
+      expect(validate(KEY, 1000).ok).toBe(true);
+    });
+    it('rejects the hole between 0 and the floor', () => {
+      const out = validate(KEY, 50);
+      expect(out.ok).toBe(false);
+      expect(!out.ok && out.error).toMatch(/0 \(off\) or >= 1000/);
+    });
+  });
+
   describe('string / color', () => {
     it('accepts strings', () => {
       expect(validate(STRING_KEY, 'anything').ok).toBe(true);

--- a/server/services/settingsRegistry.ts
+++ b/server/services/settingsRegistry.ts
@@ -28,6 +28,8 @@ export function validate(key: string, raw: unknown): ValidateResult {
         return { ok: false, error: `${key} must be >= ${opt.min}` };
       if (typeof opt.max === 'number' && n > opt.max)
         return { ok: false, error: `${key} must be <= ${opt.max}` };
+      if (typeof opt.minNonzero === 'number' && n !== 0 && n < opt.minNonzero)
+        return { ok: false, error: `${key} must be 0 (off) or >= ${opt.minNonzero}` };
       return { ok: true, value: n };
     }
     case 'string':

--- a/server/services/settingsRegistry.ts
+++ b/server/services/settingsRegistry.ts
@@ -28,8 +28,11 @@ export function validate(key: string, raw: unknown): ValidateResult {
         return { ok: false, error: `${key} must be >= ${opt.min}` };
       if (typeof opt.max === 'number' && n > opt.max)
         return { ok: false, error: `${key} must be <= ${opt.max}` };
+      // Neutral wording on purpose: what 0 MEANS (off, unlimited, …) is the
+      // option description's job — for retention "off" would be wrong, 0 keeps
+      // everything.
       if (typeof opt.minNonzero === 'number' && n !== 0 && n < opt.minNonzero)
-        return { ok: false, error: `${key} must be 0 (off) or >= ${opt.minNonzero}` };
+        return { ok: false, error: `${key} must be 0 or >= ${opt.minNonzero}` };
       return { ok: true, value: n };
     }
     case 'string':

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1777,6 +1777,29 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'devices. Must default to false: settingsService drops any row whose value ' +
       'equals the registry default, so a true default would be unstorable.',
   },
+
+  // ─── Data / retention ─────────────────────────────────────────────────
+  // How much stored history to keep, per buffer (RETENTION_PLAN.md). Rendered
+  // by the bespoke DataPane via an embedded RegistryPane. The min/max here are
+  // NOT the enforcement surface: the operator ceiling is the env var
+  // LURKER_MAX_RETENTION_LINES, and every enforcement path resolves through
+  // effectiveRetentionLines() (services/retentionLimits.ts), which clamps a
+  // stored value regardless of what a client managed to write.
+  {
+    key: 'data.retention.lines',
+    label: 'History limit (lines per buffer)',
+    category: 'data',
+    group: 'retention',
+    type: 'int',
+    min: 0,
+    max: 10_000_000,
+    default: 0,
+    description:
+      'Each buffer keeps at most this many lines; older lines are deleted ' +
+      'permanently. 0 keeps everything (up to any limit this server sets). ' +
+      'Bookmarked messages are never deleted. Export your data first if you ' +
+      'want an archive.',
+  },
 ]);
 
 const BY_KEY = new Map(REGISTRY.map((opt) => [opt.key, opt] as const));
@@ -1879,4 +1902,5 @@ export const GROUPS: Readonly<Record<string, string>> = Object.freeze({
   autocomplete: 'Autocomplete',
   formatting: 'Formatting',
   locale: 'Locale',
+  retention: 'Retention',
 });

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -96,6 +96,12 @@ export interface IntOption extends BaseOption {
   type: 'int';
   min: number;
   max: number;
+  // Extra floor applied to NONZERO values only, for knobs where 0 means
+  // "off/unlimited" but a small live value is almost certainly a mistake
+  // (retention: deletion is irreversible, so 50 lines is a typo, not an
+  // intent). Valid values are 0 or >= minNonzero; plain min/max can't
+  // express that hole.
+  minNonzero?: number;
   default: number;
 }
 
@@ -1779,12 +1785,14 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   },
 
   // ─── Data / retention ─────────────────────────────────────────────────
-  // How much stored history to keep, per buffer (RETENTION_PLAN.md). Rendered
-  // by the bespoke DataPane via an embedded RegistryPane. The min/max here are
-  // NOT the enforcement surface: the operator ceiling is the env var
+  // How much stored history to keep, per buffer (lurker-dev/RETENTION_PLAN.md).
+  // Rendered by the bespoke DataPane via an embedded RegistryPane. The min/max
+  // here are NOT the enforcement surface: the operator ceiling is the env var
   // LURKER_MAX_RETENTION_LINES, and every enforcement path resolves through
   // effectiveRetentionLines() (services/retentionLimits.ts), which clamps a
-  // stored value regardless of what a client managed to write.
+  // stored value regardless of what a client managed to write. minNonzero is
+  // write-time-only guardrailing (validate()): pruning is irreversible, and a
+  // cap like 50 is a mis-typed 5000, not a plan.
   {
     key: 'data.retention.lines',
     label: 'History limit (lines per buffer)',
@@ -1793,12 +1801,13 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     type: 'int',
     min: 0,
     max: 10_000_000,
+    minNonzero: 1000,
     default: 0,
     description:
       'Each buffer keeps at most this many lines; older lines are deleted ' +
-      'permanently. 0 keeps everything (up to any limit this server sets). ' +
-      'Bookmarked messages are never deleted. Export your data first if you ' +
-      'want an archive.',
+      'permanently. 0 keeps everything (up to any limit this server sets); ' +
+      'the smallest nonzero limit is 1,000. Bookmarked messages are never ' +
+      'deleted. Export your data first if you want an archive.',
   },
 ]);
 

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -15,7 +15,10 @@
          user's view during a history fetch, shifting scrollTop and either
          throwing off the prepend anchor math or (with browser anchoring)
          leaving scrollTop near the top so maybeRequestHistory cascades. -->
-    <div v-if="!buffer?.hasMoreOlder && messages.length" class="notice">— start of history —</div>
+    <!-- "no older", not "start of history": with retention the oldest stored
+         line is usually not the first line ever said, and claiming it is
+         would be a lie the server can't even detect (RETENTION_PLAN.md). -->
+    <div v-if="!buffer?.hasMoreOlder && messages.length" class="notice">— no older messages —</div>
     <!-- Exactly one of these renders when there are no message rows, so the
          pane is never silently blank: a fetch in flight (or pending — an
          unhydrated shell awaiting the reconciler) says so, a hydrated-but-
@@ -2758,7 +2761,7 @@ watch(
 /* Boundary between read and unread messages. Pinned to the lastReadId
    snapshot taken on buffer activation; advances only after switch-away.
    Dashed border on either side of the label, warn-colored to differentiate
-   from the muted "start of history" notice. */
+   from the muted "no older messages" notice. */
 .unread-divider {
   color: var(--warn);
   font-style: normal;

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -17,7 +17,7 @@
          leaving scrollTop near the top so maybeRequestHistory cascades. -->
     <!-- "no older", not "start of history": with retention the oldest stored
          line is usually not the first line ever said, and claiming it is
-         would be a lie the server can't even detect (RETENTION_PLAN.md). -->
+         would be a lie the server can't even detect (lurker-dev/RETENTION_PLAN.md). -->
     <div v-if="!buffer?.hasMoreOlder && messages.length" class="notice">— no older messages —</div>
     <!-- Exactly one of these renders when there are no message rows, so the
          pane is never silently blank: a fetch in flight (or pending — an

--- a/vue_client/src/components/SettingsRow.vue
+++ b/vue_client/src/components/SettingsRow.vue
@@ -38,7 +38,7 @@
         :max="opt.max"
         :value="value"
         :disabled="!!hint"
-        @change="$emit('commit', Number(($event.target as HTMLInputElement).value))"
+        @change="onIntChange"
       />
       <select
         v-else-if="opt.type === 'enum'"
@@ -100,6 +100,9 @@
         @change="$emit('commit', ($event.target as HTMLInputElement).value)"
       />
     </div>
+    <!-- A locally-caught invalid int (the minNonzero hole). The typed value is
+         NOT committed, so nothing round-trips just to be rejected. -->
+    <p v-if="intError" class="error inline">{{ intError }}</p>
     <!--
       Why this row is greyed out, and which setting to change to wake it up.
       The value behind it is untouched — see optionEnabled() — so flipping the
@@ -117,7 +120,7 @@
 import { ref } from 'vue';
 import type { SettingOption, SettingValue } from '../../../shared/settingsRegistry.js';
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     opt: SettingOption;
     value?: SettingValue;
@@ -144,12 +147,29 @@ withDefaults(
   },
 );
 
-defineEmits<{
+const emit = defineEmits<{
   commit: [value: SettingValue];
   reset: [];
 }>();
 
 const revealed = ref(false);
+
+// The one int constraint <input min/max> can't express: minNonzero leaves a
+// hole (valid: 0 or >= floor). Caught here so the hole never commits — the
+// server's validate() would reject it anyway, but a round-trip that exists
+// only to fail is worse than an inline line. Wording stays neutral (what 0
+// MEANS is the description's job) and matches the server's own error.
+const intError = ref('');
+function onIntChange(e: Event) {
+  const n = Number((e.target as HTMLInputElement).value);
+  const o = props.opt;
+  if (o.type === 'int' && typeof o.minNonzero === 'number' && n !== 0 && n < o.minNonzero) {
+    intError.value = `Must be 0 or at least ${o.minNonzero.toLocaleString()}.`;
+    return;
+  }
+  intError.value = '';
+  emit('commit', n);
+}
 
 function formatDefault(opt: SettingOption, v: SettingValue): string {
   if (Array.isArray(v)) return v.join(', ');

--- a/vue_client/src/components/settings-panes/DataPane.vue
+++ b/vue_client/src/components/settings-panes/DataPane.vue
@@ -87,6 +87,12 @@
         I understand this will populate my empty account with the imported data.
       </label>
     </div>
+
+    <hr class="hl-sep" />
+
+    <!-- Registry-backed retention settings (RETENTION_PLAN.md). Enforcement is
+         the server's sweeper; this just renders the knobs. -->
+    <RegistryPane category-id="data" embedded :only="['retention']" />
   </section>
 </template>
 
@@ -96,6 +102,7 @@ import { useRouter } from 'vue-router';
 import { api, apiMultipart } from '../../api.js';
 import { resetSession } from '../../composables/useSessionReset.js';
 import { useDataExportStore } from '../../stores/dataExport.js';
+import RegistryPane from './RegistryPane.vue';
 
 interface ExportPreview {
   settingsOnly: Record<string, number>;

--- a/vue_client/src/components/settings-panes/DataPane.vue
+++ b/vue_client/src/components/settings-panes/DataPane.vue
@@ -90,7 +90,7 @@
 
     <hr class="hl-sep" />
 
-    <!-- Registry-backed retention settings (RETENTION_PLAN.md). Enforcement is
+    <!-- Registry-backed retention settings (lurker-dev/RETENTION_PLAN.md). Enforcement is
          the server's sweeper; this just renders the knobs. -->
     <RegistryPane category-id="data" embedded :only="['retention']" />
   </section>


### PR DESCRIPTION
First slice of the retention feature: admins get an instance ceiling on stored lines per buffer, users get their own cap, and a background sweeper prunes the tail.

## What's here

- **`LURKER_MAX_RETENTION_LINES`** — operator ceiling, env var (deployment policy, tenants can't raise it). Unset/0 = unlimited, the self-host default. Fail-open on an unparseable value, loudly: a typo must never mass-delete history.
- **`data.retention.lines`** — registry setting (Settings → Data), 0 = unlimited default. There is deliberately no separate operator default: an untouched user setting resolves to unlimited and clamps to the ceiling, so the ceiling *is* the hosted default.
- **`effectiveRetentionLines()`** — the single resolver both stack through (the `effectiveUploadCapBytes` pattern).
- **Sweeper** — self-rescheduling tick over a dirty-buffer set fed by `insertMessage`; boundary probe + batched deletes ride `idx_messages_buf_unread` (no new index — EQP-pinned); every bounded statement is budgeted and yielded between, so a tick can't starve the event loop; boot seeds all buffers dirty, which makes the steady sweeper double as the backfill. Circuit breaker after 3 consecutive failing ticks, posted to the system buffer.
- **Bookmarked rows are never pruned** (they FK-cascade otherwise); they survive as extras above the cap. The exemption probe seeks the `(user_id, message_id)` PK.
- **In-flight data exports pause the sweep** — the export cursor has no snapshot isolation; pruning ahead of it would silently hole the archive.
- Account **import** seeds all buffers dirty (its inserts bypass `insertMessage`); **lowering the cap** in settings re-marks that user's buffers so it acts without waiting for traffic.
- `— start of history —` → `— no older messages —`; CLIENT_PROTOCOL.md now says stored history is not append-only.

## Deliberately not in this PR (plan PRs 2–4)

- Ceiling advertisement to the client + preset UI with the per-buffer rate hint (a stored value above the ceiling is currently shown as-is and clamped only at enforcement — known gap, lands with the presets UI).
- Per-buffer overrides, the event-noise clock, the admin Storage tab.
- Read-state re-broadcast after a prune (stale badge on an idle buffer until the next countable event/reconnect — follow-up).
- `set-bookmark` on an already-pruned id stays a silent no-op — that silence is the existing deliberate design for bookmark refusals; flagging rather than changing it.

Tests: resolver clamp matrix, sweep integration (cap, bookmark survival, FTS consistency, budget/backlog convergence, export pause, settings-change reseeding), EQP pins for both statements. Full suite: 4216 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)