### PR TITLE
Retention: closed-buffer garbage collection, opt-in (plan PR 5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,13 @@ VAPID_SUBJECT=mailto:you@example.com
 # to keep events as long as chat — but never above this. Unset (or 0) = no
 # ceiling. Same parsing rules as above.
 # LURKER_MAX_EVENT_RETENTION_HOURS=336
+#
+# Closed-buffer garbage collection ceiling: the longest a CLOSED buffer may
+# survive before it is deleted entirely (row + history), in days. Users default
+# to never (0) and can opt in; setting this forces collection for everyone at
+# this age or sooner. Buffers holding a bookmarked message are never deleted.
+# Unset (or 0) = no ceiling. Same parsing rules as above.
+# LURKER_MAX_CLOSED_BUFFER_DAYS=90
 
 # ---------------------------------------------------------------------------
 # Built-in identd (RFC 1413). For MULTI-USER deployments connecting many users

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -2474,6 +2474,17 @@ try {
   console.warn('[db] smart-filter→event-tier migration failed (will retry next boot):', err);
 }
 
+// buffer_id-leading indexes on the two satellite tables that scale with the
+// INSTANCE (not the user): a `DELETE FROM buffers` cascades into eight child
+// tables, and every one of them is keyed (user_id, buffer_id) — without these
+// the cascade full-scans buffer_reads and input_history per deleted buffer.
+// Interactive closes paid that once; closed-buffer GC (retention plan §4.5)
+// deletes buffers in bulk on the shared connection, where a per-delete scan
+// that grows with the instance is the event-loop-starvation class again.
+// After the v18 rebuild on purpose (those tables are recreated there).
+db.exec(`CREATE INDEX IF NOT EXISTS idx_buffer_reads_buffer_id ON buffer_reads(buffer_id)`);
+db.exec(`CREATE INDEX IF NOT EXISTS idx_input_history_buffer_id ON input_history(buffer_id)`);
+
 // Gate on uploaderSeedOk: if the uploader seed threw, leave schema_version
 // un-bumped so the seed retries on the next boot instead of being silently
 // skipped forever (the other version blocks are shape/data-gated, so re-running

--- a/server/db/retention.ts
+++ b/server/db/retention.ts
@@ -264,67 +264,103 @@ const noiseDeleteStmt = db.prepare(`
 // Deleting a whole buffer is the sanctioned policy-driven EXCEPTION to
 // deleteBuffer's "only when no history" contract (db/buffers.ts, the
 // evict/forget guards): the operator or user chose it, per
-// lurker-dev/RETENTION_PLAN.md §4.5. Three rules keep it honest:
-//   1. Eligibility is re-derived every pass from closed_at (julianday, so the
-//      SQLite datetime('now') form close writes and the ISO form imports
-//      stamp compare correctly) — no cursor, the eligible set shrinks to
-//      nothing once collected.
-//   2. A buffer holding ANY bookmarked message is skipped. The probe drives
-//      from the user's bookmarks (few) rather than the buffer's rows (many).
-//   3. Messages are drained in budgeted batches BEFORE the row goes — a
-//      one-statement cascade over a 100k-row buffer would fire the FTS
-//      delete trigger 100k times synchronously on the shared connection.
-//      The final row delete re-checks state = 'closed', so a buffer reopened
-//      mid-drain keeps whatever is left and is never deleted.
+// lurker-dev/RETENTION_PLAN.md §4.5. The rules that keep it honest — and
+// every one of them is enforced IN the statements, not sampled once at
+// listing time, because the drain yields to the event loop between batches
+// and the world moves while it does:
+//   1. Eligibility re-derives from closed_at each pass (julianday, so the
+//      SQLite datetime the close path writes and the ISO imports stamp both
+//      compare correctly); autojoin rows are never dead buffers; server/system
+//      pseudo-buffers store their lines elsewhere.
+//   2. A buffer holding ANY bookmarked message is skipped, and the drain
+//      itself carries the owner-scoped bookmark exemption — a bookmark placed
+//      mid-drain (search reaches closed buffers by design) stops the drain
+//      short and the row delete then refuses because rows remain.
+//   3. Every drain batch and the final row delete re-check state='closed' AND
+//      the age: a buffer reopened mid-drain stops losing rows on the very next
+//      batch, and a reopen-then-reclose (closed_at re-stamped to now) is no
+//      longer old enough. Messages drain in budgeted batches BEFORE the row
+//      goes — one cascading DELETE over a big buffer would fire the FTS
+//      trigger per row synchronously on the shared connection.
+
+// The bookmark exclusion is a bound, non-correlated subquery (materialized
+// once per statement) driving from the user's bookmarks — few — rather than a
+// correlated probe walking each candidate buffer's rows.
+const GC_AGE = `julianday(closed_at) < julianday('now') - ?`;
+const GC_BOOKMARKED_BUFFERS = `
+  SELECT m.buffer_id FROM user_bookmarks ub JOIN messages m ON m.id = ub.message_id
+   WHERE ub.user_id = ? AND m.buffer_id IS NOT NULL`;
 
 const gcEligibleStmt = db.prepare(`
   SELECT id FROM buffers
    WHERE user_id = ? AND state = 'closed' AND closed_at IS NOT NULL
-     AND kind IN ('channel', 'dm')
-     AND julianday(closed_at) < julianday('now') - ?
-   ORDER BY closed_at ASC
+     AND kind NOT IN ('server', 'system') AND autojoin = 0
+     AND ${GC_AGE}
+     AND id NOT IN (${GC_BOOKMARKED_BUFFERS})
    LIMIT ?
 `);
 
-const bookmarkedBuffersStmt = db.prepare(`
-  SELECT DISTINCT m.buffer_id AS bufferId
-    FROM user_bookmarks ub JOIN messages m ON m.id = ub.message_id
-   WHERE ub.user_id = ?
-`);
-
-/** Closed buffers past the user's GC age, oldest-closed first, minus any
- *  that still hold a bookmarked message. */
+/** Closed buffers past the user's GC age, minus any holding a bookmark. */
 export function listGcEligibleBuffers(userId: number, days: number, limit: number): number[] {
-  const protectedIds = new Set(
-    (bookmarkedBuffersStmt.all(userId) as Array<{ bufferId: number }>).map((r) => r.bufferId),
+  return (gcEligibleStmt.all(userId, days, userId, limit) as Array<{ id: number }>).map(
+    (r) => r.id,
   );
-  return (gcEligibleStmt.all(userId, days, limit + protectedIds.size) as Array<{ id: number }>)
-    .map((r) => r.id)
-    .filter((id) => !protectedIds.has(id))
-    .slice(0, limit);
 }
 
 const drainBufferStmt = db.prepare(`
   DELETE FROM messages WHERE id IN (
-    SELECT id FROM messages WHERE buffer_id = ? LIMIT ?
+    SELECT m.id FROM messages m
+      JOIN buffers b ON b.id = m.buffer_id
+     WHERE m.buffer_id = ? AND b.state = 'closed' AND ${GC_AGE.replace('closed_at', 'b.closed_at')}
+       AND NOT EXISTS (
+         SELECT 1 FROM user_bookmarks ub WHERE ub.user_id = ? AND ub.message_id = m.id
+       )
+     LIMIT ?
   )
 `);
 
-/** Delete up to `limit` rows of a buffer being collected. A return below
- *  `limit` means the buffer is empty. */
-export function drainBufferBatch(bufferId: number, limit: number): number {
-  return drainBufferStmt.run(bufferId, limit).changes;
+/** Delete up to `limit` rows of a buffer being collected, while it is still
+ *  closed and still old enough. A return below `limit` means there is
+ *  nothing more this pass may delete: the buffer is empty, or it was
+ *  reopened, or a bookmark now protects a row. */
+export function drainBufferBatch(
+  userId: number,
+  bufferId: number,
+  days: number,
+  limit: number,
+): number {
+  return drainBufferStmt.run(bufferId, days, userId, limit).changes;
 }
 
 const gcDeleteStmt = db.prepare(`
-  DELETE FROM buffers WHERE id = ? AND user_id = ? AND state = 'closed'
+  DELETE FROM buffers
+   WHERE id = ? AND user_id = ? AND state = 'closed' AND ${GC_AGE}
+     AND NOT EXISTS (SELECT 1 FROM messages WHERE buffer_id = buffers.id)
 `);
 
-/** Remove the (drained) buffer row; the FK cascade takes its satellite rows.
- *  Returns false if the buffer was reopened in the meantime — then nothing
- *  is deleted and the next pass re-evaluates it from scratch. */
-export function gcDeleteClosedBuffer(userId: number, bufferId: number): boolean {
-  return gcDeleteStmt.run(bufferId, userId).changes > 0;
+/** Remove the drained buffer row; the FK cascade takes its satellite rows.
+ *  Refuses — returns false, deletes nothing — if the buffer was reopened,
+ *  re-closed too recently, or still holds rows (a mid-drain bookmark). */
+export function gcDeleteClosedBuffer(userId: number, bufferId: number, days: number): boolean {
+  return gcDeleteStmt.run(bufferId, userId, days).changes > 0;
+}
+
+// ─── Import in flight ──────────────────────────────────────────────────────
+// The sweeper skips whole ticks while an import runs: the import commits
+// buffers (with archive closed_at values, possibly years old) before their
+// messages, one transaction per batch with event-loop yields between — GC
+// would collect a half-imported buffer and the rest of the import would mint
+// it anew as an open row (or fail on the bookmark FK). Same idea as the
+// export gate, sourced from a counter rather than a job table.
+let importsInFlight = 0;
+export function beginImport(): void {
+  importsInFlight++;
+}
+export function endImport(): void {
+  importsInFlight = Math.max(0, importsInFlight - 1);
+}
+export function importInProgress(): boolean {
+  return importsInFlight > 0;
 }
 
 /** Delete up to `limit` of this user's noise rows in [sinceIso, cutoffIso) —

--- a/server/db/retention.ts
+++ b/server/db/retention.ts
@@ -259,6 +259,74 @@ const noiseDeleteStmt = db.prepare(`
   )
 `);
 
+// ─── Closed-buffer garbage collection ──────────────────────────────────────
+//
+// Deleting a whole buffer is the sanctioned policy-driven EXCEPTION to
+// deleteBuffer's "only when no history" contract (db/buffers.ts, the
+// evict/forget guards): the operator or user chose it, per
+// lurker-dev/RETENTION_PLAN.md §4.5. Three rules keep it honest:
+//   1. Eligibility is re-derived every pass from closed_at (julianday, so the
+//      SQLite datetime('now') form close writes and the ISO form imports
+//      stamp compare correctly) — no cursor, the eligible set shrinks to
+//      nothing once collected.
+//   2. A buffer holding ANY bookmarked message is skipped. The probe drives
+//      from the user's bookmarks (few) rather than the buffer's rows (many).
+//   3. Messages are drained in budgeted batches BEFORE the row goes — a
+//      one-statement cascade over a 100k-row buffer would fire the FTS
+//      delete trigger 100k times synchronously on the shared connection.
+//      The final row delete re-checks state = 'closed', so a buffer reopened
+//      mid-drain keeps whatever is left and is never deleted.
+
+const gcEligibleStmt = db.prepare(`
+  SELECT id FROM buffers
+   WHERE user_id = ? AND state = 'closed' AND closed_at IS NOT NULL
+     AND kind IN ('channel', 'dm')
+     AND julianday(closed_at) < julianday('now') - ?
+   ORDER BY closed_at ASC
+   LIMIT ?
+`);
+
+const bookmarkedBuffersStmt = db.prepare(`
+  SELECT DISTINCT m.buffer_id AS bufferId
+    FROM user_bookmarks ub JOIN messages m ON m.id = ub.message_id
+   WHERE ub.user_id = ?
+`);
+
+/** Closed buffers past the user's GC age, oldest-closed first, minus any
+ *  that still hold a bookmarked message. */
+export function listGcEligibleBuffers(userId: number, days: number, limit: number): number[] {
+  const protectedIds = new Set(
+    (bookmarkedBuffersStmt.all(userId) as Array<{ bufferId: number }>).map((r) => r.bufferId),
+  );
+  return (gcEligibleStmt.all(userId, days, limit + protectedIds.size) as Array<{ id: number }>)
+    .map((r) => r.id)
+    .filter((id) => !protectedIds.has(id))
+    .slice(0, limit);
+}
+
+const drainBufferStmt = db.prepare(`
+  DELETE FROM messages WHERE id IN (
+    SELECT id FROM messages WHERE buffer_id = ? LIMIT ?
+  )
+`);
+
+/** Delete up to `limit` rows of a buffer being collected. A return below
+ *  `limit` means the buffer is empty. */
+export function drainBufferBatch(bufferId: number, limit: number): number {
+  return drainBufferStmt.run(bufferId, limit).changes;
+}
+
+const gcDeleteStmt = db.prepare(`
+  DELETE FROM buffers WHERE id = ? AND user_id = ? AND state = 'closed'
+`);
+
+/** Remove the (drained) buffer row; the FK cascade takes its satellite rows.
+ *  Returns false if the buffer was reopened in the meantime — then nothing
+ *  is deleted and the next pass re-evaluates it from scratch. */
+export function gcDeleteClosedBuffer(userId: number, bufferId: number): boolean {
+  return gcDeleteStmt.run(bufferId, userId).changes > 0;
+}
+
 /** Delete up to `limit` of this user's noise rows in [sinceIso, cutoffIso) —
  *  the low-water cursor bounds the walk to territory the last completed
  *  sweep hasn't already cleared. A return below `limit` means this user's

--- a/server/db/retention.ts
+++ b/server/db/retention.ts
@@ -272,10 +272,13 @@ const noiseDeleteStmt = db.prepare(`
 //      SQLite datetime the close path writes and the ISO imports stamp both
 //      compare correctly); autojoin rows are never dead buffers; server/system
 //      pseudo-buffers store their lines elsewhere.
-//   2. A buffer holding ANY bookmarked message is skipped, and the drain
-//      itself carries the owner-scoped bookmark exemption — a bookmark placed
-//      mid-drain (search reaches closed buffers by design) stops the drain
-//      short and the row delete then refuses because rows remain.
+//   2. A buffer holding ANY bookmarked message is skipped at listing, and
+//      the drain itself carries the owner-scoped bookmark exemption — a
+//      bookmark placed mid-drain (search reaches closed buffers by design) is
+//      skipped by the remaining batches while the buffer's other rows still
+//      go, and the row delete then refuses because a row remains. The
+//      bookmark can never be cascaded away; the buffer survives, closed,
+//      holding only its bookmarked line(s).
 //   3. Every drain batch and the final row delete re-check state='closed' AND
 //      the age: a buffer reopened mid-drain stops losing rows on the very next
 //      batch, and a reopen-then-reclose (closed_at re-stamped to now) is no

--- a/server/routes/adminStorage.test.ts
+++ b/server/routes/adminStorage.test.ts
@@ -72,6 +72,8 @@ describe('GET /api/admin/storage', () => {
       maxLinesState: 'none',
       maxEventHours: null,
       maxEventHoursState: 'none',
+      maxClosedBufferDays: null,
+      maxClosedBufferDaysState: 'none',
     });
     // Too few rows for a meaningful per-instance ratio → no ≈ estimates.
     expect(res.body.approxBytesPerRow).toBeNull();

--- a/server/routes/adminStorage.ts
+++ b/server/routes/adminStorage.ts
@@ -21,6 +21,7 @@ import { collectStorageAttribution, reclaimableBytes } from '../db/storageStats.
 import {
   declaredRetentionCeilingLines,
   declaredEventRetentionCeilingHours,
+  declaredClosedBufferCeilingDays,
   ceilingState,
 } from '../services/retentionLimits.js';
 
@@ -48,6 +49,7 @@ async function buildPayload(): Promise<Record<string, unknown>> {
   const dbBytes = fileBytes(DATABASE_FILE);
   const maxLines = declaredRetentionCeilingLines();
   const maxEventHours = declaredEventRetentionCeilingHours();
+  const maxClosedBufferDays = declaredClosedBufferCeilingDays();
   return {
     generatedAt: new Date().toISOString(),
     // Derived from THIS instance's file and row count rather than a baked
@@ -69,6 +71,8 @@ async function buildPayload(): Promise<Record<string, unknown>> {
       maxLinesState: ceilingState('LURKER_MAX_RETENTION_LINES', maxLines),
       maxEventHours,
       maxEventHoursState: ceilingState('LURKER_MAX_EVENT_RETENTION_HOURS', maxEventHours),
+      maxClosedBufferDays,
+      maxClosedBufferDaysState: ceilingState('LURKER_MAX_CLOSED_BUFFER_DAYS', maxClosedBufferDays),
     },
     users,
   };

--- a/server/routes/retention.test.ts
+++ b/server/routes/retention.test.ts
@@ -55,14 +55,14 @@ describe('GET /api/retention/limits', () => {
   it('reports null ceilings when the operator declared none', async () => {
     const res = await agent.get('/api/retention/limits');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ maxLines: null, maxEventHours: null });
+    expect(res.body).toEqual({ maxLines: null, maxEventHours: null, maxClosedBufferDays: null });
   });
 
   it('reports the declared ceilings', async () => {
     process.env.LURKER_MAX_RETENTION_LINES = '10000';
     process.env.LURKER_MAX_EVENT_RETENTION_HOURS = '336';
     const res = await agent.get('/api/retention/limits');
-    expect(res.body).toEqual({ maxLines: 10000, maxEventHours: 336 });
+    expect(res.body).toEqual({ maxLines: 10000, maxEventHours: 336, maxClosedBufferDays: null });
   });
 });
 

--- a/server/routes/retention.ts
+++ b/server/routes/retention.ts
@@ -14,6 +14,7 @@ import { requireAuth } from '../middleware/auth.js';
 import {
   declaredRetentionCeilingLines,
   declaredEventRetentionCeilingHours,
+  declaredClosedBufferCeilingDays,
   effectiveRetentionLines,
   effectiveEventRetentionHours,
 } from '../services/retentionLimits.js';
@@ -29,6 +30,7 @@ router.get('/limits', (_req: Request, res: Response) => {
   res.json({
     maxLines: declaredRetentionCeilingLines(),
     maxEventHours: declaredEventRetentionCeilingHours(),
+    maxClosedBufferDays: declaredClosedBufferCeilingDays(),
   });
 });
 

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -30,7 +30,12 @@ import { setImmediate as yieldToEventLoop } from 'node:timers/promises';
 import type { Statement, RunResult } from 'better-sqlite3';
 import db from '../db/index.js';
 import { EXPORT_TABLES, EXPORT_FORMAT_VERSION, IMPORT_ORDER } from '../db/exportSchema.js';
-import { seedAllBuffersDirty, clearNoiseCursorForUser } from '../db/retention.js';
+import {
+  seedAllBuffersDirty,
+  clearNoiseCursorForUser,
+  beginImport,
+  endImport,
+} from '../db/retention.js';
 import { getOption } from './settingsRegistry.js';
 import { isBuiltinThemeId, THEME_POINTER_KEYS } from '../../shared/themePresets.js';
 import themesService from './themesService.js';
@@ -605,6 +610,8 @@ export async function importFromZipFile(
   zipPath: string,
 ): Promise<ImportResult> {
   const { zip, entries } = await openZipEntries(zipPath);
+  // Pauses the retention sweeper for the duration — see importInProgress.
+  beginImport();
   try {
     // ---- manifest ----
     const manifestEntry = entries.get('manifest.json');
@@ -783,6 +790,7 @@ export async function importFromZipFile(
 
     return { manifest, counts, thumbnailsAttached };
   } finally {
+    endImport();
     zip.close();
   }
 }

--- a/server/services/retentionLimits.test.ts
+++ b/server/services/retentionLimits.test.ts
@@ -178,6 +178,13 @@ describe('effectiveClosedBufferDays', () => {
     expect(effectiveClosedBufferDays(userId)).toBe(0);
   });
 
+  it('the operator ceiling carries the same 7-day floor as the user knob', () => {
+    // A 1-day ceiling would force-delete EVERY account's closed buffers after
+    // 24h — the one path that overrides everyone must not skip the footgun rail.
+    process.env.LURKER_MAX_CLOSED_BUFFER_DAYS = '1';
+    expect(effectiveClosedBufferDays(userId)).toBe(0);
+  });
+
   it('a user setting governs; an operator ceiling forces collection for a 0 user', () => {
     setUserSetting(userId, 'data.retention.closed_buffer_days', 30);
     expect(effectiveClosedBufferDays(userId)).toBe(30);

--- a/server/services/retentionLimits.test.ts
+++ b/server/services/retentionLimits.test.ts
@@ -20,6 +20,7 @@ let effectiveRetentionLines: typeof import('./retentionLimits.js').effectiveRete
 let declaredRetentionCeilingLines: typeof import('./retentionLimits.js').declaredRetentionCeilingLines;
 let effectiveEventRetentionHours: typeof import('./retentionLimits.js').effectiveEventRetentionHours;
 let declaredEventRetentionCeilingHours: typeof import('./retentionLimits.js').declaredEventRetentionCeilingHours;
+let effectiveClosedBufferDays: typeof import('./retentionLimits.js').effectiveClosedBufferDays;
 
 let userId: number;
 
@@ -31,6 +32,7 @@ beforeAll(async () => {
     declaredRetentionCeilingLines,
     effectiveEventRetentionHours,
     declaredEventRetentionCeilingHours,
+    effectiveClosedBufferDays,
   } = await import('./retentionLimits.js'));
   userId = createUser('retention-alice').id;
 });
@@ -38,8 +40,10 @@ beforeAll(async () => {
 afterEach(() => {
   delete process.env.LURKER_MAX_RETENTION_LINES;
   delete process.env.LURKER_MAX_EVENT_RETENTION_HOURS;
+  delete process.env.LURKER_MAX_CLOSED_BUFFER_DAYS;
   deleteUserSetting(userId, 'data.retention.lines');
   deleteUserSetting(userId, 'data.retention.event_hours');
+  deleteUserSetting(userId, 'data.retention.closed_buffer_days');
 });
 
 afterAll(() => {
@@ -166,5 +170,20 @@ describe('effectiveEventRetentionHours', () => {
     // instance that upgraded — clamp to the rail and keep enforcing.
     process.env.LURKER_MAX_RETENTION_LINES = '2000000000';
     expect(declaredRetentionCeilingLines()).toBe(1_000_000_000);
+  });
+});
+
+describe('effectiveClosedBufferDays', () => {
+  it('defaults to 0 — closed buffers are kept unless the user opts in', () => {
+    expect(effectiveClosedBufferDays(userId)).toBe(0);
+  });
+
+  it('a user setting governs; an operator ceiling forces collection for a 0 user', () => {
+    setUserSetting(userId, 'data.retention.closed_buffer_days', 30);
+    expect(effectiveClosedBufferDays(userId)).toBe(30);
+    process.env.LURKER_MAX_CLOSED_BUFFER_DAYS = '14';
+    expect(effectiveClosedBufferDays(userId)).toBe(14);
+    setUserSetting(userId, 'data.retention.closed_buffer_days', 0);
+    expect(effectiveClosedBufferDays(userId)).toBe(14);
   });
 });

--- a/server/services/retentionLimits.ts
+++ b/server/services/retentionLimits.ts
@@ -138,6 +138,34 @@ export function declaredEventRetentionCeilingHours(): number | null {
   );
 }
 
+/** The operator's closed-buffer GC ceiling in days, or null when none is
+ *  declared. Fail-open on overflow like hours: a rejected ceiling means LESS
+ *  deletion, which is the safe direction for a whole-buffer delete. */
+export function declaredClosedBufferCeilingDays(): number | null {
+  return parseCeilingEnv(
+    'LURKER_MAX_CLOSED_BUFFER_DAYS',
+    'days',
+    'LURKER_MAX_CLOSED_BUFFER_DAYS=90',
+    36_500,
+    'reject',
+    "Closed buffers are collected only per each user's own setting (default: never).",
+  );
+}
+
+/**
+ * The effective closed-buffer GC age for this user, in days. 0 = never (the
+ * registry default). Same min-of-the-nonzero stacking: a user's 0 under an
+ * operator ceiling resolves to the ceiling — that is how hosted forces
+ * collection without touching anyone's settings.
+ */
+export function effectiveClosedBufferDays(userId: number): number {
+  const settings = { ...defaultsAsObject(), ...getUserSettings(userId) };
+  return clampToCeiling(
+    settings['data.retention.closed_buffer_days'],
+    declaredClosedBufferCeilingDays(),
+  );
+}
+
 /**
  * The user's own global line cap, raw: 0 = unlimited, NO ceiling applied.
  * Split out so the sweeper can resolve it once per user per tick and hand it

--- a/server/services/retentionLimits.ts
+++ b/server/services/retentionLimits.ts
@@ -159,7 +159,7 @@ export function declaredClosedBufferCeilingDays(): number | null {
     'LURKER_MAX_CLOSED_BUFFER_DAYS=90',
     36_500,
     'reject',
-    "Closed buffers are collected only per each user's own setting (default: never).",
+    "Closed buffers are collected only according to each user's own setting (default: never).",
     7,
   );
 }

--- a/server/services/retentionLimits.ts
+++ b/server/services/retentionLimits.ts
@@ -46,6 +46,7 @@ function parseCeilingEnv(
   max: number,
   overflow: 'clamp' | 'reject',
   consequence: string,
+  minNonzero = 0,
 ): number | null {
   const raw = (process.env[name] || '').trim();
   if (!raw) return null;
@@ -75,6 +76,16 @@ function parseCeilingEnv(
     }
     warnCeilingOnce(name, `${name}="${raw}" exceeds the maximum of ${max} ${unit}; using ${max}.`);
     return max;
+  }
+  // The same footgun floor the user knob carries, on the one path that
+  // overrides everyone: a ceiling below it (a units mix-up, a test value left
+  // in cell.env) would force-delete every account's data with no warning.
+  if (value !== 0 && value < minNonzero) {
+    warnCeilingOnce(
+      name,
+      `${name}="${raw}" is below the minimum of ${minNonzero} ${unit}; ignoring it. ${consequence}`,
+    );
+    return null;
   }
   return value === 0 ? null : value;
 }
@@ -149,6 +160,7 @@ export function declaredClosedBufferCeilingDays(): number | null {
     36_500,
     'reject',
     "Closed buffers are collected only per each user's own setting (default: never).",
+    7,
   );
 }
 

--- a/server/services/retentionSweeper.test.ts
+++ b/server/services/retentionSweeper.test.ts
@@ -458,7 +458,7 @@ describe('runRetentionTick', () => {
 
   it('GC collects a buffer closed past the age — row, rows, and FTS — and nothing else', async () => {
     const { userId, bufferId: old } = seedBuffer('gc-old', 6);
-    // A second buffer for the same user/network: closed too recently.
+    // A second buffer for the same user (its own network): closed too recently.
     const recentNet = createNetwork(userId, {
       name: 'gc-r',
       host: 'h',
@@ -475,7 +475,7 @@ describe('runRetentionTick', () => {
       text: 'gcrecent keep',
       self: false,
     });
-    // And one still open, closed_at long ago but reopened (state wins).
+    // And one that is simply open — never eligible.
     const openNet = createNetwork(userId, {
       name: 'gc-o',
       host: 'h',
@@ -526,6 +526,66 @@ describe('runRetentionTick', () => {
     closeBuffer(bufferId, 365);
     await runRetentionTick({ ...OPTS, noiseIntervalMs: 0 });
     expect(bufferExists(bufferId)).toBe(true);
+  });
+
+  it('GC protects a bookmark placed MID-drain: drain stops short, row delete refuses', async () => {
+    // Search reaches closed buffers by design, so a user can bookmark a line
+    // while its buffer is being drained. The exemption lives in the drain
+    // statement itself, not just the listing — and the row delete refuses
+    // while rows remain, so the bookmark can never be cascaded away.
+    const { drainBufferBatch, gcDeleteClosedBuffer } = await import('../db/retention.js');
+    const { userId, ids, bufferId } = seedBuffer('gc-middrain', 5);
+    closeBuffer(bufferId, 30);
+    expect(addBookmark(userId, ids[1])).toBe(true);
+    expect(drainBufferBatch(userId, bufferId, 7, 100)).toBe(4);
+    expect(gcDeleteClosedBuffer(userId, bufferId, 7)).toBe(false);
+    expect(bufferExists(bufferId)).toBe(true);
+    expect(rowIds(bufferId)).toEqual([ids[1]]);
+  });
+
+  it('GC stops draining a buffer that was reopened mid-drain', async () => {
+    const { drainBufferBatch, gcDeleteClosedBuffer } = await import('../db/retention.js');
+    const { userId, ids, bufferId } = seedBuffer('gc-reopen', 8);
+    closeBuffer(bufferId, 30);
+    expect(drainBufferBatch(userId, bufferId, 7, 4)).toBe(4);
+    db.prepare(`UPDATE buffers SET state = 'open', closed_at = NULL WHERE id = ?`).run(bufferId);
+    expect(drainBufferBatch(userId, bufferId, 7, 4)).toBe(0);
+    expect(gcDeleteClosedBuffer(userId, bufferId, 7)).toBe(false);
+    expect(rowIds(bufferId)).toHaveLength(4);
+    expect(ids).toHaveLength(8);
+  });
+
+  it('GC makes progress even under a budget of 2 (no busy-cadence livelock)', async () => {
+    // Reviewer's repro: noise probe + listing exhausted a budget of 2 before
+    // any drain ran, so every tick reported backlog and deleted nothing.
+    const { userId, bufferId } = seedBuffer('gc-tiny-budget', 14);
+    closeBuffer(bufferId, 10);
+    setUserSetting(userId, 'data.retention.closed_buffer_days', 7);
+    let guard = 0;
+    let backlog = true;
+    while (backlog) {
+      if (++guard > 60) throw new Error('GC livelocked under a tiny budget');
+      backlog = (await runRetentionTick({ ...OPTS, noiseIntervalMs: 0, maxBatchesPerTick: 2 }))
+        .backlog;
+    }
+    expect(bufferExists(bufferId)).toBe(false);
+  });
+
+  it('an in-flight import pauses the whole tick, like an export', async () => {
+    const { beginImport, endImport } = await import('../db/retention.js');
+    const { userId, bufferId } = seedBuffer('gc-import', 3);
+    closeBuffer(bufferId, 30);
+    setUserSetting(userId, 'data.retention.closed_buffer_days', 7);
+    beginImport();
+    try {
+      const paused = await runRetentionTick({ ...OPTS, noiseIntervalMs: 0 });
+      expect(paused.buffersExamined).toBe(0);
+      expect(bufferExists(bufferId)).toBe(true);
+    } finally {
+      endImport();
+    }
+    await runRetentionTick({ ...OPTS, noiseIntervalMs: 0 });
+    expect(bufferExists(bufferId)).toBe(false);
   });
 
   it('GC drains a big buffer across ticks under budget, then drops the row', async () => {

--- a/server/services/retentionSweeper.test.ts
+++ b/server/services/retentionSweeper.test.ts
@@ -443,6 +443,106 @@ describe('runRetentionTick', () => {
     expect(getNoiseCursor(user.id)).toBe('');
   });
 
+  // ── Closed-buffer GC ──────────────────────────────────────────────────────
+
+  /** Close a buffer as of `daysAgo` days, in the exact form the close path
+   *  writes (SQLite datetime, not ISO) — the eligibility query must handle it. */
+  function closeBuffer(bufferId: number, daysAgo: number): void {
+    db.prepare(
+      `UPDATE buffers SET state = 'closed', closed_at = datetime('now', ?) WHERE id = ?`,
+    ).run(`-${daysAgo} days`, bufferId);
+  }
+  function bufferExists(bufferId: number): boolean {
+    return !!db.prepare(`SELECT 1 FROM buffers WHERE id = ?`).get(bufferId);
+  }
+
+  it('GC collects a buffer closed past the age — row, rows, and FTS — and nothing else', async () => {
+    const { userId, bufferId: old } = seedBuffer('gc-old', 6);
+    // A second buffer for the same user/network: closed too recently.
+    const recentNet = createNetwork(userId, {
+      name: 'gc-r',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'x',
+    });
+    const recent = insertMessage({
+      networkId: recentNet!.id,
+      target: '#recent',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'x',
+      text: 'gcrecent keep',
+      self: false,
+    });
+    // And one still open, closed_at long ago but reopened (state wins).
+    const openNet = createNetwork(userId, {
+      name: 'gc-o',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'x',
+    });
+    const open = insertMessage({
+      networkId: openNet!.id,
+      target: '#open',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'x',
+      text: 'gcopen keep',
+      self: false,
+    });
+    closeBuffer(old, 10);
+    closeBuffer(recent.bufferId, 2);
+    setUserSetting(userId, 'data.retention.closed_buffer_days', 7);
+    expect(ftsHits('gcold3')).toBe(1);
+
+    const r = await runRetentionTick({ ...OPTS, noiseIntervalMs: 0 });
+
+    expect(r.buffersCollected).toBe(1);
+    expect(r.gcRowsDeleted).toBe(6);
+    expect(bufferExists(old)).toBe(false);
+    expect(ftsHits('gcold3')).toBe(0);
+    expect(bufferExists(recent.bufferId)).toBe(true);
+    expect(rowIds(recent.bufferId)).toHaveLength(1);
+    expect(bufferExists(open.bufferId)).toBe(true);
+  });
+
+  it('GC never collects a closed buffer that still holds a bookmark', async () => {
+    const { userId, ids, bufferId } = seedBuffer('gc-saved', 5);
+    expect(addBookmark(userId, ids[1])).toBe(true);
+    closeBuffer(bufferId, 30);
+    setUserSetting(userId, 'data.retention.closed_buffer_days', 7);
+
+    const r = await runRetentionTick({ ...OPTS, noiseIntervalMs: 0 });
+
+    expect(r.buffersCollected).toBe(0);
+    expect(bufferExists(bufferId)).toBe(true);
+    expect(rowIds(bufferId)).toEqual(ids);
+  });
+
+  it('GC is off by default: a closed-for-a-year buffer survives an untouched user', async () => {
+    const { bufferId } = seedBuffer('gc-default', 3);
+    closeBuffer(bufferId, 365);
+    await runRetentionTick({ ...OPTS, noiseIntervalMs: 0 });
+    expect(bufferExists(bufferId)).toBe(true);
+  });
+
+  it('GC drains a big buffer across ticks under budget, then drops the row', async () => {
+    const { userId, bufferId } = seedBuffer('gc-budget', 14);
+    closeBuffer(bufferId, 10);
+    setUserSetting(userId, 'data.retention.closed_buffer_days', 7);
+
+    let guard = 0;
+    let backlog = true;
+    while (backlog) {
+      if (++guard > 30) throw new Error('GC never converged');
+      backlog = (await runRetentionTick({ ...OPTS, noiseIntervalMs: 0, maxBatchesPerTick: 3 }))
+        .backlog;
+    }
+    expect(bufferExists(bufferId)).toBe(false);
+  });
+
   it('an in-flight export pauses the sweep without losing the dirty set', async () => {
     const { createExportJob, deleteJob } = await import('../db/dataExports.js');
     const { userId, ids, bufferId } = seedBuffer('ret-export', 12);

--- a/server/services/retentionSweeper.ts
+++ b/server/services/retentionSweeper.ts
@@ -37,12 +37,16 @@ import {
   deleteNoiseBatch,
   getNoiseCursor,
   advanceNoiseCursor,
+  listGcEligibleBuffers,
+  drainBufferBatch,
+  gcDeleteClosedBuffer,
 } from '../db/retention.js';
 import { listInflightJobs } from '../db/dataExports.js';
 import {
   effectiveRetentionLines,
   userRetentionLines,
   effectiveEventRetentionHours,
+  effectiveClosedBufferDays,
 } from './retentionLimits.js';
 import settingsService from './settingsService.js';
 import * as systemLog from './systemLog.js';
@@ -75,6 +79,9 @@ export interface RetentionTickResult {
   rowsDeleted: number;
   /** Rows the noise clock deleted (already-aged EARLY_PRUNE_TYPES rows). */
   noiseRowsDeleted: number;
+  /** Closed buffers garbage-collected this tick, and the rows drained doing it. */
+  buffersCollected: number;
+  gcRowsDeleted: number;
   /** Work remained when the tick's budget ran out. */
   backlog: boolean;
 }
@@ -105,6 +112,8 @@ export async function runRetentionTick(
     buffersExamined: 0,
     rowsDeleted: 0,
     noiseRowsDeleted: 0,
+    buffersCollected: 0,
+    gcRowsDeleted: 0,
     backlog: false,
   };
 
@@ -182,43 +191,79 @@ export async function runRetentionTick(
     }
   }
 
-  // ── The noise clock ──────────────────────────────────────────────────────
-  // Per-user, not per-buffer: the cutoff depends only on the owner's setting,
-  // and the partial index walks a user's newly-aged noise in one shape.
-  // Quiet buffers age out here without ever being dirty — the count sweep
-  // can't see them, which is the whole reason this phase exists. Each user's
-  // walk is bounded below by their persisted low-water cursor, so a pass
-  // costs O(rows aged since the last pass), not O(everything ever retained).
+  // ── The hourly per-user pass: noise clock, then closed-buffer GC ────────
+  // Per-user, not per-buffer: both cutoffs depend only on the owner's
+  // settings. Quiet and closed buffers age out here without ever being
+  // dirty — the count sweep can't see them, which is the whole reason this
+  // phase exists. The user queue persists across ticks; a step that runs out
+  // of budget mid-user returns false and the user stays at the head.
+
+  // The noise clock. Each user's walk is bounded below by their persisted
+  // low-water cursor, so a pass costs O(rows aged since the last pass), not
+  // O(everything ever retained).
+  const noiseStep = async (userId: number): Promise<boolean> => {
+    const hours = effectiveEventRetentionHours(userId);
+    if (hours <= 0) return true; // noise clock off for this user
+    const cutoffIso = new Date(Date.now() - hours * 3_600_000).toISOString();
+    const sinceIso = getNoiseCursor(userId);
+    if (sinceIso >= cutoffIso) return true; // nothing has aged past the cutoff since last pass
+    while (batchesSpent < opts.maxBatchesPerTick) {
+      await yieldToLoop();
+      const deleted = deleteNoiseBatch(userId, sinceIso, cutoffIso, opts.batchRows);
+      batchesSpent++;
+      result.noiseRowsDeleted += deleted;
+      if (deleted < opts.batchRows) {
+        // Window clear (survivors are bookmarked). Compare-and-advance, not a
+        // blind set: an insert-side rewind can land during the awaits above,
+        // and this pass's window never covered it.
+        advanceNoiseCursor(userId, sinceIso, cutoffIso);
+        return true;
+      }
+    }
+    return false; // budget died mid-user
+  };
+
+  // Closed-buffer GC (lurker-dev/RETENTION_PLAN.md §4.5). One eligible buffer
+  // at a time: drain its rows in budgeted batches, THEN drop the row — a
+  // single cascading DELETE over a big buffer would fire the FTS trigger
+  // per row synchronously. A buffer reopened mid-drain keeps what's left
+  // (the row delete re-checks state='closed').
+  const gcStep = async (userId: number): Promise<boolean> => {
+    const days = effectiveClosedBufferDays(userId);
+    if (days <= 0) return true; // GC off for this user
+    for (;;) {
+      if (batchesSpent >= opts.maxBatchesPerTick) return false;
+      const [bufferId] = listGcEligibleBuffers(userId, days, 1);
+      batchesSpent++; // the listing + bookmark probe is a real statement
+      if (bufferId === undefined) return true; // nothing (left) to collect
+      let drained = false;
+      while (batchesSpent < opts.maxBatchesPerTick) {
+        await yieldToLoop();
+        const deleted = drainBufferBatch(bufferId, opts.batchRows);
+        batchesSpent++;
+        result.gcRowsDeleted += deleted;
+        if (deleted < opts.batchRows) {
+          drained = true;
+          break;
+        }
+      }
+      if (!drained) return false; // budget died mid-drain; re-listed next pass
+      if (gcDeleteClosedBuffer(userId, bufferId)) {
+        result.buffersCollected++;
+      } else {
+        // Reopened (or otherwise no longer deletable) — don't re-list it in a
+        // tight loop this pass; the next hourly pass re-evaluates from scratch.
+        return true;
+      }
+    }
+  };
+
   if (noisePendingUsers !== null || Date.now() - lastNoiseSweepMs >= opts.noiseIntervalMs) {
     if (noisePendingUsers === null) noisePendingUsers = listUserIds();
     while (noisePendingUsers.length > 0 && batchesSpent < opts.maxBatchesPerTick) {
       const userId = noisePendingUsers[0];
-      const hours = effectiveEventRetentionHours(userId);
-      if (hours <= 0) {
-        noisePendingUsers.shift(); // noise clock off for this user
-        continue;
-      }
-      const cutoffIso = new Date(Date.now() - hours * 3_600_000).toISOString();
-      const sinceIso = getNoiseCursor(userId);
-      if (sinceIso >= cutoffIso) {
-        noisePendingUsers.shift(); // nothing has aged past the cutoff since last pass
-        continue;
-      }
-      let userDone = false;
-      while (batchesSpent < opts.maxBatchesPerTick) {
-        await yieldToLoop();
-        const deleted = deleteNoiseBatch(userId, sinceIso, cutoffIso, opts.batchRows);
-        batchesSpent++;
-        result.noiseRowsDeleted += deleted;
-        if (deleted < opts.batchRows) {
-          userDone = true; // this user's window is clear (survivors are bookmarked)
-          break;
-        }
-      }
-      if (!userDone) break; // budget died mid-user; they stay at the head for next tick
-      // Compare-and-advance, not a blind set: an insert-side rewind can land
-      // during this user's awaits, and the pass's window never covered it.
-      advanceNoiseCursor(userId, sinceIso, cutoffIso);
+      if (!(await noiseStep(userId))) break;
+      if (!(await gcStep(userId))) break;
       noisePendingUsers.shift();
     }
     if (noisePendingUsers.length === 0) {
@@ -249,7 +294,10 @@ export function wireRetentionSettingsListener(): void {
     if (Object.prototype.hasOwnProperty.call(changes, 'data.retention.lines')) {
       seedUserBuffersDirty(userId);
     }
-    if (Object.prototype.hasOwnProperty.call(changes, 'data.retention.event_hours')) {
+    if (
+      Object.prototype.hasOwnProperty.call(changes, 'data.retention.event_hours') ||
+      Object.prototype.hasOwnProperty.call(changes, 'data.retention.closed_buffer_days')
+    ) {
       // Force the clock due (-Infinity is due under ANY interval); if a pass
       // is mid-flight and already past this user, re-queue them so a lowered
       // cutoff acts now instead of next hour.

--- a/server/services/retentionSweeper.ts
+++ b/server/services/retentionSweeper.ts
@@ -40,6 +40,7 @@ import {
   listGcEligibleBuffers,
   drainBufferBatch,
   gcDeleteClosedBuffer,
+  importInProgress,
 } from '../db/retention.js';
 import { listInflightJobs } from '../db/dataExports.js';
 import {
@@ -61,8 +62,9 @@ export interface RetentionSweepOptions {
   idleDelayMs: number;
   /** Delay when the tick ran out of budget with work left. */
   busyDelayMs: number;
-  /** How often a tick also runs the noise clock (age-based pruning of
-   *  EARLY_PRUNE_TYPES). Infinity disables it; 0 runs it every tick. */
+  /** How often a tick also runs the hourly per-user pass — the noise clock
+   *  AND closed-buffer GC (operator ceilings included). Infinity disables
+   *  both; 0 runs them every tick. */
   noiseIntervalMs: number;
 }
 
@@ -99,6 +101,10 @@ const yieldToLoop = () => new Promise<void>((resolve) => setImmediate(resolve));
 // exists to prevent).
 let lastNoiseSweepMs = 0;
 let noisePendingUsers: number[] | null = null;
+// A settings change that lands while a pass is mid-flight asks for a fresh
+// pass right after this one — completion would otherwise overwrite the
+// listener's -Infinity with Date.now() and the change would wait an hour.
+let passRerunRequested = false;
 
 /**
  * One sweep pass over the currently-dirty buffers, plus — when due — the
@@ -125,6 +131,10 @@ export async function runRetentionTick(
   // nothing is forgotten. A crashed job can't wedge this: boot fails orphaned
   // in-flight rows (recoverInterruptedExports).
   if (listInflightJobs().length > 0) return result;
+  // Same for an import: it commits buffers (with archive closed_at values)
+  // before their messages, yielding between batches — GC would collect the
+  // half-imported buffer and the rest of the import would mint it anew.
+  if (importInProgress()) return result;
 
   // Per-tick cap cache: one settings read per owner, not per buffer.
   const capByUser = new Map<number, number>();
@@ -223,38 +233,46 @@ export async function runRetentionTick(
     return false; // budget died mid-user
   };
 
-  // Closed-buffer GC (lurker-dev/RETENTION_PLAN.md §4.5). One eligible buffer
-  // at a time: drain its rows in budgeted batches, THEN drop the row — a
-  // single cascading DELETE over a big buffer would fire the FTS trigger
-  // per row synchronously. A buffer reopened mid-drain keeps what's left
-  // (the row delete re-checks state='closed').
+  // Closed-buffer GC (lurker-dev/RETENTION_PLAN.md §4.5). Lists eligible
+  // buffers once, then per buffer: drain rows in budgeted batches, THEN drop
+  // the row — a single cascading DELETE over a big buffer would fire the FTS
+  // trigger per row synchronously. Every statement re-checks the world
+  // (state, age, bookmarks — see db/retention.ts), and the user's setting is
+  // re-read per buffer so switching GC off mid-tick stops it at the next
+  // buffer. Progress is GUARANTEED per step: the listing and the first drain
+  // batch run even on an exhausted budget (overshooting by ≤2 statements),
+  // otherwise a small budget could be spent entirely on the noise probe and
+  // the listing every tick and never reach a drain — a busy-cadence livelock.
+  const GC_LIST_LIMIT = 50;
   const gcStep = async (userId: number): Promise<boolean> => {
-    const days = effectiveClosedBufferDays(userId);
-    if (days <= 0) return true; // GC off for this user
     for (;;) {
-      if (batchesSpent >= opts.maxBatchesPerTick) return false;
-      const [bufferId] = listGcEligibleBuffers(userId, days, 1);
-      batchesSpent++; // the listing + bookmark probe is a real statement
-      if (bufferId === undefined) return true; // nothing (left) to collect
-      let drained = false;
-      while (batchesSpent < opts.maxBatchesPerTick) {
-        await yieldToLoop();
-        const deleted = drainBufferBatch(bufferId, opts.batchRows);
-        batchesSpent++;
-        result.gcRowsDeleted += deleted;
-        if (deleted < opts.batchRows) {
-          drained = true;
-          break;
-        }
+      const days = effectiveClosedBufferDays(userId);
+      if (days <= 0) return true; // GC off for this user
+      const eligible = listGcEligibleBuffers(userId, days, GC_LIST_LIMIT);
+      batchesSpent++; // the listing (with its bookmark subquery) is a real statement
+      if (eligible.length === 0) return true;
+      for (const bufferId of eligible) {
+        const daysNow = effectiveClosedBufferDays(userId);
+        if (daysNow <= 0) return true; // turned off mid-tick: stop here
+        let drained = false;
+        do {
+          await yieldToLoop();
+          const deleted = drainBufferBatch(userId, bufferId, daysNow, opts.batchRows);
+          batchesSpent++;
+          result.gcRowsDeleted += deleted;
+          if (deleted < opts.batchRows) {
+            drained = true; // empty — or reopened / re-closed / bookmarked, all refused below
+            break;
+          }
+        } while (batchesSpent < opts.maxBatchesPerTick);
+        if (!drained) return false; // budget died mid-drain; re-listed next pass
+        batchesSpent++; // the row delete cascades into eight tables — real work
+        if (gcDeleteClosedBuffer(userId, bufferId, daysNow)) result.buffersCollected++;
+        // A refusal (reopened, re-closed recently, or a bookmark landed) is
+        // simply left alone; the next pass re-derives eligibility from scratch.
+        if (batchesSpent >= opts.maxBatchesPerTick) return false; // user stays at head
       }
-      if (!drained) return false; // budget died mid-drain; re-listed next pass
-      if (gcDeleteClosedBuffer(userId, bufferId)) {
-        result.buffersCollected++;
-      } else {
-        // Reopened (or otherwise no longer deletable) — don't re-list it in a
-        // tight loop this pass; the next hourly pass re-evaluates from scratch.
-        return true;
-      }
+      if (eligible.length < GC_LIST_LIMIT) return true; // that was everything
     }
   };
 
@@ -268,7 +286,8 @@ export async function runRetentionTick(
     }
     if (noisePendingUsers.length === 0) {
       noisePendingUsers = null;
-      lastNoiseSweepMs = Date.now();
+      lastNoiseSweepMs = passRerunRequested ? -Infinity : Date.now();
+      passRerunRequested = false;
     } else {
       result.backlog = true; // the pass resumes from the queue head next tick
     }
@@ -302,8 +321,9 @@ export function wireRetentionSettingsListener(): void {
       // is mid-flight and already past this user, re-queue them so a lowered
       // cutoff acts now instead of next hour.
       lastNoiseSweepMs = -Infinity;
-      if (noisePendingUsers !== null && !noisePendingUsers.includes(userId)) {
-        noisePendingUsers.push(userId);
+      if (noisePendingUsers !== null) {
+        passRerunRequested = true; // the in-flight pass may already be past (or AT) this user
+        if (!noisePendingUsers.includes(userId)) noisePendingUsers.push(userId);
       }
     }
   });

--- a/server/services/settingsRegistry.test.ts
+++ b/server/services/settingsRegistry.test.ts
@@ -72,6 +72,11 @@ describe('validate', () => {
       expect(validate('data.retention.event_hours', 24).ok).toBe(true);
       expect(validate('data.retention.event_hours', 0).ok).toBe(true);
     });
+    it('closed-buffer GC floors at a week — it deletes whole buffers', () => {
+      expect(validate('data.retention.closed_buffer_days', 6).ok).toBe(false);
+      expect(validate('data.retention.closed_buffer_days', 7).ok).toBe(true);
+      expect(validate('data.retention.closed_buffer_days', 0).ok).toBe(true);
+    });
   });
 
   describe('string / color', () => {

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1836,6 +1836,28 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'smallest nonzero limit is 24. 0 keeps events as long as regular ' +
       'messages. Bookmarked messages are never deleted.',
   },
+  // Closed-buffer garbage collection: a buffer closed for longer than this
+  // is deleted ENTIRELY — row and history. Default OFF, deliberately and
+  // unlike the noise clock: closing is sidebar tidiness, not a judgment on
+  // the history (search/highlights reach into closed buffers), and this is
+  // the one knob that deletes chat rather than churn. Hosted can force it
+  // through the ceiling env var LURKER_MAX_CLOSED_BUFFER_DAYS. Buffers still
+  // holding a bookmarked message are always skipped.
+  {
+    key: 'data.retention.closed_buffer_days',
+    label: 'Delete closed buffers after (days)',
+    category: 'data',
+    group: 'retention',
+    type: 'int',
+    min: 0,
+    max: 3650,
+    minNonzero: 7,
+    default: 0,
+    description:
+      'Buffers closed for longer than this many days are deleted entirely, ' +
+      'history included. 0 keeps closed buffers forever; the smallest nonzero ' +
+      'value is 7. Buffers containing a bookmarked message are never deleted.',
+  },
 ]);
 
 const BY_KEY = new Map(REGISTRY.map((opt) => [opt.key, opt] as const));

--- a/vue_client/src/components/admin-panes/StoragePane.vue
+++ b/vue_client/src/components/admin-panes/StoragePane.vue
@@ -32,6 +32,7 @@
            someone comes to check a ceiling that isn't taking effect. -->
       <p class="muted small">Line ceiling: {{ linesCeilingText }}</p>
       <p class="muted small">Event-noise ceiling: {{ hoursCeilingText }}</p>
+      <p class="muted small">Closed-buffer ceiling: {{ daysCeilingText }}</p>
 
       <h3 class="subhead">per account</h3>
       <p v-if="stats.approxBytesPerRow != null" class="muted small">
@@ -76,6 +77,8 @@ interface StorageStats {
     maxLinesState: CeilingState;
     maxEventHours: number | null;
     maxEventHoursState: CeilingState;
+    maxClosedBufferDays: number | null;
+    maxClosedBufferDaysState: CeilingState;
   };
   users: Array<{ id: number; username: string; messageRows: number; buffers: number }>;
 }
@@ -120,6 +123,18 @@ const hoursCeilingText = computed(() => {
   }
   // Not "off": the per-user default (168h) keeps pruning without a ceiling.
   return 'none — users default to pruning event noise after a week';
+});
+
+const daysCeilingText = computed(() => {
+  const c = stats.value?.ceilings;
+  if (!c) return '';
+  if (c.maxClosedBufferDaysState === 'set' && c.maxClosedBufferDays != null) {
+    return `${c.maxClosedBufferDays} days (LURKER_MAX_CLOSED_BUFFER_DAYS) — closed buffers are collected for everyone`;
+  }
+  if (c.maxClosedBufferDaysState === 'invalid') {
+    return 'LURKER_MAX_CLOSED_BUFFER_DAYS is set but unparseable — NOT in effect, see the server log';
+  }
+  return 'none — closed buffers are kept unless a user opts in';
 });
 </script>
 

--- a/vue_client/src/components/settings-panes/DataPane.vue
+++ b/vue_client/src/components/settings-panes/DataPane.vue
@@ -377,7 +377,7 @@ const ceilingNote = computed(() => {
   const sentences: string[] = [];
   if (parts.length) sentences.push(`This server keeps at most ${parts.join(' and ')}.`);
   if (l.maxClosedBufferDays != null) {
-    sentences.push(`Closed buffers are deleted after ${l.maxClosedBufferDays} days.`);
+    sentences.push(`Closed buffers are deleted after at most ${l.maxClosedBufferDays} days.`);
   }
   return sentences.join(' ');
 });

--- a/vue_client/src/components/settings-panes/DataPane.vue
+++ b/vue_client/src/components/settings-panes/DataPane.vue
@@ -374,11 +374,12 @@ const ceilingNote = computed(() => {
   const parts: string[] = [];
   if (l.maxLines != null) parts.push(`${l.maxLines.toLocaleString()} lines per buffer`);
   if (l.maxEventHours != null) parts.push(`${l.maxEventHours} hours of event noise`);
+  const sentences: string[] = [];
+  if (parts.length) sentences.push(`This server keeps at most ${parts.join(' and ')}.`);
   if (l.maxClosedBufferDays != null) {
-    parts.push(`closed buffers for ${l.maxClosedBufferDays} days`);
+    sentences.push(`Closed buffers are deleted after ${l.maxClosedBufferDays} days.`);
   }
-  if (!parts.length) return '';
-  return `This server keeps at most ${parts.join(', ')}.`;
+  return sentences.join(' ');
 });
 
 // ~281 bytes/line all-in (row + indexes + search index), measured on the

--- a/vue_client/src/components/settings-panes/DataPane.vue
+++ b/vue_client/src/components/settings-panes/DataPane.vue
@@ -147,6 +147,31 @@
         </select>
       </div>
     </div>
+
+    <div class="ret-row">
+      <label for="ret-days">Delete closed buffers after</label>
+      <p class="muted small">
+        A buffer closed for longer than this is deleted entirely, history included. Buffers
+        containing a bookmarked message are never deleted.
+      </p>
+      <div class="editor-line">
+        <select
+          id="ret-days"
+          :key="retTick"
+          :value="String(daysValue)"
+          @change="
+            onRetentionChange(
+              'data.retention.closed_buffer_days',
+              ($event.target as HTMLSelectElement).value,
+            )
+          "
+        >
+          <option v-for="p in dayPresets" :key="p.value" :value="String(p.value)">
+            {{ p.label }}
+          </option>
+        </select>
+      </div>
+    </div>
   </section>
 </template>
 
@@ -330,7 +355,11 @@ function formatBytes(n: number): string {
 // ─── Retention ─────────────────────────────────────────────────────────────
 
 const settings = useSettingsStore();
-const limits = ref<{ maxLines: number | null; maxEventHours: number | null } | null>(null);
+const limits = ref<{
+  maxLines: number | null;
+  maxEventHours: number | null;
+  maxClosedBufferDays: number | null;
+} | null>(null);
 onMounted(async () => {
   try {
     limits.value = await api('/api/retention/limits');
@@ -341,11 +370,15 @@ onMounted(async () => {
 
 const ceilingNote = computed(() => {
   const l = limits.value;
-  if (!l || (l.maxLines == null && l.maxEventHours == null)) return '';
+  if (!l) return '';
   const parts: string[] = [];
   if (l.maxLines != null) parts.push(`${l.maxLines.toLocaleString()} lines per buffer`);
   if (l.maxEventHours != null) parts.push(`${l.maxEventHours} hours of event noise`);
-  return `This server keeps at most ${parts.join(' and ')}.`;
+  if (l.maxClosedBufferDays != null) {
+    parts.push(`closed buffers for ${l.maxClosedBufferDays} days`);
+  }
+  if (!parts.length) return '';
+  return `This server keeps at most ${parts.join(', ')}.`;
 });
 
 // ~281 bytes/line all-in (row + indexes + search index), measured on the
@@ -354,9 +387,13 @@ const BYTES_PER_LINE = 281;
 
 const LINE_PRESETS = [0, 1_000, 5_000, 10_000, 25_000, 50_000, 100_000];
 const HOUR_PRESETS = [0, 24, 72, 168, 720];
+const DAY_PRESETS = [0, 7, 30, 90, 365];
 
 const linesValue = computed(() => Number(settings.effective('data.retention.lines') ?? 0));
 const hoursValue = computed(() => Number(settings.effective('data.retention.event_hours') ?? 168));
+const daysValue = computed(() =>
+  Number(settings.effective('data.retention.closed_buffer_days') ?? 0),
+);
 
 // Every label must say what will actually HAPPEN, ceiling included: the
 // server clamps a stored 0 (and any over-ceiling value) TO the ceiling, so
@@ -411,6 +448,26 @@ const hourPresets = computed(() =>
                 ? '30 days'
                 : `${v} hours`,
     (c) => `Server maximum (${c} hours)`,
+  ),
+);
+const dayPresets = computed(() =>
+  presetList(
+    DAY_PRESETS,
+    daysValue.value,
+    limits.value?.maxClosedBufferDays ?? null,
+    (v) =>
+      v === 0
+        ? 'Never'
+        : v === 7
+          ? '1 week'
+          : v === 30
+            ? '30 days'
+            : v === 90
+              ? '90 days'
+              : v === 365
+                ? '1 year'
+                : `${v} days`,
+    (c) => `Server maximum (${c} days)`,
   ),
 );
 


### PR DESCRIPTION
The last slice of the retention plan, prompted by a user question during preview: should closed buffers eventually be collected? Closed buffers already participate in retention (capped like everything else) but never shrink to zero — this adds the option.

## Decision: opt-in, never a default

`data.retention.closed_buffer_days` defaults to **0 (never)**. A 7-day default (matching the noise clock) was considered and rejected: this is the one retention knob that deletes *chat* rather than churn, and closing a DM is sidebar tidiness, not a judgment on its history — a default would silently erase closed DM histories for users who never touched settings. 7 days is the headline preset; hosted can force collection via `LURKER_MAX_CLOSED_BUFFER_DAYS` (a user's 0 under a ceiling resolves to the ceiling, same stack as the other knobs). Floor of 7 on both the user knob and the ceiling.

## Mechanics

- Rides the hourly per-user pass beside the noise clock, same queue, same budget — with **guaranteed progress per step** (a small budget could otherwise be spent on the noise probe + listing every tick and never drain: reproduced, regression-tested).
- Eligibility: `state='closed'`, `closed_at` older than N days via `julianday` (the close path writes SQLite datetime, imports stamp ISO — both compare), not a server/system pseudo-buffer, `autojoin = 0`, and **not holding any bookmarked message** (bound subquery driving from the user's bookmarks).
- Rows are drained in budgeted batches **before** the row delete (one cascading `DELETE` over a big buffer would fire the FTS trigger per row synchronously). Every drain batch and the row delete re-check state + age + bookmarks in the statement itself, so a bookmark placed mid-drain stops the drain and the row delete refuses; a buffer reopened mid-drain stops losing rows on the next batch.
- An in-flight **import pauses the tick** (like an export already did) — GC could otherwise collect a half-imported buffer the rest of the import then minted anew.
- `buffer_id`-leading indexes on `buffer_reads` and `input_history` so the row delete's eight-table cascade doesn't full-scan the two instance-scaled tables.
- Surfaces: Never / 1 week / 30 days / 90 days / 1 year preset in Settings → Data; the ceiling in `/api/retention/limits` and the admin Storage pane (with state).

This is the sanctioned policy-driven exception to `deleteBuffer`'s "only when no history" contract, documented in `db/retention.ts`.

Tests: 4,257 passing — eligibility matrix (old/recent/open/bookmarked/default-off), mid-drain bookmark protection, reopened-mid-drain, tiny-budget convergence, import pause, ceiling floor, resolver forcing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)