### PR TITLE
Admin: Storage tab — per-account history costs + retention ceilings (plan PR 4)

### DIFF
--- a/server/db/storageStats.ts
+++ b/server/db/storageStats.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Storage attribution for the admin Storage pane
+// (lurker-dev/RETENTION_PLAN.md §3.4). Lives in db/ — this is the one place
+// that walks the messages→networks→users ownership chain for accounting, and
+// a schema migration grepping server/db must find it.
+//
+// The message counts are CHUNKED: keyset pages over idx_messages_net
+// (index-only) with a setImmediate yield between pages, because the total is
+// O(every stored row) and one synchronous statement over a large instance
+// would stall the shared connection for seconds — the snapshot-starvation
+// class this codebase has an incident scar from. Each synchronous slice is
+// bounded by PAGE_ROWS regardless of instance size.
+
+import db from './index.js';
+
+const PAGE_ROWS = 50_000;
+
+const yieldToLoop = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+const pageStmt = db.prepare(`
+  SELECT id FROM messages
+   WHERE network_id = ? AND id > ?
+   ORDER BY id ASC LIMIT ?
+`);
+
+async function countNetworkRows(networkId: number): Promise<number> {
+  let total = 0;
+  let afterId = 0;
+  for (;;) {
+    const page = pageStmt.all(networkId, afterId, PAGE_ROWS) as Array<{ id: number }>;
+    total += page.length;
+    if (page.length < PAGE_ROWS) return total;
+    afterId = page[page.length - 1].id;
+    await yieldToLoop();
+  }
+}
+
+export interface UserStorageRow {
+  id: number;
+  username: string;
+  messageRows: number;
+  buffers: number;
+}
+
+export interface StorageAttribution {
+  users: UserStorageRow[];
+  totalMessageRows: number;
+}
+
+export async function collectStorageAttribution(): Promise<StorageAttribution> {
+  const users = db.prepare(`SELECT id, username FROM users ORDER BY id`).all() as Array<{
+    id: number;
+    username: string;
+  }>;
+  const networks = db.prepare(`SELECT id, user_id AS userId FROM networks`).all() as Array<{
+    id: number;
+    userId: number;
+  }>;
+  const buffersByUser = new Map<number, number>(
+    (
+      db
+        .prepare(`SELECT user_id AS userId, COUNT(*) AS n FROM buffers GROUP BY user_id`)
+        .all() as Array<{ userId: number; n: number }>
+    ).map((r) => [r.userId, r.n]),
+  );
+
+  const rowsByUser = new Map<number, number>();
+  let totalMessageRows = 0;
+  for (const net of networks) {
+    const n = await countNetworkRows(net.id);
+    totalMessageRows += n;
+    rowsByUser.set(net.userId, (rowsByUser.get(net.userId) ?? 0) + n);
+    await yieldToLoop();
+  }
+
+  return {
+    users: users
+      .map((u) => ({
+        id: u.id,
+        username: u.username,
+        messageRows: rowsByUser.get(u.id) ?? 0,
+        buffers: buffersByUser.get(u.id) ?? 0,
+      }))
+      .sort((a, b) => b.messageRows - a.messageRows),
+    totalMessageRows,
+  };
+}
+
+/** page_size × freelist_count — freed pages new writes reuse before the file
+ *  grows (retention's deletes land here; no VACUUM runs online, by design). */
+export function reclaimableBytes(): number {
+  const pageSize = db.pragma('page_size', { simple: true }) as number;
+  const freelist = db.pragma('freelist_count', { simple: true }) as number;
+  return pageSize * freelist;
+}

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -27,6 +27,7 @@ import { isNodeMode } from '../utils/edition.js';
 import { deriveIdent, isValidIdentOverride, MAX_IDENT_LENGTH } from '../../shared/ident.js';
 import adminUploadersRouter from './adminUploaders.js';
 import adminNetworksRouter from './adminNetworks.js';
+import adminStorageRouter from './adminStorage.js';
 
 const router = Router();
 router.use(requireAuth, requireAdmin);
@@ -37,6 +38,9 @@ router.use('/uploaders', adminUploadersRouter);
 
 // Instance network presets + the network lockdown (#298). Same deal.
 router.use('/networks', adminNetworksRouter);
+
+// Storage stats + retention ceilings (lurker-dev/RETENTION_PLAN.md §3.4).
+router.use('/storage', adminStorageRouter);
 
 // invites.ts is still untyped — row shape inferred as any from the JS module
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/server/routes/adminStorage.test.ts
+++ b/server/routes/adminStorage.test.ts
@@ -16,9 +16,21 @@ let adminAgent: Awaited<ReturnType<typeof createAuthedAgent>>;
 let userAgent: Awaited<ReturnType<typeof createAuthedAgent>>;
 let aliceId: number;
 
+// The ceilings assertions read live env; a deploy-adjacent shell exporting
+// the operator knobs must not fail a correct test — and other files in the
+// same worker share this process env, so the pre-existing values go back.
+const SAVED_ENV = {
+  LURKER_MAX_RETENTION_LINES: process.env.LURKER_MAX_RETENTION_LINES,
+  LURKER_MAX_EVENT_RETENTION_HOURS: process.env.LURKER_MAX_EVENT_RETENTION_HOURS,
+};
+afterAll(() => {
+  for (const [k, v] of Object.entries(SAVED_ENV)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
 beforeAll(async () => {
-  // The ceilings assertions read live env; a deploy-adjacent shell exporting
-  // the operator knobs must not fail a correct test.
   delete process.env.LURKER_MAX_RETENTION_LINES;
   delete process.env.LURKER_MAX_EVENT_RETENTION_HOURS;
   const { createUser } = await import('../db/users.js');

--- a/server/routes/adminStorage.test.ts
+++ b/server/routes/adminStorage.test.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Integration test for the admin storage stats: real router (inheriting the
+// admin gate from routes/admin.ts), real temp DB, real per-network counts.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Express } from 'express';
+import { setupTestDb, createTestApp, createAuthedAgent } from '../test-utils/testApp.js';
+
+const ctx = setupTestDb('admin-storage');
+afterAll(() => ctx.cleanup());
+
+let app: Express;
+let adminAgent: Awaited<ReturnType<typeof createAuthedAgent>>;
+let userAgent: Awaited<ReturnType<typeof createAuthedAgent>>;
+let aliceId: number;
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  const { createNetwork } = await import('../db/networks.js');
+  const { insertMessage } = await import('../db/messages.js');
+  const adminRouter = (await import('./admin.js')).default;
+
+  const admin = createUser('storage-admin', { role: 'admin' });
+  const alice = createUser('storage-alice');
+  aliceId = alice.id;
+  const net = createNetwork(alice.id, { name: 'n', host: 'h', port: 6697, tls: true, nick: 'a' });
+  for (let i = 0; i < 20; i++) {
+    insertMessage({
+      networkId: net!.id,
+      target: '#chan',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'a',
+      text: `line ${i}`,
+      self: false,
+    });
+  }
+  app = createTestApp({ '/api/admin': adminRouter });
+  adminAgent = await createAuthedAgent(app, admin.id);
+  userAgent = await createAuthedAgent(app, alice.id);
+});
+
+describe('GET /api/admin/storage', () => {
+  it('is admin-gated', async () => {
+    expect((await userAgent.get('/api/admin/storage')).status).toBe(403);
+  });
+
+  it('reports per-user rows, file sizes, and the (unset) ceilings', async () => {
+    const res = await adminAgent.get('/api/admin/storage');
+    expect(res.status).toBe(200);
+    expect(res.body.database.fileBytes).toBeGreaterThan(0);
+    expect(res.body.ceilings).toEqual({ maxLines: null, maxEventHours: null });
+    expect(res.body.approxBytesPerRow).toBeGreaterThan(0);
+    const alice = res.body.users.find((u: { id: number }) => u.id === aliceId);
+    expect(alice.messageRows).toBe(20);
+    // #chan plus the account's system buffer.
+    expect(alice.buffers).toBeGreaterThanOrEqual(1);
+    // Sorted heaviest-first: alice (20 rows) outranks the empty admin.
+    expect(res.body.users[0].id).toBe(aliceId);
+  });
+});

--- a/server/routes/adminStorage.test.ts
+++ b/server/routes/adminStorage.test.ts
@@ -17,6 +17,10 @@ let userAgent: Awaited<ReturnType<typeof createAuthedAgent>>;
 let aliceId: number;
 
 beforeAll(async () => {
+  // The ceilings assertions read live env; a deploy-adjacent shell exporting
+  // the operator knobs must not fail a correct test.
+  delete process.env.LURKER_MAX_RETENTION_LINES;
+  delete process.env.LURKER_MAX_EVENT_RETENTION_HOURS;
   const { createUser } = await import('../db/users.js');
   const { createNetwork } = await import('../db/networks.js');
   const { insertMessage } = await import('../db/messages.js');
@@ -51,13 +55,30 @@ describe('GET /api/admin/storage', () => {
     const res = await adminAgent.get('/api/admin/storage');
     expect(res.status).toBe(200);
     expect(res.body.database.fileBytes).toBeGreaterThan(0);
-    expect(res.body.ceilings).toEqual({ maxLines: null, maxEventHours: null });
-    expect(res.body.approxBytesPerRow).toBeGreaterThan(0);
+    expect(res.body.ceilings).toEqual({
+      maxLines: null,
+      maxLinesState: 'none',
+      maxEventHours: null,
+      maxEventHoursState: 'none',
+    });
+    // Too few rows for a meaningful per-instance ratio → no ≈ estimates.
+    expect(res.body.approxBytesPerRow).toBeNull();
     const alice = res.body.users.find((u: { id: number }) => u.id === aliceId);
     expect(alice.messageRows).toBe(20);
     // #chan plus the account's system buffer.
     expect(alice.buffers).toBeGreaterThanOrEqual(1);
     // Sorted heaviest-first: alice (20 rows) outranks the empty admin.
     expect(res.body.users[0].id).toBe(aliceId);
+  });
+
+  it('distinguishes an unparseable ceiling from an unset one, on ?refresh=1', async () => {
+    process.env.LURKER_MAX_RETENTION_LINES = '100,000';
+    try {
+      const res = await adminAgent.get('/api/admin/storage?refresh=1');
+      expect(res.body.ceilings.maxLines).toBeNull();
+      expect(res.body.ceilings.maxLinesState).toBe('invalid');
+    } finally {
+      delete process.env.LURKER_MAX_RETENTION_LINES;
+    }
   });
 });

--- a/server/routes/adminStorage.ts
+++ b/server/routes/adminStorage.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Admin storage stats (lurker-dev/RETENTION_PLAN.md §3.4): the visibility
+// half of the abuse story. The plan deliberately ships NO per-account quotas
+// — this pane is how the operator finds out whether anyone is actually
+// farming buffers before any automated defense gets designed. Mounted under
+// routes/admin.ts, so requireAuth + requireAdmin are inherited.
+//
+// Costs one covering-index walk of the messages table per refresh (a
+// per-network COUNT on idx_messages_net, index-only, summed per user) — on
+// the 2M-row reference database that is on the order of 100ms of synchronous
+// work on the shared connection, so the payload is cached for a minute and
+// only an admin opening the pane ever pays it.
+
+import fs from 'fs';
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import db, { DATABASE_FILE } from '../db/index.js';
+import {
+  declaredRetentionCeilingLines,
+  declaredEventRetentionCeilingHours,
+} from '../services/retentionLimits.js';
+
+const router = Router();
+
+// Matches the measured all-in cost (row + indexes + FTS) on the reference
+// database; the UI multiplies rows by this and labels the result "≈".
+const APPROX_BYTES_PER_ROW = 281;
+
+const CACHE_TTL_MS = 60 * 1000;
+let cached: { at: number; payload: Record<string, unknown> } | null = null;
+
+function fileBytes(path: string): number {
+  try {
+    return fs.statSync(path).size;
+  } catch {
+    return 0;
+  }
+}
+
+function buildPayload(): Record<string, unknown> {
+  const pageSize = db.pragma('page_size', { simple: true }) as number;
+  const freelist = db.pragma('freelist_count', { simple: true }) as number;
+
+  const users = db.prepare(`SELECT id, username FROM users ORDER BY id`).all() as Array<{
+    id: number;
+    username: string;
+  }>;
+  const networks = db.prepare(`SELECT id, user_id AS userId FROM networks`).all() as Array<{
+    id: number;
+    userId: number;
+  }>;
+  const countByNetwork = db.prepare(`SELECT COUNT(*) AS n FROM messages WHERE network_id = ?`);
+  const buffersByUser = new Map<number, number>(
+    (
+      db
+        .prepare(`SELECT user_id AS userId, COUNT(*) AS n FROM buffers GROUP BY user_id`)
+        .all() as Array<{ userId: number; n: number }>
+    ).map((r) => [r.userId, r.n]),
+  );
+
+  const rowsByUser = new Map<number, number>();
+  for (const net of networks) {
+    const n = (countByNetwork.get(net.id) as { n: number }).n;
+    rowsByUser.set(net.userId, (rowsByUser.get(net.userId) ?? 0) + n);
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    approxBytesPerRow: APPROX_BYTES_PER_ROW,
+    database: {
+      fileBytes: fileBytes(DATABASE_FILE),
+      walBytes: fileBytes(`${DATABASE_FILE}-wal`),
+      // Freed pages SQLite will reuse before growing the file — retention's
+      // deletes land here, which is why the file stops growing rather than
+      // shrinking (no VACUUM runs online, by design).
+      reclaimableBytes: freelist * pageSize,
+    },
+    ceilings: {
+      maxLines: declaredRetentionCeilingLines(),
+      maxEventHours: declaredEventRetentionCeilingHours(),
+    },
+    users: users
+      .map((u) => ({
+        id: u.id,
+        username: u.username,
+        messageRows: rowsByUser.get(u.id) ?? 0,
+        buffers: buffersByUser.get(u.id) ?? 0,
+      }))
+      .sort((a, b) => b.messageRows - a.messageRows),
+  };
+}
+
+router.get('/', (_req: Request, res: Response) => {
+  if (!cached || Date.now() - cached.at > CACHE_TTL_MS) {
+    cached = { at: Date.now(), payload: buildPayload() };
+  }
+  res.json(cached.payload);
+});
+
+export default router;

--- a/server/routes/adminStorage.ts
+++ b/server/routes/adminStorage.ts
@@ -7,29 +7,28 @@
 // farming buffers before any automated defense gets designed. Mounted under
 // routes/admin.ts, so requireAuth + requireAdmin are inherited.
 //
-// Costs one covering-index walk of the messages table per refresh (a
-// per-network COUNT on idx_messages_net, index-only, summed per user) — on
-// the 2M-row reference database that is on the order of 100ms of synchronous
-// work on the shared connection, so the payload is cached for a minute and
-// only an admin opening the pane ever pays it.
+// The heavy walk (every stored row, attributed per account) lives in
+// db/storageStats.ts, chunked with event-loop yields so no synchronous slice
+// scales with instance size. Results are cached for a minute and built
+// single-flight; `?refresh=1` busts the cache for the admin who just deleted
+// an account and wants to see the reclaim NOW.
 
 import fs from 'fs';
 import { Router } from 'express';
-import type { Request, Response } from 'express';
-import db, { DATABASE_FILE } from '../db/index.js';
+import type { Request, Response, NextFunction } from 'express';
+import { DATABASE_FILE } from '../db/index.js';
+import { collectStorageAttribution, reclaimableBytes } from '../db/storageStats.js';
 import {
   declaredRetentionCeilingLines,
   declaredEventRetentionCeilingHours,
+  ceilingState,
 } from '../services/retentionLimits.js';
 
 const router = Router();
 
-// Matches the measured all-in cost (row + indexes + FTS) on the reference
-// database; the UI multiplies rows by this and labels the result "≈".
-const APPROX_BYTES_PER_ROW = 281;
-
 const CACHE_TTL_MS = 60 * 1000;
 let cached: { at: number; payload: Record<string, unknown> } | null = null;
+let building: Promise<Record<string, unknown>> | null = null;
 
 function fileBytes(path: string): number {
   try {
@@ -39,64 +38,65 @@ function fileBytes(path: string): number {
   }
 }
 
-function buildPayload(): Record<string, unknown> {
-  const pageSize = db.pragma('page_size', { simple: true }) as number;
-  const freelist = db.pragma('freelist_count', { simple: true }) as number;
+// Only derive a bytes/row ratio once there's enough data for the division to
+// mean something — on a near-empty instance the fixed schema overhead would
+// dominate and "20 KB per line" is a lie. Null = the client omits ≈ sizes.
+const MIN_ROWS_FOR_RATIO = 10_000;
 
-  const users = db.prepare(`SELECT id, username FROM users ORDER BY id`).all() as Array<{
-    id: number;
-    username: string;
-  }>;
-  const networks = db.prepare(`SELECT id, user_id AS userId FROM networks`).all() as Array<{
-    id: number;
-    userId: number;
-  }>;
-  const countByNetwork = db.prepare(`SELECT COUNT(*) AS n FROM messages WHERE network_id = ?`);
-  const buffersByUser = new Map<number, number>(
-    (
-      db
-        .prepare(`SELECT user_id AS userId, COUNT(*) AS n FROM buffers GROUP BY user_id`)
-        .all() as Array<{ userId: number; n: number }>
-    ).map((r) => [r.userId, r.n]),
-  );
-
-  const rowsByUser = new Map<number, number>();
-  for (const net of networks) {
-    const n = (countByNetwork.get(net.id) as { n: number }).n;
-    rowsByUser.set(net.userId, (rowsByUser.get(net.userId) ?? 0) + n);
-  }
-
+async function buildPayload(): Promise<Record<string, unknown>> {
+  const { users, totalMessageRows } = await collectStorageAttribution();
+  const dbBytes = fileBytes(DATABASE_FILE);
+  const maxLines = declaredRetentionCeilingLines();
+  const maxEventHours = declaredEventRetentionCeilingHours();
   return {
     generatedAt: new Date().toISOString(),
-    approxBytesPerRow: APPROX_BYTES_PER_ROW,
+    // Derived from THIS instance's file and row count rather than a baked
+    // constant, so schema drift and unusual content self-calibrate. Slightly
+    // generous (the whole file, messages ≈ 95% of it) — the right direction
+    // for a number an operator provisions disk from.
+    approxBytesPerRow:
+      totalMessageRows >= MIN_ROWS_FOR_RATIO ? Math.round(dbBytes / totalMessageRows) : null,
     database: {
-      fileBytes: fileBytes(DATABASE_FILE),
+      fileBytes: dbBytes,
       walBytes: fileBytes(`${DATABASE_FILE}-wal`),
-      // Freed pages SQLite will reuse before growing the file — retention's
-      // deletes land here, which is why the file stops growing rather than
-      // shrinking (no VACUUM runs online, by design).
-      reclaimableBytes: freelist * pageSize,
+      reclaimableBytes: reclaimableBytes(),
     },
+    // States, not just values: `null` alone can't distinguish "unset" from
+    // "declared but unparseable (fail-open)", and this pane is exactly where
+    // an operator comes to check — see ceilingState.
     ceilings: {
-      maxLines: declaredRetentionCeilingLines(),
-      maxEventHours: declaredEventRetentionCeilingHours(),
+      maxLines,
+      maxLinesState: ceilingState('LURKER_MAX_RETENTION_LINES', maxLines),
+      maxEventHours,
+      maxEventHoursState: ceilingState('LURKER_MAX_EVENT_RETENTION_HOURS', maxEventHours),
     },
-    users: users
-      .map((u) => ({
-        id: u.id,
-        username: u.username,
-        messageRows: rowsByUser.get(u.id) ?? 0,
-        buffers: buffersByUser.get(u.id) ?? 0,
-      }))
-      .sort((a, b) => b.messageRows - a.messageRows),
+    users,
   };
 }
 
-router.get('/', (_req: Request, res: Response) => {
-  if (!cached || Date.now() - cached.at > CACHE_TTL_MS) {
-    cached = { at: Date.now(), payload: buildPayload() };
-  }
-  res.json(cached.payload);
+router.get('/', (req: Request, res: Response, next: NextFunction) => {
+  // Async work wrapped per the no-async-endpoint-handlers rule: the handler
+  // itself stays sync, the IIFE forwards failures to next().
+  void (async () => {
+    try {
+      const fresh = req.query.refresh === '1';
+      if (!fresh && cached && Date.now() - cached.at <= CACHE_TTL_MS) {
+        res.json(cached.payload);
+        return;
+      }
+      // Single-flight: two admins (or a refresh spam) share one walk.
+      if (!building) {
+        building = buildPayload().finally(() => {
+          building = null;
+        });
+      }
+      const payload = await building;
+      cached = { at: Date.now(), payload };
+      res.json(payload);
+    } catch (err) {
+      next(err);
+    }
+  })();
 });
 
 export default router;

--- a/server/services/retentionLimits.ts
+++ b/server/services/retentionLimits.ts
@@ -82,6 +82,22 @@ export function declaredRetentionCeilingLines(): number | null {
   );
 }
 
+export type CeilingState = 'set' | 'none' | 'invalid';
+
+/**
+ * How one ceiling env var actually resolved — for surfaces that must not let
+ * an operator misread fail-open. `declared…()` returns null for three
+ * different situations (unset, explicit 0, and set-but-unparseable), and the
+ * admin Storage pane once rendered all three as "unset", sending an operator
+ * whose value had a typo off to debug env propagation while history grew
+ * unbounded.
+ */
+export function ceilingState(name: string, resolved: number | null): CeilingState {
+  if (resolved != null) return 'set';
+  const raw = (process.env[name] || '').trim();
+  return raw === '' || raw === '0' ? 'none' : 'invalid';
+}
+
 /** The operator's noise-age ceiling in hours, or null when none is declared. */
 export function declaredEventRetentionCeilingHours(): number | null {
   return parseCeilingEnv(

--- a/server/services/retentionLimits.ts
+++ b/server/services/retentionLimits.ts
@@ -95,7 +95,10 @@ export type CeilingState = 'set' | 'none' | 'invalid';
 export function ceilingState(name: string, resolved: number | null): CeilingState {
   if (resolved != null) return 'set';
   const raw = (process.env[name] || '').trim();
-  return raw === '' || raw === '0' ? 'none' : 'invalid';
+  if (raw === '') return 'none';
+  // Any all-digit zero spelling ("0", "00", …) is the explicit no-ceiling
+  // form parseCeilingEnv accepts — it must not read as "invalid" here.
+  return /^\d+$/.test(raw) && Number(raw) === 0 ? 'none' : 'invalid';
 }
 
 /** The operator's noise-age ceiling in hours, or null when none is declared. */

--- a/vue_client/src/components/admin-panes/StoragePane.vue
+++ b/vue_client/src/components/admin-panes/StoragePane.vue
@@ -1,0 +1,115 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+
+  Storage stats (lurker-dev/RETENTION_PLAN.md §3.4): how much history each
+  account holds, what the database file costs on disk, and which retention
+  ceilings the deployment declares. Visibility only — the plan deliberately
+  ships no per-account quotas, so this pane is how an operator notices
+  buffer-farming before designing any automated defense.
+-->
+
+<template>
+  <section id="admin-storage" class="settings-pane">
+    <h2>storage</h2>
+    <p class="section-desc">
+      What message history costs on this instance. Sizes marked ≈ are estimated at
+      {{ stats?.approxBytesPerRow ?? 281 }} bytes per stored line (row + indexes + search index).
+    </p>
+
+    <p v-if="error" class="error inline">{{ error }}</p>
+    <p v-else-if="!stats" class="muted small">Loading storage stats…</p>
+
+    <template v-if="stats">
+      <ul class="counts">
+        <li>database file: {{ formatBytes(stats.database.fileBytes) }}</li>
+        <li v-if="stats.database.walBytes">
+          write-ahead log: {{ formatBytes(stats.database.walBytes) }}
+        </li>
+        <li>
+          reclaimable free pages: {{ formatBytes(stats.database.reclaimableBytes) }}
+          <span class="muted small">(reused by new writes before the file grows)</span>
+        </li>
+      </ul>
+
+      <p class="muted small">
+        Retention ceilings:
+        {{
+          stats.ceilings.maxLines != null
+            ? `${stats.ceilings.maxLines.toLocaleString()} lines per buffer`
+            : 'no line ceiling (LURKER_MAX_RETENTION_LINES unset)'
+        }}
+        ·
+        {{
+          stats.ceilings.maxEventHours != null
+            ? `event noise capped at ${stats.ceilings.maxEventHours}h`
+            : 'no event-noise ceiling (LURKER_MAX_EVENT_RETENTION_HOURS unset)'
+        }}
+      </p>
+
+      <h3 class="subhead">per account</h3>
+      <ul class="device-list">
+        <li v-for="u in stats.users" :key="u.id" class="device storage-row">
+          <span class="who">{{ u.username }}</span>
+          <span class="muted small">
+            {{ u.messageRows.toLocaleString() }} lines · {{ u.buffers }} buffer(s) · ≈
+            {{ formatBytes(u.messageRows * stats.approxBytesPerRow) }}
+          </span>
+        </li>
+      </ul>
+      <p class="muted small">
+        Refreshed {{ stats.generatedAt }} — cached for a minute server-side.
+      </p>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { api } from '../../api.js';
+
+interface StorageStats {
+  generatedAt: string;
+  approxBytesPerRow: number;
+  database: { fileBytes: number; walBytes: number; reclaimableBytes: number };
+  ceilings: { maxLines: number | null; maxEventHours: number | null };
+  users: Array<{ id: number; username: string; messageRows: number; buffers: number }>;
+}
+
+const stats = ref<StorageStats | null>(null);
+const error = ref('');
+
+onMounted(async () => {
+  try {
+    stats.value = await api('/api/admin/storage');
+  } catch (e: any) {
+    error.value = e.message || 'failed to load storage stats';
+  }
+});
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+</script>
+
+<style src="../settings-panes/panes.css"></style>
+<style scoped>
+.counts {
+  list-style: disc;
+  padding-left: var(--space-9);
+  margin: var(--space-2) 0 var(--space-5);
+  color: var(--fg-muted);
+}
+.storage-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+.storage-row .who {
+  color: var(--fg);
+}
+</style>

--- a/vue_client/src/components/admin-panes/StoragePane.vue
+++ b/vue_client/src/components/admin-panes/StoragePane.vue
@@ -12,10 +12,7 @@
 <template>
   <section id="admin-storage" class="settings-pane">
     <h2>storage</h2>
-    <p class="section-desc">
-      What message history costs on this instance. Sizes marked ≈ are estimated at
-      {{ stats?.approxBytesPerRow ?? 281 }} bytes per stored line (row + indexes + search index).
-    </p>
+    <p class="section-desc">What message history costs on this instance.</p>
 
     <p v-if="error" class="error inline">{{ error }}</p>
     <p v-else-if="!stats" class="muted small">Loading storage stats…</p>
@@ -23,76 +20,107 @@
     <template v-if="stats">
       <ul class="counts">
         <li>database file: {{ formatBytes(stats.database.fileBytes) }}</li>
-        <li v-if="stats.database.walBytes">
-          write-ahead log: {{ formatBytes(stats.database.walBytes) }}
-        </li>
+        <li>write-ahead log: {{ formatBytes(stats.database.walBytes) }}</li>
         <li>
           reclaimable free pages: {{ formatBytes(stats.database.reclaimableBytes) }}
           <span class="muted small">(reused by new writes before the file grows)</span>
         </li>
       </ul>
 
-      <p class="muted small">
-        Retention ceilings:
-        {{
-          stats.ceilings.maxLines != null
-            ? `${stats.ceilings.maxLines.toLocaleString()} lines per buffer`
-            : 'no line ceiling (LURKER_MAX_RETENTION_LINES unset)'
-        }}
-        ·
-        {{
-          stats.ceilings.maxEventHours != null
-            ? `event noise capped at ${stats.ceilings.maxEventHours}h`
-            : 'no event-noise ceiling (LURKER_MAX_EVENT_RETENTION_HOURS unset)'
-        }}
-      </p>
+      <!-- States, not null-guesses: "unset" and "declared but unparseable"
+           are different operator situations, and this pane is exactly where
+           someone comes to check a ceiling that isn't taking effect. -->
+      <p class="muted small">Line ceiling: {{ linesCeilingText }}</p>
+      <p class="muted small">Event-noise ceiling: {{ hoursCeilingText }}</p>
 
       <h3 class="subhead">per account</h3>
+      <p v-if="stats.approxBytesPerRow != null" class="muted small">
+        Sizes marked ≈ use this instance's measured average of
+        {{ stats.approxBytesPerRow }} bytes per stored line.
+      </p>
       <ul class="device-list">
         <li v-for="u in stats.users" :key="u.id" class="device storage-row">
           <span class="who">{{ u.username }}</span>
           <span class="muted small">
-            {{ u.messageRows.toLocaleString() }} lines · {{ u.buffers }} buffer(s) · ≈
-            {{ formatBytes(u.messageRows * stats.approxBytesPerRow) }}
+            {{ u.messageRows.toLocaleString() }} lines · {{ u.buffers }} buffer(s)
+            <template v-if="stats.approxBytesPerRow != null">
+              · ≈ {{ formatBytes(u.messageRows * stats.approxBytesPerRow) }}
+            </template>
           </span>
         </li>
       </ul>
-      <p class="muted small">
-        Refreshed {{ stats.generatedAt }} — cached for a minute server-side.
-      </p>
+      <div class="actions">
+        <span class="muted small">Refreshed {{ formatDateTime(stats.generatedAt) }}.</span>
+        <button class="link" :disabled="refreshing" @click="load(true)">
+          {{ refreshing ? 'refreshing…' : 'refresh now' }}
+        </button>
+      </div>
     </template>
   </section>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { api } from '../../api.js';
+import { formatBytes } from '../../utils/formatBytes.js';
+import { formatDateTime } from '../../utils/timestamp.js';
+
+type CeilingState = 'set' | 'none' | 'invalid';
 
 interface StorageStats {
   generatedAt: string;
-  approxBytesPerRow: number;
+  approxBytesPerRow: number | null;
   database: { fileBytes: number; walBytes: number; reclaimableBytes: number };
-  ceilings: { maxLines: number | null; maxEventHours: number | null };
+  ceilings: {
+    maxLines: number | null;
+    maxLinesState: CeilingState;
+    maxEventHours: number | null;
+    maxEventHoursState: CeilingState;
+  };
   users: Array<{ id: number; username: string; messageRows: number; buffers: number }>;
 }
 
 const stats = ref<StorageStats | null>(null);
 const error = ref('');
+const refreshing = ref(false);
 
-onMounted(async () => {
+async function load(force = false) {
+  refreshing.value = force;
+  error.value = '';
   try {
-    stats.value = await api('/api/admin/storage');
+    stats.value = await api(`/api/admin/storage${force ? '?refresh=1' : ''}`);
   } catch (e: any) {
     error.value = e.message || 'failed to load storage stats';
+  } finally {
+    refreshing.value = false;
   }
+}
+onMounted(() => load());
+
+const linesCeilingText = computed(() => {
+  const c = stats.value?.ceilings;
+  if (!c) return '';
+  if (c.maxLinesState === 'set' && c.maxLines != null) {
+    return `${c.maxLines.toLocaleString()} lines per buffer (LURKER_MAX_RETENTION_LINES)`;
+  }
+  if (c.maxLinesState === 'invalid') {
+    return 'LURKER_MAX_RETENTION_LINES is set but unparseable — NOT in effect, see the server log';
+  }
+  return 'none — history is unbounded for users who set no limit';
 });
 
-function formatBytes(n: number): string {
-  if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
-  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
-  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
-}
+const hoursCeilingText = computed(() => {
+  const c = stats.value?.ceilings;
+  if (!c) return '';
+  if (c.maxEventHoursState === 'set' && c.maxEventHours != null) {
+    return `${c.maxEventHours} hours (LURKER_MAX_EVENT_RETENTION_HOURS)`;
+  }
+  if (c.maxEventHoursState === 'invalid') {
+    return 'LURKER_MAX_EVENT_RETENTION_HOURS is set but unparseable — NOT in effect, see the server log';
+  }
+  // Not "off": the per-user default (168h) keeps pruning without a ceiling.
+  return 'none — users default to pruning event noise after a week';
+});
 </script>
 
 <style src="../settings-panes/panes.css"></style>
@@ -111,5 +139,11 @@ function formatBytes(n: number): string {
 }
 .storage-row .who {
   color: var(--fg);
+}
+.actions {
+  display: flex;
+  gap: 1ch;
+  align-items: center;
+  padding-top: var(--space-3);
 }
 </style>

--- a/vue_client/src/utils/adminRegistry.ts
+++ b/vue_client/src/utils/adminRegistry.ts
@@ -30,6 +30,7 @@ export const ADMIN_TABS: readonly AdminTab[] = Object.freeze([
   { id: 'invites', label: 'Invites' },
   { id: 'uploaders', label: 'Uploaders' },
   { id: 'networks', label: 'Networks' },
+  { id: 'storage', label: 'Storage' },
   // { id: 'capabilities', label: 'Capabilities' },
   // { id: 'moderation', label: 'Moderation' },
 ]);

--- a/vue_client/src/utils/formatBytes.ts
+++ b/vue_client/src/utils/formatBytes.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ * Human-readable byte size, four tiers (B / KB / MB / GB). Hoisted so screens
+ * stop growing private copies — DataPane, TransfersModal, and
+ * RecentUploadsModal each carry one today, and they have already drifted
+ * (one caps at MB, one guards zero differently); migrate them here as
+ * they're next touched.
+ */
+export function formatBytes(n: number): string {
+  if (!Number.isFinite(n) || n < 0) return '0 B';
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}

--- a/vue_client/src/views/Admin.vue
+++ b/vue_client/src/views/Admin.vue
@@ -40,6 +40,7 @@ import UsersPane from '../components/admin-panes/UsersPane.vue';
 import InvitesPane from '../components/admin-panes/InvitesPane.vue';
 import UploadersPane from '../components/admin-panes/UploadersPane.vue';
 import NetworksPane from '../components/admin-panes/NetworksPane.vue';
+import StoragePane from '../components/admin-panes/StoragePane.vue';
 
 useSocket();
 
@@ -52,6 +53,7 @@ const PANES: Record<string, Component> = {
   invites: InvitesPane,
   uploaders: UploadersPane,
   networks: NetworksPane,
+  storage: StoragePane,
 };
 
 const activeTabId = computed((): string => {


### PR DESCRIPTION
Final slice of the retention plan: the visibility half of the abuse story. The plan deliberately ships **no per-account quotas** — this pane is how an operator notices buffer-farming before designing any automated defense. Stacked on #844 (base auto-retargets to main when it merges).

## What's here

- **`GET /api/admin/storage`** (inherits the admin gate): database file / WAL / reclaimable-free-page sizes, both retention ceilings **with a state** (`set` / `none` / `invalid` — null alone couldn't distinguish "unset" from "declared but unparseable, fail-open", which is exactly the misread this pane exists to prevent), and per-account line + buffer counts sorted heaviest-first.
- **The walk is chunked** (`db/storageStats.ts`): keyset pages over `idx_messages_net`, index-only, with an event-loop yield between pages — no synchronous slice scales with instance size on the shared connection. Cached 60s, built single-flight, `?refresh=1` busts it after an account deletion.
- **`≈` sizes are self-calibrating**: bytes/row is derived from this instance's own file size ÷ row count (omitted below 10k rows where the division would lie), not a baked reference constant.
- **Storage tab** in the admin panel: sizes, ceilings in plain language ("none — users default to pruning event noise after a week", *not* "off"), per-account list, refresh-now.
- `formatBytes` hoisted to `vue_client/src/utils/` — the client's fourth copy was the trigger; the three existing drifted copies migrate as touched (DataPane's deliberately untouched here to avoid colliding with #845's changes to that file).

Tests: admin gating, payload shape with env scrub, and the invalid-vs-unset ceiling distinction via `?refresh=1`. Full suite 4,237 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)