### PR TITLE
Engine restore: cap concurrent channel-state refreshes across connections (#842)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -269,7 +269,8 @@ VAPID_SUBJECT=mailto:you@example.com
 # Re-attach refresh cap (engine mode). When the app comes back to connections
 # the engine kept open, each one re-asks the server for its channel state —
 # NAMES/TOPIC/MODE per channel, then a WHO. Within a connection that is paced
-# by the server's replies; this caps how many connections do it at once, so a
+# by the server's replies; this caps how many of those per-channel steps are
+# in flight at once across ALL connections, the rest taking turns, so a
 # restart on a busy instance doesn't land every session's member lists in one
 # event-loop tick (#842). Attaches are never delayed — a session is live the
 # moment it re-attaches; only its member lists wait their turn. A no-op below

--- a/.env.example
+++ b/.env.example
@@ -266,6 +266,18 @@ VAPID_SUBJECT=mailto:you@example.com
 # LURKER_CONNECT_THROTTLE_DISABLED=true      # bypass entirely (connect with no stagger)
 
 # ---------------------------------------------------------------------------
+# Re-attach refresh cap (engine mode). When the app comes back to connections
+# the engine kept open, each one re-asks the server for its channel state —
+# NAMES/TOPIC/MODE per channel, then a WHO. Within a connection that is paced
+# by the server's replies; this caps how many connections do it at once, so a
+# restart on a busy instance doesn't land every session's member lists in one
+# event-loop tick (#842). Attaches are never delayed — a session is live the
+# moment it re-attaches; only its member lists wait their turn. A no-op below
+# the cap. 0 = no cap.
+# ---------------------------------------------------------------------------
+# LURKER_RESTORE_CONCURRENCY=4
+
+# ---------------------------------------------------------------------------
 # DCC / XDCC file-transfer download manager (#270). OFF by default and gated in
 # two tiers: this cell-wide master switch AND a per-user grant (managed by an
 # admin) must both be on before any account can receive files over DCC. Self-host

--- a/.env.example
+++ b/.env.example
@@ -268,13 +268,15 @@ VAPID_SUBJECT=mailto:you@example.com
 # ---------------------------------------------------------------------------
 # Re-attach refresh cap (engine mode). When the app comes back to connections
 # the engine kept open, each one re-asks the server for its channel state —
-# NAMES/TOPIC/MODE per channel, then a WHO. Within a connection that is paced
-# by the server's replies; this caps how many of those per-channel steps are
-# in flight at once across ALL connections, the rest taking turns, so a
-# restart on a busy instance doesn't land every session's member lists in one
+# NAMES/TOPIC/MODE per channel. Within a connection that is paced by the
+# server's replies; this caps how many of those per-channel steps are in
+# flight at once across ALL connections, the rest taking turns, so a restart
+# on a busy instance doesn't land every session's member lists in one
 # event-loop tick (#842). Attaches are never delayed — a session is live the
-# moment it re-attaches; only its member lists wait their turn. A no-op below
-# the cap. 0 = no cap.
+# moment it re-attaches; only its member lists wait their turn. The away-sync
+# WHO each NAMES reply triggers is outside this cap (one at a time per
+# connection, and skipped for channels over LURKER_RESTORE_WHO_MAX_MEMBERS).
+# A no-op below the cap. 0 = no cap.
 # ---------------------------------------------------------------------------
 # LURKER_RESTORE_CONCURRENCY=4
 

--- a/server/engine/engine.test.ts
+++ b/server/engine/engine.test.ts
@@ -15,6 +15,7 @@ import { MAX_BURST_BYTES } from './upstream.js';
 import { FakeIrcd } from '../test-utils/fakeIrcd.js';
 import { TestLink, TEST_INSTANCE } from '../test-utils/engineLink.js';
 import { createIdentdServer } from '../services/identd.js';
+import { until } from '../test-utils/until.js';
 
 const SECRET = 'spike-secret';
 type Attached = Extract<EngineToApp, { op: 'attached' }>;
@@ -75,18 +76,6 @@ async function register(l: TestLink, id: string, nick: string): Promise<void> {
   l.send({ op: 'write', id, line: `NICK ${nick}` });
   l.send({ op: 'write', id, line: `USER ${nick} 0 * :${nick}` });
   await l.waitForLine(id, / 376 /);
-}
-
-function until(pred: () => boolean, ms: number, what: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const deadline = Date.now() + ms;
-    const tick = () => {
-      if (pred()) return resolve();
-      if (Date.now() > deadline) return reject(new Error(`timed out waiting for ${what}`));
-      setTimeout(tick, 10);
-    };
-    tick();
-  });
 }
 
 // A close the app asked for is never answered with `closed` (the app's

--- a/server/server.ts
+++ b/server/server.ts
@@ -61,6 +61,7 @@ import {
 import { startIgnoreSweeper, stopIgnoreSweeper } from './services/ignoreSweeper.js';
 import { sweepTempUploads } from './routes/uploads.js';
 import { startEventLoopMonitor, stopEventLoopMonitor } from './services/eventLoopMonitor.js';
+import restoreGate from './services/restoreGate.js';
 import * as systemMessages from './db/systemMessages.js';
 
 // Wired here rather than inside processGuards (which must stay import-free —
@@ -169,7 +170,9 @@ systemLog.log({ scope: 'server', text: `Lurker server starting up (edition: ${ED
 // Watch for synchronous event-loop stalls (a heavy client-connect snapshot on
 // slow storage can starve IRC socket I/O and trip ping timeouts, dropping every
 // network at once). Console-only; read via `docker logs`. See eventLoopMonitor.
-startEventLoopMonitor();
+// The stall line names the engine-restore refreshes in flight, if any — the
+// known heavy hitter after a re-attach (#842).
+startEventLoopMonitor({ context: () => restoreGate.describeInFlight() });
 
 // Built-in identd (opt-in via LURKER_IDENTD_ENABLED). A multi-user gateway
 // needs it so IRC networks can attribute each user behind the shared IP; bind

--- a/server/services/connectScheduler.ts
+++ b/server/services/connectScheduler.ts
@@ -34,6 +34,7 @@
 // is correct. No persistence, no worker threads.
 
 import { envInt } from '../utils/envInt.js';
+import { parseTruthyEnv } from '../utils/truthyEnv.js';
 
 export interface ConnectSchedulerOptions {
   // Minimum spacing between two launches to the SAME destination host.
@@ -57,10 +58,6 @@ export interface ConnectSchedulerOptions {
 interface Task {
   hostKey: string;
   run: () => void;
-}
-
-function envFlag(name: string): boolean {
-  return /^(1|true|yes|on)$/i.test((process.env[name] || '').trim());
 }
 
 export class ConnectScheduler {
@@ -98,7 +95,7 @@ export class ConnectScheduler {
       perHostMs: envInt('LURKER_CONNECT_THROTTLE_PER_HOST_MS', 2000),
       jitterMs: envInt('LURKER_CONNECT_THROTTLE_JITTER_MS', 2000),
       globalMs: envInt('LURKER_CONNECT_THROTTLE_GLOBAL_MS', 150),
-      disabled: envFlag('LURKER_CONNECT_THROTTLE_DISABLED'),
+      disabled: parseTruthyEnv(process.env.LURKER_CONNECT_THROTTLE_DISABLED),
     });
   }
 

--- a/server/services/connectScheduler.ts
+++ b/server/services/connectScheduler.ts
@@ -33,6 +33,8 @@
 // when the throttle matters, so re-running cold-start from an empty scheduler
 // is correct. No persistence, no worker threads.
 
+import { envInt } from '../utils/envInt.js';
+
 export interface ConnectSchedulerOptions {
   // Minimum spacing between two launches to the SAME destination host.
   perHostMs?: number;
@@ -55,13 +57,6 @@ export interface ConnectSchedulerOptions {
 interface Task {
   hostKey: string;
   run: () => void;
-}
-
-function envInt(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (raw == null || raw.trim() === '') return fallback;
-  const n = Number(raw);
-  return Number.isFinite(n) && n >= 0 ? n : fallback;
 }
 
 function envFlag(name: string): boolean {

--- a/server/services/engineIntegration.test.ts
+++ b/server/services/engineIntegration.test.ts
@@ -27,17 +27,16 @@ import { setUserPaused } from '../db/users.js';
 import type { Network } from '../db/networks.js';
 import { IrcConnection } from './ircConnection.js';
 import ircManager from './ircManager.js';
-import { EngineServer } from '../engine/server.js';
-import { FakeIrcd } from '../test-utils/fakeIrcd.js';
-import {
-  EngineLink,
-  engineConfigured,
-  engineConnectionId,
-  isOurConnectionId,
-} from './engineLink.js';
+import type { EngineServer } from '../engine/server.js';
+import type { FakeIrcd } from '../test-utils/fakeIrcd.js';
+import { startEngineHarness } from '../test-utils/engineHarness.js';
+import type { EngineHarness } from '../test-utils/engineHarness.js';
+import { until as poll } from '../test-utils/until.js';
+import { EngineLink, engineConnectionId, isOurConnectionId } from './engineLink.js';
 
 const SECRET = 'integration-secret';
 
+let harness: EngineHarness;
 let ircd: FakeIrcd;
 let engine: EngineServer;
 let network: Network;
@@ -59,43 +58,18 @@ const rows = (): Row[] =>
     .prepare('SELECT id, type, target, text, nick FROM messages WHERE network_id = ? ORDER BY id')
     .all(network.id) as Row[];
 
-function until(pred: () => boolean, ms = 5000, what = 'condition'): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const deadline = Date.now() + ms;
-    const tick = () => {
-      if (pred()) return resolve();
-      if (Date.now() > deadline) {
-        const conn = ircManager.getConnection(userId, network.id);
-        return reject(
-          new Error(
-            `timed out waiting for ${what}; conn.state=${conn?.state} link=${EngineLink.shared().state} states=${JSON.stringify(stateEvents(managerEvents))} held=${engine.held()}`,
-          ),
-        );
-      }
-      setTimeout(tick, 10);
-    };
-    tick();
+// On a timeout, where things stood: the connection, the link, the manager's
+// state timeline, and what the engine still holds.
+const until = (pred: () => boolean, ms = 5000, what = 'condition') =>
+  poll(pred, ms, what, () => {
+    const conn = ircManager.getConnection(userId, network.id);
+    return `conn.state=${conn?.state} link=${EngineLink.shared().state} states=${JSON.stringify(stateEvents(managerEvents))} held=${engine.held()}`;
   });
-}
 
 beforeAll(async () => {
-  ircd = await FakeIrcd.start();
-  engine = new EngineServer({
-    secret: SECRET,
-    bufferBytes: 64 * 1024,
-    bufferTotalBytes: 1024 * 1024,
-    version: 'test',
-    log: () => {},
-  });
-  const { port } = await engine.listen(0, '127.0.0.1');
-  process.env.LURKER_ENGINE_URL = `tcp://127.0.0.1:${port}`;
-  process.env.LURKER_ENGINE_SECRET = SECRET;
-  process.env.LURKER_ENGINE_RETRY_BASE_MS = '100';
-  // A full-suite CI run starves the event loop; keep the link's heartbeat well
-  // clear of the run so it can't drop a healthy idle link mid-test.
-  process.env.LURKER_ENGINE_HEARTBEAT_MS = '600000';
-  EngineLink.resetForTests();
-  if (!engineConfigured()) throw new Error('engine mode did not switch on');
+  harness = await startEngineHarness({ secret: SECRET });
+  ircd = harness.ircd;
+  engine = harness.engine;
 
   const user = createUser('engine-int');
   userId = user.id;
@@ -115,14 +89,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  ircManager.shutdown();
-  EngineLink.resetForTests();
-  await engine.shutdown('tests done', 500);
-  await ircd.close();
-  delete process.env.LURKER_ENGINE_URL;
-  delete process.env.LURKER_ENGINE_SECRET;
-  delete process.env.LURKER_ENGINE_RETRY_BASE_MS;
-  delete process.env.LURKER_ENGINE_HEARTBEAT_MS;
+  await harness.stop();
 });
 
 const sentBy = (nick: string) => ircd.client(nick)?.sent ?? [];

--- a/server/services/engineIntegration.test.ts
+++ b/server/services/engineIntegration.test.ts
@@ -366,7 +366,11 @@ describe('IrcConnection through the engine', () => {
     ircManager.partChannel(userId, network.id, '#leaving');
     await until(() => conn.state === 'connected', 8000, 'reattached');
     await until(() => !ircd.client('lurk')!.channels.has('#leaving'), 5000, 'the late PART landed');
-    expect(conn.isChannelJoined('#leaving')).toBe(false);
+    // The app's own view settles one hop later than the ircd's: the loss can
+    // cut in before the join's 353/366 were read, and those replay from the
+    // engine backlog AFTER the synthesised JOIN was answered with the PART —
+    // upsertChannel puts the channel back until the PART's echo takes it out.
+    await until(() => !conn.isChannelJoined('#leaving'), 5000, 'the app saw its PART');
     expect(conn.isChannelJoined('#stay')).toBe(true);
   }, 20000);
 

--- a/server/services/engineRestoreConcurrency.test.ts
+++ b/server/services/engineRestoreConcurrency.test.ts
@@ -1,0 +1,304 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Across re-attached connections the channel-state refresh takes turns at a
+// process-wide cap (restoreGate, #842): with the cap at 1, the second
+// connection's first request goes out only after the first connection's last
+// gated reply came in — while the attach itself never waits, and a connection
+// that drops mid-refresh gives its turn up at once rather than at the step
+// deadline. Read off the wire against the engine + fake ircd, like
+// engineRestorePacing.test.ts.
+
+// MUST be first: redirects DATABASE_PATH before anything opens the db.
+import '../test-utils/isolateDb.js';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createUser } from '../db/users.js';
+import { createNetwork } from '../db/networks.js';
+import type { Network } from '../db/networks.js';
+import { IrcConnection } from './ircConnection.js';
+import ircManager from './ircManager.js';
+import { EngineServer } from '../engine/server.js';
+import { FakeIrcd } from '../test-utils/fakeIrcd.js';
+import { EngineLink, engineConfigured } from './engineLink.js';
+
+const SECRET = 'restore-concurrency-secret';
+// Long enough that a slot given up "at the deadline" rather than on the drop
+// is unmistakable in the second test.
+const DEADLINE_MS = 8000;
+
+interface Net {
+  nick: string;
+  channels: string[];
+  network: Network;
+}
+
+let ircd: FakeIrcd;
+let engine: EngineServer;
+let userId: number;
+
+// Every line on the wire, in causal order, tagged with the connection's nick:
+// '>' stamped as the Client writes it, '<' as the fake ircd sends it (before
+// the relay hop, so a reply is always logged ahead of the request it releases).
+interface Wire {
+  t: number;
+  dir: '>' | '<';
+  nick: string;
+  line: string;
+}
+const wire: Wire[] = [];
+
+function until(pred: () => boolean, ms: number, what: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + ms;
+    const tick = () => {
+      if (pred()) return resolve();
+      if (Date.now() > deadline) {
+        const tail = wire
+          .slice(-60)
+          .map((w) => `${w.dir} [${w.nick}] ${w.line}`)
+          .join('\n');
+        return reject(new Error(`timed out waiting for ${what}; last wire lines:\n${tail}`));
+      }
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function numericFor(line: string, numeric: string, chan: string): boolean {
+  return new RegExp(`^\\S+ ${numeric} \\S+ ${chan}\\b`).test(line);
+}
+
+function makeNet(nick: string, channels: string[]): Net {
+  const network = createNetwork(userId, {
+    name: `restore-concurrency-${nick}`,
+    host: '127.0.0.1',
+    port: ircd.port,
+    tls: 0,
+    nick,
+    autoconnect: 0,
+  })!;
+  return { nick, channels, network };
+}
+
+// A first session per network: connect, join, let the join-time WHOs finish
+// (a WHO in flight at detach has its 315 land in the engine backlog and
+// replay to the next session), then let go so the engine holds the socket.
+async function holdInEngine(nets: Net[]): Promise<void> {
+  const conns = nets.map((n) => {
+    const conn = new IrcConnection({ network: n.network, onEvent: () => {} });
+    conn.connect();
+    return conn;
+  });
+  await until(() => conns.every((c) => c.state === 'connected'), 5000, 'first sessions connected');
+  const whoAnswered = new Map<string, Set<string>>();
+  conns.forEach((conn, i) => {
+    const seen = new Set<string>();
+    whoAnswered.set(nets[i].nick, seen);
+    conn.client.on('raw', (ev: { line: string; from_server: boolean }) => {
+      const m = ev.from_server ? /^\S+ 315 \S+ (#\S+)\b/.exec(ev.line) : null;
+      if (m) seen.add(m[1].toLowerCase());
+    });
+    for (const ch of nets[i].channels) conn.join(ch);
+  });
+  await until(
+    () => conns.every((c, i) => nets[i].channels.every((ch) => c.isChannelJoined(ch))),
+    5000,
+    'first sessions joined',
+  );
+  await until(
+    () => nets.every((n) => n.channels.every((ch) => whoAnswered.get(n.nick)!.has(ch))),
+    5000,
+    "first sessions' WHOs answered",
+  );
+  for (const c of conns) c.detach();
+  await until(
+    () => conns.every((c) => c.state === 'disconnected'),
+    5000,
+    'first sessions detached',
+  );
+}
+
+function reattach(net: Net): IrcConnection {
+  const conn = ircManager.startNetwork(userId, net.network.id)!;
+  conn.client.on('raw', (ev: { line: string; from_server: boolean }) => {
+    if (!ev.from_server) wire.push({ t: Date.now(), dir: '>', nick: net.nick, line: ev.line });
+  });
+  return conn;
+}
+
+const sentBy = (nick: string, line: string) =>
+  wire.findIndex((w) => w.dir === '>' && w.nick === nick && w.line === line);
+const gotBy = (nick: string, numeric: string, chan: string) =>
+  wire.findIndex((w) => w.dir === '<' && w.nick === nick && numericFor(w.line, numeric, chan));
+const namesSentBy = (nick: string) =>
+  wire.filter((w) => w.dir === '>' && w.nick === nick && w.line.startsWith('NAMES '));
+
+beforeAll(async () => {
+  ircd = await FakeIrcd.start();
+  ircd.on('sent', (line: string, c: { nick: string | null }) =>
+    wire.push({ t: Date.now(), dir: '<', nick: c.nick ?? '?', line }),
+  );
+  engine = new EngineServer({
+    secret: SECRET,
+    bufferBytes: 64 * 1024,
+    bufferTotalBytes: 1024 * 1024,
+    version: 'test',
+    log: () => {},
+  });
+  const { port } = await engine.listen(0, '127.0.0.1');
+  process.env.LURKER_ENGINE_URL = `tcp://127.0.0.1:${port}`;
+  process.env.LURKER_ENGINE_SECRET = SECRET;
+  process.env.LURKER_ENGINE_RETRY_BASE_MS = '100';
+  // A full-suite CI run starves the event loop; keep the link's heartbeat well
+  // clear of the run so it can't drop a healthy idle link mid-test.
+  process.env.LURKER_ENGINE_HEARTBEAT_MS = '600000';
+  process.env.LURKER_RESTORE_STEP_DEADLINE_MS = String(DEADLINE_MS);
+  process.env.LURKER_RESTORE_CONCURRENCY = '1';
+  EngineLink.resetForTests();
+  if (!engineConfigured()) throw new Error('engine mode did not switch on');
+  userId = createUser('restore-concurrency').id;
+});
+
+afterAll(async () => {
+  ircManager.shutdown();
+  EngineLink.resetForTests();
+  await engine.shutdown('tests done', 500);
+  await ircd.close();
+  delete process.env.LURKER_ENGINE_URL;
+  delete process.env.LURKER_ENGINE_SECRET;
+  delete process.env.LURKER_ENGINE_RETRY_BASE_MS;
+  delete process.env.LURKER_ENGINE_HEARTBEAT_MS;
+  delete process.env.LURKER_RESTORE_STEP_DEADLINE_MS;
+  delete process.env.LURKER_RESTORE_CONCURRENCY;
+});
+
+describe('engine restore concurrency', () => {
+  it('refreshes re-attached connections one at a time at cap 1, with every attach immediate', async () => {
+    const nets = [
+      makeNet('ga', ['#ga1', '#ga2']),
+      makeNet('gb', ['#gb1', '#gb2']),
+      makeNet('gc', ['#gc1', '#gc2']),
+    ];
+    await holdInEngine(nets);
+    wire.length = 0;
+
+    // The app "restarts": every held network comes back in the same tick, as
+    // on a cell. (That the attach itself never waits at the cap is pinned by
+    // the second test, where a held refresh makes the wait observable — here
+    // the fake ircd answers so fast that all three refreshes are over before
+    // the first poll below.)
+    const conns = nets.map(reattach);
+    await until(() => conns.every((c) => c.state === 'connected'), 5000, 'all re-attached');
+
+    // Done when every network's last channel had its WHO answered.
+    const done = (n: Net) => {
+      const last = n.channels[n.channels.length - 1];
+      const who = wire.findIndex(
+        (w) => w.dir === '>' && w.nick === n.nick && w.line.startsWith(`WHO ${last}`),
+      );
+      return (
+        who >= 0 &&
+        wire
+          .slice(who)
+          .some((w) => w.dir === '<' && w.nick === n.nick && numericFor(w.line, '315', last))
+      );
+    };
+    await until(() => nets.every(done), 15000, 'every refresh answered');
+
+    // Each network asked about every channel.
+    for (const n of nets) {
+      for (const ch of n.channels) {
+        for (const cmd of ['NAMES', 'TOPIC', 'MODE']) {
+          expect(sentBy(n.nick, `${cmd} ${ch}`), `${cmd} ${ch}`).toBeGreaterThanOrEqual(0);
+        }
+      }
+    }
+
+    // One connection at a time: the NAMES sends form one contiguous run per
+    // network — no network's refresh starts inside another's.
+    const runs: string[] = [];
+    for (const w of wire) {
+      if (w.dir !== '>' || !w.line.startsWith('NAMES ')) continue;
+      if (runs[runs.length - 1] !== w.nick) runs.push(w.nick);
+    }
+    expect(runs).toHaveLength(nets.length);
+    expect(new Set(runs).size).toBe(nets.length);
+
+    // And each turn is released by the previous connection's LAST gated
+    // reply, not by anything earlier: its umode request (the first thing a
+    // refresh sends) and its first NAMES both follow the previous network's
+    // final 366 / 324 / topic reply.
+    const byNick = new Map(nets.map((n) => [n.nick, n]));
+    for (let i = 1; i < runs.length; i++) {
+      const prev = byNick.get(runs[i - 1])!;
+      const next = byNick.get(runs[i])!;
+      const lastChan = prev.channels[prev.channels.length - 1];
+      const topic = Math.max(gotBy(prev.nick, '331', lastChan), gotBy(prev.nick, '332', lastChan));
+      const lastReply = Math.max(
+        gotBy(prev.nick, '366', lastChan),
+        gotBy(prev.nick, '324', lastChan),
+        topic,
+      );
+      expect(lastReply, `last reply for ${prev.nick}`).toBeGreaterThanOrEqual(0);
+      const umode = sentBy(next.nick, `MODE ${next.nick}`);
+      expect(umode, `umode request from ${next.nick}`).toBeGreaterThanOrEqual(0);
+      expect(umode, `${next.nick}'s umode request after ${prev.nick}'s last reply`).toBeGreaterThan(
+        lastReply,
+      );
+      const firstNames = namesSentBy(next.nick)[0];
+      expect(
+        wire.indexOf(firstNames),
+        `${next.nick}'s first NAMES after ${prev.nick}'s last reply`,
+      ).toBeGreaterThan(lastReply);
+    }
+
+    // Nobody waited on a deadline: each hand-over followed its reply promptly.
+    for (let i = 1; i < runs.length; i++) {
+      const prev = byNick.get(runs[i - 1])!;
+      const next = byNick.get(runs[i])!;
+      const lastChan = prev.channels[prev.channels.length - 1];
+      const tHandOver = namesSentBy(next.nick)[0].t;
+      const tLastNames = wire[sentBy(prev.nick, `NAMES ${lastChan}`)].t;
+      expect(tHandOver - tLastNames).toBeLessThan(DEADLINE_MS / 2);
+    }
+
+    for (const c of conns) c.detach();
+    await until(() => conns.every((c) => c.state === 'disconnected'), 5000, 'detached again');
+  }, 30000);
+
+  it('a connection that drops mid-refresh gives its turn up at once, not at the step deadline', async () => {
+    const a = makeNet('gd', ['#gd1', '#gd2']);
+    const b = makeNet('ge', ['#ge1']);
+    await holdInEngine([a, b]);
+    wire.length = 0;
+
+    // A's first step can only end by the deadline: its TOPIC is never answered.
+    ircd.hold = (cmd, p, c) =>
+      c.nick === a.nick && cmd === 'TOPIC' && (p[0] ?? '').toLowerCase() === '#gd1';
+    try {
+      const connA = reattach(a);
+      await until(() => sentBy(a.nick, 'NAMES #gd1') >= 0, 5000, "A's refresh started");
+      // A holds the only slot. B attaches — live at once — and its refresh
+      // waits.
+      const connB = reattach(b);
+      await until(() => connB.state === 'connected', 5000, 'B re-attached');
+      await sleep(500);
+      expect(connB.state).toBe('connected');
+      expect(namesSentBy(b.nick)).toHaveLength(0);
+      expect(sentBy(b.nick, `MODE ${b.nick}`)).toBe(-1);
+
+      // The server drops A. Its slot comes back with the socket, and B starts
+      // — long before A's held step would have timed out.
+      const tDrop = Date.now();
+      ircd.drop(a.nick);
+      await until(() => namesSentBy(b.nick).length > 0, 5000, "B's refresh started");
+      expect(namesSentBy(b.nick)[0].t - tDrop).toBeLessThan(DEADLINE_MS / 2);
+      expect(connA.state).not.toBe('connected');
+    } finally {
+      ircd.hold = null;
+    }
+  }, 30000);
+});

--- a/server/services/engineRestoreConcurrency.test.ts
+++ b/server/services/engineRestoreConcurrency.test.ts
@@ -2,29 +2,31 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // Across re-attached connections the channel-state refresh takes turns at a
-// process-wide cap (restoreGate, #842): with the cap at 1, the second
-// connection's first request goes out only after the first connection's last
-// gated reply came in — while the attach itself never waits, and a connection
-// that drops mid-refresh gives its turn up at once rather than at the step
-// deadline. Read off the wire against the engine + fake ircd, like
+// process-wide cap, one STEP at a time (restoreGate, #842). With the cap at 1:
+// steps round-robin across connections, a step's turn ends only with its last
+// reply or the deadline (not its first reply), the attach itself never waits,
+// and a connection that drops mid-step gives its turn up at once rather than
+// at the step deadline. Read off the wire against the engine + fake ircd, like
 // engineRestorePacing.test.ts.
 
 // MUST be first: redirects DATABASE_PATH before anything opens the db.
 import '../test-utils/isolateDb.js';
+import { setTimeout as sleep } from 'node:timers/promises';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { createUser } from '../db/users.js';
 import { createNetwork } from '../db/networks.js';
 import type { Network } from '../db/networks.js';
 import { IrcConnection } from './ircConnection.js';
 import ircManager from './ircManager.js';
-import { EngineServer } from '../engine/server.js';
-import { FakeIrcd } from '../test-utils/fakeIrcd.js';
-import { EngineLink, engineConfigured } from './engineLink.js';
+import { startEngineHarness } from '../test-utils/engineHarness.js';
+import type { EngineHarness } from '../test-utils/engineHarness.js';
+import { until as poll } from '../test-utils/until.js';
 
 const SECRET = 'restore-concurrency-secret';
-// Long enough that a slot given up "at the deadline" rather than on the drop
-// is unmistakable in the second test.
-const DEADLINE_MS = 8000;
+// The first test's held step can only end by this deadline: long enough to
+// tell "released by the deadline" from "released by a reply", short enough
+// not to slow the suite. The second test sets its own, longer one.
+const DEADLINE_MS = 1500;
 
 interface Net {
   nick: string;
@@ -32,8 +34,7 @@ interface Net {
   network: Network;
 }
 
-let ircd: FakeIrcd;
-let engine: EngineServer;
+let harness: EngineHarness;
 let userId: number;
 
 // Every line on the wire, in causal order, tagged with the connection's nick:
@@ -46,26 +47,13 @@ interface Wire {
   line: string;
 }
 const wire: Wire[] = [];
-
-function until(pred: () => boolean, ms: number, what: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const deadline = Date.now() + ms;
-    const tick = () => {
-      if (pred()) return resolve();
-      if (Date.now() > deadline) {
-        const tail = wire
-          .slice(-60)
-          .map((w) => `${w.dir} [${w.nick}] ${w.line}`)
-          .join('\n');
-        return reject(new Error(`timed out waiting for ${what}; last wire lines:\n${tail}`));
-      }
-      setTimeout(tick, 10);
-    };
-    tick();
-  });
-}
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const wireTail = () =>
+  'last wire lines:\n' +
+  wire
+    .slice(-60)
+    .map((w) => `${w.dir} [${w.nick}] ${w.line}`)
+    .join('\n');
+const until = (pred: () => boolean, ms: number, what: string) => poll(pred, ms, what, wireTail);
 
 function numericFor(line: string, numeric: string, chan: string): boolean {
   return new RegExp(`^\\S+ ${numeric} \\S+ ${chan}\\b`).test(line);
@@ -75,7 +63,7 @@ function makeNet(nick: string, channels: string[]): Net {
   const network = createNetwork(userId, {
     name: `restore-concurrency-${nick}`,
     host: '127.0.0.1',
-    port: ircd.port,
+    port: harness.ircd.port,
     tls: 0,
     nick,
     autoconnect: 0,
@@ -133,50 +121,29 @@ const sentBy = (nick: string, line: string) =>
   wire.findIndex((w) => w.dir === '>' && w.nick === nick && w.line === line);
 const gotBy = (nick: string, numeric: string, chan: string) =>
   wire.findIndex((w) => w.dir === '<' && w.nick === nick && numericFor(w.line, numeric, chan));
-const namesSentBy = (nick: string) =>
-  wire.filter((w) => w.dir === '>' && w.nick === nick && w.line.startsWith('NAMES '));
+const namesSends = () => wire.filter((w) => w.dir === '>' && w.line.startsWith('NAMES '));
+const namesSentBy = (nick: string) => namesSends().filter((w) => w.nick === nick);
 
 beforeAll(async () => {
-  ircd = await FakeIrcd.start();
-  ircd.on('sent', (line: string, c: { nick: string | null }) =>
+  harness = await startEngineHarness({
+    secret: SECRET,
+    env: {
+      LURKER_RESTORE_CONCURRENCY: '1',
+      LURKER_RESTORE_STEP_DEADLINE_MS: String(DEADLINE_MS),
+    },
+  });
+  harness.ircd.on('sent', (line: string, c: { nick: string | null }) =>
     wire.push({ t: Date.now(), dir: '<', nick: c.nick ?? '?', line }),
   );
-  engine = new EngineServer({
-    secret: SECRET,
-    bufferBytes: 64 * 1024,
-    bufferTotalBytes: 1024 * 1024,
-    version: 'test',
-    log: () => {},
-  });
-  const { port } = await engine.listen(0, '127.0.0.1');
-  process.env.LURKER_ENGINE_URL = `tcp://127.0.0.1:${port}`;
-  process.env.LURKER_ENGINE_SECRET = SECRET;
-  process.env.LURKER_ENGINE_RETRY_BASE_MS = '100';
-  // A full-suite CI run starves the event loop; keep the link's heartbeat well
-  // clear of the run so it can't drop a healthy idle link mid-test.
-  process.env.LURKER_ENGINE_HEARTBEAT_MS = '600000';
-  process.env.LURKER_RESTORE_STEP_DEADLINE_MS = String(DEADLINE_MS);
-  process.env.LURKER_RESTORE_CONCURRENCY = '1';
-  EngineLink.resetForTests();
-  if (!engineConfigured()) throw new Error('engine mode did not switch on');
   userId = createUser('restore-concurrency').id;
 });
 
 afterAll(async () => {
-  ircManager.shutdown();
-  EngineLink.resetForTests();
-  await engine.shutdown('tests done', 500);
-  await ircd.close();
-  delete process.env.LURKER_ENGINE_URL;
-  delete process.env.LURKER_ENGINE_SECRET;
-  delete process.env.LURKER_ENGINE_RETRY_BASE_MS;
-  delete process.env.LURKER_ENGINE_HEARTBEAT_MS;
-  delete process.env.LURKER_RESTORE_STEP_DEADLINE_MS;
-  delete process.env.LURKER_RESTORE_CONCURRENCY;
+  await harness.stop();
 });
 
 describe('engine restore concurrency', () => {
-  it('refreshes re-attached connections one at a time at cap 1, with every attach immediate', async () => {
+  it('runs one step at a time across connections, round-robin, each turn ending with its last reply or the deadline', async () => {
     const nets = [
       makeNet('ga', ['#ga1', '#ga2']),
       makeNet('gb', ['#gb1', '#gb2']),
@@ -185,120 +152,130 @@ describe('engine restore concurrency', () => {
     await holdInEngine(nets);
     wire.length = 0;
 
-    // The app "restarts": every held network comes back in the same tick, as
-    // on a cell. (That the attach itself never waits at the cap is pinned by
-    // the second test, where a held refresh makes the wait observable — here
-    // the fake ircd answers so fast that all three refreshes are over before
-    // the first poll below.)
-    const conns = nets.map(reattach);
-    await until(() => conns.every((c) => c.state === 'connected'), 5000, 'all re-attached');
+    // One step — ga's #ga1 — never gets its 324: its NAMES and TOPIC are
+    // answered at once, and the turn must still not pass until the deadline.
+    // (MODE rather than WHO: the WHO is outside the gate, and irc-framework
+    // serialises WHOs behind their 315.) Everything else answers instantly.
+    const HELD = '#ga1';
+    harness.ircd.hold = (cmd, p, c) =>
+      c.nick === 'ga' && cmd === 'MODE' && (p[0] ?? '').toLowerCase() === HELD;
+    try {
+      // The app "restarts": every held network comes back in the same tick,
+      // as on a cell.
+      const conns = nets.map(reattach);
+      await until(() => conns.every((c) => c.state === 'connected'), 5000, 'all re-attached');
+      // Done when every network's last channel had its WHO answered.
+      const done = (n: Net) => {
+        const last = n.channels[n.channels.length - 1];
+        const who = sentBy(n.nick, `WHO ${last}`);
+        return (
+          who >= 0 &&
+          wire
+            .slice(who)
+            .some((w) => w.dir === '<' && w.nick === n.nick && numericFor(w.line, '315', last))
+        );
+      };
+      await until(() => nets.every(done), DEADLINE_MS + 10000, 'every refresh answered');
 
-    // Done when every network's last channel had its WHO answered.
-    const done = (n: Net) => {
-      const last = n.channels[n.channels.length - 1];
-      const who = wire.findIndex(
-        (w) => w.dir === '>' && w.nick === n.nick && w.line.startsWith(`WHO ${last}`),
-      );
-      return (
-        who >= 0 &&
-        wire
-          .slice(who)
-          .some((w) => w.dir === '<' && w.nick === n.nick && numericFor(w.line, '315', last))
-      );
-    };
-    await until(() => nets.every(done), 15000, 'every refresh answered');
-
-    // Each network asked about every channel.
-    for (const n of nets) {
-      for (const ch of n.channels) {
-        for (const cmd of ['NAMES', 'TOPIC', 'MODE']) {
-          expect(sentBy(n.nick, `${cmd} ${ch}`), `${cmd} ${ch}`).toBeGreaterThanOrEqual(0);
+      // Each network asked about every channel.
+      for (const n of nets) {
+        for (const ch of n.channels) {
+          for (const cmd of ['NAMES', 'TOPIC', 'MODE', 'WHO']) {
+            expect(sentBy(n.nick, `${cmd} ${ch}`), `${cmd} ${ch}`).toBeGreaterThanOrEqual(0);
+          }
         }
       }
-    }
 
-    // One connection at a time: the NAMES sends form one contiguous run per
-    // network — no network's refresh starts inside another's.
-    const runs: string[] = [];
-    for (const w of wire) {
-      if (w.dir !== '>' || !w.line.startsWith('NAMES ')) continue;
-      if (runs[runs.length - 1] !== w.nick) runs.push(w.nick);
-    }
-    expect(runs).toHaveLength(nets.length);
-    expect(new Set(runs).size).toBe(nets.length);
+      // Round-robin: at every point of the NAMES sequence no connection is
+      // more than one step ahead of another (all have the same channel count).
+      const seq = namesSends();
+      const counts = new Map(nets.map((n) => [n.nick, 0]));
+      for (const w of seq) {
+        counts.set(w.nick, counts.get(w.nick)! + 1);
+        const c = [...counts.values()];
+        expect(Math.max(...c) - Math.min(...c), `after ${w.nick} ${w.line}`).toBeLessThanOrEqual(1);
+      }
+      expect(seq).toHaveLength(6);
 
-    // And each turn is released by the previous connection's LAST gated
-    // reply, not by anything earlier: its umode request (the first thing a
-    // refresh sends) and its first NAMES both follow the previous network's
-    // final 366 / 324 / topic reply.
-    const byNick = new Map(nets.map((n) => [n.nick, n]));
-    for (let i = 1; i < runs.length; i++) {
-      const prev = byNick.get(runs[i - 1])!;
-      const next = byNick.get(runs[i])!;
-      const lastChan = prev.channels[prev.channels.length - 1];
-      const topic = Math.max(gotBy(prev.nick, '331', lastChan), gotBy(prev.nick, '332', lastChan));
-      const lastReply = Math.max(
-        gotBy(prev.nick, '366', lastChan),
-        gotBy(prev.nick, '324', lastChan),
-        topic,
-      );
-      expect(lastReply, `last reply for ${prev.nick}`).toBeGreaterThanOrEqual(0);
-      const umode = sentBy(next.nick, `MODE ${next.nick}`);
-      expect(umode, `umode request from ${next.nick}`).toBeGreaterThanOrEqual(0);
-      expect(umode, `${next.nick}'s umode request after ${prev.nick}'s last reply`).toBeGreaterThan(
-        lastReply,
-      );
-      const firstNames = namesSentBy(next.nick)[0];
-      expect(
-        wire.indexOf(firstNames),
-        `${next.nick}'s first NAMES after ${prev.nick}'s last reply`,
-      ).toBeGreaterThan(lastReply);
-    }
+      // One step in flight: each step's turn ended before the next NAMES went
+      // out — with all three replies in, or, for the held step, with the
+      // deadline and not a moment sooner, its two answered replies
+      // notwithstanding.
+      for (let i = 1; i < seq.length; i++) {
+        const prev = seq[i - 1];
+        const next = seq[i];
+        const chan = prev.line.slice('NAMES '.length);
+        const nextIdx = wire.indexOf(next);
+        const topic = Math.max(gotBy(prev.nick, '331', chan), gotBy(prev.nick, '332', chan));
+        expect(topic, `topic reply ${chan}`).toBeGreaterThanOrEqual(0);
+        expect(topic, `topic reply ${chan} before ${next.nick}'s NAMES`).toBeLessThan(nextIdx);
+        const names = gotBy(prev.nick, '366', chan);
+        expect(names, `366 ${chan}`).toBeGreaterThanOrEqual(0);
+        expect(names, `366 ${chan} before ${next.nick}'s NAMES`).toBeLessThan(nextIdx);
+        // The held step alone has no 324 and waits out the deadline (one
+        // clock on both sides, and a timer never fires early); every other
+        // step has its 324 in before the next NAMES and hands over promptly.
+        const held = chan === HELD;
+        const mode = gotBy(prev.nick, '324', chan);
+        const gap = next.t - prev.t;
+        expect(
+          {
+            chan,
+            modeReplyBeforeNext: mode >= 0 && mode < nextIdx,
+            waitedForDeadline: gap >= DEADLINE_MS - 5,
+            handedOverPromptly: gap < DEADLINE_MS / 2,
+          },
+          `turn after ${chan}`,
+        ).toEqual({
+          chan,
+          modeReplyBeforeNext: !held,
+          waitedForDeadline: held,
+          handedOverPromptly: !held,
+        });
+      }
 
-    // Nobody waited on a deadline: each hand-over followed its reply promptly.
-    for (let i = 1; i < runs.length; i++) {
-      const prev = byNick.get(runs[i - 1])!;
-      const next = byNick.get(runs[i])!;
-      const lastChan = prev.channels[prev.channels.length - 1];
-      const tHandOver = namesSentBy(next.nick)[0].t;
-      const tLastNames = wire[sentBy(prev.nick, `NAMES ${lastChan}`)].t;
-      expect(tHandOver - tLastNames).toBeLessThan(DEADLINE_MS / 2);
+      for (const c of conns) c.detach();
+      await until(() => conns.every((c) => c.state === 'disconnected'), 5000, 'detached again');
+    } finally {
+      harness.ircd.hold = null;
     }
-
-    for (const c of conns) c.detach();
-    await until(() => conns.every((c) => c.state === 'disconnected'), 5000, 'detached again');
   }, 30000);
 
-  it('a connection that drops mid-refresh gives its turn up at once, not at the step deadline', async () => {
+  it('a connection that drops mid-step gives its turn up at once, not at the step deadline; the attach never waited', async () => {
+    // Long enough that a turn given up "at the deadline" rather than on the
+    // drop is unmistakable.
+    const LONG_DEADLINE_MS = 8000;
+    process.env.LURKER_RESTORE_STEP_DEADLINE_MS = String(LONG_DEADLINE_MS);
     const a = makeNet('gd', ['#gd1', '#gd2']);
     const b = makeNet('ge', ['#ge1']);
     await holdInEngine([a, b]);
     wire.length = 0;
 
     // A's first step can only end by the deadline: its TOPIC is never answered.
-    ircd.hold = (cmd, p, c) =>
+    harness.ircd.hold = (cmd, p, c) =>
       c.nick === a.nick && cmd === 'TOPIC' && (p[0] ?? '').toLowerCase() === '#gd1';
     try {
       const connA = reattach(a);
-      await until(() => sentBy(a.nick, 'NAMES #gd1') >= 0, 5000, "A's refresh started");
-      // A holds the only slot. B attaches — live at once — and its refresh
+      await until(() => sentBy(a.nick, 'NAMES #gd1') >= 0, 5000, "A's first step started");
+      // A holds the only slot. B attaches — live at once, its umode asked at
+      // once (that is one line, not what the cap bounds) — and its first step
       // waits.
       const connB = reattach(b);
       await until(() => connB.state === 'connected', 5000, 'B re-attached');
       await sleep(500);
       expect(connB.state).toBe('connected');
+      expect(sentBy(b.nick, `MODE ${b.nick}`)).toBeGreaterThanOrEqual(0);
       expect(namesSentBy(b.nick)).toHaveLength(0);
-      expect(sentBy(b.nick, `MODE ${b.nick}`)).toBe(-1);
 
-      // The server drops A. Its slot comes back with the socket, and B starts
-      // — long before A's held step would have timed out.
+      // The server drops A. Its turn comes back with the socket, and B's step
+      // goes out — long before A's held step would have timed out.
       const tDrop = Date.now();
-      ircd.drop(a.nick);
-      await until(() => namesSentBy(b.nick).length > 0, 5000, "B's refresh started");
-      expect(namesSentBy(b.nick)[0].t - tDrop).toBeLessThan(DEADLINE_MS / 2);
+      harness.ircd.drop(a.nick);
+      await until(() => namesSentBy(b.nick).length > 0, 5000, "B's first step started");
+      expect(namesSentBy(b.nick)[0].t - tDrop).toBeLessThan(LONG_DEADLINE_MS / 2);
       expect(connA.state).not.toBe('connected');
     } finally {
-      ircd.hold = null;
+      harness.ircd.hold = null;
     }
   }, 30000);
 });

--- a/server/services/engineRestoreConcurrency.test.ts
+++ b/server/services/engineRestoreConcurrency.test.ts
@@ -19,8 +19,7 @@ import type { Network } from '../db/networks.js';
 import { IrcConnection } from './ircConnection.js';
 import ircManager from './ircManager.js';
 import { startEngineHarness } from '../test-utils/engineHarness.js';
-import type { EngineHarness } from '../test-utils/engineHarness.js';
-import { until as poll } from '../test-utils/until.js';
+import type { EngineHarness, WireLine } from '../test-utils/engineHarness.js';
 
 const SECRET = 'restore-concurrency-secret';
 // The first test's held step can only end by this deadline: long enough to
@@ -35,25 +34,9 @@ interface Net {
 }
 
 let harness: EngineHarness;
+let wire: WireLine[];
 let userId: number;
-
-// Every line on the wire, in causal order, tagged with the connection's nick:
-// '>' stamped as the Client writes it, '<' as the fake ircd sends it (before
-// the relay hop, so a reply is always logged ahead of the request it releases).
-interface Wire {
-  t: number;
-  dir: '>' | '<';
-  nick: string;
-  line: string;
-}
-const wire: Wire[] = [];
-const wireTail = () =>
-  'last wire lines:\n' +
-  wire
-    .slice(-60)
-    .map((w) => `${w.dir} [${w.nick}] ${w.line}`)
-    .join('\n');
-const until = (pred: () => boolean, ms: number, what: string) => poll(pred, ms, what, wireTail);
+const until = (pred: () => boolean, ms: number, what: string) => harness.until(pred, ms, what);
 
 function numericFor(line: string, numeric: string, chan: string): boolean {
   return new RegExp(`^\\S+ ${numeric} \\S+ ${chan}\\b`).test(line);
@@ -107,13 +90,13 @@ async function holdInEngine(nets: Net[]): Promise<void> {
     5000,
     'first sessions detached',
   );
+  // Only the second sessions' lines matter from here.
+  wire.length = 0;
 }
 
 function reattach(net: Net): IrcConnection {
   const conn = ircManager.startNetwork(userId, net.network.id)!;
-  conn.client.on('raw', (ev: { line: string; from_server: boolean }) => {
-    if (!ev.from_server) wire.push({ t: Date.now(), dir: '>', nick: net.nick, line: ev.line });
-  });
+  harness.tap(conn, net.nick);
   return conn;
 }
 
@@ -132,9 +115,7 @@ beforeAll(async () => {
       LURKER_RESTORE_STEP_DEADLINE_MS: String(DEADLINE_MS),
     },
   });
-  harness.ircd.on('sent', (line: string, c: { nick: string | null }) =>
-    wire.push({ t: Date.now(), dir: '<', nick: c.nick ?? '?', line }),
-  );
+  wire = harness.wire;
   userId = createUser('restore-concurrency').id;
 });
 
@@ -150,7 +131,6 @@ describe('engine restore concurrency', () => {
       makeNet('gc', ['#gc1', '#gc2']),
     ];
     await holdInEngine(nets);
-    wire.length = 0;
 
     // One step — ga's #ga1 — never gets its 324: its NAMES and TOPIC are
     // answered at once, and the turn must still not pass until the deadline.
@@ -249,7 +229,6 @@ describe('engine restore concurrency', () => {
     const a = makeNet('gd', ['#gd1', '#gd2']);
     const b = makeNet('ge', ['#ge1']);
     await holdInEngine([a, b]);
-    wire.length = 0;
 
     // A's first step can only end by the deadline: its TOPIC is never answered.
     harness.ircd.hold = (cmd, p, c) =>
@@ -276,6 +255,53 @@ describe('engine restore concurrency', () => {
       expect(connA.state).not.toBe('connected');
     } finally {
       harness.ircd.hold = null;
+    }
+  }, 30000);
+
+  it("replies the last process's in-flight step left in the engine backlog are the restore's, even while the first step is still queued", async () => {
+    // The previous process let go with a step out; its 353/366 arrived at
+    // the engine afterwards and replay to this one right after `restored`.
+    // With the cap full, the channel's own step is still queued when they
+    // land — and they must still be read as the restore's: here, the WHO
+    // size gate (pinned to 0, so every restore WHO is skipped) has to apply
+    // to the replayed 366 as it does to the step's own.
+    process.env.LURKER_RESTORE_STEP_DEADLINE_MS = '8000';
+    process.env.LURKER_RESTORE_WHO_MAX_MEMBERS = '0';
+    const blocker = makeNet('gy', ['#gy1']);
+    const x = makeNet('gx', ['#gx1']);
+    await holdInEngine([blocker, x]);
+    // While no app is attached: the tail of a step the last process had out.
+    harness.ircd.sendRaw(x.nick, ':fake.test 353 gx = #gx1 :gx');
+    harness.ircd.sendRaw(x.nick, ':fake.test 366 gx #gx1 :End of /NAMES list');
+
+    // The blocker takes the only slot with a step that never ends.
+    harness.ircd.hold = (cmd, p, c) =>
+      c.nick === blocker.nick && cmd === 'TOPIC' && (p[0] ?? '').toLowerCase() === '#gy1';
+    try {
+      reattach(blocker);
+      await until(() => sentBy(blocker.nick, 'NAMES #gy1') >= 0, 5000, "blocker's step started");
+      const connX = reattach(x);
+      await until(() => connX.state === 'connected', 5000, 'X re-attached');
+      await sleep(500);
+      // X's step is queued, the replayed 366 has been through the userlist
+      // handler, and no WHO went out for it.
+      expect(namesSentBy(x.nick)).toHaveLength(0);
+      expect(sentBy(x.nick, 'WHO #gx1')).toBe(-1);
+
+      // Once its turn comes the step still asks (the replay is not credited
+      // to it), and its own 366 is gated the same way.
+      harness.ircd.drop(blocker.nick);
+      await until(() => sentBy(x.nick, 'NAMES #gx1') >= 0, 5000, "X's step started");
+      await until(
+        () => wire.filter((w) => w.dir === '<' && numericFor(w.line, '366', '#gx1')).length >= 2,
+        5000,
+        "X's own 366",
+      );
+      await sleep(200);
+      expect(sentBy(x.nick, 'WHO #gx1')).toBe(-1);
+    } finally {
+      harness.ircd.hold = null;
+      delete process.env.LURKER_RESTORE_WHO_MAX_MEMBERS;
     }
   }, 30000);
 });

--- a/server/services/engineRestoreConcurrency.test.ts
+++ b/server/services/engineRestoreConcurrency.test.ts
@@ -42,6 +42,17 @@ function numericFor(line: string, numeric: string, chan: string): boolean {
   return new RegExp(`^\\S+ ${numeric} \\S+ ${chan}\\b`).test(line);
 }
 
+// Set a knob for one test and hand back the way to put it back — the value
+// it had, or unset, so the next test in this file sees what the harness set.
+function setEnv(name: string, value: string): () => void {
+  const prev = process.env[name];
+  process.env[name] = value;
+  return () => {
+    if (prev === undefined) delete process.env[name];
+    else process.env[name] = prev;
+  };
+}
+
 function makeNet(nick: string, channels: string[]): Net {
   const network = createNetwork(userId, {
     name: `restore-concurrency-${nick}`,
@@ -225,7 +236,7 @@ describe('engine restore concurrency', () => {
     // Long enough that a turn given up "at the deadline" rather than on the
     // drop is unmistakable.
     const LONG_DEADLINE_MS = 8000;
-    process.env.LURKER_RESTORE_STEP_DEADLINE_MS = String(LONG_DEADLINE_MS);
+    const restoreDeadline = setEnv('LURKER_RESTORE_STEP_DEADLINE_MS', String(LONG_DEADLINE_MS));
     const a = makeNet('gd', ['#gd1', '#gd2']);
     const b = makeNet('ge', ['#ge1']);
     await holdInEngine([a, b]);
@@ -255,6 +266,7 @@ describe('engine restore concurrency', () => {
       expect(connA.state).not.toBe('connected');
     } finally {
       harness.ircd.hold = null;
+      restoreDeadline();
     }
   }, 30000);
 
@@ -265,8 +277,8 @@ describe('engine restore concurrency', () => {
     // land — and they must still be read as the restore's: here, the WHO
     // size gate (pinned to 0, so every restore WHO is skipped) has to apply
     // to the replayed 366 as it does to the step's own.
-    process.env.LURKER_RESTORE_STEP_DEADLINE_MS = '8000';
-    process.env.LURKER_RESTORE_WHO_MAX_MEMBERS = '0';
+    const restoreDeadline = setEnv('LURKER_RESTORE_STEP_DEADLINE_MS', '8000');
+    const restoreWhoMax = setEnv('LURKER_RESTORE_WHO_MAX_MEMBERS', '0');
     const blocker = makeNet('gy', ['#gy1']);
     const x = makeNet('gx', ['#gx1']);
     await holdInEngine([blocker, x]);
@@ -301,7 +313,8 @@ describe('engine restore concurrency', () => {
       expect(sentBy(x.nick, 'WHO #gx1')).toBe(-1);
     } finally {
       harness.ircd.hold = null;
-      delete process.env.LURKER_RESTORE_WHO_MAX_MEMBERS;
+      restoreWhoMax();
+      restoreDeadline();
     }
   }, 30000);
 });

--- a/server/services/engineRestoreConcurrency.test.ts
+++ b/server/services/engineRestoreConcurrency.test.ts
@@ -20,6 +20,7 @@ import { IrcConnection } from './ircConnection.js';
 import ircManager from './ircManager.js';
 import { startEngineHarness } from '../test-utils/engineHarness.js';
 import type { EngineHarness, WireLine } from '../test-utils/engineHarness.js';
+import { setEnv } from '../test-utils/env.js';
 
 const SECRET = 'restore-concurrency-secret';
 // The first test's held step can only end by this deadline: long enough to
@@ -40,17 +41,6 @@ const until = (pred: () => boolean, ms: number, what: string) => harness.until(p
 
 function numericFor(line: string, numeric: string, chan: string): boolean {
   return new RegExp(`^\\S+ ${numeric} \\S+ ${chan}\\b`).test(line);
-}
-
-// Set a knob for one test and hand back the way to put it back — the value
-// it had, or unset, so the next test in this file sees what the harness set.
-function setEnv(name: string, value: string): () => void {
-  const prev = process.env[name];
-  process.env[name] = value;
-  return () => {
-    if (prev === undefined) delete process.env[name];
-    else process.env[name] = prev;
-  };
 }
 
 function makeNet(nick: string, channels: string[]): Net {

--- a/server/services/engineRestorePacing.test.ts
+++ b/server/services/engineRestorePacing.test.ts
@@ -17,8 +17,7 @@ import { IrcConnection } from './ircConnection.js';
 import ircManager from './ircManager.js';
 import type { FakeIrcd } from '../test-utils/fakeIrcd.js';
 import { startEngineHarness } from '../test-utils/engineHarness.js';
-import type { EngineHarness } from '../test-utils/engineHarness.js';
-import { until as poll } from '../test-utils/until.js';
+import type { EngineHarness, WireLine } from '../test-utils/engineHarness.js';
 
 const SECRET = 'restore-pacing-secret';
 const CHANNELS = ['#p1', '#p2', '#p3', '#p4', '#p5', '#p6'];
@@ -34,26 +33,11 @@ let ircd: FakeIrcd;
 let network: Network;
 let userId: number;
 
-// Every line on the wire, in causal order: '>' is stamped as the Client writes
-// it — the same synchronous chain that arms the step deadline, so the timing
-// assertions read one clock — and '<' as the fake ircd sends it, which is
-// before the relay hop, so a reply is always logged ahead of the request it
-// releases. (Recording both at the Client would log them the other way round:
-// Lurker's own 'raw' handler runs first and writes the next request inside it.)
-interface Wire {
-  t: number;
-  dir: '>' | '<';
-  line: string;
-}
-const wire: Wire[] = [];
-const wireTail = () =>
-  'last wire lines:\n' +
-  wire
-    .slice(-60)
-    .map((w) => `${w.dir} ${w.line}`)
-    .join('\n');
-const until = (pred: () => boolean, ms = 5000, what = 'condition') =>
-  poll(pred, ms, what, wireTail);
+// Every line on the wire, in causal order — the harness's log (see WireLine
+// for why '<' is stamped at the ircd and '>' at the Client); the timing
+// assertions below read one clock because of it.
+let wire: WireLine[];
+const until = (pred: () => boolean, ms: number, what: string) => harness.until(pred, ms, what);
 
 beforeAll(async () => {
   harness = await startEngineHarness({
@@ -61,6 +45,7 @@ beforeAll(async () => {
     env: { LURKER_RESTORE_STEP_DEADLINE_MS: String(DEADLINE_MS) },
   });
   ircd = harness.ircd;
+  wire = harness.wire;
   const user = createUser('restore-pacing');
   userId = user.id;
   network = createNetwork(user.id, {
@@ -96,13 +81,12 @@ describe('engine restore pacing', () => {
     await until(() => whoAnswered.size === CHANNELS.length, 5000, "first session's WHOs answered");
     conn.detach();
     await until(() => conn.state === 'disconnected', 5000, 'detached');
+    // Only the second session's lines matter from here.
+    wire.length = 0;
 
     ircd.hold = (cmd, p) => cmd === 'TOPIC' && (p[0] ?? '').toLowerCase() === HELD;
     const conn2 = ircManager.startNetwork(userId, network.id)!;
-    ircd.on('sent', (line: string) => wire.push({ t: Date.now(), dir: '<', line }));
-    conn2.client.on('raw', (ev: { line: string; from_server: boolean }) => {
-      if (!ev.from_server) wire.push({ t: Date.now(), dir: '>', line: ev.line });
-    });
+    harness.tap(conn2, 'pace');
     await until(() => conn2.state === 'connected', 5000, 'reattached');
     // Done when the last channel's own WHO — the one this session sent — is
     // answered.

--- a/server/services/engineRestorePacing.test.ts
+++ b/server/services/engineRestorePacing.test.ts
@@ -15,9 +15,10 @@ import { createNetwork } from '../db/networks.js';
 import type { Network } from '../db/networks.js';
 import { IrcConnection } from './ircConnection.js';
 import ircManager from './ircManager.js';
-import { EngineServer } from '../engine/server.js';
-import { FakeIrcd } from '../test-utils/fakeIrcd.js';
-import { EngineLink, engineConfigured } from './engineLink.js';
+import type { FakeIrcd } from '../test-utils/fakeIrcd.js';
+import { startEngineHarness } from '../test-utils/engineHarness.js';
+import type { EngineHarness } from '../test-utils/engineHarness.js';
+import { until as poll } from '../test-utils/until.js';
 
 const SECRET = 'restore-pacing-secret';
 const CHANNELS = ['#p1', '#p2', '#p3', '#p4', '#p5', '#p6'];
@@ -28,8 +29,8 @@ const CHANNELS = ['#p1', '#p2', '#p3', '#p4', '#p5', '#p6'];
 const HELD = '#p3';
 const DEADLINE_MS = 1500;
 
+let harness: EngineHarness;
 let ircd: FakeIrcd;
-let engine: EngineServer;
 let network: Network;
 let userId: number;
 
@@ -45,44 +46,21 @@ interface Wire {
   line: string;
 }
 const wire: Wire[] = [];
-
-function until(pred: () => boolean, ms = 5000, what = 'condition'): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const deadline = Date.now() + ms;
-    const tick = () => {
-      if (pred()) return resolve();
-      if (Date.now() > deadline) {
-        const tail = wire
-          .slice(-60)
-          .map((w) => `${w.dir} ${w.line}`)
-          .join('\n');
-        return reject(new Error(`timed out waiting for ${what}; last wire lines:\n${tail}`));
-      }
-      setTimeout(tick, 10);
-    };
-    tick();
-  });
-}
+const wireTail = () =>
+  'last wire lines:\n' +
+  wire
+    .slice(-60)
+    .map((w) => `${w.dir} ${w.line}`)
+    .join('\n');
+const until = (pred: () => boolean, ms = 5000, what = 'condition') =>
+  poll(pred, ms, what, wireTail);
 
 beforeAll(async () => {
-  ircd = await FakeIrcd.start();
-  engine = new EngineServer({
+  harness = await startEngineHarness({
     secret: SECRET,
-    bufferBytes: 64 * 1024,
-    bufferTotalBytes: 1024 * 1024,
-    version: 'test',
-    log: () => {},
+    env: { LURKER_RESTORE_STEP_DEADLINE_MS: String(DEADLINE_MS) },
   });
-  const { port } = await engine.listen(0, '127.0.0.1');
-  process.env.LURKER_ENGINE_URL = `tcp://127.0.0.1:${port}`;
-  process.env.LURKER_ENGINE_SECRET = SECRET;
-  process.env.LURKER_ENGINE_RETRY_BASE_MS = '100';
-  // A full-suite CI run starves the event loop; keep the link's heartbeat well
-  // clear of the run so it can't drop a healthy idle link mid-test.
-  process.env.LURKER_ENGINE_HEARTBEAT_MS = '600000';
-  process.env.LURKER_RESTORE_STEP_DEADLINE_MS = String(DEADLINE_MS);
-  EngineLink.resetForTests();
-  if (!engineConfigured()) throw new Error('engine mode did not switch on');
+  ircd = harness.ircd;
   const user = createUser('restore-pacing');
   userId = user.id;
   network = createNetwork(user.id, {
@@ -96,15 +74,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  ircManager.shutdown();
-  EngineLink.resetForTests();
-  await engine.shutdown('tests done', 500);
-  await ircd.close();
-  delete process.env.LURKER_ENGINE_URL;
-  delete process.env.LURKER_ENGINE_SECRET;
-  delete process.env.LURKER_ENGINE_RETRY_BASE_MS;
-  delete process.env.LURKER_ENGINE_HEARTBEAT_MS;
-  delete process.env.LURKER_RESTORE_STEP_DEADLINE_MS;
+  await harness.stop();
 });
 
 describe('engine restore pacing', () => {

--- a/server/services/engineRestoreWhoGate.test.ts
+++ b/server/services/engineRestoreWhoGate.test.ts
@@ -16,50 +16,30 @@ import { createNetwork } from '../db/networks.js';
 import type { Network } from '../db/networks.js';
 import { IrcConnection } from './ircConnection.js';
 import ircManager from './ircManager.js';
-import { EngineServer } from '../engine/server.js';
-import { FakeIrcd } from '../test-utils/fakeIrcd.js';
-import { EngineLink, engineConfigured } from './engineLink.js';
+import type { FakeIrcd } from '../test-utils/fakeIrcd.js';
+import { startEngineHarness } from '../test-utils/engineHarness.js';
+import type { EngineHarness } from '../test-utils/engineHarness.js';
+import { until } from '../test-utils/until.js';
 
 const SECRET = 'who-gate-secret';
 const CHANNELS = ['#wa', '#wb', '#wc'];
+let harness: EngineHarness;
 let ircd: FakeIrcd;
-let engine: EngineServer;
 let network: Network;
 let userId: number;
 
 const sentBy = (nick: string) => ircd.client(nick)?.sent ?? [];
 
-function until(pred: () => boolean, ms = 5000, what = 'condition'): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const deadline = Date.now() + ms;
-    const tick = () => {
-      if (pred()) return resolve();
-      if (Date.now() > deadline) return reject(new Error(`timed out waiting for ${what}`));
-      setTimeout(tick, 10);
-    };
-    tick();
-  });
-}
-
 beforeAll(async () => {
-  ircd = await FakeIrcd.start();
-  engine = new EngineServer({
+  harness = await startEngineHarness({
     secret: SECRET,
-    bufferBytes: 64 * 1024,
-    bufferTotalBytes: 1024 * 1024,
-    version: 'test',
-    log: () => {},
+    env: {
+      LURKER_RESTORE_STEP_DEADLINE_MS: '1500',
+      // 0 → every restored channel (>= 1 member: us) is over the threshold.
+      LURKER_RESTORE_WHO_MAX_MEMBERS: '0',
+    },
   });
-  const { port } = await engine.listen(0, '127.0.0.1');
-  process.env.LURKER_ENGINE_URL = `tcp://127.0.0.1:${port}`;
-  process.env.LURKER_ENGINE_SECRET = SECRET;
-  process.env.LURKER_ENGINE_RETRY_BASE_MS = '100';
-  process.env.LURKER_ENGINE_HEARTBEAT_MS = '600000';
-  process.env.LURKER_RESTORE_STEP_DEADLINE_MS = '1500';
-  // 0 → every restored channel (>= 1 member: us) is over the threshold.
-  process.env.LURKER_RESTORE_WHO_MAX_MEMBERS = '0';
-  EngineLink.resetForTests();
-  if (!engineConfigured()) throw new Error('engine mode did not switch on');
+  ircd = harness.ircd;
   const user = createUser('who-gate');
   userId = user.id;
   network = createNetwork(user.id, {
@@ -73,16 +53,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  ircManager.shutdown();
-  EngineLink.resetForTests();
-  await engine.shutdown('tests done', 500);
-  await ircd.close();
-  delete process.env.LURKER_ENGINE_URL;
-  delete process.env.LURKER_ENGINE_SECRET;
-  delete process.env.LURKER_ENGINE_RETRY_BASE_MS;
-  delete process.env.LURKER_ENGINE_HEARTBEAT_MS;
-  delete process.env.LURKER_RESTORE_STEP_DEADLINE_MS;
-  delete process.env.LURKER_RESTORE_WHO_MAX_MEMBERS;
+  await harness.stop();
 });
 
 describe('engine restore WHO size-gate', () => {

--- a/server/services/engineTransport.test.ts
+++ b/server/services/engineTransport.test.ts
@@ -16,6 +16,7 @@ import type { Client, ConnectOptions } from 'irc-framework';
 import { EngineServer } from '../engine/server.js';
 import { FakeIrcd } from '../test-utils/fakeIrcd.js';
 import { EngineLink } from './engineLink.js';
+import { until as poll } from '../test-utils/until.js';
 import {
   ENGINE_CLOSE,
   EngineTransport,
@@ -128,21 +129,8 @@ function makeClient(link: EngineLink, id: string, nick: string, opts: { timeoutM
 
 // Poll for a condition; on timeout, say which one and show the timeline so a
 // failure reads as "never saw X after [...]" rather than a bare 5000ms.
-function until(pred: () => boolean, what: string, dump?: () => unknown, ms = 4000): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const deadline = Date.now() + ms;
-    const tick = () => {
-      if (pred()) return resolve();
-      if (Date.now() > deadline) {
-        return reject(
-          new Error(`timed out waiting for ${what}; timeline: ${JSON.stringify(dump?.() ?? null)}`),
-        );
-      }
-      setTimeout(tick, 10);
-    };
-    tick();
-  });
-}
+const until = (pred: () => boolean, what: string, dump?: () => unknown, ms = 4000) =>
+  poll(pred, ms, what, () => `timeline: ${JSON.stringify(dump?.() ?? null)}`);
 
 describe('EngineTransport', () => {
   it('dials fresh through the engine and registers like a socket would', async () => {

--- a/server/services/eventLoopMonitor.test.ts
+++ b/server/services/eventLoopMonitor.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The stall line carries the caller's context when there is one — what was in
+// flight, not just how long — and is unchanged (and unbroken) when there is
+// none or the context provider itself fails.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { startEventLoopMonitor, stopEventLoopMonitor } from './eventLoopMonitor.js';
+
+// Well above the warn threshold so the histogram sees an unambiguous stall on
+// a loaded CI box, well below anything that would slow the suite.
+const BLOCK_MS = 150;
+const WARN_MS = 50;
+
+function block(ms: number): void {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    /* spin: a synchronous stall is the thing under test */
+  }
+}
+
+function until(pred: () => boolean, ms: number, what: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + ms;
+    const tick = () => {
+      if (pred()) return resolve();
+      if (Date.now() > deadline) return reject(new Error(`timed out waiting for ${what}`));
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+async function stallReport(context?: () => string | null): Promise<string> {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  startEventLoopMonitor({ intervalMs: 100, warnMs: WARN_MS, context });
+  // Node's delay histogram takes its first tick after enable() as the
+  // baseline and records nothing for it, so a block that starts before that
+  // tick (20 ms resolution) is invisible. Let it pass.
+  await new Promise((r) => setTimeout(r, 50));
+  block(BLOCK_MS);
+  await until(() => warn.mock.calls.length > 0, 3000, 'a stall report');
+  return String(warn.mock.calls[0][0]);
+}
+
+afterEach(() => {
+  stopEventLoopMonitor();
+  vi.restoreAllMocks();
+});
+
+describe('eventLoopMonitor', () => {
+  it('appends the context to the stall line', async () => {
+    const line = await stallReport(
+      () => 're-attach channel-state refreshes in flight: 2 (net 1 #a, net 2 #b)',
+    );
+    expect(line).toMatch(/^\[event-loop\] stalled ~\d+ms — synchronous work blocked socket I\/O/);
+    expect(line).toMatch(
+      /near this line\); re-attach channel-state refreshes in flight: 2 \(net 1 #a, net 2 #b\)$/,
+    );
+  });
+
+  it('appends nothing when there is no context', async () => {
+    const line = await stallReport(() => null);
+    expect(line).toMatch(/near this line\)$/);
+  });
+
+  it('is unchanged when the context provider throws', async () => {
+    const line = await stallReport(() => {
+      throw new Error('boom');
+    });
+    expect(line).toMatch(/near this line\)$/);
+  });
+});

--- a/server/services/eventLoopMonitor.test.ts
+++ b/server/services/eventLoopMonitor.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { startEventLoopMonitor, stopEventLoopMonitor } from './eventLoopMonitor.js';
+import { until } from '../test-utils/until.js';
 
 // Well above the warn threshold so the histogram sees an unambiguous stall on
 // a loaded CI box, well below anything that would slow the suite.
@@ -18,18 +19,6 @@ function block(ms: number): void {
   while (Date.now() < end) {
     /* spin: a synchronous stall is the thing under test */
   }
-}
-
-function until(pred: () => boolean, ms: number, what: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const deadline = Date.now() + ms;
-    const tick = () => {
-      if (pred()) return resolve();
-      if (Date.now() > deadline) return reject(new Error(`timed out waiting for ${what}`));
-      setTimeout(tick, 10);
-    };
-    tick();
-  });
 }
 
 async function stallReport(context?: () => string | null): Promise<string> {

--- a/server/services/eventLoopMonitor.test.ts
+++ b/server/services/eventLoopMonitor.test.ts
@@ -23,6 +23,9 @@ function block(ms: number): void {
 
 async function stallReport(context?: () => string | null): Promise<string> {
   const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  // A dev shell that exports the kill switch would otherwise make every case
+  // here an opaque timeout.
+  delete process.env.LURKER_EVENT_LOOP_MONITOR_DISABLED;
   startEventLoopMonitor({ intervalMs: 100, warnMs: WARN_MS, context });
   // Node's delay histogram takes its first tick after enable() as the
   // baseline and records nothing for it, so a block that starts before that

--- a/server/services/eventLoopMonitor.ts
+++ b/server/services/eventLoopMonitor.ts
@@ -39,8 +39,15 @@ function envFlag(name: string): boolean {
 
 // intervalMs: how often we poll the histogram for its window max. warnMs:
 // minimum stall (max delay seen in a window) worth logging — below this is
-// normal scheduler jitter, not a stall.
-export function startEventLoopMonitor(opts: { intervalMs?: number; warnMs?: number } = {}): void {
+// normal scheduler jitter, not a stall. context: what to append to the line —
+// which subsystem's work is in flight — so the next report says where the time
+// went, not just how long. Sampled at the poll, i.e. just AFTER the stall it
+// reports (the stall itself is synchronous, so nothing can sample during it);
+// a null/empty answer appends nothing, and a throw is swallowed — the monitor
+// must never be the thing that fails on the stall path.
+export function startEventLoopMonitor(
+  opts: { intervalMs?: number; warnMs?: number; context?: () => string | null } = {},
+): void {
   if (envFlag('LURKER_EVENT_LOOP_MONITOR_DISABLED')) return;
   if (timer) return;
   // Floor the poll interval so a misconfigured 0/tiny value can't turn into a
@@ -60,9 +67,19 @@ export function startEventLoopMonitor(opts: { intervalMs?: number; warnMs?: numb
     const maxMs = Math.round(h.max / 1e6);
     h.reset();
     if (maxMs >= warnMs) {
+      let context = '';
+      if (opts.context) {
+        try {
+          const c = opts.context();
+          if (c) context = `; ${c}`;
+        } catch (_) {
+          /* never let a describe() break the monitor */
+        }
+      }
       console.warn(
         `[event-loop] stalled ~${maxMs}ms — synchronous work blocked socket I/O ` +
-          `(a stall past ~120s trips IRC ping timeouts; watch for a reconnect burst near this line)`,
+          `(a stall past ~120s trips IRC ping timeouts; watch for a reconnect burst near this line)` +
+          context,
       );
     }
   }, intervalMs);

--- a/server/services/eventLoopMonitor.ts
+++ b/server/services/eventLoopMonitor.ts
@@ -23,13 +23,10 @@
 
 import { monitorEventLoopDelay, type IntervalHistogram } from 'node:perf_hooks';
 import { envInt } from '../utils/envInt.js';
+import { parseTruthyEnv } from '../utils/truthyEnv.js';
 
 let timer: ReturnType<typeof setInterval> | null = null;
 let histogram: IntervalHistogram | null = null;
-
-function envFlag(name: string): boolean {
-  return /^(1|true|yes|on)$/i.test((process.env[name] || '').trim());
-}
 
 // intervalMs: how often we poll the histogram for its window max. warnMs:
 // minimum stall (max delay seen in a window) worth logging — below this is
@@ -42,7 +39,7 @@ function envFlag(name: string): boolean {
 export function startEventLoopMonitor(
   opts: { intervalMs?: number; warnMs?: number; context?: () => string | null } = {},
 ): void {
-  if (envFlag('LURKER_EVENT_LOOP_MONITOR_DISABLED')) return;
+  if (parseTruthyEnv(process.env.LURKER_EVENT_LOOP_MONITOR_DISABLED)) return;
   if (timer) return;
   // Floor the poll interval so a misconfigured 0/tiny value can't turn into a
   // setInterval(0) hot loop; 100ms is plenty fine-grained for reporting the

--- a/server/services/eventLoopMonitor.ts
+++ b/server/services/eventLoopMonitor.ts
@@ -22,16 +22,10 @@
 // Cheap: the histogram samples in native code; the poll is one read per second.
 
 import { monitorEventLoopDelay, type IntervalHistogram } from 'node:perf_hooks';
+import { envInt } from '../utils/envInt.js';
 
 let timer: ReturnType<typeof setInterval> | null = null;
 let histogram: IntervalHistogram | null = null;
-
-function envInt(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (raw == null || raw.trim() === '') return fallback;
-  const n = Number(raw);
-  return Number.isFinite(n) && n >= 0 ? n : fallback;
-}
 
 function envFlag(name: string): boolean {
   return /^(1|true|yes|on)$/i.test((process.env[name] || '').trim());

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -4064,6 +4064,20 @@ export class IrcConnection {
         });
         this.rawQuiet('MODE', this.currentNick);
         this.restoreQueue = [...this.channels.values()].map((ch) => ch.name);
+        // Every queued channel is marked quiet now, not when its own step goes
+        // out: the LAST process may have let go with a step in flight, and
+        // that step's replies sit in the engine backlog, delivered right after
+        // this phase — the size gate on the WHO and the server-buffer filter
+        // must read them as the restore's. With the cap full, even the first
+        // channel's step can still be queued when they land. Each step re-marks
+        // its channel as it goes out, so a long wait cannot outlive the window.
+        for (const name of this.restoreQueue) {
+          this.restoreQuiet.set(name.toLowerCase(), {
+            until: Date.now() + RESTORE_QUIET_MS,
+            mode: true,
+            topic: true,
+          });
+        }
         this.drainRestoreQueue();
         // A socket the engine registered on its own never had its
         // post-registration steps: the connect commands run now, and the
@@ -4156,7 +4170,10 @@ export class IrcConnection {
   // are free slots queues its next step behind everyone already waiting —
   // round-robin, every session's first member list early, rather than one
   // connection's whole walk at a time. Under the cap the step goes out
-  // synchronously, so a small instance sees no change.
+  // synchronously, so a small instance sees no change. The turn ends with the
+  // step's replies, so the WHO those trigger is outside the cap too — one in
+  // flight per connection (the framework's queue), size-gated, but across
+  // connections as parallel as before.
   private drainRestoreQueue(): void {
     this.endRestoreStep();
     // Skip what we are no longer in (a backlog KICK may have arrived in
@@ -4176,32 +4193,45 @@ export class IrcConnection {
   // The step itself, once it has its turn. Membership is checked again here:
   // a backlog KICK may have landed while the turn was queued, and a request
   // for a channel we are no longer in would resurrect it with the replies.
+  // A throw anywhere in here moves on to the next channel rather than ending
+  // the walk: the gate would drop the slot and log, but nothing else would
+  // ever call back for this connection — no reply can retire a step that was
+  // never set, and no deadline was armed.
   private sendRestoreStep(name: string): void {
     if (!this.isChannelJoined(name)) {
       this.drainRestoreQueue();
       return;
     }
-    this.restoreQuiet.set(name.toLowerCase(), {
-      until: Date.now() + RESTORE_QUIET_MS,
-      mode: true,
-      topic: true,
-    });
-    // Keyed by the network's own fold: the replies echo the channel as the
-    // server spells it, which on an rfc1459 network is not a toLowerCase away.
-    this.restoreStep = {
-      key: foldTargetFor(this.network.id, name),
-      owed: new Set(['names', 'topic', 'mode']),
-    };
-    this.rawQuiet('NAMES', name);
-    this.rawQuiet('TOPIC', name);
-    this.rawQuiet('MODE', name);
-    this.restoreTimer = setTimeout(
-      () => {
-        this.restoreTimer = null;
-        if (!this.disposed && this.state === 'connected') this.drainRestoreQueue();
-      },
-      Math.max(1, reconnectEnvInt('LURKER_RESTORE_STEP_DEADLINE_MS', RESTORE_STEP_DEADLINE_MS)),
-    );
+    try {
+      this.restoreQuiet.set(name.toLowerCase(), {
+        until: Date.now() + RESTORE_QUIET_MS,
+        mode: true,
+        topic: true,
+      });
+      // Keyed by the network's own fold: the replies echo the channel as the
+      // server spells it, which on an rfc1459 network is not a toLowerCase
+      // away.
+      this.restoreStep = {
+        key: foldTargetFor(this.network.id, name),
+        owed: new Set(['names', 'topic', 'mode']),
+      };
+      this.rawQuiet('NAMES', name);
+      this.rawQuiet('TOPIC', name);
+      this.rawQuiet('MODE', name);
+      this.restoreTimer = setTimeout(
+        () => {
+          this.restoreTimer = null;
+          if (!this.disposed && this.state === 'connected') this.drainRestoreQueue();
+        },
+        Math.max(1, reconnectEnvInt('LURKER_RESTORE_STEP_DEADLINE_MS', RESTORE_STEP_DEADLINE_MS)),
+      );
+    } catch (err) {
+      console.warn(
+        `[irc] restore: step for ${name} on network ${this.network.id} threw; skipping it:`,
+        (err as Error)?.message || err,
+      );
+      this.drainRestoreQueue();
+    }
   }
 
   // A server line naming the in-flight step's channel: retire the reply it is,

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -41,6 +41,7 @@ import ignoreRulesService from './ignoreRulesService.js';
 import connectScheduler from './connectScheduler.js';
 import restoreGate from './restoreGate.js';
 import type { RestoreSlot } from './restoreGate.js';
+import { envInt as reconnectEnvInt } from '../utils/envInt.js';
 import { decideStamp } from './insertDecisions.js';
 import * as systemLog from './systemLog.js';
 import { effectiveSetting, effectiveSettings } from './settingsService.js';
@@ -258,13 +259,6 @@ const SEND_REJECTION_ATTRIBUTION_MS = 15000;
 // EXCEPT a confidently-classified terminal reason (a detected ban or a hard SASL
 // auth failure), where retrying can't help and hammering an actively-rejecting
 // server is antisocial — those stop and require a manual reconnect.
-
-function reconnectEnvInt(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (raw == null || raw.trim() === '') return fallback;
-  const n = Number(raw);
-  return Number.isFinite(n) && n >= 0 ? n : fallback;
-}
 
 // First-retry delay; each subsequent attempt doubles up to the cap.
 const RECONNECT_BASE_MS = reconnectEnvInt('LURKER_RECONNECT_BASE_MS', 2000);
@@ -726,9 +720,9 @@ export class IrcConnection {
   // The restore step in flight: the folded channel and which of its replies
   // are still owed. Null between steps and outside a restore.
   private restoreStep: { key: string; owed: Set<RestoreReply> } | null;
-  // This connection's turn at the process-wide refresh cap (restoreGate):
-  // waiting or held from `restored` until the queue drains or the restore is
-  // abandoned. Null outside a restore.
+  // The step's turn at the process-wide cap (restoreGate): reserved when the
+  // step is queued, held while its requests are out, given back with the step.
+  // Null between steps and outside a restore, like restoreStep.
   private restoreSlot: RestoreSlot | null;
   private engineTransport: EngineTransport | null;
   private engineSocketAlive: boolean;
@@ -4058,10 +4052,19 @@ export class IrcConnection {
         // 353/366, no 332, and the join handler's MODE is skipped on a restore —
         // so ask, one channel at a time, each waiting for the last one's
         // replies (drainRestoreQueue), keeping each channel's replies out of
-        // the server buffer until they arrive. Across connections the asking
-        // waits its turn at the process-wide cap (beginRestoreRefresh).
+        // the server buffer until they arrive. Across connections each step
+        // also takes a turn at the process-wide cap (see drainRestoreQueue).
+        // Our umodes were set after the burst ended (the post-MOTD `MODE nick
+        // +i`), so they are not in the replay either; one line, asked at once
+        // — it is the per-channel replies the cap bounds, not this.
+        this.restoreQuiet.set('*', {
+          until: Date.now() + RESTORE_QUIET_MS,
+          mode: true,
+          topic: false,
+        });
+        this.rawQuiet('MODE', this.currentNick);
         this.restoreQueue = [...this.channels.values()].map((ch) => ch.name);
-        this.beginRestoreRefresh();
+        this.drainRestoreQueue();
         // A socket the engine registered on its own never had its
         // post-registration steps: the connect commands run now, and the
         // manager's rejoin (onceRestored, at `live`) covers the autojoin list.
@@ -4110,58 +4113,19 @@ export class IrcConnection {
     this.restoreUnattended = false;
     this.restoredCallbacks = [];
     this.restoreQueue = [];
-    this.endRestoreRefresh();
+    this.endRestoreStep();
     this.restoreQuiet.clear();
   }
 
+  // The step is over — answered, timed out, or abandoned (resetRestoreState
+  // on close / connect / dial / attach). Its turn at the cap goes back with
+  // it, whether it was held or still queued.
   private endRestoreStep(): void {
     if (this.restoreTimer) {
       clearTimeout(this.restoreTimer);
       this.restoreTimer = null;
     }
     this.restoreStep = null;
-  }
-
-  // The refresh after a re-attach — our umode, then each channel's state —
-  // starts when the process-wide cap (restoreGate, #842) has room for it: at
-  // once under the cap, otherwise when an earlier connection's queue drains.
-  // The attach is already complete by now (the replay walked, the session is
-  // live); what waits is only when the member lists come back. The umode
-  // request and its quiet window are set here rather than at `restored` so a
-  // wait longer than RESTORE_QUIET_MS cannot leave the 221 rendering as
-  // history.
-  private beginRestoreRefresh(): void {
-    this.endRestoreRefresh();
-    const slot = restoreGate.acquire(
-      () => `net ${this.network.id} ${this.restoreStep?.key ?? '(between steps)'}`,
-      (granted) => {
-        this.restoreSlot = granted;
-        if (this.disposed || this.state !== 'connected') {
-          this.endRestoreRefresh();
-          return;
-        }
-        // Our umodes were set after the burst ended (the post-MOTD `MODE nick
-        // +i`), so they are not in the replay either.
-        this.restoreQuiet.set('*', {
-          until: Date.now() + RESTORE_QUIET_MS,
-          mode: true,
-          topic: false,
-        });
-        this.rawQuiet('MODE', this.currentNick);
-        this.drainRestoreQueue();
-      },
-    );
-    // Granted synchronously: the start above already recorded (or, with an
-    // empty queue, already released) it. Still queued: keep it so an abort
-    // can leave the queue.
-    if (slot.state() === 'waiting') this.restoreSlot = slot;
-  }
-
-  // Done with, or done waiting for, the refresh. Every abort path funnels
-  // here (resetRestoreState on close / connect / dial / attach, and dispose),
-  // so a slot cannot outlive the restore that took it.
-  private endRestoreRefresh(): void {
-    this.endRestoreStep();
     const slot = this.restoreSlot;
     this.restoreSlot = null;
     slot?.release();
@@ -4181,6 +4145,18 @@ export class IrcConnection {
   // WHO is deliberately NOT part of the gate: irc-framework's queue never
   // recovers from a 315 that does not come, and a step waiting on it would
   // turn that one lost reply into a deadline wait for every channel after it.
+  //
+  // Across connections each step is also a turn at the process-wide cap
+  // (restoreGate, #842). A re-attach brings every held connection back in the
+  // same tick — on purpose, the attach registers nothing on the ircd — and
+  // with nothing spreading the refreshes out, N first replies (member rebuild
+  // + WS fan-out, all synchronous) land together: the [event-loop] stall a
+  // busy instance sees after a restart. Each step is its own reservation at
+  // the back of the gate's FIFO, so a connection with more channels than there
+  // are free slots queues its next step behind everyone already waiting —
+  // round-robin, every session's first member list early, rather than one
+  // connection's whole walk at a time. Under the cap the step goes out
+  // synchronously, so a small instance sees no change.
   private drainRestoreQueue(): void {
     this.endRestoreStep();
     // Skip what we are no longer in (a backlog KICK may have arrived in
@@ -4190,11 +4166,19 @@ export class IrcConnection {
     while (name !== undefined && !this.isChannelJoined(name)) {
       name = this.restoreQueue.shift();
     }
-    if (name === undefined) {
-      // Drained: the next connection waiting at the cap may start. Its last
-      // channel's WHO may still be answering — that is outside the gate on
-      // purpose (see above), and one WHO per connection is the most it adds.
-      this.endRestoreRefresh();
+    if (name === undefined) return;
+    const channel = name;
+    const slot = restoreGate.reserve(() => `net ${this.network.id} ${channel}`);
+    this.restoreSlot = slot;
+    slot.start(() => this.sendRestoreStep(channel));
+  }
+
+  // The step itself, once it has its turn. Membership is checked again here:
+  // a backlog KICK may have landed while the turn was queued, and a request
+  // for a channel we are no longer in would resurrect it with the replies.
+  private sendRestoreStep(name: string): void {
+    if (!this.isChannelJoined(name)) {
+      this.drainRestoreQueue();
       return;
     }
     this.restoreQuiet.set(name.toLowerCase(), {
@@ -4215,7 +4199,6 @@ export class IrcConnection {
       () => {
         this.restoreTimer = null;
         if (!this.disposed && this.state === 'connected') this.drainRestoreQueue();
-        else this.endRestoreRefresh();
       },
       Math.max(1, reconnectEnvInt('LURKER_RESTORE_STEP_DEADLINE_MS', RESTORE_STEP_DEADLINE_MS)),
     );
@@ -6149,9 +6132,6 @@ export class IrcConnection {
     this.clearReconnectTimer();
     this.stopLagPinger();
     this.cancelPendingConnectCommands();
-    // A refresh still queued at the cap must not be granted to a dead
-    // connection, and one in flight must not hold the slot until 'close'.
-    this.endRestoreRefresh();
     // Abort any in-flight DCC downloads (their sockets are independent of the IRC
     // socket, so they'd otherwise outlive this connection) and drop resume timers.
     for (const receiver of this.dccReceivers.values()) receiver.cancel();

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -39,6 +39,8 @@ import {
 import highlightRulesService from './highlightRulesService.js';
 import ignoreRulesService from './ignoreRulesService.js';
 import connectScheduler from './connectScheduler.js';
+import restoreGate from './restoreGate.js';
+import type { RestoreSlot } from './restoreGate.js';
 import { decideStamp } from './insertDecisions.js';
 import * as systemLog from './systemLog.js';
 import { effectiveSetting, effectiveSettings } from './settingsService.js';
@@ -724,6 +726,10 @@ export class IrcConnection {
   // The restore step in flight: the folded channel and which of its replies
   // are still owed. Null between steps and outside a restore.
   private restoreStep: { key: string; owed: Set<RestoreReply> } | null;
+  // This connection's turn at the process-wide refresh cap (restoreGate):
+  // waiting or held from `restored` until the queue drains or the restore is
+  // abandoned. Null outside a restore.
+  private restoreSlot: RestoreSlot | null;
   private engineTransport: EngineTransport | null;
   private engineSocketAlive: boolean;
   // folded channel → the state replies still owed from the restore's own
@@ -840,6 +846,7 @@ export class IrcConnection {
     this.restoreQueue = [];
     this.restoreTimer = null;
     this.restoreStep = null;
+    this.restoreSlot = null;
     this.engineTransport = null;
     this.engineSocketAlive = false;
     this.restoreQuiet = new Map();
@@ -4051,17 +4058,10 @@ export class IrcConnection {
         // 353/366, no 332, and the join handler's MODE is skipped on a restore —
         // so ask, one channel at a time, each waiting for the last one's
         // replies (drainRestoreQueue), keeping each channel's replies out of
-        // the server buffer until they arrive.
-        // Our umodes were set after the burst ended (the post-MOTD `MODE nick
-        // +i`), so they are not in the replay either.
-        this.restoreQuiet.set('*', {
-          until: Date.now() + RESTORE_QUIET_MS,
-          mode: true,
-          topic: false,
-        });
-        this.rawQuiet('MODE', this.currentNick);
+        // the server buffer until they arrive. Across connections the asking
+        // waits its turn at the process-wide cap (beginRestoreRefresh).
         this.restoreQueue = [...this.channels.values()].map((ch) => ch.name);
-        this.drainRestoreQueue();
+        this.beginRestoreRefresh();
         // A socket the engine registered on its own never had its
         // post-registration steps: the connect commands run now, and the
         // manager's rejoin (onceRestored, at `live`) covers the autojoin list.
@@ -4110,7 +4110,7 @@ export class IrcConnection {
     this.restoreUnattended = false;
     this.restoredCallbacks = [];
     this.restoreQueue = [];
-    this.endRestoreStep();
+    this.endRestoreRefresh();
     this.restoreQuiet.clear();
   }
 
@@ -4120,6 +4120,51 @@ export class IrcConnection {
       this.restoreTimer = null;
     }
     this.restoreStep = null;
+  }
+
+  // The refresh after a re-attach — our umode, then each channel's state —
+  // starts when the process-wide cap (restoreGate, #842) has room for it: at
+  // once under the cap, otherwise when an earlier connection's queue drains.
+  // The attach is already complete by now (the replay walked, the session is
+  // live); what waits is only when the member lists come back. The umode
+  // request and its quiet window are set here rather than at `restored` so a
+  // wait longer than RESTORE_QUIET_MS cannot leave the 221 rendering as
+  // history.
+  private beginRestoreRefresh(): void {
+    this.endRestoreRefresh();
+    const slot = restoreGate.acquire(
+      () => `net ${this.network.id} ${this.restoreStep?.key ?? '(between steps)'}`,
+      (granted) => {
+        this.restoreSlot = granted;
+        if (this.disposed || this.state !== 'connected') {
+          this.endRestoreRefresh();
+          return;
+        }
+        // Our umodes were set after the burst ended (the post-MOTD `MODE nick
+        // +i`), so they are not in the replay either.
+        this.restoreQuiet.set('*', {
+          until: Date.now() + RESTORE_QUIET_MS,
+          mode: true,
+          topic: false,
+        });
+        this.rawQuiet('MODE', this.currentNick);
+        this.drainRestoreQueue();
+      },
+    );
+    // Granted synchronously: the start above already recorded (or, with an
+    // empty queue, already released) it. Still queued: keep it so an abort
+    // can leave the queue.
+    if (slot.state() === 'waiting') this.restoreSlot = slot;
+  }
+
+  // Done with, or done waiting for, the refresh. Every abort path funnels
+  // here (resetRestoreState on close / connect / dial / attach, and dispose),
+  // so a slot cannot outlive the restore that took it.
+  private endRestoreRefresh(): void {
+    this.endRestoreStep();
+    const slot = this.restoreSlot;
+    this.restoreSlot = null;
+    slot?.release();
   }
 
   // One channel in flight. The next channel's three requests go out when this
@@ -4145,7 +4190,13 @@ export class IrcConnection {
     while (name !== undefined && !this.isChannelJoined(name)) {
       name = this.restoreQueue.shift();
     }
-    if (name === undefined) return;
+    if (name === undefined) {
+      // Drained: the next connection waiting at the cap may start. Its last
+      // channel's WHO may still be answering — that is outside the gate on
+      // purpose (see above), and one WHO per connection is the most it adds.
+      this.endRestoreRefresh();
+      return;
+    }
     this.restoreQuiet.set(name.toLowerCase(), {
       until: Date.now() + RESTORE_QUIET_MS,
       mode: true,
@@ -4164,6 +4215,7 @@ export class IrcConnection {
       () => {
         this.restoreTimer = null;
         if (!this.disposed && this.state === 'connected') this.drainRestoreQueue();
+        else this.endRestoreRefresh();
       },
       Math.max(1, reconnectEnvInt('LURKER_RESTORE_STEP_DEADLINE_MS', RESTORE_STEP_DEADLINE_MS)),
     );
@@ -6097,6 +6149,9 @@ export class IrcConnection {
     this.clearReconnectTimer();
     this.stopLagPinger();
     this.cancelPendingConnectCommands();
+    // A refresh still queued at the cap must not be granted to a dead
+    // connection, and one in flight must not hold the slot until 'close'.
+    this.endRestoreRefresh();
     // Abort any in-flight DCC downloads (their sockets are independent of the IRC
     // socket, so they'd otherwise outlive this connection) and drop resume timers.
     for (const receiver of this.dccReceivers.values()) receiver.cancel();

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -962,8 +962,9 @@ class IrcManager extends EventEmitter {
     // Drop any queued (not-yet-fired) connect launches first — otherwise a
     // staggered launch could fire against a connection we're about to tear down.
     connectScheduler.reset();
-    // Likewise a channel-state refresh still queued at the cap (#842): the
-    // detaches below would otherwise grant it to a connection on its way out.
+    // Likewise a channel-state refresh step still queued at the cap (#842):
+    // each detach below releases its own step synchronously, which would
+    // otherwise grant the next queued one to a connection on its way out.
     restoreGate.reset();
     for (const userMap of this.byUser.values()) {
       for (const conn of userMap.values()) {

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -11,6 +11,7 @@ import {
 } from './engineLink.js';
 import * as systemLog from './systemLog.js';
 import connectScheduler from './connectScheduler.js';
+import restoreGate from './restoreGate.js';
 import { listNetworksForUser, getNetwork } from '../db/networks.js';
 import type { Network } from '../db/networks.js';
 import {
@@ -961,6 +962,9 @@ class IrcManager extends EventEmitter {
     // Drop any queued (not-yet-fired) connect launches first — otherwise a
     // staggered launch could fire against a connection we're about to tear down.
     connectScheduler.reset();
+    // Likewise a channel-state refresh still queued at the cap (#842): the
+    // detaches below would otherwise grant it to a connection on its way out.
+    restoreGate.reset();
     for (const userMap of this.byUser.values()) {
       for (const conn of userMap.values()) {
         try {

--- a/server/services/restoreGate.test.ts
+++ b/server/services/restoreGate.test.ts
@@ -2,37 +2,28 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // The gate on its own: FIFO grant, synchronous start under the cap, release
-// from either side of the cap, and the two things that would wedge it for the
-// life of the process — a start that throws, and a start that hands its slot
-// straight back. The wire-level behaviour (what a re-attached connection sends
-// and when) is engineRestoreConcurrency.test.ts.
+// from either side of the cap, round-robin re-queueing, and the things that
+// would wedge it for the life of the process — a step that throws, and a step
+// that hands its turn straight back. The wire-level behaviour (what a
+// re-attached connection sends and when) is engineRestoreConcurrency.test.ts.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { RestoreGate } from './restoreGate.js';
 import type { RestoreSlot } from './restoreGate.js';
 
-interface Asked {
-  slot: RestoreSlot;
-  // The slot `run` was handed, once it has been.
-  granted: RestoreSlot | null;
-}
-
-function ask(
+// Reserve a step and ask for its turn; `started` records the order steps ran.
+function step(
   g: RestoreGate,
   label: string,
   started: string[],
-  onStart?: (slot: RestoreSlot) => void,
-): Asked {
-  const asked: Asked = { slot: null as unknown as RestoreSlot, granted: null };
-  asked.slot = g.acquire(
-    () => label,
-    (s) => {
-      asked.granted = s;
-      started.push(label);
-      onStart?.(s);
-    },
-  );
-  return asked;
+  body?: (slot: RestoreSlot) => void,
+): RestoreSlot {
+  const slot = g.reserve(() => label);
+  slot.start(() => {
+    started.push(label);
+    body?.(slot);
+  });
+  return slot;
 }
 
 afterEach(() => {
@@ -40,106 +31,127 @@ afterEach(() => {
 });
 
 describe('RestoreGate', () => {
-  it('starts at once, inside acquire, while under the cap', () => {
+  it('starts at once, inside start(), while under the cap', () => {
     const g = new RestoreGate({ concurrency: () => 2 });
     const started: string[] = [];
-    const a = ask(g, 'A', started);
+    step(g, 'A', started);
     expect(started).toEqual(['A']);
-    expect(a.granted).toBe(a.slot);
-    expect(a.slot.state()).toBe('active');
-    ask(g, 'B', started);
+    step(g, 'B', started);
     expect(started).toEqual(['A', 'B']);
     expect(g.activeCount()).toBe(2);
     expect(g.waitingCount()).toBe(0);
   });
 
-  it('queues past the cap, FIFO, and grants as slots come back', () => {
+  it('queues past the cap, FIFO, and grants as turns come back', () => {
     const g = new RestoreGate({ concurrency: () => 2 });
     const started: string[] = [];
-    const a = ask(g, 'A', started);
-    const b = ask(g, 'B', started);
-    const c = ask(g, 'C', started);
-    const d = ask(g, 'D', started);
+    const a = step(g, 'A', started);
+    const b = step(g, 'B', started);
+    step(g, 'C', started);
+    step(g, 'D', started);
     expect(started).toEqual(['A', 'B']);
-    expect(c.granted).toBeNull();
-    expect(c.slot.state()).toBe('waiting');
     expect(g.waitingCount()).toBe(2);
 
-    a.slot.release();
+    a.release();
     expect(started).toEqual(['A', 'B', 'C']);
-    expect(a.slot.state()).toBe('released');
-    expect(c.slot.state()).toBe('active');
-    expect(d.slot.state()).toBe('waiting');
     expect(g.activeCount()).toBe(2);
+    expect(g.waitingCount()).toBe(1);
 
-    b.slot.release();
+    b.release();
     expect(started).toEqual(['A', 'B', 'C', 'D']);
     expect(g.activeCount()).toBe(2);
     expect(g.waitingCount()).toBe(0);
   });
 
-  it('a waiter that gives up leaves the queue and is never started', () => {
+  it('a queued step that is released leaves the queue and never runs', () => {
     const g = new RestoreGate({ concurrency: () => 1 });
     const started: string[] = [];
-    const a = ask(g, 'A', started);
-    const b = ask(g, 'B', started);
-    ask(g, 'C', started);
-    b.slot.release();
-    expect(b.slot.state()).toBe('released');
+    const a = step(g, 'A', started);
+    const b = step(g, 'B', started);
+    step(g, 'C', started);
+    b.release();
     expect(g.waitingCount()).toBe(1);
-    a.slot.release();
+    a.release();
     expect(started).toEqual(['A', 'C']);
+  });
+
+  it('a slot released before start() never starts, and start() is once-only', () => {
+    const g = new RestoreGate({ concurrency: () => 0 });
+    const started: string[] = [];
+    const early = g.reserve(() => 'early');
+    early.release();
+    early.start(() => started.push('early'));
+    expect(started).toEqual([]);
+    expect(g.activeCount()).toBe(0);
+
+    const twice = g.reserve(() => 'twice');
+    twice.start(() => started.push('twice'));
+    twice.start(() => started.push('twice again'));
+    expect(started).toEqual(['twice']);
+    expect(g.activeCount()).toBe(1);
   });
 
   it('release is idempotent — a second release frees nobody else', () => {
     const g = new RestoreGate({ concurrency: () => 1 });
     const started: string[] = [];
-    const a = ask(g, 'A', started);
-    ask(g, 'B', started);
-    ask(g, 'C', started);
-    a.slot.release();
-    a.slot.release();
+    const a = step(g, 'A', started);
+    step(g, 'B', started);
+    step(g, 'C', started);
+    a.release();
+    a.release();
     expect(started).toEqual(['A', 'B']);
     expect(g.activeCount()).toBe(1);
     expect(g.waitingCount()).toBe(1);
   });
 
-  it('a start that throws holds nothing', () => {
+  it('a step that throws holds nothing', () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {});
     const g = new RestoreGate({ concurrency: () => 1 });
     const started: string[] = [];
-    g.acquire(
-      () => 'A',
-      () => {
-        throw new Error('boom');
-      },
-    );
+    g.reserve(() => 'A').start(() => {
+      throw new Error('boom');
+    });
     expect(g.activeCount()).toBe(0);
-    ask(g, 'B', started);
+    step(g, 'B', started);
     expect(started).toEqual(['B']);
     expect(error).toHaveBeenCalledTimes(1);
   });
 
-  it('a start that finishes synchronously hands the slot straight on', () => {
+  it('a step that gives its turn straight back hands it on', () => {
     const g = new RestoreGate({ concurrency: () => 1 });
     const started: string[] = [];
-    const a = ask(g, 'A', started);
-    // B has nothing to refresh: it releases inside its own start, the way a
-    // connection with no channels drains its queue before drainRestoreQueue
-    // returns. C must not be stranded behind that.
-    ask(g, 'B', started, (s) => s.release());
-    const c = ask(g, 'C', started);
-    a.slot.release();
+    const a = step(g, 'A', started);
+    // B has nothing to ask after all (its channel was left while it queued):
+    // it releases inside its own run. C must not be stranded behind that.
+    step(g, 'B', started, (s) => s.release());
+    step(g, 'C', started);
+    a.release();
     expect(started).toEqual(['A', 'B', 'C']);
-    expect(c.slot.state()).toBe('active');
     expect(g.activeCount()).toBe(1);
     expect(g.waitingCount()).toBe(0);
+  });
+
+  it("a connection's next step re-queues behind everyone waiting (round-robin)", () => {
+    const g = new RestoreGate({ concurrency: () => 1 });
+    const started: string[] = [];
+    const a1 = step(g, 'A1', started);
+    const b1 = step(g, 'B1', started);
+    const c1 = step(g, 'C1', started);
+    // A's step ends and A reserves its next one — a new reservation, behind
+    // B and C, the way drainRestoreQueue does — so B and C go first.
+    a1.release();
+    step(g, 'A2', started);
+    expect(started).toEqual(['A1', 'B1']);
+    b1.release();
+    expect(started).toEqual(['A1', 'B1', 'C1']);
+    c1.release();
+    expect(started).toEqual(['A1', 'B1', 'C1', 'A2']);
   });
 
   it('a cap of 0 is no cap', () => {
     const g = new RestoreGate({ concurrency: () => 0 });
     const started: string[] = [];
-    for (const label of ['A', 'B', 'C', 'D', 'E']) ask(g, label, started);
+    for (const label of ['A', 'B', 'C', 'D', 'E']) step(g, label, started);
     expect(started).toEqual(['A', 'B', 'C', 'D', 'E']);
     expect(g.waitingCount()).toBe(0);
   });
@@ -148,12 +160,12 @@ describe('RestoreGate', () => {
     let cap = 1;
     const g = new RestoreGate({ concurrency: () => cap });
     const started: string[] = [];
-    ask(g, 'A', started);
-    ask(g, 'B', started);
-    ask(g, 'C', started);
+    step(g, 'A', started);
+    step(g, 'B', started);
+    step(g, 'C', started);
     expect(started).toEqual(['A']);
     cap = 3;
-    ask(g, 'D', started);
+    step(g, 'D', started);
     expect(started).toEqual(['A', 'B', 'C']);
     expect(g.waitingCount()).toBe(1);
   });
@@ -162,76 +174,75 @@ describe('RestoreGate', () => {
     const g = new RestoreGate({ concurrency: () => 2 });
     expect(g.describeInFlight()).toBeNull();
     const started: string[] = [];
-    const a = ask(g, 'net 1 #a', started);
-    ask(g, 'net 2 (between steps)', started);
-    ask(g, 'net 3 #c', started);
+    const a = step(g, 'net 1 #a', started);
+    step(g, 'net 2 #b', started);
+    step(g, 'net 3 #c', started);
     expect(g.describeInFlight()).toBe(
-      're-attach channel-state refreshes in flight: 2 (net 1 #a, net 2 (between steps)); 1 waiting',
+      're-attach channel-state refresh steps in flight: 2 (net 1 #a, net 2 #b); 1 waiting',
     );
-    a.slot.release();
+    a.release();
     expect(g.describeInFlight()).toBe(
-      're-attach channel-state refreshes in flight: 2 (net 2 (between steps), net 3 #c)',
+      're-attach channel-state refresh steps in flight: 2 (net 2 #b, net 3 #c)',
     );
   });
 
   it('names at most six holders and survives a describe that throws', () => {
     const g = new RestoreGate({ concurrency: () => 0 });
     for (let i = 1; i <= 8; i++) {
-      g.acquire(
-        () => {
-          if (i === 2) throw new Error('no label');
-          return `net ${i}`;
-        },
-        () => {},
-      );
+      g.reserve(() => {
+        if (i === 2) throw new Error('no label');
+        return `net ${i}`;
+      }).start(() => {});
     }
     expect(g.describeInFlight()).toBe(
-      're-attach channel-state refreshes in flight: 8 (net 1, ?, net 3, net 4, net 5, net 6, +2 more)',
+      're-attach channel-state refresh steps in flight: 8 (net 1, ?, net 3, net 4, net 5, net 6, +2 more)',
     );
   });
 
-  it('reset drops everything; a slot from before the reset releases as a no-op', () => {
+  it('reset drops everything and runs nothing; handles from before it are no-ops', () => {
     const g = new RestoreGate({ concurrency: () => 1 });
     const started: string[] = [];
-    const a = ask(g, 'A', started);
-    const b = ask(g, 'B', started);
+    const a = step(g, 'A', started);
+    step(g, 'B', started);
     g.reset();
     expect(g.activeCount()).toBe(0);
     expect(g.waitingCount()).toBe(0);
-    expect(b.slot.state()).toBe('released');
-    a.slot.release();
+    a.release();
     expect(started).toEqual(['A']);
-    ask(g, 'C', started);
+    step(g, 'C', started);
     expect(started).toEqual(['A', 'C']);
   });
 
-  it('logs once when the cap is first hit and once when the burst drains', () => {
+  it('logs once when the cap is first hit and once when the burst drains, counting the steps that waited', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
     let now = 1_000;
     const g = new RestoreGate({ concurrency: () => 1, now: () => now });
     const started: string[] = [];
-    const a = ask(g, 'A', started);
+    const a = step(g, 'A', started);
     expect(log).not.toHaveBeenCalled();
-    const b = ask(g, 'B', started);
-    const c = ask(g, 'C', started);
-    const d = ask(g, 'D', started);
+    const b = step(g, 'B', started);
+    const c = step(g, 'C', started);
+    const d = step(g, 'D', started);
     expect(log).toHaveBeenCalledTimes(1);
     expect(String(log.mock.calls[0][0])).toBe(
-      '[restore-gate] 1 connection refreshing channel state after re-attach; queuing the rest (LURKER_RESTORE_CONCURRENCY=1)',
+      '[restore-gate] 1 channel-state refresh step in flight after re-attach; the rest take turns (LURKER_RESTORE_CONCURRENCY=1)',
     );
+    // C leaves the queue without ever running: not a step that waited for
+    // a turn, so not in the count.
+    c.release();
     now += 2_500;
-    a.slot.release();
-    b.slot.release();
-    c.slot.release();
+    a.release();
+    b.release();
     expect(log).toHaveBeenCalledTimes(1);
-    d.slot.release();
+    d.release();
+    expect(started).toEqual(['A', 'B', 'D']);
     expect(log).toHaveBeenCalledTimes(2);
     expect(String(log.mock.calls[1][0])).toBe(
-      '[restore-gate] re-attach refreshes drained: 3 waited their turn, 2.5s since the cap was first hit',
+      '[restore-gate] re-attach refreshes drained: 2 steps waited for a turn, 2.5s since the cap was first hit',
     );
     // The next burst logs afresh.
-    ask(g, 'E', started);
-    ask(g, 'F', started);
+    step(g, 'E', started);
+    step(g, 'F', started);
     expect(log).toHaveBeenCalledTimes(3);
   });
 });

--- a/server/services/restoreGate.test.ts
+++ b/server/services/restoreGate.test.ts
@@ -245,4 +245,24 @@ describe('RestoreGate', () => {
     step(g, 'F', started);
     expect(log).toHaveBeenCalledTimes(3);
   });
+
+  it('does not count a step enqueued and granted inside the same pass as having waited', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const g = new RestoreGate({ concurrency: () => 1, now: () => 0 });
+    const started: string[] = [];
+    const a = step(g, 'A', started);
+    // B waits behind A. When granted, B finds nothing to ask (its channel
+    // was left while it queued): it gives the slot back and reserves its next
+    // step from inside its own run, the way drainRestoreQueue does. That next
+    // step is granted by the same pass — it never waited.
+    let c: RestoreSlot | null = null;
+    step(g, 'B', started, (slot) => {
+      slot.release();
+      c = step(g, 'C', started);
+    });
+    a.release();
+    expect(started).toEqual(['A', 'B', 'C']);
+    c!.release();
+    expect(String(log.mock.calls[1][0])).toContain('1 step waited for a turn');
+  });
 });

--- a/server/services/restoreGate.test.ts
+++ b/server/services/restoreGate.test.ts
@@ -1,0 +1,237 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The gate on its own: FIFO grant, synchronous start under the cap, release
+// from either side of the cap, and the two things that would wedge it for the
+// life of the process — a start that throws, and a start that hands its slot
+// straight back. The wire-level behaviour (what a re-attached connection sends
+// and when) is engineRestoreConcurrency.test.ts.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { RestoreGate } from './restoreGate.js';
+import type { RestoreSlot } from './restoreGate.js';
+
+interface Asked {
+  slot: RestoreSlot;
+  // The slot `run` was handed, once it has been.
+  granted: RestoreSlot | null;
+}
+
+function ask(
+  g: RestoreGate,
+  label: string,
+  started: string[],
+  onStart?: (slot: RestoreSlot) => void,
+): Asked {
+  const asked: Asked = { slot: null as unknown as RestoreSlot, granted: null };
+  asked.slot = g.acquire(
+    () => label,
+    (s) => {
+      asked.granted = s;
+      started.push(label);
+      onStart?.(s);
+    },
+  );
+  return asked;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('RestoreGate', () => {
+  it('starts at once, inside acquire, while under the cap', () => {
+    const g = new RestoreGate({ concurrency: () => 2 });
+    const started: string[] = [];
+    const a = ask(g, 'A', started);
+    expect(started).toEqual(['A']);
+    expect(a.granted).toBe(a.slot);
+    expect(a.slot.state()).toBe('active');
+    ask(g, 'B', started);
+    expect(started).toEqual(['A', 'B']);
+    expect(g.activeCount()).toBe(2);
+    expect(g.waitingCount()).toBe(0);
+  });
+
+  it('queues past the cap, FIFO, and grants as slots come back', () => {
+    const g = new RestoreGate({ concurrency: () => 2 });
+    const started: string[] = [];
+    const a = ask(g, 'A', started);
+    const b = ask(g, 'B', started);
+    const c = ask(g, 'C', started);
+    const d = ask(g, 'D', started);
+    expect(started).toEqual(['A', 'B']);
+    expect(c.granted).toBeNull();
+    expect(c.slot.state()).toBe('waiting');
+    expect(g.waitingCount()).toBe(2);
+
+    a.slot.release();
+    expect(started).toEqual(['A', 'B', 'C']);
+    expect(a.slot.state()).toBe('released');
+    expect(c.slot.state()).toBe('active');
+    expect(d.slot.state()).toBe('waiting');
+    expect(g.activeCount()).toBe(2);
+
+    b.slot.release();
+    expect(started).toEqual(['A', 'B', 'C', 'D']);
+    expect(g.activeCount()).toBe(2);
+    expect(g.waitingCount()).toBe(0);
+  });
+
+  it('a waiter that gives up leaves the queue and is never started', () => {
+    const g = new RestoreGate({ concurrency: () => 1 });
+    const started: string[] = [];
+    const a = ask(g, 'A', started);
+    const b = ask(g, 'B', started);
+    ask(g, 'C', started);
+    b.slot.release();
+    expect(b.slot.state()).toBe('released');
+    expect(g.waitingCount()).toBe(1);
+    a.slot.release();
+    expect(started).toEqual(['A', 'C']);
+  });
+
+  it('release is idempotent — a second release frees nobody else', () => {
+    const g = new RestoreGate({ concurrency: () => 1 });
+    const started: string[] = [];
+    const a = ask(g, 'A', started);
+    ask(g, 'B', started);
+    ask(g, 'C', started);
+    a.slot.release();
+    a.slot.release();
+    expect(started).toEqual(['A', 'B']);
+    expect(g.activeCount()).toBe(1);
+    expect(g.waitingCount()).toBe(1);
+  });
+
+  it('a start that throws holds nothing', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const g = new RestoreGate({ concurrency: () => 1 });
+    const started: string[] = [];
+    g.acquire(
+      () => 'A',
+      () => {
+        throw new Error('boom');
+      },
+    );
+    expect(g.activeCount()).toBe(0);
+    ask(g, 'B', started);
+    expect(started).toEqual(['B']);
+    expect(error).toHaveBeenCalledTimes(1);
+  });
+
+  it('a start that finishes synchronously hands the slot straight on', () => {
+    const g = new RestoreGate({ concurrency: () => 1 });
+    const started: string[] = [];
+    const a = ask(g, 'A', started);
+    // B has nothing to refresh: it releases inside its own start, the way a
+    // connection with no channels drains its queue before drainRestoreQueue
+    // returns. C must not be stranded behind that.
+    ask(g, 'B', started, (s) => s.release());
+    const c = ask(g, 'C', started);
+    a.slot.release();
+    expect(started).toEqual(['A', 'B', 'C']);
+    expect(c.slot.state()).toBe('active');
+    expect(g.activeCount()).toBe(1);
+    expect(g.waitingCount()).toBe(0);
+  });
+
+  it('a cap of 0 is no cap', () => {
+    const g = new RestoreGate({ concurrency: () => 0 });
+    const started: string[] = [];
+    for (const label of ['A', 'B', 'C', 'D', 'E']) ask(g, label, started);
+    expect(started).toEqual(['A', 'B', 'C', 'D', 'E']);
+    expect(g.waitingCount()).toBe(0);
+  });
+
+  it('reads the cap live', () => {
+    let cap = 1;
+    const g = new RestoreGate({ concurrency: () => cap });
+    const started: string[] = [];
+    ask(g, 'A', started);
+    ask(g, 'B', started);
+    ask(g, 'C', started);
+    expect(started).toEqual(['A']);
+    cap = 3;
+    ask(g, 'D', started);
+    expect(started).toEqual(['A', 'B', 'C']);
+    expect(g.waitingCount()).toBe(1);
+  });
+
+  it('describes what is in flight, and nothing when idle', () => {
+    const g = new RestoreGate({ concurrency: () => 2 });
+    expect(g.describeInFlight()).toBeNull();
+    const started: string[] = [];
+    const a = ask(g, 'net 1 #a', started);
+    ask(g, 'net 2 (between steps)', started);
+    ask(g, 'net 3 #c', started);
+    expect(g.describeInFlight()).toBe(
+      're-attach channel-state refreshes in flight: 2 (net 1 #a, net 2 (between steps)); 1 waiting',
+    );
+    a.slot.release();
+    expect(g.describeInFlight()).toBe(
+      're-attach channel-state refreshes in flight: 2 (net 2 (between steps), net 3 #c)',
+    );
+  });
+
+  it('names at most six holders and survives a describe that throws', () => {
+    const g = new RestoreGate({ concurrency: () => 0 });
+    for (let i = 1; i <= 8; i++) {
+      g.acquire(
+        () => {
+          if (i === 2) throw new Error('no label');
+          return `net ${i}`;
+        },
+        () => {},
+      );
+    }
+    expect(g.describeInFlight()).toBe(
+      're-attach channel-state refreshes in flight: 8 (net 1, ?, net 3, net 4, net 5, net 6, +2 more)',
+    );
+  });
+
+  it('reset drops everything; a slot from before the reset releases as a no-op', () => {
+    const g = new RestoreGate({ concurrency: () => 1 });
+    const started: string[] = [];
+    const a = ask(g, 'A', started);
+    const b = ask(g, 'B', started);
+    g.reset();
+    expect(g.activeCount()).toBe(0);
+    expect(g.waitingCount()).toBe(0);
+    expect(b.slot.state()).toBe('released');
+    a.slot.release();
+    expect(started).toEqual(['A']);
+    ask(g, 'C', started);
+    expect(started).toEqual(['A', 'C']);
+  });
+
+  it('logs once when the cap is first hit and once when the burst drains', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    let now = 1_000;
+    const g = new RestoreGate({ concurrency: () => 1, now: () => now });
+    const started: string[] = [];
+    const a = ask(g, 'A', started);
+    expect(log).not.toHaveBeenCalled();
+    const b = ask(g, 'B', started);
+    const c = ask(g, 'C', started);
+    const d = ask(g, 'D', started);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(String(log.mock.calls[0][0])).toBe(
+      '[restore-gate] 1 connection refreshing channel state after re-attach; queuing the rest (LURKER_RESTORE_CONCURRENCY=1)',
+    );
+    now += 2_500;
+    a.slot.release();
+    b.slot.release();
+    c.slot.release();
+    expect(log).toHaveBeenCalledTimes(1);
+    d.slot.release();
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(String(log.mock.calls[1][0])).toBe(
+      '[restore-gate] re-attach refreshes drained: 3 waited their turn, 2.5s since the cap was first hit',
+    );
+    // The next burst logs afresh.
+    ask(g, 'E', started);
+    ask(g, 'F', started);
+    expect(log).toHaveBeenCalledTimes(3);
+  });
+});

--- a/server/services/restoreGate.ts
+++ b/server/services/restoreGate.ts
@@ -28,19 +28,27 @@
 // answers slowly (or not at all: the step deadline) holds a slot for one step
 // at a time, never for all of its channels.
 //
-// Model: a counting semaphore with a FIFO wait queue, not a rate limiter like
-// connectScheduler. A connect may never register, so the scheduler can't await
-// one; a step has a definite end (its replies, or the deadline) and definite
-// abort points (the socket closes, the connection re-dials or re-attaches, the
-// network is removed), all of which release the slot. Under the cap a step
-// starts synchronously inside start(), so a single-user instance with a
-// handful of networks sees no change at all.
+// Model: a counting semaphore with a FIFO wait queue. Not connectScheduler (a
+// rate limiter: a connect may never register, so it can't await one; a step
+// has a definite end — its replies or the deadline — and definite abort
+// points, all of which release the slot). Not utils/slotPool either: that one
+// grants asynchronously, so a step could never go out synchronously under the
+// cap (the "small instance sees no change" property), and a queued waiter
+// cannot be dropped, which every abort path here needs.
 //
-// This bounds ONE producer of the post-restart burst: the refresh a re-attach
-// runs for channels the socket is already in. A socket the engine registered
-// unattended has no channels to refresh; its autojoin JOINs at `live`, and a
-// non-engine restart's fresh connects (spaced only by connectScheduler), each
-// bring their own volunteered 353/366 + WHO per channel, ungated here.
+// What this bounds, and what it does not. A turn covers the NAMES/TOPIC/MODE
+// requests and ends with their replies. The WHO that the NAMES reply triggers
+// is outside it, on purpose: irc-framework serialises WHOs behind their 315
+// and never recovers from one that does not come, so a turn held for it would
+// turn one lost reply into a deadline wait per remaining channel. Its
+// 352-per-member reply is trimmed by the size gate (RESTORE_WHO_MAX_MEMBERS)
+// and held to one in flight per connection by that queue, but across
+// connections it is as parallel as before. And this bounds ONE producer of the
+// post-restart burst: a re-attach's refresh of channels the socket is already
+// in. A socket the engine registered unattended has none to refresh — its
+// autojoin JOINs at `live` — and a non-engine restart's fresh connects (spaced
+// only by connectScheduler) each bring their own volunteered 353/366 + WHO per
+// channel, ungated here.
 
 import { envInt } from '../utils/envInt.js';
 
@@ -70,7 +78,7 @@ interface Entry {
   describe: () => string;
   run: (() => void) | null;
   released: boolean;
-  // Sat in the queue before being granted — what the drained log counts.
+  // Still queued when a grant pass ended — what the drained log counts.
   waited: boolean;
 }
 
@@ -108,7 +116,8 @@ export class RestoreGate {
       start: (run) => {
         if (entry.released || entry.run) return;
         entry.run = run;
-        this.enqueue(entry);
+        this.waiting.push(entry);
+        this.pump();
       },
       release: () => this.release(entry),
     };
@@ -151,9 +160,9 @@ export class RestoreGate {
   // itself about to detach — three requests whose replies land in the engine
   // backlog and replay to the next process as if it had asked. Any other
   // caller strands whatever was queued (its channels never get refreshed) and
-  // lifts the cap for the steps still running.
+  // lifts the cap for the steps still running. A handle from before the reset
+  // releases as a no-op.
   reset(): void {
-    for (const entry of this.waiting) entry.released = true;
     this.waiting.length = 0;
     this.active.clear();
     this.burst = null;
@@ -164,37 +173,20 @@ export class RestoreGate {
     return Number.isFinite(n) && n > 0 ? n : Infinity;
   }
 
-  private enqueue(entry: Entry): void {
-    this.waiting.push(entry);
-    this.pump();
-    if (!this.waiting.includes(entry)) return;
-    entry.waited = true;
-    if (!this.burst) {
-      this.burst = { since: this.now(), queued: 0 };
-      const n = this.active.size;
-      console.log(
-        `[restore-gate] ${n} channel-state refresh step${n === 1 ? '' : 's'} in flight after re-attach; ` +
-          `the rest take turns (LURKER_RESTORE_CONCURRENCY=${this.limit()})`,
-      );
-    }
-  }
-
   private release(entry: Entry): void {
     entry.released = true;
     const w = this.waiting.indexOf(entry);
-    if (w >= 0) {
-      this.waiting.splice(w, 1);
-      this.noteIdle();
-      return;
-    }
-    if (!this.active.delete(entry.id)) return;
+    if (w >= 0) this.waiting.splice(w, 1);
+    else if (!this.active.delete(entry.id)) return;
     this.pump();
   }
 
   // Grant slots to waiters, FIFO, while there is room. Re-entrant calls (a
   // run() that reserves or releases synchronously — a connection re-queues its
   // next step from inside the release of its last) return at once; the outer
-  // loop re-reads the counts each pass and picks the change up.
+  // loop re-reads the counts each pass and picks the change up. Only the
+  // outer pass does the burst bookkeeping, once it is over: a step enqueued
+  // mid-pass and granted by the same pass never waited.
   private pump(): void {
     if (this.pumping) return;
     this.pumping = true;
@@ -214,6 +206,17 @@ export class RestoreGate {
       }
     } finally {
       this.pumping = false;
+    }
+    for (const entry of this.waiting) {
+      if (entry.waited) continue;
+      entry.waited = true;
+      if (this.burst) continue;
+      this.burst = { since: this.now(), queued: 0 };
+      const n = this.active.size;
+      console.log(
+        `[restore-gate] ${n} channel-state refresh step${n === 1 ? '' : 's'} in flight after re-attach; ` +
+          `the rest take turns (LURKER_RESTORE_CONCURRENCY=${this.limit()})`,
+      );
     }
     this.noteIdle();
   }

--- a/server/services/restoreGate.ts
+++ b/server/services/restoreGate.ts
@@ -21,33 +21,46 @@
 // the ircd side while it does — the socket is up, the engine answered PINGs
 // throughout — it is only "when does this channel's member list come back".
 //
+// The unit of a turn is one STEP (one channel's three requests), not a
+// connection's whole walk: each step is its own reservation at the back of the
+// FIFO, so with more connections than slots the steps round-robin — every
+// session's first member list comes back early, and a connection whose server
+// answers slowly (or not at all: the step deadline) holds a slot for one step
+// at a time, never for all of its channels.
+//
 // Model: a counting semaphore with a FIFO wait queue, not a rate limiter like
 // connectScheduler. A connect may never register, so the scheduler can't await
-// one; a refresh has a definite end (its queue drains) and definite abort
-// points (the socket closes, the connection re-dials or re-attaches, the
-// network is removed), all of which release the slot. A holder that stalls is
-// bounded by drainRestoreQueue's per-step deadline: every step ends, so every
-// queue drains, so every slot comes back.
+// one; a step has a definite end (its replies, or the deadline) and definite
+// abort points (the socket closes, the connection re-dials or re-attaches, the
+// network is removed), all of which release the slot. Under the cap a step
+// starts synchronously inside start(), so a single-user instance with a
+// handful of networks sees no change at all.
 //
-// Under the cap the refresh starts synchronously inside acquire(), so a
-// single-user instance with a handful of networks sees no change at all.
+// This bounds ONE producer of the post-restart burst: the refresh a re-attach
+// runs for channels the socket is already in. A socket the engine registered
+// unattended has no channels to refresh; its autojoin JOINs at `live`, and a
+// non-engine restart's fresh connects (spaced only by connectScheduler), each
+// bring their own volunteered 353/366 + WHO per channel, ungated here.
+
+import { envInt } from '../utils/envInt.js';
 
 const DEFAULT_CONCURRENCY = 4;
 // How many holders describeInFlight() names before it says "+N more".
 const DESCRIBE_MAX = 6;
 
-export type RestoreSlotState = 'waiting' | 'active' | 'released';
-
 export interface RestoreSlot {
-  // Give the slot back, or leave the queue if it was never granted. Idempotent.
+  // Ask for the turn. `run` fires when a slot is free — synchronously, inside
+  // start(), while the gate is under its cap. Once only; a slot released
+  // before it came up never starts.
+  start(run: () => void): void;
+  // Give the turn back, or leave the queue if it never came up. Idempotent.
   release(): void;
-  state(): RestoreSlotState;
 }
 
 export interface RestoreGateOptions {
-  // How many refreshes may run at once; 0 (or non-finite) = no cap. Read on
-  // every decision, like the other restore knobs, so a test — or an operator —
-  // does not have to restart the process for it to take.
+  // How many steps may be in flight at once; 0 (or non-finite) = no cap. Read
+  // on every decision, like the other restore knobs, so a test — or an
+  // operator — does not have to restart the process for it to take.
   concurrency?: () => number;
   now?: () => number;
 }
@@ -55,15 +68,10 @@ export interface RestoreGateOptions {
 interface Entry {
   id: number;
   describe: () => string;
-  run: (slot: RestoreSlot) => void;
-  slot: RestoreSlot;
-}
-
-function envInt(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (raw == null || raw.trim() === '') return fallback;
-  const n = Number(raw);
-  return Number.isFinite(n) && n >= 0 ? n : fallback;
+  run: (() => void) | null;
+  released: boolean;
+  // Sat in the queue before being granted — what the drained log counts.
+  waited: boolean;
 }
 
 export class RestoreGate {
@@ -73,8 +81,8 @@ export class RestoreGate {
   private readonly active = new Map<number, Entry>();
   private nextId = 1;
   private pumping = false;
-  // Set from the first refresh that has to wait until every refresh is done —
-  // one log line at each end of the burst, never one per queued session.
+  // Set from the first step that has to wait until every step is done — one
+  // log line at each end of the burst, never one per queued step.
   private burst: { since: number; queued: number } | null = null;
 
   constructor(opts: RestoreGateOptions = {}) {
@@ -83,34 +91,27 @@ export class RestoreGate {
     this.now = opts.now ?? (() => Date.now());
   }
 
-  // Ask for a slot. `run` is called with the slot the moment one is free —
-  // synchronously, inside this call, when the gate is under its cap — and the
-  // caller keeps the slot until its refresh is done or abandoned. `describe`
-  // labels the holder for the event-loop monitor (describeInFlight).
-  acquire(describe: () => string, run: (slot: RestoreSlot) => void): RestoreSlot {
-    const id = this.nextId++;
-    const slot: RestoreSlot = {
-      release: () => this.release(id),
-      state: () => {
-        if (this.active.has(id)) return 'active';
-        return this.waiting.some((e) => e.id === id) ? 'waiting' : 'released';
-      },
+  // A slot handle for one step. Two-phase so the caller holds the handle
+  // BEFORE anything can run: start() may grant synchronously, and the step it
+  // runs may give the slot straight back (nothing to ask after all) — with a
+  // one-call API the caller would have nothing to release yet. `describe`
+  // labels the step for the event-loop monitor (describeInFlight).
+  reserve(describe: () => string): RestoreSlot {
+    const entry: Entry = {
+      id: this.nextId++,
+      describe,
+      run: null,
+      released: false,
+      waited: false,
     };
-    const entry: Entry = { id, describe, run, slot };
-    this.waiting.push(entry);
-    this.pump();
-    if (this.waiting.includes(entry)) {
-      if (!this.burst) {
-        this.burst = { since: this.now(), queued: 0 };
-        const n = this.active.size;
-        console.log(
-          `[restore-gate] ${n} connection${n === 1 ? '' : 's'} refreshing channel state after re-attach; ` +
-            `queuing the rest (LURKER_RESTORE_CONCURRENCY=${this.limit()})`,
-        );
-      }
-      this.burst.queued++;
-    }
-    return slot;
+    return {
+      start: (run) => {
+        if (entry.released || entry.run) return;
+        entry.run = run;
+        this.enqueue(entry);
+      },
+      release: () => this.release(entry),
+    };
   }
 
   activeCount(): number {
@@ -123,7 +124,7 @@ export class RestoreGate {
 
   // What the gate is doing right now, for the [event-loop] stall line, or null
   // when idle. Sampled by the monitor at its poll, which runs after the stall
-  // it reports — so this names the refreshes in flight just after, which for a
+  // it reports — so this names the steps in flight just after, which for a
   // stall caused by their replies is the same set.
   describeInFlight(): string | null {
     if (this.active.size === 0 && this.waiting.length === 0) return null;
@@ -141,13 +142,18 @@ export class RestoreGate {
     const more = this.active.size - names.length;
     const list = names.length ? ` (${names.join(', ')}${more > 0 ? `, +${more} more` : ''})` : '';
     const waiting = this.waiting.length > 0 ? `; ${this.waiting.length} waiting` : '';
-    return `re-attach channel-state refreshes in flight: ${this.active.size}${list}${waiting}`;
+    return `re-attach channel-state refresh steps in flight: ${this.active.size}${list}${waiting}`;
   }
 
-  // Drop everything. Called on shutdown (the connections are being detached
-  // and nothing should start a refresh) and by tests. A slot handed out before
-  // the reset releases as a no-op.
+  // Drop everything, running nothing. For shutdown ONLY, and before the
+  // connections are detached: a detach's synchronous 'close' releases its slot,
+  // which would otherwise grant the next queued step to a connection that is
+  // itself about to detach — three requests whose replies land in the engine
+  // backlog and replay to the next process as if it had asked. Any other
+  // caller strands whatever was queued (its channels never get refreshed) and
+  // lifts the cap for the steps still running.
   reset(): void {
+    for (const entry of this.waiting) entry.released = true;
     this.waiting.length = 0;
     this.active.clear();
     this.burst = null;
@@ -158,21 +164,37 @@ export class RestoreGate {
     return Number.isFinite(n) && n > 0 ? n : Infinity;
   }
 
-  private release(id: number): void {
-    const w = this.waiting.findIndex((e) => e.id === id);
+  private enqueue(entry: Entry): void {
+    this.waiting.push(entry);
+    this.pump();
+    if (!this.waiting.includes(entry)) return;
+    entry.waited = true;
+    if (!this.burst) {
+      this.burst = { since: this.now(), queued: 0 };
+      const n = this.active.size;
+      console.log(
+        `[restore-gate] ${n} channel-state refresh step${n === 1 ? '' : 's'} in flight after re-attach; ` +
+          `the rest take turns (LURKER_RESTORE_CONCURRENCY=${this.limit()})`,
+      );
+    }
+  }
+
+  private release(entry: Entry): void {
+    entry.released = true;
+    const w = this.waiting.indexOf(entry);
     if (w >= 0) {
       this.waiting.splice(w, 1);
       this.noteIdle();
       return;
     }
-    if (!this.active.delete(id)) return;
+    if (!this.active.delete(entry.id)) return;
     this.pump();
   }
 
   // Grant slots to waiters, FIFO, while there is room. Re-entrant calls (a
-  // run() that acquires or releases synchronously — a connection with no
-  // channels drains its queue inside its own start) return at once; the
-  // outer loop re-reads the counts each pass and picks the change up.
+  // run() that reserves or releases synchronously — a connection re-queues its
+  // next step from inside the release of its last) return at once; the outer
+  // loop re-reads the counts each pass and picks the change up.
   private pump(): void {
     if (this.pumping) return;
     this.pumping = true;
@@ -180,12 +202,13 @@ export class RestoreGate {
       while (this.waiting.length > 0 && this.active.size < this.limit()) {
         const entry = this.waiting.shift()!;
         this.active.set(entry.id, entry);
+        if (entry.waited && this.burst) this.burst.queued++;
         try {
-          entry.run(entry.slot);
+          entry.run!();
         } catch (err) {
           // A start that threw holds nothing; keeping its slot would wedge
-          // every refresh behind it for the life of the process.
-          console.error('[restore-gate] refresh start threw', err);
+          // every step behind it for the life of the process.
+          console.error('[restore-gate] refresh step threw', err);
           this.active.delete(entry.id);
         }
       }
@@ -198,8 +221,9 @@ export class RestoreGate {
   private noteIdle(): void {
     if (!this.burst || this.waiting.length > 0 || this.active.size > 0) return;
     const secs = ((this.now() - this.burst.since) / 1000).toFixed(1);
+    const n = this.burst.queued;
     console.log(
-      `[restore-gate] re-attach refreshes drained: ${this.burst.queued} waited their turn, ` +
+      `[restore-gate] re-attach refreshes drained: ${n} step${n === 1 ? '' : 's'} waited for a turn, ` +
         `${secs}s since the cap was first hit`,
     );
     this.burst = null;

--- a/server/services/restoreGate.ts
+++ b/server/services/restoreGate.ts
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Cross-connection cap on the channel-state refresh after an engine re-attach.
+// See issue #842.
+//
+// When the app re-attaches to the connections the engine kept open, each one
+// asks the server about every channel it is in — NAMES/TOPIC/MODE, then the
+// WHO the NAMES reply triggers. drainRestoreQueue (ircConnection.ts) paces that
+// WITHIN a connection: one channel in flight, the next released by the previous
+// one's replies. Across N connections nothing paced it: all N started in the
+// tick the engine said `restored`, and their 353/366 replies (member rebuild +
+// WS fan-out, all synchronous) landed together. Measured on a 30-session cell:
+// one ~1.4 s [event-loop] stall a few seconds after attach, linear in the
+// session count.
+//
+// The attach itself is deliberately NOT staggered (ircManager skips
+// connectScheduler for it — an attach registers nothing on the ircd) and stays
+// immediate: buffered lines are delivered and the session is live the moment it
+// re-attaches. Only the refresh waits its turn here, and nothing is at stake on
+// the ircd side while it does — the socket is up, the engine answered PINGs
+// throughout — it is only "when does this channel's member list come back".
+//
+// Model: a counting semaphore with a FIFO wait queue, not a rate limiter like
+// connectScheduler. A connect may never register, so the scheduler can't await
+// one; a refresh has a definite end (its queue drains) and definite abort
+// points (the socket closes, the connection re-dials or re-attaches, the
+// network is removed), all of which release the slot. A holder that stalls is
+// bounded by drainRestoreQueue's per-step deadline: every step ends, so every
+// queue drains, so every slot comes back.
+//
+// Under the cap the refresh starts synchronously inside acquire(), so a
+// single-user instance with a handful of networks sees no change at all.
+
+const DEFAULT_CONCURRENCY = 4;
+// How many holders describeInFlight() names before it says "+N more".
+const DESCRIBE_MAX = 6;
+
+export type RestoreSlotState = 'waiting' | 'active' | 'released';
+
+export interface RestoreSlot {
+  // Give the slot back, or leave the queue if it was never granted. Idempotent.
+  release(): void;
+  state(): RestoreSlotState;
+}
+
+export interface RestoreGateOptions {
+  // How many refreshes may run at once; 0 (or non-finite) = no cap. Read on
+  // every decision, like the other restore knobs, so a test — or an operator —
+  // does not have to restart the process for it to take.
+  concurrency?: () => number;
+  now?: () => number;
+}
+
+interface Entry {
+  id: number;
+  describe: () => string;
+  run: (slot: RestoreSlot) => void;
+  slot: RestoreSlot;
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw == null || raw.trim() === '') return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+export class RestoreGate {
+  private readonly cap: () => number;
+  private readonly now: () => number;
+  private readonly waiting: Entry[] = [];
+  private readonly active = new Map<number, Entry>();
+  private nextId = 1;
+  private pumping = false;
+  // Set from the first refresh that has to wait until every refresh is done —
+  // one log line at each end of the burst, never one per queued session.
+  private burst: { since: number; queued: number } | null = null;
+
+  constructor(opts: RestoreGateOptions = {}) {
+    this.cap =
+      opts.concurrency ?? (() => envInt('LURKER_RESTORE_CONCURRENCY', DEFAULT_CONCURRENCY));
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  // Ask for a slot. `run` is called with the slot the moment one is free —
+  // synchronously, inside this call, when the gate is under its cap — and the
+  // caller keeps the slot until its refresh is done or abandoned. `describe`
+  // labels the holder for the event-loop monitor (describeInFlight).
+  acquire(describe: () => string, run: (slot: RestoreSlot) => void): RestoreSlot {
+    const id = this.nextId++;
+    const slot: RestoreSlot = {
+      release: () => this.release(id),
+      state: () => {
+        if (this.active.has(id)) return 'active';
+        return this.waiting.some((e) => e.id === id) ? 'waiting' : 'released';
+      },
+    };
+    const entry: Entry = { id, describe, run, slot };
+    this.waiting.push(entry);
+    this.pump();
+    if (this.waiting.includes(entry)) {
+      if (!this.burst) {
+        this.burst = { since: this.now(), queued: 0 };
+        const n = this.active.size;
+        console.log(
+          `[restore-gate] ${n} connection${n === 1 ? '' : 's'} refreshing channel state after re-attach; ` +
+            `queuing the rest (LURKER_RESTORE_CONCURRENCY=${this.limit()})`,
+        );
+      }
+      this.burst.queued++;
+    }
+    return slot;
+  }
+
+  activeCount(): number {
+    return this.active.size;
+  }
+
+  waitingCount(): number {
+    return this.waiting.length;
+  }
+
+  // What the gate is doing right now, for the [event-loop] stall line, or null
+  // when idle. Sampled by the monitor at its poll, which runs after the stall
+  // it reports — so this names the refreshes in flight just after, which for a
+  // stall caused by their replies is the same set.
+  describeInFlight(): string | null {
+    if (this.active.size === 0 && this.waiting.length === 0) return null;
+    const names: string[] = [];
+    for (const entry of this.active.values()) {
+      if (names.length >= DESCRIBE_MAX) break;
+      let label: string;
+      try {
+        label = entry.describe();
+      } catch (_) {
+        label = '?';
+      }
+      names.push(label);
+    }
+    const more = this.active.size - names.length;
+    const list = names.length ? ` (${names.join(', ')}${more > 0 ? `, +${more} more` : ''})` : '';
+    const waiting = this.waiting.length > 0 ? `; ${this.waiting.length} waiting` : '';
+    return `re-attach channel-state refreshes in flight: ${this.active.size}${list}${waiting}`;
+  }
+
+  // Drop everything. Called on shutdown (the connections are being detached
+  // and nothing should start a refresh) and by tests. A slot handed out before
+  // the reset releases as a no-op.
+  reset(): void {
+    this.waiting.length = 0;
+    this.active.clear();
+    this.burst = null;
+  }
+
+  private limit(): number {
+    const n = this.cap();
+    return Number.isFinite(n) && n > 0 ? n : Infinity;
+  }
+
+  private release(id: number): void {
+    const w = this.waiting.findIndex((e) => e.id === id);
+    if (w >= 0) {
+      this.waiting.splice(w, 1);
+      this.noteIdle();
+      return;
+    }
+    if (!this.active.delete(id)) return;
+    this.pump();
+  }
+
+  // Grant slots to waiters, FIFO, while there is room. Re-entrant calls (a
+  // run() that acquires or releases synchronously — a connection with no
+  // channels drains its queue inside its own start) return at once; the
+  // outer loop re-reads the counts each pass and picks the change up.
+  private pump(): void {
+    if (this.pumping) return;
+    this.pumping = true;
+    try {
+      while (this.waiting.length > 0 && this.active.size < this.limit()) {
+        const entry = this.waiting.shift()!;
+        this.active.set(entry.id, entry);
+        try {
+          entry.run(entry.slot);
+        } catch (err) {
+          // A start that threw holds nothing; keeping its slot would wedge
+          // every refresh behind it for the life of the process.
+          console.error('[restore-gate] refresh start threw', err);
+          this.active.delete(entry.id);
+        }
+      }
+    } finally {
+      this.pumping = false;
+    }
+    this.noteIdle();
+  }
+
+  private noteIdle(): void {
+    if (!this.burst || this.waiting.length > 0 || this.active.size > 0) return;
+    const secs = ((this.now() - this.burst.since) / 1000).toFixed(1);
+    console.log(
+      `[restore-gate] re-attach refreshes drained: ${this.burst.queued} waited their turn, ` +
+        `${secs}s since the cap was first hit`,
+    );
+    this.burst = null;
+  }
+}
+
+// Process-wide singleton used by IrcConnection. Tests construct their own
+// instances with injected config rather than poking this one.
+const restoreGate = new RestoreGate();
+export default restoreGate;

--- a/server/test-utils/engineHarness.ts
+++ b/server/test-utils/engineHarness.ts
@@ -1,19 +1,44 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// The rig an engine-restore test runs on: a fake ircd, an engine holding
-// sockets to it, and this process switched into engine mode against that
-// engine. Importers must load '../test-utils/isolateDb.js' first, as with any
-// test that touches ircManager.
+// The rig an engine-mode test runs on: a fake ircd, an engine holding sockets
+// to it, this process switched into engine mode against that engine, and a
+// log of the wire between them. Importers must load '../test-utils/isolateDb.js'
+// first, as with any test that touches ircManager.
 
 import { EngineServer } from '../engine/server.js';
 import { EngineLink, engineConfigured } from '../services/engineLink.js';
 import ircManager from '../services/ircManager.js';
+import type { IrcConnection } from '../services/ircConnection.js';
 import { FakeIrcd } from './fakeIrcd.js';
+import { until } from './until.js';
+
+// One line on the wire, tagged with the connection's nick. '<' is stamped as
+// the fake ircd sends it — before the relay hop, so a reply is always logged
+// ahead of the request it releases — and '>' as the Client writes it, the
+// same synchronous chain that arms a restore step's deadline, so timing
+// assertions read one clock. (Recording both at the Client would log them the
+// other way round: Lurker's own 'raw' handler runs first and writes the next
+// request inside it.)
+export interface WireLine {
+  t: number;
+  dir: '>' | '<';
+  nick: string;
+  line: string;
+}
 
 export interface EngineHarness {
   ircd: FakeIrcd;
   engine: EngineServer;
+  // Every line the ircd wrote, from the start, plus every line a tapped
+  // connection's Client wrote. A test that only cares about its second
+  // session clears it (`wire.length = 0`) once the first has let go.
+  wire: WireLine[];
+  // Record what this connection's Client writes, as `nick`.
+  tap(conn: IrcConnection, nick: string): void;
+  wireTail(): string;
+  // until() with the wire tail as the timeout's detail.
+  until(pred: () => boolean, ms: number, what: string): Promise<void>;
   // Detach every connection, stop the engine and the ircd, and delete every
   // env var start set — so a knob one test file sets cannot leak into the
   // next file of a full-suite run.
@@ -26,6 +51,10 @@ export async function startEngineHarness(opts: {
   env?: Record<string, string>;
 }): Promise<EngineHarness> {
   const ircd = await FakeIrcd.start();
+  const wire: WireLine[] = [];
+  ircd.on('sent', (line: string, c: { nick: string | null }) =>
+    wire.push({ t: Date.now(), dir: '<', nick: c.nick ?? '?', line }),
+  );
   const engine = new EngineServer({
     secret: opts.secret,
     bufferBytes: 64 * 1024,
@@ -46,9 +75,23 @@ export async function startEngineHarness(opts: {
   for (const [k, v] of Object.entries(env)) process.env[k] = v;
   EngineLink.resetForTests();
   if (!engineConfigured()) throw new Error('engine mode did not switch on');
+  const wireTail = () =>
+    'last wire lines:\n' +
+    wire
+      .slice(-60)
+      .map((w) => `${w.dir} [${w.nick}] ${w.line}`)
+      .join('\n');
   return {
     ircd,
     engine,
+    wire,
+    tap(conn, nick) {
+      conn.client.on('raw', (ev: { line: string; from_server: boolean }) => {
+        if (!ev.from_server) wire.push({ t: Date.now(), dir: '>', nick, line: ev.line });
+      });
+    },
+    wireTail,
+    until: (pred, ms, what) => until(pred, ms, what, wireTail),
     async stop() {
       ircManager.shutdown();
       EngineLink.resetForTests();

--- a/server/test-utils/engineHarness.ts
+++ b/server/test-utils/engineHarness.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The rig an engine-restore test runs on: a fake ircd, an engine holding
+// sockets to it, and this process switched into engine mode against that
+// engine. Importers must load '../test-utils/isolateDb.js' first, as with any
+// test that touches ircManager.
+
+import { EngineServer } from '../engine/server.js';
+import { EngineLink, engineConfigured } from '../services/engineLink.js';
+import ircManager from '../services/ircManager.js';
+import { FakeIrcd } from './fakeIrcd.js';
+
+export interface EngineHarness {
+  ircd: FakeIrcd;
+  engine: EngineServer;
+  // Detach every connection, stop the engine and the ircd, and delete every
+  // env var start set — so a knob one test file sets cannot leak into the
+  // next file of a full-suite run.
+  stop(): Promise<void>;
+}
+
+export async function startEngineHarness(opts: {
+  secret: string;
+  // Per-test knobs (LURKER_RESTORE_*, …), set alongside the engine ones.
+  env?: Record<string, string>;
+}): Promise<EngineHarness> {
+  const ircd = await FakeIrcd.start();
+  const engine = new EngineServer({
+    secret: opts.secret,
+    bufferBytes: 64 * 1024,
+    bufferTotalBytes: 1024 * 1024,
+    version: 'test',
+    log: () => {},
+  });
+  const { port } = await engine.listen(0, '127.0.0.1');
+  const env: Record<string, string> = {
+    LURKER_ENGINE_URL: `tcp://127.0.0.1:${port}`,
+    LURKER_ENGINE_SECRET: opts.secret,
+    LURKER_ENGINE_RETRY_BASE_MS: '100',
+    // A full-suite CI run starves the event loop; keep the link's heartbeat
+    // well clear of the run so it can't drop a healthy idle link mid-test.
+    LURKER_ENGINE_HEARTBEAT_MS: '600000',
+    ...opts.env,
+  };
+  for (const [k, v] of Object.entries(env)) process.env[k] = v;
+  EngineLink.resetForTests();
+  if (!engineConfigured()) throw new Error('engine mode did not switch on');
+  return {
+    ircd,
+    engine,
+    async stop() {
+      ircManager.shutdown();
+      EngineLink.resetForTests();
+      await engine.shutdown('tests done', 500);
+      await ircd.close();
+      for (const k of Object.keys(env)) delete process.env[k];
+    },
+  };
+}

--- a/server/test-utils/engineHarness.ts
+++ b/server/test-utils/engineHarness.ts
@@ -11,6 +11,7 @@ import { EngineLink, engineConfigured } from '../services/engineLink.js';
 import ircManager from '../services/ircManager.js';
 import type { IrcConnection } from '../services/ircConnection.js';
 import { FakeIrcd } from './fakeIrcd.js';
+import { setEnvAll } from './env.js';
 import { until } from './until.js';
 
 // One line on the wire, tagged with the connection's nick. '<' is stamped as
@@ -39,9 +40,9 @@ export interface EngineHarness {
   wireTail(): string;
   // until() with the wire tail as the timeout's detail.
   until(pred: () => boolean, ms: number, what: string): Promise<void>;
-  // Detach every connection, stop the engine and the ircd, and delete every
-  // env var start set — so a knob one test file sets cannot leak into the
-  // next file of a full-suite run.
+  // Detach every connection, stop the engine and the ircd, and put back every
+  // env var start set — to what it was, or unset — so a knob one test file
+  // sets cannot leak into the next file of a full-suite run.
   stop(): Promise<void>;
 }
 
@@ -63,7 +64,7 @@ export async function startEngineHarness(opts: {
     log: () => {},
   });
   const { port } = await engine.listen(0, '127.0.0.1');
-  const env: Record<string, string> = {
+  const restoreEnv = setEnvAll({
     LURKER_ENGINE_URL: `tcp://127.0.0.1:${port}`,
     LURKER_ENGINE_SECRET: opts.secret,
     LURKER_ENGINE_RETRY_BASE_MS: '100',
@@ -71,8 +72,7 @@ export async function startEngineHarness(opts: {
     // well clear of the run so it can't drop a healthy idle link mid-test.
     LURKER_ENGINE_HEARTBEAT_MS: '600000',
     ...opts.env,
-  };
-  for (const [k, v] of Object.entries(env)) process.env[k] = v;
+  });
   EngineLink.resetForTests();
   if (!engineConfigured()) throw new Error('engine mode did not switch on');
   const wireTail = () =>
@@ -97,7 +97,7 @@ export async function startEngineHarness(opts: {
       EngineLink.resetForTests();
       await engine.shutdown('tests done', 500);
       await ircd.close();
-      for (const k of Object.keys(env)) delete process.env[k];
+      restoreEnv();
     },
   };
 }

--- a/server/test-utils/env.ts
+++ b/server/test-utils/env.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Set env knobs for the span of a test (or a harness) and hand back the way to
+// put them back — each to the value it had, or unset — so what one test sets
+// is invisible to the next, whether they share a file or a worker.
+
+export function setEnv(name: string, value: string): () => void {
+  const prev = process.env[name];
+  process.env[name] = value;
+  return () => {
+    if (prev === undefined) delete process.env[name];
+    else process.env[name] = prev;
+  };
+}
+
+export function setEnvAll(vars: Record<string, string>): () => void {
+  const restores = Object.entries(vars).map(([k, v]) => setEnv(k, v));
+  return () => {
+    for (const restore of restores) restore();
+  };
+}

--- a/server/test-utils/until.ts
+++ b/server/test-utils/until.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Poll a predicate every 10 ms until it holds or `ms` pass. `what` names the
+// wait in the timeout error; `dump` adds context to it (a wire-log tail, a
+// connection's state) so a timeout says where things stood, not just that
+// they did.
+export function until(
+  pred: () => boolean,
+  ms = 5000,
+  what = 'condition',
+  dump?: () => string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + ms;
+    const tick = () => {
+      if (pred()) return resolve();
+      if (Date.now() > deadline) {
+        const detail = dump ? `; ${dump()}` : '';
+        return reject(new Error(`timed out waiting for ${what}${detail}`));
+      }
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}

--- a/server/test-utils/until.ts
+++ b/server/test-utils/until.ts
@@ -4,7 +4,10 @@
 // Poll a predicate every 10 ms until it holds or `ms` pass. `what` names the
 // wait in the timeout error; `dump` adds context to it (a wire-log tail, a
 // connection's state) so a timeout says where things stood, not just that
-// they did.
+// they did. A predicate that throws rejects with its error rather than
+// throwing out of a timer tick — an uncaught exception plus a promise that
+// never settles is two confusing failures for one cause — and a dump that
+// throws is reported inside the timeout error, never in place of it.
 export function until(
   pred: () => boolean,
   ms = 5000,
@@ -14,9 +17,22 @@ export function until(
   return new Promise((resolve, reject) => {
     const deadline = Date.now() + ms;
     const tick = () => {
-      if (pred()) return resolve();
+      let holds: boolean;
+      try {
+        holds = pred();
+      } catch (err) {
+        return reject(err instanceof Error ? err : new Error(String(err)));
+      }
+      if (holds) return resolve();
       if (Date.now() > deadline) {
-        const detail = dump ? `; ${dump()}` : '';
+        let detail = '';
+        if (dump) {
+          try {
+            detail = `; ${dump()}`;
+          } catch (err) {
+            detail = `; (dump threw: ${(err as Error)?.message ?? err})`;
+          }
+        }
         return reject(new Error(`timed out waiting for ${what}${detail}`));
       }
       setTimeout(tick, 10);

--- a/server/utils/envInt.test.ts
+++ b/server/utils/envInt.test.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { envInt } from './envInt.js';
+
+const NAME = 'LURKER_ENV_INT_TEST';
+
+afterEach(() => {
+  delete process.env[NAME];
+});
+
+describe('envInt', () => {
+  it('falls back when unset or blank', () => {
+    expect(envInt(NAME, 7)).toBe(7);
+    process.env[NAME] = '   ';
+    expect(envInt(NAME, 7)).toBe(7);
+  });
+
+  it('reads a whole number, 0 included', () => {
+    process.env[NAME] = ' 12 ';
+    expect(envInt(NAME, 7)).toBe(12);
+    process.env[NAME] = '0';
+    expect(envInt(NAME, 7)).toBe(0);
+  });
+
+  it('falls back on anything that is not a whole number >= 0', () => {
+    const raws = ['0.5', '-1', 'abc', 'Infinity', '1e400', '3px'];
+    const parsed = Object.fromEntries(
+      raws.map((raw) => {
+        process.env[NAME] = raw;
+        return [raw, envInt(NAME, 7)];
+      }),
+    );
+    expect(parsed).toEqual(Object.fromEntries(raws.map((raw) => [raw, 7])));
+  });
+});

--- a/server/utils/envInt.ts
+++ b/server/utils/envInt.ts
@@ -1,13 +1,15 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// A non-negative numeric knob from the environment. Unset or blank → the
-// fallback; anything that is not a finite number >= 0 → the fallback. 0 is a
-// legitimate value (several knobs read it as "off" or "no cap"), so a caller
-// that needs a floor applies it itself.
+// A non-negative integer knob from the environment. Unset or blank → the
+// fallback; anything that is not a whole number >= 0 → the fallback too, so
+// a misconfiguration ("0.5", "abc", "-1") does not turn into a truncated
+// timer or a cap of 1.5 that admits 2. 0 is a legitimate value (several knobs
+// read it as "off" or "no cap"), so a caller that needs a floor applies it
+// itself.
 export function envInt(name: string, fallback: number): number {
   const raw = process.env[name];
   if (raw == null || raw.trim() === '') return fallback;
   const n = Number(raw);
-  return Number.isFinite(n) && n >= 0 ? n : fallback;
+  return Number.isInteger(n) && n >= 0 ? n : fallback;
 }

--- a/server/utils/envInt.ts
+++ b/server/utils/envInt.ts
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// A non-negative numeric knob from the environment. Unset or blank → the
+// fallback; anything that is not a finite number >= 0 → the fallback. 0 is a
+// legitimate value (several knobs read it as "off" or "no cap"), so a caller
+// that needs a floor applies it itself.
+export function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw == null || raw.trim() === '') return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}


### PR DESCRIPTION
Closes #842.

## What

On a re-attach every engine-held connection started its per-channel NAMES/TOPIC/MODE refresh in the same tick. #840's pacing is reply-gated *within* a connection; across N connections it was N-parallel, and N first replies (member rebuild + WS fan-out, all synchronous) landing together is the `[event-loop] stalled ~1358ms` the roswell canary saw 4.6 s after a 30-session attach.

`restoreGate` is a process-wide FIFO semaphore — `LURKER_RESTORE_CONCURRENCY`, default 4, `0` = no cap, read live. The unit of a turn is one **step** (one channel's three requests), not a connection's whole walk: each step reserves at the back of the FIFO, so with more connections than slots the steps round-robin — every session's first member list comes back early, and a connection whose server answers slowly (or not at all: the step deadline) holds a slot for one step at a time. Under the cap a step goes out synchronously inside `start()`, so a small self-host sees no change.

Attaches are untouched, as the issue asks: a session is `connected` with its buffered lines delivered before its first step queues. The umode `MODE nick` is asked at `restored`, ungated (one line per connection is not what the cap bounds, and deferring it left the self-label without modes for the wait). Every queued channel is marked `restoreQuiet` at `restored`, not as each step goes out — replies to a step the *previous* process had in flight sit in the engine backlog and replay right after the phase, and the WHO size gate and server-buffer filter must read them as the restore's even while the channel's own step is still queued.

`eventLoopMonitor` takes a `context` provider; the stall line now names the steps in flight (`; re-attach channel-state refresh steps in flight: 4 (net 3 #chan, …); 26 waiting`), sampled at the poll just after the stall.

## What this does not bound

The away-sync WHO each 366 triggers stays outside the cap, on purpose (#840's rule: a 315 that never comes wedges irc-framework's WHO queue for the socket's life, and "sent" vs "queued" is not observable from outside the framework). It is size-gated (`LURKER_RESTORE_WHO_MAX_MEMBERS`) and one-in-flight per connection, but across connections as parallel as before. Nor does the gate touch an unattended socket's autojoin JOINs at `live` or a cold start's fresh connects. The gate header, `drainRestoreQueue`, and `.env.example` say so; a per-tick bound on member-rebuild + fan-out in the userlist handler would be the source-agnostic follow-up if the stall proves WHO-dominated.

## Also in here

- `server/utils/envInt.ts` replaces four identical env parsers (`engineLink.ts`'s own has different zero semantics and is left alone); `envFlag` copies use `utils/truthyEnv`.
- `server/test-utils/until.ts` + `engineHarness.ts` (fake ircd + engine + engine-mode env + wire log; `stop()` deletes every env it set) now back all the app-side engine tests; `engine.test.ts` / `engineTransport.test.ts` use the shared `until`.

## Tests

- `restoreGate.test.ts` — FIFO grant, synchronous start under the cap, release from either side, round-robin re-queueing, a step that throws or hands its turn straight back, live cap, `describeInFlight`, burst logging (counts only steps that actually waited).
- `engineRestoreConcurrency.test.ts` — against engine + fake ircd at cap 1: a held MODE makes one step end only by the deadline, and the test asserts round-robin over the NAMES sequence, one step in flight, and that the step's two *answered* replies did not pass the turn (against the fake ircd all three replies land in one pass, so without a held reply "last reply" and "first reply" are indistinguishable); a connection dropped mid-step gives its turn up at once, not at the deadline, with the next connection's umode already out; the backlog-replay case above with the WHO threshold at 0.
- `eventLoopMonitor.test.ts` — the context on the stall line, absent, and throwing.
- Mutants killed by the engine tests: no cap; first-reply release; a finished step keeping its turn; no quiet-mark at `restored`; the `waited` over-count.

`npm run check` green; full `npm test` 4278/4278. Two `/code-review high` rounds applied (the first moved the design from a slot per connection to a slot per step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
