### PR TITLE
Nick completion suffix is a setting (#835)

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1667,6 +1667,27 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       "input as you type any 2+ character prefix (no '@' required), tap or " +
       'click a nick to insert it.',
   },
+  // What a nick picks up when completed at the START of a line — the
+  // addressing form, `nick: `. Stored as the punctuation alone, with the
+  // trailing space always appended by the client (irssi's completion_char,
+  // HexChat's completion_suffix): every meaningful value is then visible in a
+  // text field, `/set input.completion.nick_suffix ,` needs no quoting, and
+  // "space only" is the empty string rather than an invisible ' '. Not an enum
+  // — the ask (#835) was for the common four AND free-form, and a string gets
+  // both without a new registry type.
+  {
+    key: 'input.completion.nick_suffix',
+    label: 'Nick completion suffix',
+    category: 'input',
+    group: 'autocomplete',
+    type: 'string',
+    default: ':',
+    description:
+      'Punctuation placed after a nick completed at the start of a line — the ' +
+      '"nick: " addressing form. A space always follows it; leave it empty for ' +
+      'a bare space. Applies to Tab, the @ picker, the suggestion strip, and ' +
+      'Reply. Mid-line completions are unaffected.',
+  },
 
   // ─── Input bar (formatting) ──────────────────────────────────────────
   // Surfaces the mIRC palette popover for users who want to insert colour /

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1669,12 +1669,13 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   },
   // What a nick picks up when completed at the START of a line — the
   // addressing form, `nick: `. Stored as the punctuation alone, with the
-  // trailing space always appended by the client (irssi's completion_char,
-  // HexChat's completion_suffix): every meaningful value is then visible in a
-  // text field, `/set input.completion.nick_suffix ,` needs no quoting, and
-  // "space only" is the empty string rather than an invisible ' '. Not an enum
-  // — the ask (#835) was for the common four AND free-form, and a string gets
-  // both without a new registry type.
+  // trailing space always appended by the client (irssi's completion_char):
+  // every meaningful value is then visible in a text field, `/set
+  // input.completion.nick_suffix ,` needs no quoting, and "space only" is the
+  // empty string rather than an invisible ' '. The trade is that "no space"
+  // and "two spaces" are inexpressible, which nobody has asked for. Not an
+  // enum — the ask (#835) was for the common four AND free-form, and a string
+  // gets both without a new registry type.
   {
     key: 'input.completion.nick_suffix',
     label: 'Nick completion suffix',
@@ -1684,9 +1685,9 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     default: ':',
     description:
       'Punctuation placed after a nick completed at the start of a line — the ' +
-      '"nick: " addressing form. A space always follows it; leave it empty for ' +
-      'a bare space. Applies to Tab, the @ picker, the suggestion strip, and ' +
-      'Reply. Mid-line completions are unaffected.',
+      '"nick: " addressing form: ":" (default), ",", ";", or empty for a bare ' +
+      'space. A space always follows it. Applies to Tab, the @ picker, the ' +
+      'suggestion strip, and Reply; mid-line completions are unaffected.',
   },
 
   // ─── Input bar (formatting) ──────────────────────────────────────────

--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -306,6 +306,65 @@ describe('MessageInput Tab-completion', () => {
       expect(el.value).toBe('bob, sure');
     });
 
+    it('Reply recognises a draft addressed under another form', async () => {
+      // The draft can predate a settings change, or come from a client with its
+      // own form (iOS still writes `nick: `, and drafts sync) — any punctuation
+      // after the nick counts, so this must not become `bob, bob: sure`.
+      seedStores('#zebra');
+      useSettingsStore().values['input.completion.nick_suffix'] = ',';
+      const { el } = await mountComposer();
+
+      await type(el, 'bob: sure');
+      addressNick('bob');
+      await flush();
+      expect(el.value).toBe('bob: sure');
+    });
+
+    it('Reply still addresses a draft that merely opens with the nick as a word', async () => {
+      // "will" is a nick and a word. Under any non-empty suffix the bare
+      // `will ` form is NOT an address, so Reply prepends — the "already
+      // addressed" check must demand punctuation, not just the nick.
+      seedStores('#zebra');
+      const { el } = await mountComposer();
+
+      await type(el, 'will you come?');
+      addressNick('will');
+      await flush();
+      expect(el.value).toBe('will: will you come?');
+    });
+
+    it('under an empty suffix, a draft opening with the nick already counts as addressed', async () => {
+      // With "space only" the addressed form and the nick-as-a-word form are
+      // the same text; that ambiguity is the convention's, and Reply follows
+      // it rather than producing `bob bob is wrong`.
+      seedStores('#zebra');
+      useSettingsStore().values['input.completion.nick_suffix'] = '';
+      const { el } = await mountComposer();
+
+      await type(el, 'bob is wrong');
+      addressNick('bob');
+      await flush();
+      expect(el.value).toBe('bob is wrong');
+    });
+
+    it('drops trailing whitespace typed into the setting instead of doubling it', async () => {
+      // The description shows the form as `nick: `; typing exactly that into
+      // the field is the natural mistake, and a quoted " " from /set is the
+      // natural way to ask for "space only".
+      seedStores('#zebra');
+      useSettingsStore().values['input.completion.nick_suffix'] = ', ';
+      const { el } = await mountComposer();
+
+      await type(el, '@al');
+      await tab(el);
+      expect(el.value).toBe('alexis, ');
+
+      useSettingsStore().values['input.completion.nick_suffix'] = ' ';
+      await type(el, 'bo');
+      await tab(el);
+      expect(el.value).toBe('bob ');
+    });
+
     it('never offers your own nick', async () => {
       // Both m-nicks match "@m"; only mallory may be offered. The positive half
       // of this assertion matters as much as the negative one — with `me` as the

--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -19,7 +19,7 @@ import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useRecentBuffersStore } from '../stores/recentBuffers.js';
 import { useDraftStore } from '../stores/drafts.js';
-import { useComposerOverlay, selectNick } from '../composables/useComposerOverlay.js';
+import { useComposerOverlay, selectNick, addressNick } from '../composables/useComposerOverlay.js';
 import { useViewport } from '../composables/useViewport.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useScrollState } from '../composables/useScrollState.js';
@@ -243,6 +243,67 @@ describe('MessageInput Tab-completion', () => {
 
       await tab(el);
       expect(el.value).toBe('alice: ');
+    });
+
+    // The addressing punctuation is a setting (#835). It stores the mark alone
+    // and the space is always appended, so the four cases below are the four
+    // code paths that seed a line-start session — picker, in-place Tab, strip,
+    // Reply — each read through the one helper, and any of them could regress
+    // back to the literal on its own.
+    it('takes the addressing punctuation from the setting, across the cycle', async () => {
+      seedStores('#zebra');
+      useSettingsStore().values['input.completion.nick_suffix'] = ',';
+      const { el } = await mountComposer();
+
+      await type(el, '@al');
+      await tab(el);
+      expect(el.value).toBe('alexis, ');
+
+      await tab(el);
+      expect(el.value).toBe('alice, ');
+    });
+
+    it('addresses with a bare space when the punctuation setting is empty', async () => {
+      // In-place Tab (no '@', no picker) is the path that appends nothing
+      // mid-line, so it is the one most likely to be handed '' and drop the
+      // space too.
+      seedStores('#zebra');
+      useSettingsStore().values['input.completion.nick_suffix'] = '';
+      const { el } = await mountComposer();
+
+      await type(el, 'al');
+      await tab(el);
+      expect(el.value).toBe('alexis ');
+    });
+
+    it('applies the setting to a strip pick at line start', async () => {
+      seedStores('#zebra');
+      useSettingsStore().values['input.completion.nick_suffix'] = ';';
+      isMobile.value = true;
+      const { el } = await mountComposer();
+
+      await type(el, 'al');
+      selectNick('alexis');
+      await flush();
+      expect(el.value).toBe('alexis; ');
+    });
+
+    it('applies the setting to Reply, and recognises an already-addressed draft', async () => {
+      seedStores('#zebra');
+      useSettingsStore().values['input.completion.nick_suffix'] = ',';
+      const { el } = await mountComposer();
+
+      await type(el, 'sure');
+      addressNick('bob');
+      await flush();
+      expect(el.value).toBe('bob, sure');
+
+      // Already addressed under THIS suffix — a second Reply must not stack a
+      // second `bob, ` (the check compares against the configured form, not
+      // the old literal).
+      addressNick('bob');
+      await flush();
+      expect(el.value).toBe('bob, sure');
     });
 
     it('never offers your own nick', async () => {

--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -333,6 +333,25 @@ describe('MessageInput Tab-completion', () => {
       expect(el.value).toBe('will: will you come?');
     });
 
+    it('Reply does not mistake a longer nick for the addressed one', async () => {
+      // `bob_` is bob's ghost and `bobł` is someone else; a draft addressed to
+      // either must not read as "already addressed to bob". The mark run has
+      // to exclude nick characters — Unicode letters (`\w` is ASCII-only) and
+      // the RFC specials — not just `\w`.
+      seedStores('#zebra');
+      const { el } = await mountComposer();
+
+      await type(el, 'bob_: hi');
+      addressNick('bob');
+      await flush();
+      expect(el.value).toBe('bob: bob_: hi');
+
+      await type(el, 'bobł hi');
+      addressNick('bob');
+      await flush();
+      expect(el.value).toBe('bob: bobł hi');
+    });
+
     it('under an empty suffix, a draft opening with the nick already counts as addressed', async () => {
       // With "space only" the addressed form and the nick-as-a-word form are
       // the same text; that ambiguity is the convention's, and Reply follows

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -655,8 +655,8 @@ function endTypingTo(target: { networkId: number; target: string } | null | unde
 interface CompletionState {
   prefix: string;
   tail: string;
-  // What follows the pick: ': ' for a nick being addressed at line start, ' '
-  // for a channel committed out of the ChannelPicker, '' otherwise. Stored on
+  // What follows the pick: addressSuffix() for a nick being addressed at line
+  // start, ' ' for a channel committed out of the ChannelPicker, '' otherwise. Stored on
   // the session rather than re-derived on each cycle so every Tab reproduces
   // the same shape of insertion the first one made — the picker commits with a
   // trailing space, in-place completion doesn't, and a cycle seeded from the
@@ -811,6 +811,17 @@ function tokenAtCursor(
 // (see the call sites).
 function isAtLineStart(before: string): boolean {
   return /(^|\n)\s*$/.test(before);
+}
+
+// What a nick takes when it opens the line — the addressing form. The setting
+// stores the punctuation alone and the space is always ours to add (see the
+// registry entry), so "space only" is the empty string. Read once when a
+// session is seeded, never per cycle: the suffix rides on CompletionState so a
+// setting change mid-walk can't change the shape of the insertion under the
+// caret. Shared by Tab, the @ picker, the strip, and Reply (#835).
+function addressSuffix(): string {
+  const punct = settings.effective('input.completion.nick_suffix');
+  return `${typeof punct === 'string' ? punct : ':'} `;
 }
 
 function buildNickMatches(buf: Buffer, networkId: number, prefix: string): string[] {
@@ -1352,9 +1363,9 @@ function onKeydown(e: KeyboardEvent): void {
 
   const prefix = value.slice(0, start);
   const tail = value.slice(end);
-  // A nick at line start is being *addressed* and wants an opening ': '.
+  // A nick at line start is being *addressed* and wants the addressing suffix.
   // Channels never take one — the '#' is already part of the name.
-  const suffix = !isChannel && isAtLineStart(prefix) ? ': ' : '';
+  const suffix = !isChannel && isAtLineStart(prefix) ? addressSuffix() : '';
 
   completion = { prefix, tail, suffix, matches, index: 0, caret: 0 };
   applyCompletion();
@@ -1617,13 +1628,13 @@ function onPickerSelect(nick: string): void {
   }
   const buf = buffer.value;
   const networkId = active.value?.networkId;
-  // A nick at the start of a line is being addressed → ': '; mid-sentence gets
-  // a bare space. Identical to the mobile strip (onStripSelect). In-place Tab-
-  // completion shares the isAtLineStart() check but appends nothing
-  // mid-sentence — which is exactly why the suffix rides on the session instead
-  // of being re-derived on each cycle: a walk seeded from here has to keep
-  // reproducing the space the picker already inserted.
-  const suffix = isAtLineStart(text.value.slice(0, pickerTokenStart)) ? ': ' : ' ';
+  // A nick at the start of a line is being addressed → addressSuffix();
+  // mid-sentence gets a bare space. Identical to the mobile strip
+  // (onStripSelect). In-place Tab-completion shares the isAtLineStart() check
+  // but appends nothing mid-sentence — which is exactly why the suffix rides on
+  // the session instead of being re-derived on each cycle: a walk seeded from
+  // here has to keep reproducing the space the picker already inserted.
+  const suffix = isAtLineStart(text.value.slice(0, pickerTokenStart)) ? addressSuffix() : ' ';
   // pickerQuery is the token minus its '@' — the bare prefix buildNickMatches
   // expects. Read before commitCompletion, which closes the picker and clears it.
   commitCompletion({
@@ -1643,7 +1654,7 @@ function onChannelPickerSelect(channel: string): void {
   const networkId = active.value?.networkId;
   const token = text.value.slice(channelPickerTokenStart, channelPickerTokenEnd);
   // Channels just get a trailing space — there's no "addressing" form like
-  // nicks' ': ', and the '#' is already part of the inserted name. The sent
+  // nicks' addressSuffix(), and the '#' is already part of the inserted name. The sent
   // `#channel` renders as a clickable join link for the recipient
   // (RenderSegments → openChannel), which is the whole point (issue #154).
   commitCompletion({
@@ -1662,11 +1673,11 @@ function onStripSelect(nick: string): void {
   }
   const buf = buffer.value;
   const networkId = active.value?.networkId;
-  // A nick at the start of a line is being addressed → ': '; mid-sentence
-  // gets a bare space (what the old @-menu was missing — task #198). Shares
-  // isAtLineStart() with Tab-completion and the desktop picker.
+  // A nick at the start of a line is being addressed → addressSuffix();
+  // mid-sentence gets a bare space (what the old @-menu was missing — task
+  // #198). Shares isAtLineStart() with Tab-completion and the desktop picker.
   const draft = text.value;
-  const suffix = isAtLineStart(draft.slice(0, stripTokenStart)) ? ': ' : ' ';
+  const suffix = isAtLineStart(draft.slice(0, stripTokenStart)) ? addressSuffix() : ' ';
   // The strip is prefix-less: its token is the bare word under the cursor, which
   // is already the prefix buildNickMatches wants (no '@' to strip).
   const token = draft.slice(stripTokenStart, stripTokenEnd);
@@ -1679,9 +1690,10 @@ function onStripSelect(nick: string): void {
   });
 }
 
-// Reply action from the message list's action bar: prepend `nick: ` to the
-// current draft (unless it's already addressed to them) and focus the
-// composer. Mirrors the history-recall focus dance — setInputAndCaretEnd owns
+// Reply action from the message list's action bar: prepend the addressing form
+// (`nick: ` under the default suffix) to the current draft, unless it's already
+// addressed to them, and focus the composer. Mirrors the history-recall focus
+// dance — setInputAndCaretEnd owns
 // the `cycling` guard, and the focus()-in-a-microtask matches onHistorySelect
 // so iOS raises the keyboard from the originating tap.
 function addressInComposer(nick: string): void {
@@ -1692,7 +1704,7 @@ function addressInComposer(nick: string): void {
   // old text afterward. Same reset onHistorySelect does for the same reason.
   resetCompletion();
   resetHistoryNav();
-  const prefix = `${nick}: `;
+  const prefix = nick + addressSuffix();
   const cur = text.value;
   const next = cur.startsWith(prefix) ? cur : cur ? `${prefix}${cur}` : prefix;
   setInputAndCaretEnd(next);

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -833,18 +833,26 @@ function addressSuffix(): string {
   return `${addressPunct()} `;
 }
 
+// A character that cannot continue a nick, which is what "punctuation after
+// the nick" has to mean for isAddressedTo(): not a letter or digit (Unicode —
+// `\w` is ASCII-only, so `bobł` would read as bob + a mark), not whitespace,
+// and not one of the RFC 2812 nick specials `[]\`_^{|}-` — or `bob_: hi`
+// would count as addressing bob, and bob_ is every ghost's nick.
+const NOT_NICK_CHAR = '[^\\p{L}\\p{N}\\s_\\[\\]\\\\`^{|}-]';
+
 // Whether `draft` already opens by addressing `nick`, so Reply is idempotent.
 // Not just the configured form: a draft can carry an older setting's form, or
 // one another client wrote (iOS still says `nick: `, and drafts sync), so any
-// run of punctuation after the nick counts. The bare `nick ` form only counts
-// when it IS the configured form — otherwise a draft that merely opens with a
-// nick that is also a word ("will you come?") would swallow the Reply. Under an
-// empty setting that draft is indistinguishable from an addressed one, which
-// is the ambiguity of the convention itself, not something to second-guess.
+// run of punctuation after the nick counts — plus the configured mark
+// verbatim, whatever it is. The bare `nick ` form only counts when it IS the
+// configured form — otherwise a draft that merely opens with a nick that is
+// also a word ("will you come?") would swallow the Reply. Under an empty
+// setting that draft is indistinguishable from an addressed one, which is the
+// ambiguity of the convention itself, not something to second-guess.
 function isAddressedTo(draft: string, nick: string): boolean {
   const punct = addressPunct();
-  const marks = punct ? `(?:${escapeRegex(punct)}|[^\\w\\s]+)` : '[^\\w\\s]*';
-  return new RegExp(`^${escapeRegex(nick)}${marks}\\s`, 'i').test(draft);
+  const marks = punct ? `(?:${escapeRegex(punct)}|${NOT_NICK_CHAR}+)` : `${NOT_NICK_CHAR}*`;
+  return new RegExp(`^${escapeRegex(nick)}${marks}\\s`, 'iu').test(draft);
 }
 
 function buildNickMatches(buf: Buffer, networkId: number, prefix: string): string[] {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -185,6 +185,7 @@ import { useIgnoresStore, type IgnoreEntry } from '../stores/ignores.js';
 import { useRelayBotsStore } from '../stores/relayBots.js';
 import { useHighlightRulesStore, type HighlightRule } from '../stores/highlightRules.js';
 import { isChannelTarget } from '../../../shared/channels.js';
+import { escapeRegex } from '../../../shared/textMatch.js';
 import { parseIgnoreArgs } from '../../../shared/parseIgnore.js';
 import { parseHighlightArgs } from '../../../shared/parseHighlight.js';
 import { highlightRuleDetailParts } from '../utils/highlightFormat.js';
@@ -805,7 +806,7 @@ function tokenAtCursor(
 // True when `before` (the text preceding a token) sits at the start of a
 // logical line — nothing but whitespace since the last newline, or the very
 // start of the input. Callers use this to detect a nick that's being
-// *addressed* and so wants an opening ': '. Shared by Tab-completion and both
+// *addressed* and so wants addressSuffix(). Shared by Tab-completion and both
 // @-driven selectors so all three detect line starts identically, including
 // on multi-line drafts; what each appends *off* a line start still differs
 // (see the call sites).
@@ -813,15 +814,37 @@ function isAtLineStart(before: string): boolean {
   return /(^|\n)\s*$/.test(before);
 }
 
-// What a nick takes when it opens the line — the addressing form. The setting
-// stores the punctuation alone and the space is always ours to add (see the
-// registry entry), so "space only" is the empty string. Read once when a
-// session is seeded, never per cycle: the suffix rides on CompletionState so a
-// setting change mid-walk can't change the shape of the insertion under the
-// caret. Shared by Tab, the @ picker, the strip, and Reply (#835).
+// The punctuation a nick takes when it opens the line, per the setting. The
+// value stores the mark alone and the space is always ours to add (see the
+// registry entry), so "space only" is the empty string. Trailing whitespace is
+// dropped rather than doubled: the description shows the form as `nick: `, and
+// typing exactly that into the field is the natural mistake — and it lets
+// `/set … " "` land on "space only" too.
+function addressPunct(): string {
+  return String(settings.effective('input.completion.nick_suffix')).trimEnd();
+}
+
+// What a nick takes when it opens the line — the addressing form. Read once
+// when a session is seeded, never per cycle: the suffix rides on
+// CompletionState so a setting change mid-walk can't change the shape of the
+// insertion under the caret. Shared by Tab, the @ picker, the strip, and Reply
+// (#835).
 function addressSuffix(): string {
-  const punct = settings.effective('input.completion.nick_suffix');
-  return `${typeof punct === 'string' ? punct : ':'} `;
+  return `${addressPunct()} `;
+}
+
+// Whether `draft` already opens by addressing `nick`, so Reply is idempotent.
+// Not just the configured form: a draft can carry an older setting's form, or
+// one another client wrote (iOS still says `nick: `, and drafts sync), so any
+// run of punctuation after the nick counts. The bare `nick ` form only counts
+// when it IS the configured form — otherwise a draft that merely opens with a
+// nick that is also a word ("will you come?") would swallow the Reply. Under an
+// empty setting that draft is indistinguishable from an addressed one, which
+// is the ambiguity of the convention itself, not something to second-guess.
+function isAddressedTo(draft: string, nick: string): boolean {
+  const punct = addressPunct();
+  const marks = punct ? `(?:${escapeRegex(punct)}|[^\\w\\s]+)` : '[^\\w\\s]*';
+  return new RegExp(`^${escapeRegex(nick)}${marks}\\s`, 'i').test(draft);
 }
 
 function buildNickMatches(buf: Buffer, networkId: number, prefix: string): string[] {
@@ -1704,10 +1727,8 @@ function addressInComposer(nick: string): void {
   // old text afterward. Same reset onHistorySelect does for the same reason.
   resetCompletion();
   resetHistoryNav();
-  const prefix = nick + addressSuffix();
   const cur = text.value;
-  const next = cur.startsWith(prefix) ? cur : cur ? `${prefix}${cur}` : prefix;
-  setInputAndCaretEnd(next);
+  setInputAndCaretEnd(isAddressedTo(cur, nick) ? cur : nick + addressSuffix() + cur);
   queueMicrotask(() => inputEl.value?.focus());
 }
 
@@ -3140,7 +3161,10 @@ function runSet(argLine: string, networkId: number | null, target: string): void
   const opt = lookupSetting(args.key);
   if (!opt) return reply(`/set: unknown setting "${args.key}" — /set lists available keys`);
   if (args.kind === 'keyonly') {
-    return reply(`usage: /set ${opt.key} <value>  (or /get ${opt.key} to read it)`);
+    // A text key's empty value is only reachable as `""` — a bare `/set key `
+    // trims down to exactly this branch — so say so where the user is stuck.
+    const empty = opt.type === 'string' || opt.type === 'string-list' ? '; "" to empty it' : '';
+    return reply(`usage: /set ${opt.key} <value>  (or /get ${opt.key} to read it${empty})`);
   }
   const coerced = coerceSettingValue(opt, args.rawValue);
   if (!coerced.ok) return reply(`/set: ${coerced.error}`);


### PR DESCRIPTION
Closes #835.

## What

`input.completion.nick_suffix` — the punctuation placed after a nick completed at the **start of a line** (the addressing form). Default `:`, i.e. today's `nick: `. Lives in Settings → Input → Autocomplete next to the suggestion-strip toggle, and via `/set input.completion.nick_suffix ,`.

One helper, `addressSuffix()`, feeds all four line-start sites: in-place Tab, the `@` picker, the mobile strip, and **Reply** (not in the issue, but it's the same addressing form — a user who picked `,` would otherwise still get `:` from the action bar). Mid-line completions are unchanged.

## Why a `string`, not the issue's enum + custom field

The setting stores the **punctuation alone** and the client always appends the space — irssi's `completion_char`. So `:` `,` `;` are all visible in a text field, `/set` needs no quoting, and "space only" is the empty string rather than an invisible `' '`. The issue asked for the four common values *and* free-form; a plain `string` gets both without a new enum-with-custom registry type threaded through the server validator, `SettingsRow`, and `/set`. The trade is that "no space" and "two spaces" are inexpressible, which nobody has asked for.

## Review round (`/code-review high`)

- Reply's "already addressed" guard was a `startsWith` against the configured form, which the setting broke: under an empty suffix `bob is wrong` + Reply(bob) was a silent no-op, and a draft addressed under an older form (`bob: sure` — or one iOS wrote; drafts sync) got `bob, ` stacked on top. Now `isAddressedTo()`: the nick, a run of punctuation, whitespace. The bare `nick ` form only counts when that *is* the configured form, so `will you come?` + Reply(will) still addresses under `:`.
- Trailing whitespace in the value is dropped (`: ` typed into the field no longer doubles the space; `/set … " "` means space-only).
- `/set <key>` with no value now says `""` empties a text key — the only route to the documented empty value.

## Tests

Eight new cases in `MessageInput.completion.test.ts`: one per site that reads the setting (picker + cycle, in-place Tab, strip, Reply), plus Reply against an older form, Reply on a nick-as-word draft, the empty-suffix ambiguity pinned, and whitespace trimming. Existing `alexis: ` assertions stand as the default case. `npm run check` + full `npm test` (302 files / 4289) green.

## Not in this PR

iOS hardcodes `": "` in `NickCompletion.swift` and `ComposerBar.swift`; it already reads registry values via `Settings.string(_:default:)`, so the port is small — follow-up in lurker-ios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
