### PR TITLE
Retention: the noise clock — presence noise ages out early (plan PR 3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,13 @@ VAPID_SUBJECT=mailto:you@example.com
 # always kept. A value that won't parse is ignored WITH a warning — a typo
 # must never mass-delete history.
 # LURKER_MAX_RETENTION_LINES=100000
+#
+# Companion ceiling for the noise clock: the longest any user may keep
+# presence/server noise (joins, parts, quits, nick/mode changes, MOTDs), in
+# hours. Users default to one week (168) and can set their own value — or 0
+# to keep events as long as chat — but never above this. Unset (or 0) = no
+# ceiling. Same parsing rules as above.
+# LURKER_MAX_EVENT_RETENTION_HOURS=336
 
 # ---------------------------------------------------------------------------
 # Built-in identd (RFC 1413). For MULTI-USER deployments connecting many users

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -2190,26 +2190,50 @@ db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_net_nick
 // stays small and every entry the sweep walks is a deletion candidate;
 // buffer_id rides along so the per-user ownership join reads index-only.
 // The predicate list is GENERATED from shared EARLY_PRUNE_TYPES — the sweep
-// statements in db/retention.ts generate theirs the same way, and the drift
-// test in messagesEqp.test.ts pins the live index's SQL against the set, so
-// an edited set with a stale index fails CI instead of silently no longer
-// covering the new type. Sorted so the rendering is deterministic.
+// statements in db/retention.ts generate theirs the same way (and pin the
+// index with INDEXED BY, which refuses to prepare against a predicate the
+// query no longer implies). Sorted so the rendering is deterministic.
 export const EARLY_PRUNE_TYPES_SQL = [...EARLY_PRUNE_TYPES]
   .sort()
   .map((t) => `'${t}'`)
   .join(', ');
-if (
-  !indexExists('idx_messages_noise_time') &&
-  db.prepare(`SELECT 1 FROM messages LIMIT 1 OFFSET ?`).get(INDEX_BUILD_WARN_ROWS)
-) {
-  console.warn(
-    `[db] building idx_messages_noise_time — one-time, blocks startup, not resumable. ` +
-      `Do not kill the process.`,
-  );
-}
-db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_noise_time
+
+/**
+ * Build — or REBUILD — the noise-clock index so its predicate always matches
+ * the current EARLY_PRUNE_TYPES. Self-healing on purpose: `CREATE INDEX IF
+ * NOT EXISTS` keys on the name alone, so after an edit to the shared set a
+ * deployed database would keep its stale index and the INDEXED BY statements
+ * in db/retention.ts would fail to prepare AT MODULE LOAD — a boot
+ * crash-loop, on every instance, that a fresh-DB CI run can never see.
+ * Comparing the live DDL and dropping on mismatch turns "the set changed"
+ * into an ordinary one-time rebuild instead. Exported so the rebuild path is
+ * testable against a deliberately-stale index (messagesEqp.test.ts).
+ */
+export function ensureNoiseIndexCurrent(): void {
+  const ddl = `CREATE INDEX IF NOT EXISTS idx_messages_noise_time
          ON messages(time, buffer_id)
-         WHERE type IN (${EARLY_PRUNE_TYPES_SQL})`);
+         WHERE type IN (${EARLY_PRUNE_TYPES_SQL})`;
+  const live = db
+    .prepare(`SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?`)
+    .get('idx_messages_noise_time') as { sql: string } | undefined;
+  if (
+    live &&
+    (!live.sql.includes(`(${EARLY_PRUNE_TYPES_SQL})`) || !live.sql.includes('(time, buffer_id)'))
+  ) {
+    db.exec(`DROP INDEX idx_messages_noise_time`);
+  }
+  if (
+    !indexExists('idx_messages_noise_time') &&
+    db.prepare(`SELECT 1 FROM messages LIMIT 1 OFFSET ?`).get(INDEX_BUILD_WARN_ROWS)
+  ) {
+    console.warn(
+      `[db] building idx_messages_noise_time — one-time, blocks startup, not resumable. ` +
+        `Do not kill the process.`,
+    );
+  }
+  db.exec(ddl);
+}
+ensureNoiseIndexCurrent();
 
 // --- v18: satellite tables onto buffer_id (#695) -----------------------------
 //

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -8,6 +8,7 @@ import { seedFavoritesFromContacts } from './contactsToFavoritesSeed.js';
 import path from 'path';
 import fs from 'fs';
 import { isNodeMode } from '../utils/edition.js';
+import { EARLY_PRUNE_TYPES } from '../../shared/eventFilter.js';
 import { foldBufferCase } from './foldBufferCase.js';
 import {
   normalizeMessagesBufferIds,
@@ -2181,6 +2182,34 @@ db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_net
 db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_net_nick
          ON messages(network_id, nick COLLATE NOCASE, id DESC,
                      buffer_id, type, from_ignored, mirrored)`);
+
+// Retention's noise clock (lurker-dev/RETENTION_PLAN.md §3.3): age-based
+// pruning needs a time-ordered access path, and messages.time is otherwise
+// unindexed — count-based retention deliberately never needed one. Partial
+// over exactly the early-prune types (roughly a third of rows), so the b-tree
+// stays small and every entry the sweep walks is a deletion candidate;
+// buffer_id rides along so the per-user ownership join reads index-only.
+// The predicate list is GENERATED from shared EARLY_PRUNE_TYPES — the sweep
+// statements in db/retention.ts generate theirs the same way, and the drift
+// test in messagesEqp.test.ts pins the live index's SQL against the set, so
+// an edited set with a stale index fails CI instead of silently no longer
+// covering the new type. Sorted so the rendering is deterministic.
+export const EARLY_PRUNE_TYPES_SQL = [...EARLY_PRUNE_TYPES]
+  .sort()
+  .map((t) => `'${t}'`)
+  .join(', ');
+if (
+  !indexExists('idx_messages_noise_time') &&
+  db.prepare(`SELECT 1 FROM messages LIMIT 1 OFFSET ?`).get(INDEX_BUILD_WARN_ROWS)
+) {
+  console.warn(
+    `[db] building idx_messages_noise_time — one-time, blocks startup, not resumable. ` +
+      `Do not kill the process.`,
+  );
+}
+db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_noise_time
+         ON messages(time, buffer_id)
+         WHERE type IN (${EARLY_PRUNE_TYPES_SQL})`);
 
 // --- v18: satellite tables onto buffer_id (#695) -----------------------------
 //

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -2195,7 +2195,10 @@ db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_net_nick
 // query no longer implies). Sorted so the rendering is deterministic.
 export const EARLY_PRUNE_TYPES_SQL = [...EARLY_PRUNE_TYPES]
   .sort()
-  .map((t) => `'${t}'`)
+  // '' → '''' escaping: today's members are internal constants, but this
+  // string becomes DDL and statement text verbatim — cheap to make that safe
+  // against a future type name containing a quote.
+  .map((t) => `'${t.replace(/'/g, "''")}'`)
   .join(', ');
 
 /**

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -7,7 +7,8 @@ import {
   resolveBufferIdByNetwork,
   resolveOrMintForInsert,
 } from './bufferResolve.js';
-import { markBufferDirty } from './retention.js';
+import { markBufferDirty, noteNoiseInsert } from './retention.js';
+import { EARLY_PRUNE_TYPES } from '../../shared/eventFilter.js';
 import { countsTowardPage } from '../../shared/eventFilter.js';
 import type { PageUnit } from '../../shared/eventFilter.js';
 import type { ModeChange } from '../../shared/modes.js';
@@ -183,6 +184,10 @@ export function insertMessage(row: MessageInput): {
   const id = result.lastInsertRowid;
   // Retention prunes lazily: the sweep only ever looks at buffers that grew.
   markBufferDirty(bufferId);
+  // A noise row whose stored time lies in the past (server-time/replay) can
+  // land below the owner's noise-clock cursor; this rewinds it so the row is
+  // still swept. See noteNoiseInsert.
+  if (EARLY_PRUNE_TYPES.has(row.type)) noteNoiseInsert(bufferId, row.time);
   const altRow = altByIdStmt.get(id) as { alt: number } | undefined;
   // bufferId returned so the live publish path can stamp it onto the enriched
   // event without a second resolve — the wire's `irc` frames carry it.

--- a/server/db/messagesEqp.test.ts
+++ b/server/db/messagesEqp.test.ts
@@ -217,7 +217,19 @@ describe('noise-clock paths', () => {
     expect(detail).toMatch(/USING (COVERING )?INDEX idx_messages_noise_time \(time<\?\)/);
   });
 
-  it('the live index predicate matches the shared EARLY_PRUNE_TYPES set', () => {
+  it('a stale index predicate is rebuilt by the boot self-heal, not left to crash', async () => {
+    // Simulate a deployed DB whose index predates an EARLY_PRUNE_TYPES edit:
+    // without the heal, db/retention.ts's INDEXED BY statements fail to
+    // prepare at module load — a boot crash-loop a fresh-DB CI run can never
+    // reproduce, which is exactly why this exercises the rebuild path
+    // directly instead of asserting the (always-fresh) index matches.
+    const { ensureNoiseIndexCurrent } = await import('./index.js');
+    db.exec(`DROP INDEX idx_messages_noise_time`);
+    db.exec(
+      `CREATE INDEX idx_messages_noise_time ON messages(time, buffer_id)
+        WHERE type IN ('join', 'quit')`,
+    );
+    ensureNoiseIndexCurrent();
     const row = db
       .prepare(`SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?`)
       .get('idx_messages_noise_time') as { sql: string } | undefined;

--- a/server/db/messagesEqp.test.ts
+++ b/server/db/messagesEqp.test.ts
@@ -187,3 +187,40 @@ describe('retention prune paths', () => {
     );
   });
 });
+
+// The noise clock's access path (db/retention.ts deleteNoiseBatch). Two pins:
+// the partial index must drive the time-range scan (SQLite only considers it
+// when the query's type list implies the index predicate — both are generated
+// from shared EARLY_PRUNE_TYPES, so they match by construction), and the LIVE
+// index's DDL must still contain the generated list — someone widening the
+// shared set without migrating the index would otherwise silently stop
+// covering the new type.
+describe('noise-clock paths', () => {
+  let earlyPruneSql: string;
+  beforeAll(async () => {
+    ({ EARLY_PRUNE_TYPES_SQL: earlyPruneSql } = await import('./index.js'));
+  });
+
+  it('the noise delete subselect drives the partial time index', () => {
+    const detail = plan(
+      `SELECT m.id FROM messages m INDEXED BY idx_messages_noise_time
+        JOIN buffers b ON b.id = m.buffer_id
+        WHERE m.type IN (${earlyPruneSql})
+          AND m.time < '2026-01-01T00:00:00.000Z'
+          AND b.user_id = 1
+          AND NOT EXISTS (
+            SELECT 1 FROM user_bookmarks ub
+             WHERE ub.user_id = 1 AND ub.message_id = m.id
+          )
+        LIMIT 500`,
+    );
+    expect(detail).toMatch(/USING (COVERING )?INDEX idx_messages_noise_time \(time<\?\)/);
+  });
+
+  it('the live index predicate matches the shared EARLY_PRUNE_TYPES set', () => {
+    const row = db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?`)
+      .get('idx_messages_noise_time') as { sql: string } | undefined;
+    expect(row?.sql).toContain(`(${earlyPruneSql})`);
+  });
+});

--- a/server/db/retention.ts
+++ b/server/db/retention.ts
@@ -12,7 +12,7 @@
 // keeps messages_fts in sync through these deletes, so search never sees a
 // pruned row.
 
-import db from './index.js';
+import db, { EARLY_PRUNE_TYPES_SQL } from './index.js';
 
 // Buffers that took an insert since the sweeper last looked. In-memory on
 // purpose: a restart just means the next boot seeds every buffer dirty and
@@ -101,4 +101,46 @@ export function deleteRetentionBatch(
   limit: number,
 ): number {
   return deleteBatchStmt.run(bufferId, boundaryId, ownerUserId, limit).changes;
+}
+
+// ─── The noise clock ───────────────────────────────────────────────────────
+
+/** Every account, for the per-user noise sweep. Bounded by the user count,
+ *  which is small on every edition. */
+export function listUserIds(): number[] {
+  return (db.prepare(`SELECT id FROM users`).all() as Array<{ id: number }>).map((r) => r.id);
+}
+
+// One bounded bite of a user's over-age noise. INDEXED BY is load-bearing
+// twice over: (1) this schema never runs ANALYZE, and without the hint the
+// planner drives from buffers(user_id) and walks every one of the user's
+// buffers row-by-row — the exact shape the search indexes were built to kill;
+// (2) SQLite refuses to prepare an INDEXED BY whose partial-index predicate
+// the query no longer implies, so widening EARLY_PRUNE_TYPES without
+// migrating the index fails the boot loudly instead of silently scanning.
+// `time < ?` is a lexicographic compare on the stored ISO-8601 strings, the
+// same ordering assumption CHATHISTORY's window queries already rely on
+// (db/messages.ts loadHistoryWindow). The NOT EXISTS is the same owner-scoped
+// bookmark exemption as the count sweep — and it must be here in the SELECT,
+// not just "skipped at delete": an exempt row that stayed a candidate would
+// make a batch of survivors read as progress forever.
+const noiseDeleteStmt = db.prepare(`
+  DELETE FROM messages WHERE id IN (
+    SELECT m.id FROM messages m INDEXED BY idx_messages_noise_time
+     JOIN buffers b ON b.id = m.buffer_id
+     WHERE m.type IN (${EARLY_PRUNE_TYPES_SQL})
+       AND m.time < ?
+       AND b.user_id = ?
+       AND NOT EXISTS (
+         SELECT 1 FROM user_bookmarks ub
+          WHERE ub.user_id = ? AND ub.message_id = m.id
+       )
+     LIMIT ?
+  )
+`);
+
+/** Delete up to `limit` of this user's noise rows older than `cutoffIso`.
+ *  A return below `limit` means this user's over-age noise is done. */
+export function deleteNoiseBatch(userId: number, cutoffIso: string, limit: number): number {
+  return noiseDeleteStmt.run(cutoffIso, userId, userId, limit).changes;
 }

--- a/server/db/retention.ts
+++ b/server/db/retention.ts
@@ -111,6 +111,47 @@ export function listUserIds(): number[] {
   return (db.prepare(`SELECT id FROM users`).all() as Array<{ id: number }>).map((r) => r.id);
 }
 
+// Per-user low-water marks for the noise sweep, persisted in app_meta as one
+// JSON map (userId → the cutoff ISO the last completed sweep reached). The
+// cursor is what keeps the sweep O(newly-aged rows): without it every pass
+// re-walks permanently-retained index entries — bookmarked noise, and the
+// entire backlog of any event_hours=0 user — from the oldest entry up, per
+// user, forever. Persisted (not in-memory) because that re-walk is exactly
+// what a restart must not re-pay. Deliberate edge: un-bookmarking noise that
+// already fell below the owner's cursor never revisits it — the line cap
+// remains its only reaper. Orphaned entries for deleted users are harmless
+// and tiny.
+const NOISE_CURSOR_KEY = 'retention_noise_cursors';
+
+function readNoiseCursors(): Record<string, string> {
+  const row = db.prepare(`SELECT value FROM app_meta WHERE key = ?`).get(NOISE_CURSOR_KEY) as
+    | { value: string }
+    | undefined;
+  if (!row) return {};
+  try {
+    const parsed = JSON.parse(row.value);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Where this user's last completed noise sweep stopped ('' = never swept —
+ *  compares below every ISO timestamp, so the first sweep walks from the
+ *  beginning). */
+export function getNoiseCursor(userId: number): string {
+  return readNoiseCursors()[String(userId)] ?? '';
+}
+
+export function setNoiseCursor(userId: number, cutoffIso: string): void {
+  const cursors = readNoiseCursors();
+  cursors[String(userId)] = cutoffIso;
+  db.prepare(
+    `INSERT INTO app_meta (key, value) VALUES (?, ?)
+     ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
+  ).run(NOISE_CURSOR_KEY, JSON.stringify(cursors));
+}
+
 // One bounded bite of a user's over-age noise. INDEXED BY is load-bearing
 // twice over: (1) this schema never runs ANALYZE, and without the hint the
 // planner drives from buffers(user_id) and walks every one of the user's
@@ -129,6 +170,7 @@ const noiseDeleteStmt = db.prepare(`
     SELECT m.id FROM messages m INDEXED BY idx_messages_noise_time
      JOIN buffers b ON b.id = m.buffer_id
      WHERE m.type IN (${EARLY_PRUNE_TYPES_SQL})
+       AND m.time >= ?
        AND m.time < ?
        AND b.user_id = ?
        AND NOT EXISTS (
@@ -139,8 +181,15 @@ const noiseDeleteStmt = db.prepare(`
   )
 `);
 
-/** Delete up to `limit` of this user's noise rows older than `cutoffIso`.
- *  A return below `limit` means this user's over-age noise is done. */
-export function deleteNoiseBatch(userId: number, cutoffIso: string, limit: number): number {
-  return noiseDeleteStmt.run(cutoffIso, userId, userId, limit).changes;
+/** Delete up to `limit` of this user's noise rows in [sinceIso, cutoffIso) —
+ *  the low-water cursor bounds the walk to territory the last completed
+ *  sweep hasn't already cleared. A return below `limit` means this user's
+ *  window is done. */
+export function deleteNoiseBatch(
+  userId: number,
+  sinceIso: string,
+  cutoffIso: string,
+  limit: number,
+): number {
+  return noiseDeleteStmt.run(sinceIso, cutoffIso, userId, userId, limit).changes;
 }

--- a/server/db/retention.ts
+++ b/server/db/retention.ts
@@ -129,8 +129,16 @@ function readNoiseCursors(): Record<string, string> {
     | undefined;
   if (!row) return {};
   try {
-    const parsed = JSON.parse(row.value);
-    return parsed && typeof parsed === 'object' ? (parsed as Record<string, string>) : {};
+    const parsed = JSON.parse(row.value) as unknown;
+    if (!parsed || typeof parsed !== 'object') return {};
+    // Keep only string values: a corrupted/hand-edited blob must degrade to
+    // "sweep from the beginning", never to a non-string reaching a SQL bind
+    // (which would throw every tick and trip the retention circuit breaker).
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v === 'string') out[k] = v;
+    }
+    return out;
   } catch {
     return {};
   }
@@ -150,6 +158,36 @@ export function setNoiseCursor(userId: number, cutoffIso: string): void {
     `INSERT INTO app_meta (key, value) VALUES (?, ?)
      ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
   ).run(NOISE_CURSOR_KEY, JSON.stringify(cursors));
+  noiseCursorCache?.set(userId, cutoffIso);
+}
+
+// In-memory mirror of the cursor map, hydrated on first use, for the one
+// consumer that runs on the message-insert hot path (noteNoiseInsert below)
+// and must not pay an app_meta read per join/quit.
+let noiseCursorCache: Map<number, string> | null = null;
+
+function cachedNoiseCursor(userId: number): string {
+  if (noiseCursorCache === null) {
+    noiseCursorCache = new Map(Object.entries(readNoiseCursors()).map(([k, v]) => [Number(k), v]));
+  }
+  return noiseCursorCache.get(userId) ?? '';
+}
+
+/**
+ * Called by insertMessage for every EARLY_PRUNE_TYPES row: stored times are
+ * allowed to lie in the past (server-time tags, bouncer replay), so a noise
+ * row can land BELOW its owner's low-water cursor — territory the sweep
+ * treats as already cleared and would otherwise never revisit, contradicting
+ * the setting's "deleted once older than N hours" promise. Rewinding the
+ * cursor to the row's own time puts it back in the next pass's window. Cost
+ * on the ordinary path (live event, time ≈ now): one PK owner probe and a
+ * string compare.
+ */
+export function noteNoiseInsert(bufferId: number, timeIso: string): void {
+  const ownerId = bufferOwnerId(bufferId);
+  if (ownerId === undefined) return;
+  const cursor = cachedNoiseCursor(ownerId);
+  if (cursor !== '' && timeIso < cursor) setNoiseCursor(ownerId, timeIso);
 }
 
 // One bounded bite of a user's over-age noise. INDEXED BY is load-bearing

--- a/server/services/retentionLimits.test.ts
+++ b/server/services/retentionLimits.test.ts
@@ -18,20 +18,23 @@ let setUserSetting: typeof import('../db/settings.js').setUserSetting;
 let deleteUserSetting: typeof import('../db/settings.js').deleteUserSetting;
 let effectiveRetentionLines: typeof import('./retentionLimits.js').effectiveRetentionLines;
 let declaredRetentionCeilingLines: typeof import('./retentionLimits.js').declaredRetentionCeilingLines;
+let effectiveEventRetentionHours: typeof import('./retentionLimits.js').effectiveEventRetentionHours;
 
 let userId: number;
 
 beforeAll(async () => {
   ({ createUser } = await import('../db/users.js'));
   ({ setUserSetting, deleteUserSetting } = await import('../db/settings.js'));
-  ({ effectiveRetentionLines, declaredRetentionCeilingLines } =
+  ({ effectiveRetentionLines, declaredRetentionCeilingLines, effectiveEventRetentionHours } =
     await import('./retentionLimits.js'));
   userId = createUser('retention-alice').id;
 });
 
 afterEach(() => {
   delete process.env.LURKER_MAX_RETENTION_LINES;
+  delete process.env.LURKER_MAX_EVENT_RETENTION_HOURS;
   deleteUserSetting(userId, 'data.retention.lines');
+  deleteUserSetting(userId, 'data.retention.event_hours');
 });
 
 afterAll(() => {
@@ -120,5 +123,27 @@ describe('effectiveRetentionLines', () => {
     // thousands of rows per case.
     setUserSetting(userId, 'data.retention.lines', 50);
     expect(effectiveRetentionLines(userId)).toBe(50);
+  });
+});
+
+describe('effectiveEventRetentionHours', () => {
+  it('an untouched user gets the registry default (168 — the clock is ON)', () => {
+    expect(effectiveEventRetentionHours(userId)).toBe(168);
+  });
+
+  it('a user setting alone governs, and 0 turns the clock off', () => {
+    setUserSetting(userId, 'data.retention.event_hours', 72);
+    expect(effectiveEventRetentionHours(userId)).toBe(72);
+    setUserSetting(userId, 'data.retention.event_hours', 0);
+    expect(effectiveEventRetentionHours(userId)).toBe(0);
+  });
+
+  it('the ceiling clamps: default stays under it, 0 becomes it, above it clamps', () => {
+    process.env.LURKER_MAX_EVENT_RETENTION_HOURS = '336';
+    expect(effectiveEventRetentionHours(userId)).toBe(168);
+    setUserSetting(userId, 'data.retention.event_hours', 0);
+    expect(effectiveEventRetentionHours(userId)).toBe(336);
+    setUserSetting(userId, 'data.retention.event_hours', 500);
+    expect(effectiveEventRetentionHours(userId)).toBe(336);
   });
 });

--- a/server/services/retentionLimits.test.ts
+++ b/server/services/retentionLimits.test.ts
@@ -19,14 +19,19 @@ let deleteUserSetting: typeof import('../db/settings.js').deleteUserSetting;
 let effectiveRetentionLines: typeof import('./retentionLimits.js').effectiveRetentionLines;
 let declaredRetentionCeilingLines: typeof import('./retentionLimits.js').declaredRetentionCeilingLines;
 let effectiveEventRetentionHours: typeof import('./retentionLimits.js').effectiveEventRetentionHours;
+let declaredEventRetentionCeilingHours: typeof import('./retentionLimits.js').declaredEventRetentionCeilingHours;
 
 let userId: number;
 
 beforeAll(async () => {
   ({ createUser } = await import('../db/users.js'));
   ({ setUserSetting, deleteUserSetting } = await import('../db/settings.js'));
-  ({ effectiveRetentionLines, declaredRetentionCeilingLines, effectiveEventRetentionHours } =
-    await import('./retentionLimits.js'));
+  ({
+    effectiveRetentionLines,
+    declaredRetentionCeilingLines,
+    effectiveEventRetentionHours,
+    declaredEventRetentionCeilingHours,
+  } = await import('./retentionLimits.js'));
   userId = createUser('retention-alice').id;
 });
 
@@ -145,5 +150,13 @@ describe('effectiveEventRetentionHours', () => {
     expect(effectiveEventRetentionHours(userId)).toBe(336);
     setUserSetting(userId, 'data.retention.event_hours', 500);
     expect(effectiveEventRetentionHours(userId)).toBe(336);
+  });
+
+  it('an absurdly large ceiling fails open instead of feeding date math', () => {
+    // 9999999999 hours survives the digits regex but would make
+    // new Date(now - hours*3600e3) throw RangeError in the sweeper — and the
+    // circuit breaker would then stop ALL retention, line cap included.
+    process.env.LURKER_MAX_EVENT_RETENTION_HOURS = '9999999999';
+    expect(declaredEventRetentionCeilingHours()).toBeNull();
   });
 });

--- a/server/services/retentionLimits.ts
+++ b/server/services/retentionLimits.ts
@@ -38,16 +38,27 @@ const warnedBadCeiling = new Set<string>();
  * only safe direction for these knobs: a typo that resolved to some small
  * number would quietly mass-delete history that cannot be restored.
  */
-function parseCeilingEnv(name: string, unit: string, example: string): number | null {
+function parseCeilingEnv(
+  name: string,
+  unit: string,
+  example: string,
+  max: number,
+  consequence: string,
+): number | null {
   const raw = (process.env[name] || '').trim();
   if (!raw) return null;
   const value = /^\d+$/.test(raw) ? Number(raw) : NaN;
-  if (!Number.isFinite(value)) {
+  // The upper bound is a sanity rail, not policy: an extra-digit typo that
+  // survived the regex would otherwise flow into date arithmetic downstream
+  // (an hours value past ~275,000 years makes new Date() throw, and the
+  // sweeper's circuit breaker would then stop ALL retention — the exact
+  // blast radius fail-open exists to prevent).
+  if (!Number.isFinite(value) || value > max) {
     if (!warnedBadCeiling.has(name)) {
       warnedBadCeiling.add(name);
       const text =
-        `${name}="${raw}" is not a whole number of ${unit}; ignoring it. ` +
-        `History is NOT bounded by this ceiling. Use a bare integer, e.g. ${example}.`;
+        `${name}="${raw}" is not a whole number of ${unit} (max ${max}); ignoring it. ` +
+        `${consequence} Use a bare integer, e.g. ${example}.`;
       console.warn(`[lurker] ${text}`);
       // Also into the system buffer: "the ceiling never took effect" is an
       // operator-facing condition, and stdout is not an operator surface.
@@ -64,6 +75,10 @@ export function declaredRetentionCeilingLines(): number | null {
     'LURKER_MAX_RETENTION_LINES',
     'lines',
     'LURKER_MAX_RETENTION_LINES=100000',
+    1_000_000_000,
+    // Accurate for THIS var: an untouched user resolves to unlimited, so no
+    // ceiling really does mean nothing is pruned by line count.
+    'History is NOT bounded by an instance ceiling.',
   );
 }
 
@@ -73,6 +88,13 @@ export function declaredEventRetentionCeilingHours(): number | null {
     'LURKER_MAX_EVENT_RETENTION_HOURS',
     'hours',
     'LURKER_MAX_EVENT_RETENTION_HOURS=336',
+    87_600,
+    // Deliberately different from the lines message: ignoring THIS ceiling
+    // does not stop noise pruning — every untouched user still runs the
+    // 168-hour registry default. Saying "not bounded" here misled the
+    // operator into thinking the noise clock was inert.
+    "The noise clock still runs at each user's own setting (default 168 hours); " +
+      'only the operator ceiling is missing.',
   );
 }
 

--- a/server/services/retentionLimits.ts
+++ b/server/services/retentionLimits.ts
@@ -24,33 +24,30 @@ import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject } from './settingsRegistry.js';
 import * as systemLog from './systemLog.js';
 
-// Warn once per process, not per sweep tick: a misconfiguration that repeats
-// every minute is noise rather than a signal.
-let warnedBadCeiling = false;
+// Warn once per process PER VAR, not per sweep tick: a misconfiguration that
+// repeats every minute is noise rather than a signal.
+const warnedBadCeiling = new Set<string>();
 
 /**
- * What the operator DECLARED, in lines per buffer, or null when they declared
- * no ceiling. `0` is accepted as an explicit "no ceiling" spelling and is not
- * a misconfiguration.
+ * Parse one ceiling env var: a bare decimal integer, `0` accepted as an
+ * explicit "no ceiling" spelling. Strictness is the point — Number()
+ * coercions like "1.9" → 1 or "1e5" → 100000 would silently enable pruning
+ * with a ceiling the operator never wrote.
  *
- * Anything unparseable falls back to NO ceiling, loudly. Fail-open is the only
- * safe direction for this particular knob: a typo that resolved to some small
+ * Anything unparseable falls back to NO ceiling, loudly. Fail-open is the
+ * only safe direction for these knobs: a typo that resolved to some small
  * number would quietly mass-delete history that cannot be restored.
  */
-export function declaredRetentionCeilingLines(): number | null {
-  const raw = (process.env.LURKER_MAX_RETENTION_LINES || '').trim();
+function parseCeilingEnv(name: string, unit: string, example: string): number | null {
+  const raw = (process.env[name] || '').trim();
   if (!raw) return null;
-  // Strictly a bare decimal integer. Number() coercions like "1.9" → 1 or
-  // "1e5" → 100000 would silently enable pruning with a ceiling the operator
-  // never wrote, which is exactly what fail-open exists to prevent.
-  const lines = /^\d+$/.test(raw) ? Number(raw) : NaN;
-  if (!Number.isFinite(lines)) {
-    if (!warnedBadCeiling) {
-      warnedBadCeiling = true;
+  const value = /^\d+$/.test(raw) ? Number(raw) : NaN;
+  if (!Number.isFinite(value)) {
+    if (!warnedBadCeiling.has(name)) {
+      warnedBadCeiling.add(name);
       const text =
-        `LURKER_MAX_RETENTION_LINES="${raw}" is not a whole number of ` +
-        'lines; ignoring it. History is NOT bounded by an instance ceiling. ' +
-        'Use a bare integer, e.g. LURKER_MAX_RETENTION_LINES=100000.';
+        `${name}="${raw}" is not a whole number of ${unit}; ignoring it. ` +
+        `History is NOT bounded by this ceiling. Use a bare integer, e.g. ${example}.`;
       console.warn(`[lurker] ${text}`);
       // Also into the system buffer: "the ceiling never took effect" is an
       // operator-facing condition, and stdout is not an operator surface.
@@ -58,7 +55,25 @@ export function declaredRetentionCeilingLines(): number | null {
     }
     return null;
   }
-  return lines === 0 ? null : lines;
+  return value === 0 ? null : value;
+}
+
+/** The operator's per-buffer line ceiling, or null when none is declared. */
+export function declaredRetentionCeilingLines(): number | null {
+  return parseCeilingEnv(
+    'LURKER_MAX_RETENTION_LINES',
+    'lines',
+    'LURKER_MAX_RETENTION_LINES=100000',
+  );
+}
+
+/** The operator's noise-age ceiling in hours, or null when none is declared. */
+export function declaredEventRetentionCeilingHours(): number | null {
+  return parseCeilingEnv(
+    'LURKER_MAX_EVENT_RETENTION_HOURS',
+    'hours',
+    'LURKER_MAX_EVENT_RETENTION_HOURS=336',
+  );
 }
 
 /**
@@ -69,9 +84,27 @@ export function declaredRetentionCeilingLines(): number | null {
  */
 export function effectiveRetentionLines(userId: number): number {
   const settings = { ...defaultsAsObject(), ...getUserSettings(userId) };
-  const n = Number(settings['data.retention.lines']);
-  const userCap = Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
-  const ceiling = declaredRetentionCeilingLines();
-  if (ceiling == null) return userCap;
-  return userCap === 0 ? ceiling : Math.min(userCap, ceiling);
+  return clampToCeiling(settings['data.retention.lines'], declaredRetentionCeilingLines());
+}
+
+/**
+ * The effective noise-clock age for this user, in hours — rows in
+ * EARLY_PRUNE_TYPES older than this are pruned regardless of the line cap.
+ * 0 = the noise clock is off (events live as long as chat). Same
+ * min-of-the-nonzero stacking as the line cap; the registry default (168) is
+ * what an untouched user gets.
+ */
+export function effectiveEventRetentionHours(userId: number): number {
+  const settings = { ...defaultsAsObject(), ...getUserSettings(userId) };
+  return clampToCeiling(
+    settings['data.retention.event_hours'],
+    declaredEventRetentionCeilingHours(),
+  );
+}
+
+function clampToCeiling(rawSetting: unknown, ceiling: number | null): number {
+  const n = Number(rawSetting);
+  const userValue = Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
+  if (ceiling == null) return userValue;
+  return userValue === 0 ? ceiling : Math.min(userValue, ceiling);
 }

--- a/server/services/retentionSweeper.test.ts
+++ b/server/services/retentionSweeper.test.ts
@@ -304,6 +304,36 @@ describe('runRetentionTick', () => {
     expect(rowIds(r.bufferId)).toEqual([]);
   });
 
+  it('a noise pass under budget resumes where it stopped instead of restarting', async () => {
+    // Three fresh users, one old noise row each. With a budget of 2 the pass
+    // MUST span ticks: the pre-fix code restarted from the first user every
+    // tick, so once users outnumbered the budget the tail was never pruned
+    // and backlog never cleared.
+    const seeded = ['noise-q1', 'noise-q2', 'noise-q3'].map((name) => {
+      const u = createUser(name);
+      const net = createNetwork(u.id, { name, host: 'h', port: 6697, tls: true, nick: 'n' });
+      const r = insertMessage({
+        networkId: net!.id,
+        target: '#chan',
+        time: new Date(Date.now() - 10 * 24 * 3_600_000).toISOString(),
+        type: 'join',
+        nick: 'x',
+        text: null,
+        self: false,
+      });
+      return { bufferId: r.bufferId };
+    });
+
+    let guard = 0;
+    let backlog = true;
+    while (backlog) {
+      if (++guard > 30) throw new Error('noise pass never converged');
+      backlog = (await runRetentionTick({ ...OPTS, noiseIntervalMs: 0, maxBatchesPerTick: 2 }))
+        .backlog;
+    }
+    for (const s of seeded) expect(rowIds(s.bufferId)).toEqual([]);
+  });
+
   it('an in-flight export pauses the sweep without losing the dirty set', async () => {
     const { createExportJob, deleteJob } = await import('../db/dataExports.js');
     const { userId, ids, bufferId } = seedBuffer('ret-export', 12);

--- a/server/services/retentionSweeper.test.ts
+++ b/server/services/retentionSweeper.test.ts
@@ -334,6 +334,43 @@ describe('runRetentionTick', () => {
     for (const s of seeded) expect(rowIds(s.bufferId)).toEqual([]);
   });
 
+  it('replayed noise below the cursor rewinds it and still gets swept', async () => {
+    // Stored times may lie in the past (server-time tags, bouncer replay), so
+    // a noise row can be INSERTED below the low-water mark a completed pass
+    // left behind — territory the sweep believes is already clear. The
+    // insert-side rewind is what keeps the "deleted once older than N hours"
+    // promise for those rows.
+    const user = createUser('noise-replay');
+    const net = createNetwork(user.id, {
+      name: 'noise-replay',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'n',
+    });
+    const row = (time: string) =>
+      insertMessage({
+        networkId: net!.id,
+        target: '#chan',
+        time,
+        type: 'quit',
+        nick: 'x',
+        text: null,
+        self: false,
+      });
+    // A completed pass advances this user's cursor to their 168h-default cutoff.
+    const fresh = row(new Date().toISOString());
+    await runRetentionTick({ ...OPTS, noiseIntervalMs: 0 });
+    expect(rowIds(fresh.bufferId)).toEqual([Number(fresh.id)]);
+
+    // Replay lands a rows-old quit BELOW that cursor…
+    const replayed = row(new Date(Date.now() - 30 * 24 * 3_600_000).toISOString());
+    // …and the next pass still deletes it.
+    await runRetentionTick({ ...OPTS, noiseIntervalMs: 0 });
+    expect(rowIds(fresh.bufferId)).toEqual([Number(fresh.id)]);
+    expect(rowIds(replayed.bufferId)).not.toContain(Number(replayed.id));
+  });
+
   it('an in-flight export pauses the sweep without losing the dirty set', async () => {
     const { createExportJob, deleteJob } = await import('../db/dataExports.js');
     const { userId, ids, bufferId } = seedBuffer('ret-export', 12);

--- a/server/services/retentionSweeper.test.ts
+++ b/server/services/retentionSweeper.test.ts
@@ -40,8 +40,15 @@ afterAll(() => {
 });
 
 // Tiny knobs so the budget/backlog behavior is exercised with dozens of rows,
-// not hundreds of thousands.
-const OPTS = { batchRows: 4, maxBatchesPerTick: 100, idleDelayMs: 0, busyDelayMs: 0 };
+// not hundreds of thousands. noiseIntervalMs Infinity keeps the noise clock
+// out of the count-sweep tests; the noise tests pass 0 to force it.
+const OPTS = {
+  batchRows: 4,
+  maxBatchesPerTick: 100,
+  idleDelayMs: 0,
+  busyDelayMs: 0,
+  noiseIntervalMs: Infinity,
+};
 
 const BASE = Date.parse('2026-08-26T00:00:00Z');
 
@@ -174,6 +181,127 @@ describe('runRetentionTick', () => {
     const updated = settingsService.update(userId, { 'data.retention.lines': 1000 });
     expect(updated.ok).toBe(true);
     expect(takeDirtyBuffers()).toContain(bufferId);
+  });
+
+  it('the noise clock ages out old noise; chat, kicks, recent noise, bookmarks survive', async () => {
+    const user = createUser('noise-mix');
+    const net = createNetwork(user.id, {
+      name: 'noise-mix',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'n',
+    });
+    const old = new Date(Date.now() - 10 * 24 * 3_600_000).toISOString();
+    const recent = new Date().toISOString();
+    const row = (type: string, time: string, text: string) => {
+      const r = insertMessage({
+        networkId: net!.id,
+        target: '#chan',
+        time,
+        type,
+        nick: 'someone',
+        text,
+        self: false,
+      });
+      return { id: Number(r.id), bufferId: r.bufferId };
+    };
+    const oldChat = row('message', old, 'kept chat');
+    const oldKick = row('kick', old, 'kept kick');
+    const oldTopic = row('topic', old, 'kept topic');
+    const doomed = ['join', 'quit', 'motd', 'mode', 'away'].map((t) => row(t, old, `${t} noise`));
+    const savedQuit = row('quit', old, 'bookmarked noise');
+    const recentJoin = row('join', recent, 'recent noise');
+    expect(addBookmark(user.id, savedQuit.id)).toBe(true);
+    setUserSetting(user.id, 'data.retention.event_hours', 24);
+
+    const result = await runRetentionTick({ ...OPTS, noiseIntervalMs: 0 });
+
+    expect(result.noiseRowsDeleted).toBe(doomed.length);
+    expect(rowIds(oldChat.bufferId)).toEqual(
+      [oldChat, oldKick, oldTopic, savedQuit, recentJoin].map((r) => r.id),
+    );
+  });
+
+  it('the noise clock is ON by default: an untouched user loses week-old noise', async () => {
+    const user = createUser('noise-default');
+    const net = createNetwork(user.id, {
+      name: 'noise-default',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'n',
+    });
+    const seed = (time: string) =>
+      insertMessage({
+        networkId: net!.id,
+        target: '#chan',
+        time,
+        type: 'join',
+        nick: 'someone',
+        text: null,
+        self: false,
+      });
+    const oldJoin = seed(new Date(Date.now() - 10 * 24 * 3_600_000).toISOString());
+    const freshJoin = seed(new Date(Date.now() - 3_600_000).toISOString());
+
+    await runRetentionTick({ ...OPTS, noiseIntervalMs: 0 });
+
+    expect(rowIds(oldJoin.bufferId)).toEqual([Number(freshJoin.id)]);
+  });
+
+  it('event_hours 0 turns the noise clock off for that user', async () => {
+    const user = createUser('noise-off');
+    const net = createNetwork(user.id, {
+      name: 'noise-off',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'n',
+    });
+    setUserSetting(user.id, 'data.retention.event_hours', 0);
+    const r = insertMessage({
+      networkId: net!.id,
+      target: '#chan',
+      time: new Date(Date.now() - 30 * 24 * 3_600_000).toISOString(),
+      type: 'quit',
+      nick: 'someone',
+      text: 'ancient',
+      self: false,
+    });
+
+    await runRetentionTick({ ...OPTS, noiseIntervalMs: 0 });
+
+    expect(rowIds(r.bufferId)).toEqual([Number(r.id)]);
+  });
+
+  it('changing event_hours flags the noise clock due without waiting for the interval', async () => {
+    const { wireRetentionSettingsListener } = await import('./retentionSweeper.js');
+    const settingsService = (await import('./settingsService.js')).default;
+    const user = createUser('noise-flag');
+    const net = createNetwork(user.id, {
+      name: 'noise-flag',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'n',
+    });
+    const r = insertMessage({
+      networkId: net!.id,
+      target: '#chan',
+      time: new Date(Date.now() - 10 * 24 * 3_600_000).toISOString(),
+      type: 'part',
+      nick: 'someone',
+      text: null,
+      self: false,
+    });
+
+    // Interval Infinity: only the settings-change flag can trigger the phase.
+    wireRetentionSettingsListener();
+    expect(settingsService.update(user.id, { 'data.retention.event_hours': 24 }).ok).toBe(true);
+    await runRetentionTick(OPTS);
+
+    expect(rowIds(r.bufferId)).toEqual([]);
   });
 
   it('an in-flight export pauses the sweep without losing the dirty set', async () => {

--- a/server/services/retentionSweeper.ts
+++ b/server/services/retentionSweeper.ts
@@ -35,6 +35,8 @@ import {
   deleteRetentionBatch,
   listUserIds,
   deleteNoiseBatch,
+  getNoiseCursor,
+  setNoiseCursor,
 } from '../db/retention.js';
 import { listInflightJobs } from '../db/dataExports.js';
 import { effectiveRetentionLines, effectiveEventRetentionHours } from './retentionLimits.js';
@@ -76,11 +78,16 @@ export interface RetentionTickResult {
 const yieldToLoop = () => new Promise<void>((resolve) => setImmediate(resolve));
 
 // Noise-clock scheduling state. `lastNoiseSweepMs = 0` makes the first tick
-// after boot run the noise phase (budgeted like everything else); the flag is
-// set when a user's event_hours setting changes so the change acts within a
-// tick instead of within an hour.
+// after boot start a pass; the settings listener forces one with -Infinity
+// (due under ANY interval, Infinity included). `noisePendingUsers` is the
+// pass's cursor ACROSS ticks: a budget-exhausted tick leaves the unfinished
+// user at the head and the next tick resumes there — without it the pass
+// restarts from the first user every tick, and once noise-enabled users
+// outnumber the budget the tail is never reached and the sweeper busy-loops
+// forever (the same livelock class the count sweep's drained dirty set
+// exists to prevent).
 let lastNoiseSweepMs = 0;
-let noiseSweepDue = false;
+let noisePendingUsers: number[] | null = null;
 
 /**
  * One sweep pass over the currently-dirty buffers, plus — when due — the
@@ -170,42 +177,46 @@ export async function runRetentionTick(
 
   // ── The noise clock ──────────────────────────────────────────────────────
   // Per-user, not per-buffer: the cutoff depends only on the owner's setting,
-  // and the partial index walks all of a user's over-age noise in one shape.
+  // and the partial index walks a user's newly-aged noise in one shape.
   // Quiet buffers age out here without ever being dirty — the count sweep
-  // can't see them, which is the whole reason this phase exists. Not losable
-  // on error the way the dirty set is: due-ness re-derives from the interval.
-  if (noiseSweepDue || Date.now() - lastNoiseSweepMs >= opts.noiseIntervalMs) {
-    let finished = true;
-    for (const userId of listUserIds()) {
-      if (batchesSpent >= opts.maxBatchesPerTick) {
-        finished = false;
-        break;
-      }
+  // can't see them, which is the whole reason this phase exists. Each user's
+  // walk is bounded below by their persisted low-water cursor, so a pass
+  // costs O(rows aged since the last pass), not O(everything ever retained).
+  if (noisePendingUsers !== null || Date.now() - lastNoiseSweepMs >= opts.noiseIntervalMs) {
+    if (noisePendingUsers === null) noisePendingUsers = listUserIds();
+    while (noisePendingUsers.length > 0 && batchesSpent < opts.maxBatchesPerTick) {
+      const userId = noisePendingUsers[0];
       const hours = effectiveEventRetentionHours(userId);
-      if (hours <= 0) continue; // noise clock off for this user
+      if (hours <= 0) {
+        noisePendingUsers.shift(); // noise clock off for this user
+        continue;
+      }
       const cutoffIso = new Date(Date.now() - hours * 3_600_000).toISOString();
+      const sinceIso = getNoiseCursor(userId);
+      if (sinceIso >= cutoffIso) {
+        noisePendingUsers.shift(); // nothing has aged past the cutoff since last pass
+        continue;
+      }
       let userDone = false;
       while (batchesSpent < opts.maxBatchesPerTick) {
         await yieldToLoop();
-        const deleted = deleteNoiseBatch(userId, cutoffIso, opts.batchRows);
+        const deleted = deleteNoiseBatch(userId, sinceIso, cutoffIso, opts.batchRows);
         batchesSpent++;
         result.noiseRowsDeleted += deleted;
         if (deleted < opts.batchRows) {
-          userDone = true; // this user's over-age noise is gone (or bookmarked)
+          userDone = true; // this user's window is clear (survivors are bookmarked)
           break;
         }
       }
-      if (!userDone) {
-        finished = false;
-        break;
-      }
+      if (!userDone) break; // budget died mid-user; they stay at the head for next tick
+      setNoiseCursor(userId, cutoffIso);
+      noisePendingUsers.shift();
     }
-    if (finished) {
+    if (noisePendingUsers.length === 0) {
+      noisePendingUsers = null;
       lastNoiseSweepMs = Date.now();
-      noiseSweepDue = false;
     } else {
-      noiseSweepDue = true;
-      result.backlog = true;
+      result.backlog = true; // the pass resumes from the queue head next tick
     }
   }
 
@@ -230,7 +241,13 @@ export function wireRetentionSettingsListener(): void {
       seedUserBuffersDirty(userId);
     }
     if (Object.prototype.hasOwnProperty.call(changes, 'data.retention.event_hours')) {
-      noiseSweepDue = true;
+      // Force the clock due (-Infinity is due under ANY interval); if a pass
+      // is mid-flight and already past this user, re-queue them so a lowered
+      // cutoff acts now instead of next hour.
+      lastNoiseSweepMs = -Infinity;
+      if (noisePendingUsers !== null && !noisePendingUsers.includes(userId)) {
+        noisePendingUsers.push(userId);
+      }
     }
   });
 }

--- a/server/services/retentionSweeper.ts
+++ b/server/services/retentionSweeper.ts
@@ -33,9 +33,11 @@ import {
   bufferOwnerId,
   retentionBoundaryId,
   deleteRetentionBatch,
+  listUserIds,
+  deleteNoiseBatch,
 } from '../db/retention.js';
 import { listInflightJobs } from '../db/dataExports.js';
-import { effectiveRetentionLines } from './retentionLimits.js';
+import { effectiveRetentionLines, effectiveEventRetentionHours } from './retentionLimits.js';
 import settingsService from './settingsService.js';
 import * as systemLog from './systemLog.js';
 
@@ -49,6 +51,9 @@ export interface RetentionSweepOptions {
   idleDelayMs: number;
   /** Delay when the tick ran out of budget with work left. */
   busyDelayMs: number;
+  /** How often a tick also runs the noise clock (age-based pruning of
+   *  EARLY_PRUNE_TYPES). Infinity disables it; 0 runs it every tick. */
+  noiseIntervalMs: number;
 }
 
 export const RETENTION_SWEEP_DEFAULTS: RetentionSweepOptions = {
@@ -56,25 +61,41 @@ export const RETENTION_SWEEP_DEFAULTS: RetentionSweepOptions = {
   maxBatchesPerTick: 20,
   idleDelayMs: 60 * 1000,
   busyDelayMs: 5 * 1000,
+  noiseIntervalMs: 60 * 60 * 1000,
 };
 
 export interface RetentionTickResult {
   buffersExamined: number;
   rowsDeleted: number;
+  /** Rows the noise clock deleted (already-aged EARLY_PRUNE_TYPES rows). */
+  noiseRowsDeleted: number;
   /** Work remained when the tick's budget ran out. */
   backlog: boolean;
 }
 
 const yieldToLoop = () => new Promise<void>((resolve) => setImmediate(resolve));
 
+// Noise-clock scheduling state. `lastNoiseSweepMs = 0` makes the first tick
+// after boot run the noise phase (budgeted like everything else); the flag is
+// set when a user's event_hours setting changes so the change acts within a
+// tick instead of within an hour.
+let lastNoiseSweepMs = 0;
+let noiseSweepDue = false;
+
 /**
- * One sweep pass over the currently-dirty buffers. Exported for tests; the
- * production loop below is just this on a timer.
+ * One sweep pass over the currently-dirty buffers, plus — when due — the
+ * noise clock's per-user age sweep. Exported for tests; the production loop
+ * below is just this on a timer.
  */
 export async function runRetentionTick(
   opts: RetentionSweepOptions = RETENTION_SWEEP_DEFAULTS,
 ): Promise<RetentionTickResult> {
-  const result: RetentionTickResult = { buffersExamined: 0, rowsDeleted: 0, backlog: false };
+  const result: RetentionTickResult = {
+    buffersExamined: 0,
+    rowsDeleted: 0,
+    noiseRowsDeleted: 0,
+    backlog: false,
+  };
 
   // A with-history export pages the messages table by ascending id with no
   // snapshot isolation (services/exportService.ts) — deleting rows ahead of
@@ -146,16 +167,60 @@ export async function runRetentionTick(
       throw err;
     }
   }
+
+  // ── The noise clock ──────────────────────────────────────────────────────
+  // Per-user, not per-buffer: the cutoff depends only on the owner's setting,
+  // and the partial index walks all of a user's over-age noise in one shape.
+  // Quiet buffers age out here without ever being dirty — the count sweep
+  // can't see them, which is the whole reason this phase exists. Not losable
+  // on error the way the dirty set is: due-ness re-derives from the interval.
+  if (noiseSweepDue || Date.now() - lastNoiseSweepMs >= opts.noiseIntervalMs) {
+    let finished = true;
+    for (const userId of listUserIds()) {
+      if (batchesSpent >= opts.maxBatchesPerTick) {
+        finished = false;
+        break;
+      }
+      const hours = effectiveEventRetentionHours(userId);
+      if (hours <= 0) continue; // noise clock off for this user
+      const cutoffIso = new Date(Date.now() - hours * 3_600_000).toISOString();
+      let userDone = false;
+      while (batchesSpent < opts.maxBatchesPerTick) {
+        await yieldToLoop();
+        const deleted = deleteNoiseBatch(userId, cutoffIso, opts.batchRows);
+        batchesSpent++;
+        result.noiseRowsDeleted += deleted;
+        if (deleted < opts.batchRows) {
+          userDone = true; // this user's over-age noise is gone (or bookmarked)
+          break;
+        }
+      }
+      if (!userDone) {
+        finished = false;
+        break;
+      }
+    }
+    if (finished) {
+      lastNoiseSweepMs = Date.now();
+      noiseSweepDue = false;
+    } else {
+      noiseSweepDue = true;
+      result.backlog = true;
+    }
+  }
+
   return result;
 }
 
 let settingsListenerWired = false;
 
 /**
- * Re-examine a user's buffers when their retention setting changes. Without
- * this, a lowered cap only takes effect per-buffer on the next insert or the
- * next restart — and the setting's copy promises deletion, not "deletion,
- * eventually, if the buffer stays active". Exported for tests; idempotent.
+ * React to retention settings changes. Without this, a lowered line cap only
+ * takes effect per-buffer on the next insert or the next restart — and the
+ * settings copy promises deletion, not "deletion, eventually, if the buffer
+ * stays active". An event_hours change flags the noise clock due instead:
+ * that sweep is per-user, so there is no per-buffer state to seed. Exported
+ * for tests; idempotent.
  */
 export function wireRetentionSettingsListener(): void {
   if (settingsListenerWired) return;
@@ -163,6 +228,9 @@ export function wireRetentionSettingsListener(): void {
   settingsService.on('event', ({ userId, changes }) => {
     if (Object.prototype.hasOwnProperty.call(changes, 'data.retention.lines')) {
       seedUserBuffersDirty(userId);
+    }
+    if (Object.prototype.hasOwnProperty.call(changes, 'data.retention.event_hours')) {
+      noiseSweepDue = true;
     }
   });
 }

--- a/server/services/settingsRegistry.test.ts
+++ b/server/services/settingsRegistry.test.ts
@@ -67,6 +67,11 @@ describe('validate', () => {
       expect(out.ok).toBe(false);
       expect(!out.ok && out.error).toMatch(/0 or >= 1000/);
     });
+    it('the hours knob carries its own floor (24) — it acts even faster', () => {
+      expect(validate('data.retention.event_hours', 23).ok).toBe(false);
+      expect(validate('data.retention.event_hours', 24).ok).toBe(true);
+      expect(validate('data.retention.event_hours', 0).ok).toBe(true);
+    });
   });
 
   describe('string / color', () => {

--- a/shared/eventFilter.ts
+++ b/shared/eventFilter.ts
@@ -107,10 +107,11 @@ export function isNoiseType(type: string): boolean {
  * caveat above) but arithmetic: they are so rare that early-pruning them
  * saves nothing, and deleting them buys risk for no bytes.
  *
- * ⚠ The partial index idx_messages_noise_time and the noise-sweep statements
- * (server/db) both generate their type lists from this set. Editing it
- * changes the statements on next boot but NOT the already-built index — the
- * drift test in messagesEqp.test.ts fails until the index is migrated.
+ * The partial index idx_messages_noise_time and the noise-sweep statements
+ * (server/db) both generate their type lists from this set. Editing it is
+ * safe: ensureNoiseIndexCurrent (db/index.ts) compares the live index DDL at
+ * boot and rebuilds on mismatch, so deployed databases self-heal instead of
+ * crash-looping on the statements' INDEXED BY.
  */
 export const EARLY_PRUNE_TYPES: ReadonlySet<string> = new Set([
   ...NOISE_TYPES,

--- a/shared/eventFilter.ts
+++ b/shared/eventFilter.ts
@@ -94,6 +94,32 @@ export function isNoiseType(type: string): boolean {
   return NOISE_TYPES.has(type);
 }
 
+/**
+ * The row types retention's noise clock ages out early
+ * (lurker-dev/RETENTION_PLAN.md §3.3) — a STORAGE set, deliberately separate
+ * from the display sets above: what a reader wants hidden and what is worth
+ * disk forever are different questions with overlapping answers.
+ *
+ * It is NOISE_TYPES plus the server-status row types that never reach the
+ * filters at all: `motd` (re-sent on every connect — 5% of the reference
+ * database by itself), `usermode`, `away`, `back`. `kick` / `topic` /
+ * `invite` stay on the chat clock — not out of principle (see the NOISE_TYPES
+ * caveat above) but arithmetic: they are so rare that early-pruning them
+ * saves nothing, and deleting them buys risk for no bytes.
+ *
+ * ⚠ The partial index idx_messages_noise_time and the noise-sweep statements
+ * (server/db) both generate their type lists from this set. Editing it
+ * changes the statements on next boot but NOT the already-built index — the
+ * drift test in messagesEqp.test.ts fails until the index is migrated.
+ */
+export const EARLY_PRUNE_TYPES: ReadonlySet<string> = new Set([
+  ...NOISE_TYPES,
+  'motd',
+  'usermode',
+  'away',
+  'back',
+]);
+
 // ─── Page sizing ───────────────────────────────────────────────────────────
 
 /**

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1809,6 +1809,29 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'the smallest nonzero limit is 1,000. Bookmarked messages are never ' +
       'deleted. Export your data first if you want an archive.',
   },
+  // The noise clock: presence/server churn ages out on its own (shorter)
+  // schedule regardless of the line limit. Default ON at one week — the
+  // operator weighed 72h against 168h and chose the week because these rows
+  // feed search-driven fact-finding ("when did X last quit"). The deletable
+  // set is shared/eventFilter.ts EARLY_PRUNE_TYPES, not something clients
+  // enumerate. Enforced through effectiveEventRetentionHours(), ceiling env
+  // var LURKER_MAX_EVENT_RETENTION_HOURS — same stack as the line cap.
+  {
+    key: 'data.retention.event_hours',
+    label: 'Event history age limit (hours)',
+    category: 'data',
+    group: 'retention',
+    type: 'int',
+    min: 0,
+    max: 87_600,
+    default: 168,
+    description:
+      'Presence and server noise — joins, parts, quits, nick and mode ' +
+      'changes, MOTDs, away toggles — is deleted permanently once older than ' +
+      'this many hours, regardless of the line limit. 168 = one week. 0 keeps ' +
+      'events as long as regular messages. Bookmarked messages are never ' +
+      'deleted.',
+  },
 ]);
 
 const BY_KEY = new Map(REGISTRY.map((opt) => [opt.key, opt] as const));

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1824,13 +1824,17 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     type: 'int',
     min: 0,
     max: 87_600,
+    // Same guardrail rationale as the lines floor, and this knob acts FASTER
+    // (the settings listener flags the sweep due immediately): a typed 1 or
+    // 17 would permanently delete nearly all event history within a tick.
+    minNonzero: 24,
     default: 168,
     description:
       'Presence and server noise — joins, parts, quits, nick and mode ' +
       'changes, MOTDs, away toggles — is deleted permanently once older than ' +
-      'this many hours, regardless of the line limit. 168 = one week. 0 keeps ' +
-      'events as long as regular messages. Bookmarked messages are never ' +
-      'deleted.',
+      'this many hours, regardless of the line limit. 168 = one week; the ' +
+      'smallest nonzero limit is 24. 0 keeps events as long as regular ' +
+      'messages. Bookmarked messages are never deleted.',
   },
 ]);
 


### PR DESCRIPTION
Second slice of retention: presence/server churn gets its own, shorter clock. On the reference dev DB, week-old noise is **37% of all remaining rows** — this is the biggest storage win in the plan.

## What's here

- **`EARLY_PRUNE_TYPES`** (shared, next to `NOISE_TYPES`): the event-filter noise set plus `motd` (5% of the reference DB alone — re-sent every connect), `usermode`, `away`, `back`. `kick`/`topic`/`invite` stay on the chat clock — arithmetic, not principle: 154 kicks in 693k rows means pruning them saves nothing.
- **`data.retention.event_hours`** — default **168** (one week; chosen over 72h because these rows feed search-driven fact-finding), `minNonzero: 24` (this knob acts within a tick and deletion is irreversible), 0 = events live as long as chat. Ceiling env var **`LURKER_MAX_EVENT_RETENTION_HOURS`**, same resolver stack and fail-open parsing as the line cap — now with an upper bound, because an extra-digit typo would otherwise throw `RangeError` in date math and trip the breaker that stops *all* retention.
- **Partial covering index `idx_messages_noise_time (time, buffer_id)`** over exactly the early-prune types, predicate *generated* from the shared set. **Self-healing**: `ensureNoiseIndexCurrent()` compares the live DDL at boot and rebuilds on mismatch, so editing the set is an ordinary one-time rebuild instead of a crash-loop on the sweep statements' `INDEXED BY` (which pins the plan — the no-ANALYZE planner otherwise drives from `buffers(user_id)` and walks every buffer row-by-row). Probed on a copy of the 191MB dev DB: build 0.13s, 500-row batch ~10ms.
- **The sweep**: per-user (quiet buffers age out without ever being "dirty"), inside the existing tick, hourly or immediately on an `event_hours` change. Two structures from the review: the user queue **persists across ticks** so an under-budget pass resumes instead of restarting (restarting livelocks once noise-enabled users outnumber the budget), and each user has a **persisted low-water cursor** so a pass costs O(rows aged since last pass) — never re-walking bookmarked survivors or an `event_hours=0` user's retained backlog. Bookmark exemption rides in the SELECT, owner-scoped, PK-seek.

## Notes for review

- The `motd`/`usermode`/`away`/`back` widening beyond `NOISE_TYPES` is the one judgment call not explicitly operator-confirmed — trivially trimmed if wanted (edit the shared set; the index self-heals).
- Deliberate edge: un-bookmarking noise already below the owner's cursor never revisits it; the line cap remains its only reaper.
- Pre-existing flake spotted while gating (unrelated to this diff): `app.test.ts` "404s GET /mcp too" failed once in a full run (401 ≠ 404, edition-gating order sensitivity), passes 3× isolated and on re-run.

Tests: 4,233 passing — resolver matrix incl. the oversized-ceiling fail-open, noise sweep integration (type survival matrix, default-on, 0-off, settings-change immediacy, budget-spanning pass convergence, bookmark survival), EQP pin for the index-driven plan, and a real stale-index rebuild test replacing the tautological drift check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)