### PR TITLE
Account recovery links: admin-issued, one-time, password or passkey

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,10 @@ npm-debug.log
 .DS_Store
 .vscode
 .idea
+
+# Test files never run in the image. `**/` is load-bearing: .dockerignore
+# patterns are anchored at the build context root, so a bare `*.test.ts` matches
+# only top-level files and would leave every server/ and tools/ test in the
+# runtime layer.
+**/*.test.ts
+**/*.spec.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,10 @@ COPY package*.json ./
 COPY tsconfig*.json ./
 COPY server/ ./server/
 COPY shared/ ./shared/
+# Operator CLIs (`npm run recovery-link`, tools/fold-buffer-case.ts). Both are
+# documented as `docker compose exec` one-liners, which only works if they're
+# actually in the image — they run under the same tsx as the server.
+COPY tools/ ./tools/
 COPY --from=vue-builder /app/vue_client/dist ./vue_client/dist
 
 RUN mkdir -p /app/data

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -36,12 +36,14 @@ Lurker accounts have no email address, so there is no "forgot my password" email
 
 Opening it lets them set a password _or_ enroll a new passkey. Both matter: a member whose only credential was a passkey on a lost phone has no password to reset.
 
+Either way, the account ends up with **exactly one** sign-in method — the one they just chose. Recovery assumes the account may have been taken over, and a password an attacker set or a passkey they enrolled would otherwise survive it.
+
 A few things worth knowing:
 
 - **The URL is shown once.** Only its hash is stored, so nothing can display it again. Lost it? Issue another — that invalidates the first.
 - **Single use, 24 hours.** Redeeming it or letting it expire ends it; **revoke recovery** ends it early.
 - **Redeeming cuts off every other way in.** A lockout is indistinguishable from a takeover, so recovery assumes one: web sessions, open connections, attached bouncer clients, API tokens, and push registrations for that account all go. The member will need to sign in again on their other devices, re-issue any API tokens, and re-enable notifications.
-- **Existing passkeys survive.** Recovery adds a way in; it never removes one.
+- **Every other credential is replaced.** The old password and all previously enrolled passkeys stop working, so a member with several passkeys re-enrolls the ones they still have.
 
 ### When the only admin is locked out
 
@@ -186,7 +188,7 @@ environment:
 
 Restart Lurker, log in with your password, then visit **Settings → Passkeys** and register one. Passkeys require HTTPS for any non-localhost hostname — browsers won't allow the WebAuthn ceremony otherwise.
 
-**Lost your passkey?** Just log in with your password and remove the dead passkey from the settings panel.
+**Lost your passkey?** Just log in with your password and remove the dead passkey from the settings panel. If it was your only way in, ask your admin for a [recovery link](#account-recovery).
 
 ### Web Push notifications
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -40,7 +40,7 @@ A few things worth knowing:
 
 - **The URL is shown once.** Only its hash is stored, so nothing can display it again. Lost it? Issue another — that invalidates the first.
 - **Single use, 24 hours.** Redeeming it or letting it expire ends it; **revoke recovery** ends it early.
-- **Redeeming signs that account out everywhere else.** A lockout is indistinguishable from a takeover, so every other session is dropped and every open connection is closed.
+- **Redeeming cuts off every other way in.** A lockout is indistinguishable from a takeover, so recovery assumes one: web sessions, open connections, attached bouncer clients, API tokens, and push registrations for that account all go. The member will need to sign in again on their other devices, re-issue any API tokens, and re-enable notifications.
 - **Existing passkeys survive.** Recovery adds a way in; it never removes one.
 
 ### When the only admin is locked out

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -40,7 +40,7 @@ A few things worth knowing:
 
 - **The URL is shown once.** Only its hash is stored, so nothing can display it again. Lost it? Issue another — that invalidates the first.
 - **Single use, 24 hours.** Redeeming it or letting it expire ends it; **revoke recovery** ends it early.
-- **Redeeming signs that account out everywhere else.** A lockout is indistinguishable from a takeover, so every other session is dropped.
+- **Redeeming signs that account out everywhere else.** A lockout is indistinguishable from a takeover, so every other session is dropped and every open connection is closed.
 - **Existing passkeys survive.** Recovery adds a way in; it never removes one.
 
 ### When the only admin is locked out

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -25,9 +25,33 @@ The very first time you open the app it'll prompt you to create the initial admi
 
 - Invite additional users (each user gets their own IRC networks, history, and settings)
 - Reset their own password from the settings panel
+- Issue recovery links for anyone locked out (see [Account recovery](#account-recovery))
 - Eventually manage the system from the admin panel
 
 Lurker is multi-user — anyone you invite gets their own private set of networks. There is no public sign-up; new accounts can only be created through admin-issued invite links.
+
+## Account recovery
+
+Lurker accounts have no email address, so there is no "forgot my password" email to send. Recovery runs through you instead: in **Admin → Users**, the **recovery link** button on a member's row mints a single-use URL, and you hand it to them over a channel you already trust — IRC, Signal, in person.
+
+Opening it lets them set a password _or_ enroll a new passkey. Both matter: a member whose only credential was a passkey on a lost phone has no password to reset.
+
+A few things worth knowing:
+
+- **The URL is shown once.** Only its hash is stored, so nothing can display it again. Lost it? Issue another — that invalidates the first.
+- **Single use, 24 hours.** Redeeming it or letting it expire ends it; **revoke recovery** ends it early.
+- **Redeeming signs that account out everywhere else.** A lockout is indistinguishable from a takeover, so every other session is dropped.
+- **Existing passkeys survive.** Recovery adds a way in; it never removes one.
+
+### When the only admin is locked out
+
+Nobody is left to click the button, so mint the link from a shell on the server:
+
+```bash
+docker compose exec lurker npm run recovery-link -- your-username
+```
+
+It prints the same URL. `WEBAUTHN_ORIGIN` supplies the base address; pass `--url https://lurker.example.com` if you haven't set it.
 
 ## Updating
 
@@ -595,19 +619,15 @@ That makes the arrangement safe, not tuned: the buffer budget (`LURKER_ENGINE_BU
 
 ## Troubleshooting
 
-### Forgot the admin password
+### Locked out of an account
 
-The cleanest path is to invite a second admin from your phone if you're still logged in there, then have them reset things from the admin panel.
-
-If you're locked out everywhere, the fallback is to clear the password hash directly with sqlite and re-bootstrap. With the server stopped:
+If you're an admin and still signed in somewhere, issue that member a recovery link from **Admin → Users**. If it's your own account and you're locked out everywhere, mint one from a shell:
 
 ```bash
-docker compose down
-sqlite3 data/lurker.db "DELETE FROM users WHERE username = 'your-username';"
-docker compose up -d
+docker compose exec lurker npm run recovery-link -- your-username
 ```
 
-This destroys that user's account and history. If you were the only user, the next visit will return you to the first-run wizard so you can create a fresh admin. (A proper password-reset CLI is on the roadmap.)
+Either way, see [Account recovery](#account-recovery) — nothing is deleted and no history is lost.
 
 ### Port 8015 already in use
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -10,6 +10,7 @@ This chapter walks you from a fresh account to chatting in your first channel.
 
 - Hosted: creating an account at [app.lurker.chat](https://app.lurker.chat).
 - Self-hosted: the invite flow and first-run setup.
+- Locked out: self-hosted accounts carry no email address, so your instance admin issues a one-time recovery link instead. See [Account recovery](/SELF_HOSTING#account-recovery).
 
 ## Connecting to a network
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "docs:build": "npm run build --prefix docs",
     "install:all": "npm install && npm install --prefix vue_client && npm install --prefix docs",
     "start": "tsx server/server.ts",
+    "recovery-link": "tsx tools/recovery-link.ts",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc -p tsconfig.json",

--- a/server/db/accountRecovery.test.ts
+++ b/server/db/accountRecovery.test.ts
@@ -29,7 +29,7 @@ afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
 describe('createRecoveryToken', () => {
   it('returns a high-entropy base64url token and stores only its hash', () => {
     const u = createUser('r-hash');
-    const token = recovery.createRecoveryToken(u.id, admin.id);
+    const { token } = recovery.createRecoveryToken(u.id, admin.id);
     expect(token).toMatch(/^[A-Za-z0-9_-]{40,}$/);
 
     // The raw token must not appear anywhere in the row -- a read of this table
@@ -44,15 +44,16 @@ describe('createRecoveryToken', () => {
   it('expires 24 hours out', () => {
     const u = createUser('r-ttl');
     const now = Date.UTC(2026, 0, 1);
-    recovery.createRecoveryToken(u.id, admin.id, now);
-    const info = recovery.getRecoveryTokenForUser(u.id, now)!;
-    expect(Date.parse(info.expiresAt) - now).toBe(DAY);
+    const { expiresAt } = recovery.createRecoveryToken(u.id, admin.id, now);
+    expect(Date.parse(expiresAt) - now).toBe(DAY);
+    // The returned expiry is the one that was stored, not a second computation.
+    expect(recovery.getRecoveryTokenForUser(u.id, now)!.expiresAt).toBe(expiresAt);
   });
 
   it('issuing a new link invalidates the outstanding one', () => {
     const u = createUser('r-replace');
-    const first = recovery.createRecoveryToken(u.id, admin.id);
-    const second = recovery.createRecoveryToken(u.id, admin.id);
+    const { token: first } = recovery.createRecoveryToken(u.id, admin.id);
+    const { token: second } = recovery.createRecoveryToken(u.id, admin.id);
     expect(second).not.toBe(first);
     expect(recovery.findLiveRecoveryToken(first)).toBeNull();
     expect(recovery.findLiveRecoveryToken(second)).toMatchObject({ userId: u.id });
@@ -75,7 +76,7 @@ describe('createRecoveryToken', () => {
 describe('findLiveRecoveryToken', () => {
   it('finds a live token by its raw value', () => {
     const u = createUser('r-find');
-    const token = recovery.createRecoveryToken(u.id, admin.id);
+    const { token } = recovery.createRecoveryToken(u.id, admin.id);
     expect(recovery.findLiveRecoveryToken(token)).toMatchObject({
       userId: u.id,
       createdBy: admin.id,
@@ -85,7 +86,7 @@ describe('findLiveRecoveryToken', () => {
   it('returns null for unknown, empty, and expired tokens alike', () => {
     const u = createUser('r-find-dead');
     const now = Date.UTC(2026, 0, 1);
-    const token = recovery.createRecoveryToken(u.id, admin.id, now);
+    const { token } = recovery.createRecoveryToken(u.id, admin.id, now);
     expect(recovery.findLiveRecoveryToken('nope')).toBeNull();
     expect(recovery.findLiveRecoveryToken('')).toBeNull();
     expect(recovery.findLiveRecoveryToken(null)).toBeNull();
@@ -94,7 +95,7 @@ describe('findLiveRecoveryToken', () => {
 
   it('does not spend the token', () => {
     const u = createUser('r-probe');
-    const token = recovery.createRecoveryToken(u.id, admin.id);
+    const { token } = recovery.createRecoveryToken(u.id, admin.id);
     recovery.findLiveRecoveryToken(token);
     recovery.findLiveRecoveryToken(token);
     expect(recovery.consumeRecoveryToken(token)).toBe(u.id);
@@ -104,7 +105,7 @@ describe('findLiveRecoveryToken', () => {
 describe('consumeRecoveryToken', () => {
   it('spends a live token exactly once', () => {
     const u = createUser('r-consume');
-    const token = recovery.createRecoveryToken(u.id, admin.id);
+    const { token } = recovery.createRecoveryToken(u.id, admin.id);
     expect(recovery.consumeRecoveryToken(token)).toBe(u.id);
     // The second attempt is the one a leaked link would make.
     expect(recovery.consumeRecoveryToken(token)).toBeNull();
@@ -114,10 +115,10 @@ describe('consumeRecoveryToken', () => {
   it('refuses an expired token', () => {
     const u = createUser('r-consume-expired');
     const now = Date.UTC(2026, 0, 1);
-    const token = recovery.createRecoveryToken(u.id, admin.id, now);
+    const { token } = recovery.createRecoveryToken(u.id, admin.id, now);
     expect(recovery.consumeRecoveryToken(token, now + DAY + 1)).toBeNull();
     // Still live a minute before the deadline.
-    const fresh = recovery.createRecoveryToken(u.id, admin.id, now);
+    const { token: fresh } = recovery.createRecoveryToken(u.id, admin.id, now);
     expect(recovery.consumeRecoveryToken(fresh, now + DAY - 60_000)).toBe(u.id);
   });
 
@@ -142,7 +143,7 @@ describe('purgeExpiredRecoveryTokens', () => {
     const live = createUser('r-purge-live');
     const now = Date.UTC(2026, 0, 1);
     recovery.createRecoveryToken(stale.id, admin.id, now);
-    const liveToken = recovery.createRecoveryToken(live.id, admin.id, now + DAY);
+    const { token: liveToken } = recovery.createRecoveryToken(live.id, admin.id, now + DAY);
     recovery.purgeExpiredRecoveryTokens(now + DAY + 1);
     expect(
       db.prepare('SELECT 1 FROM account_recovery_tokens WHERE user_id = ?').get(stale.id),
@@ -156,7 +157,7 @@ describe('purgeExpiredRecoveryTokens', () => {
 describe('foreign keys', () => {
   it('deleting the account wipes its link', () => {
     const u = createUser('r-cascade');
-    const token = recovery.createRecoveryToken(u.id, admin.id);
+    const { token } = recovery.createRecoveryToken(u.id, admin.id);
     db.prepare('DELETE FROM users WHERE id = ?').run(u.id);
     expect(recovery.findLiveRecoveryToken(token)).toBeNull();
   });
@@ -166,7 +167,7 @@ describe('foreign keys', () => {
     // to the account being recovered, not to whoever issued it.
     const issuer = createUser('r-departing-admin', { role: 'admin' });
     const u = createUser('r-orphaned-link');
-    const token = recovery.createRecoveryToken(u.id, issuer.id);
+    const { token } = recovery.createRecoveryToken(u.id, issuer.id);
     db.prepare('DELETE FROM users WHERE id = ?').run(issuer.id);
     expect(recovery.findLiveRecoveryToken(token)).toMatchObject({ userId: u.id, createdBy: null });
     expect(recovery.consumeRecoveryToken(token)).toBe(u.id);

--- a/server/db/accountRecovery.test.ts
+++ b/server/db/accountRecovery.test.ts
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createHash } from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-recovery-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let recovery: typeof import('./accountRecovery.js');
+let createUser: typeof import('./users.js').createUser;
+let db: typeof import('./index.js').default;
+let admin: ReturnType<typeof import('./users.js').createUser>;
+
+const DAY = 24 * 60 * 60 * 1000;
+
+beforeAll(async () => {
+  recovery = await import('./accountRecovery.js');
+  ({ createUser } = await import('./users.js'));
+  ({ default: db } = await import('./index.js'));
+  admin = createUser('r-admin', { role: 'admin' });
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+describe('createRecoveryToken', () => {
+  it('returns a high-entropy base64url token and stores only its hash', () => {
+    const u = createUser('r-hash');
+    const token = recovery.createRecoveryToken(u.id, admin.id);
+    expect(token).toMatch(/^[A-Za-z0-9_-]{40,}$/);
+
+    // The raw token must not appear anywhere in the row -- a read of this table
+    // is not supposed to be enough to recover the account.
+    const row = db
+      .prepare('SELECT * FROM account_recovery_tokens WHERE user_id = ?')
+      .get(u.id) as Record<string, unknown>;
+    expect(Object.values(row)).not.toContain(token);
+    expect(row.token_hash).toBe(createHash('sha256').update(token).digest('hex'));
+  });
+
+  it('expires 24 hours out', () => {
+    const u = createUser('r-ttl');
+    const now = Date.UTC(2026, 0, 1);
+    recovery.createRecoveryToken(u.id, admin.id, now);
+    const info = recovery.getRecoveryTokenForUser(u.id, now)!;
+    expect(Date.parse(info.expiresAt) - now).toBe(DAY);
+  });
+
+  it('issuing a new link invalidates the outstanding one', () => {
+    const u = createUser('r-replace');
+    const first = recovery.createRecoveryToken(u.id, admin.id);
+    const second = recovery.createRecoveryToken(u.id, admin.id);
+    expect(second).not.toBe(first);
+    expect(recovery.findLiveRecoveryToken(first)).toBeNull();
+    expect(recovery.findLiveRecoveryToken(second)).toMatchObject({ userId: u.id });
+    // One row per account, always.
+    const count = db
+      .prepare('SELECT COUNT(*) AS n FROM account_recovery_tokens WHERE user_id = ?')
+      .get(u.id) as { n: number };
+    expect(count.n).toBe(1);
+  });
+
+  it('records the issuing admin, and tolerates the CLI issuing anonymously', () => {
+    const u = createUser('r-issuer');
+    recovery.createRecoveryToken(u.id, admin.id);
+    expect(recovery.getRecoveryTokenForUser(u.id)!.createdBy).toBe(admin.id);
+    recovery.createRecoveryToken(u.id, null);
+    expect(recovery.getRecoveryTokenForUser(u.id)!.createdBy).toBeNull();
+  });
+});
+
+describe('findLiveRecoveryToken', () => {
+  it('finds a live token by its raw value', () => {
+    const u = createUser('r-find');
+    const token = recovery.createRecoveryToken(u.id, admin.id);
+    expect(recovery.findLiveRecoveryToken(token)).toMatchObject({
+      userId: u.id,
+      createdBy: admin.id,
+    });
+  });
+
+  it('returns null for unknown, empty, and expired tokens alike', () => {
+    const u = createUser('r-find-dead');
+    const now = Date.UTC(2026, 0, 1);
+    const token = recovery.createRecoveryToken(u.id, admin.id, now);
+    expect(recovery.findLiveRecoveryToken('nope')).toBeNull();
+    expect(recovery.findLiveRecoveryToken('')).toBeNull();
+    expect(recovery.findLiveRecoveryToken(null)).toBeNull();
+    expect(recovery.findLiveRecoveryToken(token, now + DAY + 1)).toBeNull();
+  });
+
+  it('does not spend the token', () => {
+    const u = createUser('r-probe');
+    const token = recovery.createRecoveryToken(u.id, admin.id);
+    recovery.findLiveRecoveryToken(token);
+    recovery.findLiveRecoveryToken(token);
+    expect(recovery.consumeRecoveryToken(token)).toBe(u.id);
+  });
+});
+
+describe('consumeRecoveryToken', () => {
+  it('spends a live token exactly once', () => {
+    const u = createUser('r-consume');
+    const token = recovery.createRecoveryToken(u.id, admin.id);
+    expect(recovery.consumeRecoveryToken(token)).toBe(u.id);
+    // The second attempt is the one a leaked link would make.
+    expect(recovery.consumeRecoveryToken(token)).toBeNull();
+    expect(recovery.findLiveRecoveryToken(token)).toBeNull();
+  });
+
+  it('refuses an expired token', () => {
+    const u = createUser('r-consume-expired');
+    const now = Date.UTC(2026, 0, 1);
+    const token = recovery.createRecoveryToken(u.id, admin.id, now);
+    expect(recovery.consumeRecoveryToken(token, now + DAY + 1)).toBeNull();
+    // Still live a minute before the deadline.
+    const fresh = recovery.createRecoveryToken(u.id, admin.id, now);
+    expect(recovery.consumeRecoveryToken(fresh, now + DAY - 60_000)).toBe(u.id);
+  });
+
+  it('refuses an unknown token', () => {
+    expect(recovery.consumeRecoveryToken('not-a-token')).toBeNull();
+  });
+});
+
+describe('deleteRecoveryTokensForUser', () => {
+  it('revokes an outstanding link and reports whether there was one', () => {
+    const u = createUser('r-revoke');
+    recovery.createRecoveryToken(u.id, admin.id);
+    expect(recovery.deleteRecoveryTokensForUser(u.id)).toBe(true);
+    expect(recovery.getRecoveryTokenForUser(u.id)).toBeNull();
+    expect(recovery.deleteRecoveryTokensForUser(u.id)).toBe(false);
+  });
+});
+
+describe('purgeExpiredRecoveryTokens', () => {
+  it('drops expired rows and keeps live ones', () => {
+    const stale = createUser('r-purge-stale');
+    const live = createUser('r-purge-live');
+    const now = Date.UTC(2026, 0, 1);
+    recovery.createRecoveryToken(stale.id, admin.id, now);
+    const liveToken = recovery.createRecoveryToken(live.id, admin.id, now + DAY);
+    recovery.purgeExpiredRecoveryTokens(now + DAY + 1);
+    expect(
+      db.prepare('SELECT 1 FROM account_recovery_tokens WHERE user_id = ?').get(stale.id),
+    ).toBeUndefined();
+    expect(recovery.findLiveRecoveryToken(liveToken, now + DAY + 1)).toMatchObject({
+      userId: live.id,
+    });
+  });
+});
+
+describe('foreign keys', () => {
+  it('deleting the account wipes its link', () => {
+    const u = createUser('r-cascade');
+    const token = recovery.createRecoveryToken(u.id, admin.id);
+    db.prepare('DELETE FROM users WHERE id = ?').run(u.id);
+    expect(recovery.findLiveRecoveryToken(token)).toBeNull();
+  });
+
+  it('deleting the issuing admin leaves the link usable', () => {
+    // An admin leaving must not strand a member mid-recovery -- the link belongs
+    // to the account being recovered, not to whoever issued it.
+    const issuer = createUser('r-departing-admin', { role: 'admin' });
+    const u = createUser('r-orphaned-link');
+    const token = recovery.createRecoveryToken(u.id, issuer.id);
+    db.prepare('DELETE FROM users WHERE id = ?').run(issuer.id);
+    expect(recovery.findLiveRecoveryToken(token)).toMatchObject({ userId: u.id, createdBy: null });
+    expect(recovery.consumeRecoveryToken(token)).toBe(u.id);
+  });
+});

--- a/server/db/accountRecovery.ts
+++ b/server/db/accountRecovery.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
-import { insertCredential } from './webauthnCredentials.js';
+import { insertCredential, deleteAllForUser as deleteAllPasskeys } from './webauthnCredentials.js';
+import { setPasswordHash } from './users.js';
 import type { InsertCredentialFields } from './webauthnCredentials.js';
 import {
   generateRecoveryToken,
@@ -103,8 +104,39 @@ export function consumeRecoveryToken(token: string, now = Date.now()): number | 
 }
 
 /**
+ * Spend a recovery link, clear every OTHER credential on the account, and set
+ * the new password — all atomically. Returns the user id, or null if the link
+ * was already gone.
+ *
+ * The credential wipe is the point, not housekeeping. Recovery exists because an
+ * account may have been taken over, and an attacker who enrolled a passkey keeps
+ * a way in that a password change cannot touch. Redeeming therefore leaves
+ * exactly one credential: the one just established.
+ */
+export function spendRecoveryAndSetPassword(
+  token: string,
+  passwordHash: string,
+  now = Date.now(),
+): number | null {
+  const run = db.transaction((): number | null => {
+    const userId = consumeRecoveryToken(token, now);
+    if (userId === null) return null;
+    deleteAllPasskeys(userId);
+    setPasswordHash(userId, passwordHash);
+    return userId;
+  });
+  return run();
+}
+
+/**
  * Spend a recovery link and enroll a passkey as ONE atomic step, returning the
  * user id on success or null if the link was already gone.
+ *
+ * Also clears the password and every pre-existing passkey, for the same reason
+ * as above: an attacker who took the account over by SETTING a password would
+ * otherwise still know it and be back in seconds. A password is pure knowledge,
+ * so the "can't be used without the authenticator" argument that once exempted
+ * credentials here does not cover it.
  *
  * They cannot be separate statements. `webauthn_credentials.credential_id` is
  * UNIQUE across the whole instance, while the ceremony's excludeCredentials only
@@ -135,7 +167,11 @@ export function spendRecoveryAndEnroll(
     if (!info || info.userId !== expectedUserId) return null;
     const userId = consumeRecoveryToken(token, now);
     if (userId === null) return null;
-    // The one statement that can fail. Its throw is what rolls the consume back.
+    // Before the insert, so a duplicate-credential throw rolls the wipe back too
+    // and the member keeps everything they had.
+    deleteAllPasskeys(userId);
+    setPasswordHash(userId, null);
+    // The one statement that can fail. Its throw is what rolls all of this back.
     insertCredential({ ...credential, userId });
     return userId;
   });

--- a/server/db/accountRecovery.ts
+++ b/server/db/accountRecovery.ts
@@ -1,10 +1,14 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { createHash, randomBytes } from 'crypto';
 import db from './index.js';
 import { insertCredential } from './webauthnCredentials.js';
 import type { InsertCredentialFields } from './webauthnCredentials.js';
+import {
+  generateRecoveryToken,
+  hashRecoveryToken,
+  recoveryExpiresAt,
+} from './accountRecoveryToken.js';
 
 // Admin-issued, single-use account recovery links (#855). Lurker accounts carry
 // no email address, so there is nothing a self-service "forgot password" flow
@@ -20,10 +24,6 @@ import type { InsertCredentialFields } from './webauthnCredentials.js';
 // expires_at is an ISO-8601 UTC string (lexicographically ordered) compared
 // against a caller-supplied `now`, so expiry is directly unit-testable.
 
-// Hand-delivered over IRC/Signal/in person rather than emailed, so this is a day
-// rather than the control plane's hour.
-const TTL_MS = 24 * 60 * 60 * 1000;
-
 /** A recovery link as the admin panel sees it. Never includes the token. */
 export interface RecoveryTokenInfo {
   userId: number;
@@ -32,13 +32,10 @@ export interface RecoveryTokenInfo {
   createdAt: string;
 }
 
-function hashToken(token: string): string {
-  return createHash('sha256').update(token).digest('hex');
-}
-
 /**
- * Issue a recovery link for `userId` and return the RAW token to put in the URL.
- * Only the hash is stored, and only the caller ever sees this value.
+ * Issue a recovery link for `userId`, returning the RAW token to put in the URL
+ * along with its expiry. Only the hash is stored, and only the caller ever sees
+ * the raw value.
  *
  * Any outstanding link for the account is replaced: user_id is UNIQUE, so the
  * upsert is what "issuing a new link invalidates the old one" means.
@@ -47,9 +44,9 @@ export function createRecoveryToken(
   userId: number,
   createdBy: number | null,
   now = Date.now(),
-): string {
-  const token = randomBytes(32).toString('base64url');
-  const expiresAt = new Date(now + TTL_MS).toISOString();
+): { token: string; expiresAt: string } {
+  const token = generateRecoveryToken();
+  const expiresAt = recoveryExpiresAt(now);
   db.prepare(
     `INSERT INTO account_recovery_tokens (token_hash, user_id, created_by, expires_at)
      VALUES (?, ?, ?, ?)
@@ -58,8 +55,12 @@ export function createRecoveryToken(
        created_by = excluded.created_by,
        expires_at = excluded.expires_at,
        created_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')`,
-  ).run(hashToken(token), userId, createdBy, expiresAt);
-  return token;
+  ).run(hashRecoveryToken(token), userId, createdBy, expiresAt);
+  // Returned rather than left for the caller to re-read: a concurrent revoke
+  // between the write and a follow-up SELECT would hand back nothing, and by
+  // then the raw token exists only in this local — the response would be lost
+  // AND the previous link already replaced.
+  return { token, expiresAt };
 }
 
 /**
@@ -80,7 +81,7 @@ export function findLiveRecoveryToken(
          FROM account_recovery_tokens
         WHERE token_hash = ? AND expires_at > ?`,
     )
-    .get(hashToken(token), new Date(now).toISOString()) as RecoveryTokenInfo | undefined;
+    .get(hashRecoveryToken(token), new Date(now).toISOString()) as RecoveryTokenInfo | undefined;
   return row ?? null;
 }
 
@@ -97,7 +98,7 @@ export function consumeRecoveryToken(token: string, now = Date.now()): number | 
         WHERE token_hash = ? AND expires_at > ?
       RETURNING user_id AS userId`,
     )
-    .get(hashToken(token), new Date(now).toISOString()) as { userId: number } | undefined;
+    .get(hashRecoveryToken(token), new Date(now).toISOString()) as { userId: number } | undefined;
   return row?.userId ?? null;
 }
 

--- a/server/db/accountRecovery.ts
+++ b/server/db/accountRecovery.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { createHash, randomBytes } from 'crypto';
+import db from './index.js';
+
+// Admin-issued, single-use account recovery links (#855). Lurker accounts carry
+// no email address, so there is nothing a self-service "forgot password" flow
+// could verify a request against. Instead an admin issues a link for a specific
+// account and hands it over out of band; redeeming it sets a password or
+// enrolls a passkey.
+//
+// Only the SHA-256 of the token is persisted -- the raw value lives in the link
+// and nowhere else, so reading this table cannot recover an account. The token
+// is 32 random bytes, so an unsalted hash is enough: unlike a password it isn't
+// guessable, and lookup stays a single indexed hit.
+//
+// expires_at is an ISO-8601 UTC string (lexicographically ordered) compared
+// against a caller-supplied `now`, so expiry is directly unit-testable.
+
+// Hand-delivered over IRC/Signal/in person rather than emailed, so this is a day
+// rather than the control plane's hour.
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+/** A recovery link as the admin panel sees it. Never includes the token. */
+export interface RecoveryTokenInfo {
+  userId: number;
+  createdBy: number | null;
+  expiresAt: string;
+  createdAt: string;
+}
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+/**
+ * Issue a recovery link for `userId` and return the RAW token to put in the URL.
+ * Only the hash is stored, and only the caller ever sees this value.
+ *
+ * Any outstanding link for the account is replaced: user_id is UNIQUE, so the
+ * upsert is what "issuing a new link invalidates the old one" means.
+ */
+export function createRecoveryToken(
+  userId: number,
+  createdBy: number | null,
+  now = Date.now(),
+): string {
+  const token = randomBytes(32).toString('base64url');
+  const expiresAt = new Date(now + TTL_MS).toISOString();
+  db.prepare(
+    `INSERT INTO account_recovery_tokens (token_hash, user_id, created_by, expires_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(user_id) DO UPDATE SET
+       token_hash = excluded.token_hash,
+       created_by = excluded.created_by,
+       expires_at = excluded.expires_at,
+       created_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')`,
+  ).run(hashToken(token), userId, createdBy, expiresAt);
+  return token;
+}
+
+/**
+ * Look up a token without spending it, for the landing page's status probe.
+ * Returns null for a token that is unknown OR expired -- the page shows the same
+ * dead end either way, and separating them would let a caller confirm that a
+ * token was once real.
+ */
+export function findLiveRecoveryToken(
+  token: string | null | undefined,
+  now = Date.now(),
+): RecoveryTokenInfo | null {
+  if (!token) return null;
+  const row = db
+    .prepare(
+      `SELECT user_id AS userId, created_by AS createdBy,
+              expires_at AS expiresAt, created_at AS createdAt
+         FROM account_recovery_tokens
+        WHERE token_hash = ? AND expires_at > ?`,
+    )
+    .get(hashToken(token), new Date(now).toISOString()) as RecoveryTokenInfo | undefined;
+  return row ?? null;
+}
+
+/**
+ * Atomically spend a live token, returning the user id if THIS call spent it and
+ * null otherwise. Check-and-spend is one guarded statement, so two simultaneous
+ * redemptions cannot both win. Deleting the row IS the single-use rule: there is
+ * no spent-but-present state for a later read to misjudge.
+ */
+export function consumeRecoveryToken(token: string, now = Date.now()): number | null {
+  const row = db
+    .prepare(
+      `DELETE FROM account_recovery_tokens
+        WHERE token_hash = ? AND expires_at > ?
+      RETURNING user_id AS userId`,
+    )
+    .get(hashToken(token), new Date(now).toISOString()) as { userId: number } | undefined;
+  return row?.userId ?? null;
+}
+
+/** The outstanding link for an account, if any. Powers the admin panel badge. */
+export function getRecoveryTokenForUser(
+  userId: number,
+  now = Date.now(),
+): RecoveryTokenInfo | null {
+  const row = db
+    .prepare(
+      `SELECT user_id AS userId, created_by AS createdBy,
+              expires_at AS expiresAt, created_at AS createdAt
+         FROM account_recovery_tokens
+        WHERE user_id = ? AND expires_at > ?`,
+    )
+    .get(userId, new Date(now).toISOString()) as RecoveryTokenInfo | undefined;
+  return row ?? null;
+}
+
+/** Revoke an account's outstanding link. True if there was one to revoke. */
+export function deleteRecoveryTokensForUser(userId: number): boolean {
+  const info = db.prepare('DELETE FROM account_recovery_tokens WHERE user_id = ?').run(userId);
+  return info.changes > 0;
+}
+
+/**
+ * Drop expired rows. Nothing depends on this for correctness -- every read
+ * already filters on expires_at -- it just keeps a dead row from occupying the
+ * one slot an account gets and showing up in a raw table dump.
+ */
+export function purgeExpiredRecoveryTokens(now = Date.now()): void {
+  db.prepare('DELETE FROM account_recovery_tokens WHERE expires_at <= ?').run(
+    new Date(now).toISOString(),
+  );
+}

--- a/server/db/accountRecovery.ts
+++ b/server/db/accountRecovery.ts
@@ -3,6 +3,8 @@
 
 import { createHash, randomBytes } from 'crypto';
 import db from './index.js';
+import { insertCredential } from './webauthnCredentials.js';
+import type { InsertCredentialFields } from './webauthnCredentials.js';
 
 // Admin-issued, single-use account recovery links (#855). Lurker accounts carry
 // no email address, so there is nothing a self-service "forgot password" flow
@@ -99,6 +101,46 @@ export function consumeRecoveryToken(token: string, now = Date.now()): number | 
   return row?.userId ?? null;
 }
 
+/**
+ * Spend a recovery link and enroll a passkey as ONE atomic step, returning the
+ * user id on success or null if the link was already gone.
+ *
+ * They cannot be separate statements. `webauthn_credentials.credential_id` is
+ * UNIQUE across the whole instance, while the ceremony's excludeCredentials only
+ * covers the account being recovered — so an authenticator already enrolled on
+ * some OTHER account here passes the ceremony and then fails the insert. Split
+ * apart, that leaves the link spent and no credential written: the member's one
+ * link is gone and they are still locked out. Rolled back together, the link
+ * survives and they can retry with a different authenticator.
+ *
+ * `expectedUserId` pins the link to the account the challenge was issued for, so
+ * a challenge cannot be redirected onto a different account's link.
+ *
+ * Throws whatever the insert throws (SQLITE_CONSTRAINT for a duplicate
+ * credential); the caller turns that into a 409.
+ */
+export function spendRecoveryAndEnroll(
+  token: string,
+  expectedUserId: number,
+  credential: Omit<InsertCredentialFields, 'userId'>,
+  now = Date.now(),
+): number | null {
+  const run = db.transaction((): number | null => {
+    // Both rejections are checked BEFORE anything is written. A plain `return`
+    // from a better-sqlite3 transaction COMMITS — only a throw rolls back — so a
+    // bail-out after the consume would spend the link on its way out. Order is
+    // the guard here, not the transaction.
+    const info = findLiveRecoveryToken(token, now);
+    if (!info || info.userId !== expectedUserId) return null;
+    const userId = consumeRecoveryToken(token, now);
+    if (userId === null) return null;
+    // The one statement that can fail. Its throw is what rolls the consume back.
+    insertCredential({ ...credential, userId });
+    return userId;
+  });
+  return run();
+}
+
 /** The outstanding link for an account, if any. Powers the admin panel badge. */
 export function getRecoveryTokenForUser(
   userId: number,
@@ -113,6 +155,21 @@ export function getRecoveryTokenForUser(
     )
     .get(userId, new Date(now).toISOString()) as RecoveryTokenInfo | undefined;
   return row ?? null;
+}
+
+/**
+ * Every account with a live link, as {userId → expiresAt}. One query for the
+ * admin roster; the per-user getRecoveryTokenForUser is for single-row callers.
+ */
+export function listRecoveryExpiries(now = Date.now()): Map<number, string> {
+  const rows = db
+    .prepare(
+      `SELECT user_id AS userId, expires_at AS expiresAt
+         FROM account_recovery_tokens
+        WHERE expires_at > ?`,
+    )
+    .all(new Date(now).toISOString()) as { userId: number; expiresAt: string }[];
+  return new Map(rows.map((r) => [r.userId, r.expiresAt]));
 }
 
 /** Revoke an account's outstanding link. True if there was one to revoke. */

--- a/server/db/accountRecoveryToken.ts
+++ b/server/db/accountRecoveryToken.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The token primitives for account recovery (#855), deliberately split from
+// db/accountRecovery.ts so they can be used WITHOUT importing db/index.ts.
+//
+// That import is not free: db/index.ts runs the whole migration + seed pipeline
+// in its module body. The server does that once at boot, which is correct — but
+// tools/recovery-link.ts is documented as `docker compose exec` against a
+// RUNNING server, so pulling it in would make the CLI a second process running
+// migrations against a database the server is actively writing. The realistic
+// failure is SQLITE_BUSY, and this tool's whole reason to exist is the
+// sole-admin-locked-out emergency: the worst possible moment for it to fail.
+//
+// Keeping the hashing and the TTL here means the CLI can open a bare connection
+// (as tools/fold-buffer-case.ts does) while both callers still agree on exactly
+// what a recovery token is.
+
+import { createHash, randomBytes } from 'crypto';
+
+/**
+ * Hand-delivered over IRC/Signal/in person rather than emailed, so this is a day
+ * rather than the control plane's hour.
+ */
+export const RECOVERY_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * 32 random bytes, base64url. High enough entropy that the token is not
+ * guessable, which is what lets the stored form be an unsalted hash and what
+ * makes failure-backoff on the redemption route pointless.
+ */
+export function generateRecoveryToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+/**
+ * The stored form. Only this ever reaches the database — the raw token lives in
+ * the link and nowhere else, so reading the table cannot recover an account.
+ * Unsalted is fine here precisely because the input isn't guessable, and it
+ * keeps lookup a single indexed hit.
+ */
+export function hashRecoveryToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+/** Expiry as an ISO-8601 UTC string — lexicographically ordered, so SQLite can compare it directly. */
+export function recoveryExpiresAt(now = Date.now()): string {
+  return new Date(now + RECOVERY_TTL_MS).toISOString();
+}

--- a/server/db/apiTokens.ts
+++ b/server/db/apiTokens.ts
@@ -119,6 +119,23 @@ export function revoke(id: number, userId: number): boolean {
   return revokeStmt.run(id, userId).changes > 0;
 }
 
+/**
+ * Revoke every live token for a user, returning how many were revoked.
+ *
+ * For account recovery (#855): an API token is an independent bearer credential
+ * that outlives any session, so someone who held the account could mint one and
+ * keep read-write REST/MCP/IRC access straight through a recovery. "Every
+ * session predating the recovery is assumed hostile" has to include these.
+ * Soft-revokes, like revoke() — the row stays as a record of what was cut off.
+ */
+export function revokeAllForUser(userId: number): number {
+  return db
+    .prepare(
+      `UPDATE api_tokens SET revoked_at = datetime('now') WHERE user_id = ? AND revoked_at IS NULL`,
+    )
+    .run(userId).changes;
+}
+
 export function touchLastUsed(id: number): void {
   touchStmt.run(id);
 }

--- a/server/db/apiTokens.ts
+++ b/server/db/apiTokens.ts
@@ -74,6 +74,12 @@ const revokeStmt = db.prepare(`
    WHERE id = ? AND user_id = ? AND revoked_at IS NULL
 `);
 
+const revokeAllForUserStmt = db.prepare(`
+  UPDATE api_tokens
+     SET revoked_at = datetime('now')
+   WHERE user_id = ? AND revoked_at IS NULL
+`);
+
 // Mirror users.touchUserLastSeen: throttle in SQL so a busy client doesn't
 // rewrite the row on every call. No in-memory Map needed.
 const touchStmt = db.prepare(`
@@ -129,11 +135,7 @@ export function revoke(id: number, userId: number): boolean {
  * Soft-revokes, like revoke() — the row stays as a record of what was cut off.
  */
 export function revokeAllForUser(userId: number): number {
-  return db
-    .prepare(
-      `UPDATE api_tokens SET revoked_at = datetime('now') WHERE user_id = ? AND revoked_at IS NULL`,
-    )
-    .run(userId).changes;
+  return revokeAllForUserStmt.run(userId).changes;
 }
 
 export function touchLastUsed(id: number): void {

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -550,6 +550,14 @@ export const EXPORT_TABLES = Object.freeze({
     reason: 'admin/instance-scoped invitation state, not user data',
   },
 
+  account_recovery_tokens: {
+    mode: 'skip',
+    reason:
+      'a live credential for one account on THIS instance — carrying it to another would ' +
+      'hand the archive holder a way in, and it is stored hashed so it could not be redeemed ' +
+      'anywhere anyway',
+  },
+
   api_tokens: {
     mode: 'skip',
     reason:

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -276,6 +276,35 @@ function migrate() {
     CREATE INDEX IF NOT EXISTS idx_invite_tokens_unused
       ON invite_tokens(token) WHERE used_by_user_id IS NULL;
 
+    -- Admin-issued account recovery links (#855). A member locked out of an
+    -- account redeems one to set a password or enroll a fresh passkey; there is
+    -- no email address to run a self-service reset against.
+    --
+    -- Only the SHA-256 of the token is stored. The raw value exists solely in
+    -- the link the admin hands over, so a read of this table cannot recover an
+    -- account -- unlike invite_tokens, which stores its token raw because an
+    -- invite only creates a NEW account rather than taking over an existing one.
+    --
+    -- user_id is UNIQUE: issuing a link replaces any outstanding one, so there
+    -- is at most one row per account and 'invalidate the others' costs nothing.
+    -- Redemption DELETEs the row, which is what makes a link single-use.
+    --
+    -- created_by is SET NULL rather than CASCADE because the link belongs to the
+    -- account being recovered, not to the admin who issued it -- an admin
+    -- leaving must not strand a member mid-recovery. The #590 resurrection trap
+    -- that made invite_tokens.used_by_user_id CASCADE cannot recur here:
+    -- liveness reads expires_at only, and a spent row is gone rather than
+    -- flagged, so no nulled column can turn a dead link live again.
+    CREATE TABLE IF NOT EXISTS account_recovery_tokens (
+      token_hash TEXT PRIMARY KEY,
+      user_id INTEGER NOT NULL UNIQUE,
+      created_by INTEGER,
+      expires_at TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
+    );
+
     CREATE TABLE IF NOT EXISTS webauthn_credentials (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       user_id INTEGER NOT NULL,

--- a/server/db/pushSubscriptions.ts
+++ b/server/db/pushSubscriptions.ts
@@ -247,6 +247,19 @@ export function deleteById(id: number, userId: number): void {
   db.prepare('DELETE FROM push_subscriptions WHERE id = ? AND user_id = ?').run(id, userId);
 }
 
+/**
+ * Drop every push registration for a user, returning how many went.
+ *
+ * For account recovery (#855). A subscription is keyed on user_id alone with no
+ * link to the session that created it, so a device that held the account keeps
+ * receiving the member's incoming message content long after its session and
+ * socket are gone. The member re-enables notifications on their own devices,
+ * which is the right trade against leaking messages to one declared hostile.
+ */
+export function deleteAllForUser(userId: number): number {
+  return db.prepare('DELETE FROM push_subscriptions WHERE user_id = ?').run(userId).changes;
+}
+
 export function touchSubscription(id: number): void {
   // strftime with Z suffix so the value parses back as UTC on the client.
   // SQLite's bare datetime('now') returns 'YYYY-MM-DD HH:MM:SS' with no TZ

--- a/server/db/sessions.test.ts
+++ b/server/db/sessions.test.ts
@@ -85,6 +85,25 @@ describe('purgeExpiredSessions', () => {
   });
 });
 
+describe('deleteSessionsForUser', () => {
+  it('drops every session for one user and leaves other accounts alone', () => {
+    const u = createUser('s-revoke');
+    const other = createUser('s-revoke-bystander');
+    const { token: a } = sessions.createSession(u.id);
+    const { token: b } = sessions.createSession(u.id);
+    const { token: theirs } = sessions.createSession(other.id);
+    expect(sessions.deleteSessionsForUser(u.id)).toBe(2);
+    expect(sessions.findSession(a)).toBeNull();
+    expect(sessions.findSession(b)).toBeNull();
+    expect(sessions.findSession(theirs)).toBeTruthy();
+  });
+
+  it('is a no-op for an account with no sessions', () => {
+    const u = createUser('s-revoke-empty');
+    expect(sessions.deleteSessionsForUser(u.id)).toBe(0);
+  });
+});
+
 describe('FK cascade', () => {
   it('deleting a user wipes their sessions', () => {
     const u = createUser('s-cascade');

--- a/server/db/sessions.ts
+++ b/server/db/sessions.ts
@@ -43,6 +43,24 @@ export function deleteSession(token: string | null | undefined): void {
   db.prepare('DELETE FROM sessions WHERE token = ?').run(token);
 }
 
+/**
+ * Sign an account out everywhere. Used after an account recovery (#855): the
+ * lockout that made recovery necessary is indistinguishable from a takeover, so
+ * every session minted before the reset is assumed hostile. The caller mints a
+ * fresh session afterwards so the device doing the recovery stays signed in.
+ *
+ * ⚠ This drops the session ROWS, which is what every future request and /ws
+ * upgrade is checked against — but a WebSocket that is ALREADY open holds its
+ * authenticated user in the socket's closure and is not re-checked, so it keeps
+ * streaming until it disconnects. Closing live sockets on revocation is #567,
+ * which owns the same gap for PUT /password.
+ *
+ * Returns the number of sessions dropped.
+ */
+export function deleteSessionsForUser(userId: number): number {
+  return db.prepare('DELETE FROM sessions WHERE user_id = ?').run(userId).changes;
+}
+
 export function purgeExpiredSessions(): void {
   // expires_at is written as ISO 8601 ('YYYY-MM-DDTHH:MM:SS.sssZ') while
   // datetime('now') returns SQLite-local format ('YYYY-MM-DD HH:MM:SS').

--- a/server/db/sessions.ts
+++ b/server/db/sessions.ts
@@ -50,10 +50,11 @@ export function deleteSession(token: string | null | undefined): void {
  * fresh session afterwards so the device doing the recovery stays signed in.
  *
  * ⚠ This drops the session ROWS, which is what every future request and /ws
- * upgrade is checked against — but a WebSocket that is ALREADY open holds its
- * authenticated user in the socket's closure and is not re-checked, so it keeps
- * streaming until it disconnects. Closing live sockets on revocation is #567,
- * which owns the same gap for PUT /password.
+ * upgrade is checked against. It does NOT touch a socket that is already open —
+ * that one holds its authenticated user in its own closure and is never
+ * re-checked. Callers that mean "signed out everywhere" must pair this with
+ * wsHub.closeSocketsForUser(); the recovery routes do. (PUT /password still
+ * doesn't — that's #567.)
  *
  * Returns the number of sessions dropped.
  */

--- a/server/db/webauthnCredentials.ts
+++ b/server/db/webauthnCredentials.ts
@@ -139,6 +139,19 @@ export function updateLabel(id: number, userId: number, label: string | null): b
   return result.changes > 0;
 }
 
+/**
+ * Remove every passkey on an account, returning how many went.
+ *
+ * For account recovery (#855), which assumes the account was taken over: a
+ * passkey the attacker enrolled is a way back in that survives a password
+ * change, and nothing distinguishes it from the member's own. Note this has no
+ * last-credential guard, unlike deleteById — the recovery path re-establishes a
+ * credential in the same transaction, so the account is never left unreachable.
+ */
+export function deleteAllForUser(userId: number): number {
+  return db.prepare('DELETE FROM webauthn_credentials WHERE user_id = ?').run(userId).changes;
+}
+
 export function deleteById(id: number, userId: number): boolean {
   const result = db
     .prepare('DELETE FROM webauthn_credentials WHERE id = ? AND user_id = ?')

--- a/server/routes/accountRecovery.test.ts
+++ b/server/routes/accountRecovery.test.ts
@@ -64,6 +64,19 @@ describe('POST /api/admin/users/:id/recovery', () => {
     expect(JSON.stringify(list.body)).not.toContain(token);
   });
 
+  it('reports every outstanding link in one listing', async () => {
+    const a = createUser('listing-a');
+    const b = createUser('listing-b');
+    const none = createUser('listing-none');
+    await issue(a.id);
+    await issue(b.id);
+    const list = await adminAgent.get('/api/admin/users');
+    const row = (id: number) => list.body.users.find((r: { id: number }) => r.id === id);
+    expect(row(a.id).recoveryExpiresAt).toBeTruthy();
+    expect(row(b.id).recoveryExpiresAt).toBeTruthy();
+    expect(row(none.id).recoveryExpiresAt).toBeNull();
+  });
+
   it('404s for an account that does not exist', async () => {
     const res = await adminAgent.post('/api/admin/users/999999/recovery');
     expect(res.status).toBe(404);
@@ -228,6 +241,30 @@ describe('POST /api/auth/recovery/:token/password', () => {
     expect(res.status).toBe(400);
   });
 
+  it('still works for an IP already throttled by failed logins', async () => {
+    // The regression this route's missing guardCredentialAttempt prevents:
+    // failing at sign-in is HOW someone ends up needing recovery, so a shared
+    // login backoff would 429 exactly the person the link was issued for.
+    const u = createUser('redeem-throttled');
+    setPasswordHash(u.id, hashPassword('theoldpassword'));
+    const { token } = await issue(u.id);
+    for (let i = 0; i < 12; i++) {
+      await testRequest(app)
+        .post('/api/auth/login/password')
+        .send({ username: 'redeem-throttled', password: 'wrongpassword' });
+    }
+    // Sign-in is now backed off for this IP...
+    const blocked = await testRequest(app)
+      .post('/api/auth/login/password')
+      .send({ username: 'redeem-throttled', password: 'theoldpassword' });
+    expect(blocked.status).toBe(429);
+    // ...and recovery still lets them back in.
+    const res = await testRequest(app)
+      .post(`/api/auth/recovery/${token}/password`)
+      .send({ password: 'thenewpassword' });
+    expect(res.status).toBe(200);
+  });
+
   it('leaves existing passkeys alone', async () => {
     // Recovery restores a way in; it is not a way to strip someone's
     // credentials out from under them.
@@ -248,6 +285,80 @@ describe('POST /api/auth/recovery/:token/password', () => {
       .post(`/api/auth/recovery/${token}/password`)
       .send({ password: 'passwordalongside' });
     expect(countForUser(u.id)).toBe(1);
+  });
+});
+
+describe('spendRecoveryAndEnroll', () => {
+  it('rolls the spend back when the passkey is already registered elsewhere', async () => {
+    // credential_id is UNIQUE across the instance while the ceremony only
+    // excludes THIS account's keys, so an authenticator enrolled on another
+    // account here clears WebAuthn and then fails the insert. If that spent the
+    // link, the member would be left with no passkey and no way back in.
+    const other = createUser('enroll-owner');
+    const u = createUser('enroll-clash');
+    const { insertCredential, countForUser } = await import('../db/webauthnCredentials.js');
+    insertCredential({
+      userId: other.id,
+      credentialId: 'cred-owned-by-someone-else',
+      publicKey: Buffer.from('key'),
+      counter: 0,
+      transports: ['internal'],
+      deviceType: 'singleDevice',
+      backedUp: false,
+      label: null,
+    });
+    const { token } = await issue(u.id);
+    expect(() =>
+      recovery.spendRecoveryAndEnroll(token, u.id, {
+        credentialId: 'cred-owned-by-someone-else',
+        publicKey: Buffer.from('key'),
+        counter: 0,
+        transports: ['internal'],
+        deviceType: 'singleDevice',
+        backedUp: false,
+        label: null,
+      }),
+    ).toThrow(/UNIQUE constraint failed/);
+    // The link survives, so they can retry with a different authenticator.
+    expect(recovery.findLiveRecoveryToken(token)).toMatchObject({ userId: u.id });
+    expect(countForUser(u.id)).toBe(0);
+  });
+
+  it('enrolls and spends together on the happy path', async () => {
+    const u = createUser('enroll-happy');
+    const { countForUser } = await import('../db/webauthnCredentials.js');
+    const { token } = await issue(u.id);
+    expect(
+      recovery.spendRecoveryAndEnroll(token, u.id, {
+        credentialId: 'cred-enrolled-by-recovery',
+        publicKey: Buffer.from('key'),
+        counter: 0,
+        transports: ['internal'],
+        deviceType: 'singleDevice',
+        backedUp: false,
+        label: null,
+      }),
+    ).toBe(u.id);
+    expect(countForUser(u.id)).toBe(1);
+    expect(recovery.findLiveRecoveryToken(token)).toBeNull();
+  });
+
+  it('refuses a link belonging to a different account than the challenge', async () => {
+    const u = createUser('enroll-pinned');
+    const other = createUser('enroll-pinned-other');
+    const { token } = await issue(u.id);
+    expect(
+      recovery.spendRecoveryAndEnroll(token, other.id, {
+        credentialId: 'cred-never-written',
+        publicKey: Buffer.from('key'),
+        counter: 0,
+        transports: ['internal'],
+        deviceType: 'singleDevice',
+        backedUp: false,
+        label: null,
+      }),
+    ).toBeNull();
+    expect(recovery.findLiveRecoveryToken(token)).toMatchObject({ userId: u.id });
   });
 });
 

--- a/server/routes/accountRecovery.test.ts
+++ b/server/routes/accountRecovery.test.ts
@@ -265,6 +265,38 @@ describe('POST /api/auth/recovery/:token/password', () => {
     expect(res.status).toBe(200);
   });
 
+  it('revokes API tokens, which outlive every session', async () => {
+    // An attacker holding the account can mint a read-write bearer token and
+    // walk away; without this it keeps working straight through the recovery.
+    const u = createUser('redeem-api-tokens');
+    const apiTokens = await import('../db/apiTokens.js');
+    apiTokens.createToken({ userId: u.id, name: 'attacker script', scope: 'read-write' });
+    expect(apiTokens.listForUser(u.id).filter((t) => !t.revokedAt)).toHaveLength(1);
+    const { token } = await issue(u.id);
+    await testRequest(app)
+      .post(`/api/auth/recovery/${token}/password`)
+      .send({ password: 'revokethetokens' });
+    expect(apiTokens.listForUser(u.id).filter((t) => !t.revokedAt)).toHaveLength(0);
+  });
+
+  it('drops push registrations, which leak message content to an evicted device', async () => {
+    const u = createUser('redeem-push');
+    const push = await import('../db/pushSubscriptions.js');
+    push.upsertSubscription(u.id, {
+      transport: 'webpush',
+      endpoint: 'https://push.example/attacker-device',
+      p256dh: 'key',
+      auth: 'auth',
+      userAgent: 'attacker browser',
+    });
+    expect(push.listAllForUser(u.id)).toHaveLength(1);
+    const { token } = await issue(u.id);
+    await testRequest(app)
+      .post(`/api/auth/recovery/${token}/password`)
+      .send({ password: 'dropthepushsubs' });
+    expect(push.listAllForUser(u.id)).toHaveLength(0);
+  });
+
   it('leaves existing passkeys alone', async () => {
     // Recovery restores a way in; it is not a way to strip someone's
     // credentials out from under them.

--- a/server/routes/accountRecovery.test.ts
+++ b/server/routes/accountRecovery.test.ts
@@ -297,26 +297,27 @@ describe('POST /api/auth/recovery/:token/password', () => {
     expect(push.listAllForUser(u.id)).toHaveLength(0);
   });
 
-  it('leaves existing passkeys alone', async () => {
-    // Recovery restores a way in; it is not a way to strip someone's
-    // credentials out from under them.
-    const u = createUser('redeem-keeps-passkeys');
+  it('removes every existing passkey, which an attacker could have planted', async () => {
+    // Changing the password is worthless while a passkey someone else enrolled
+    // still opens the door. Redeeming leaves exactly the credential just set.
+    const u = createUser('redeem-wipes-passkeys');
     const { insertCredential, countForUser } = await import('../db/webauthnCredentials.js');
     insertCredential({
       userId: u.id,
-      credentialId: 'cred-kept-through-recovery',
+      credentialId: 'cred-planted-by-attacker',
       publicKey: Buffer.from('key'),
       counter: 0,
       transports: ['internal'],
       deviceType: 'singleDevice',
       backedUp: false,
-      label: 'old laptop',
+      label: 'attacker laptop',
     });
     const { token } = await issue(u.id);
-    await testRequest(app)
+    const res = await testRequest(app)
       .post(`/api/auth/recovery/${token}/password`)
       .send({ password: 'passwordalongside' });
-    expect(countForUser(u.id)).toBe(1);
+    expect(res.status).toBe(200);
+    expect(countForUser(u.id)).toBe(0);
   });
 });
 
@@ -390,6 +391,79 @@ describe('spendRecoveryAndEnroll', () => {
         label: null,
       }),
     ).toBeNull();
+    expect(recovery.findLiveRecoveryToken(token)).toMatchObject({ userId: u.id });
+  });
+});
+
+describe('recovering with a passkey clears the password', () => {
+  it('leaves an attacker who SET a password unable to sign back in', async () => {
+    // The takeover this feature exists for: someone sets a password on the
+    // account. Alice, whose only credential was a passkey on a lost phone,
+    // recovers with a new passkey. If the password survived, they are back in
+    // seconds — and a password is pure knowledge, so the "can't be used without
+    // the authenticator" argument that spares a passkey does not cover it.
+    const u = createUser('passkey-clears-password');
+    setPasswordHash(u.id, hashPassword('theattackerspassword'));
+    const { token } = await issue(u.id);
+    expect(
+      recovery.spendRecoveryAndEnroll(token, u.id, {
+        credentialId: 'cred-alices-new-phone',
+        publicKey: Buffer.from('key'),
+        counter: 0,
+        transports: ['internal'],
+        deviceType: 'singleDevice',
+        backedUp: false,
+        label: 'new phone',
+      }),
+    ).toBe(u.id);
+    // Asserted on the stored hash rather than through POST /login/password: the
+    // throttle test above deliberately trips this IP's login backoff, so a login
+    // here would 429 and prove nothing about the credential.
+    expect(getPasswordHash(u.id)).toBeNull();
+    expect(verifyPassword('theattackerspassword', getPasswordHash(u.id))).toBe(false);
+  });
+
+  it('rolls the credential wipe back when the enroll fails', async () => {
+    // A failed ceremony must not cost the member their existing credentials on
+    // top of leaving them locked out.
+    const other = createUser('wipe-rollback-owner');
+    const u = createUser('wipe-rollback');
+    const { insertCredential, countForUser } = await import('../db/webauthnCredentials.js');
+    setPasswordHash(u.id, hashPassword('thememberspassword'));
+    insertCredential({
+      userId: u.id,
+      credentialId: 'cred-the-member-still-has',
+      publicKey: Buffer.from('key'),
+      counter: 0,
+      transports: ['internal'],
+      deviceType: 'singleDevice',
+      backedUp: false,
+      label: null,
+    });
+    insertCredential({
+      userId: other.id,
+      credentialId: 'cred-clashing',
+      publicKey: Buffer.from('key'),
+      counter: 0,
+      transports: ['internal'],
+      deviceType: 'singleDevice',
+      backedUp: false,
+      label: null,
+    });
+    const { token } = await issue(u.id);
+    expect(() =>
+      recovery.spendRecoveryAndEnroll(token, u.id, {
+        credentialId: 'cred-clashing',
+        publicKey: Buffer.from('key'),
+        counter: 0,
+        transports: ['internal'],
+        deviceType: 'singleDevice',
+        backedUp: false,
+        label: null,
+      }),
+    ).toThrow(/UNIQUE constraint failed/);
+    expect(countForUser(u.id)).toBe(1);
+    expect(getPasswordHash(u.id)).toBeTruthy();
     expect(recovery.findLiveRecoveryToken(token)).toMatchObject({ userId: u.id });
   });
 });

--- a/server/routes/accountRecovery.test.ts
+++ b/server/routes/accountRecovery.test.ts
@@ -1,0 +1,332 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// End-to-end cover for admin-issued account recovery links (#855): an admin
+// issues one, the locked-out member redeems it, and every session that predated
+// the recovery dies. Both routers are mounted so the loop runs as it does in
+// production rather than through hand-built rows.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Express } from 'express';
+import {
+  setupTestDb,
+  createTestApp,
+  createAuthedAgent,
+  testRequest,
+} from '../test-utils/testApp.js';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+
+const ctx = setupTestDb('routes-account-recovery');
+
+let app: Express;
+let adminAgent: LurkerTestAgent;
+let createUser: typeof import('../db/users.js').createUser;
+let setPasswordHash: typeof import('../db/users.js').setPasswordHash;
+let getPasswordHash: typeof import('../db/users.js').getPasswordHash;
+let hashPassword: typeof import('../services/password.js').hashPassword;
+let verifyPassword: typeof import('../services/password.js').verifyPassword;
+let recovery: typeof import('../db/accountRecovery.js');
+let admin: ReturnType<typeof import('../db/users.js').createUser>;
+
+// Issue a link for `userId` as the admin and hand back its raw token.
+async function issue(userId: number): Promise<{ token: string; url: string; status: number }> {
+  const res = await adminAgent.post(`/api/admin/users/${userId}/recovery`);
+  const url: string = res.body?.recovery?.url ?? '';
+  return { token: url.split('/recover/')[1] ?? '', url, status: res.status };
+}
+
+beforeAll(async () => {
+  ({ createUser, setPasswordHash, getPasswordHash } = await import('../db/users.js'));
+  ({ hashPassword, verifyPassword } = await import('../services/password.js'));
+  recovery = await import('../db/accountRecovery.js');
+  const authRouter = (await import('./auth.js')).default;
+  const adminRouter = (await import('./admin.js')).default;
+  app = createTestApp({ '/api/auth': authRouter, '/api/admin': adminRouter });
+  admin = createUser('recovery-admin', { role: 'admin' });
+  adminAgent = await createAuthedAgent(app, admin.id);
+});
+
+afterAll(() => ctx.cleanup());
+
+describe('POST /api/admin/users/:id/recovery', () => {
+  it('issues a link, and the URL is the only place the token exists', async () => {
+    const u = createUser('link-issued');
+    const { status, url, token } = await issue(u.id);
+    expect(status).toBe(200);
+    expect(url).toContain(`/recover/${token}`);
+    expect(token).toMatch(/^[A-Za-z0-9_-]{40,}$/);
+    // Stored hashed: the admin listing can say a link is outstanding but can
+    // never re-show it.
+    expect(recovery.getRecoveryTokenForUser(u.id)).toMatchObject({ createdBy: admin.id });
+    const list = await adminAgent.get('/api/admin/users');
+    const row = list.body.users.find((r: { id: number }) => r.id === u.id);
+    expect(row.recoveryExpiresAt).toBeTruthy();
+    expect(JSON.stringify(list.body)).not.toContain(token);
+  });
+
+  it('404s for an account that does not exist', async () => {
+    const res = await adminAgent.post('/api/admin/users/999999/recovery');
+    expect(res.status).toBe(404);
+  });
+
+  it('is refused for a non-admin', async () => {
+    const member = createUser('link-nonadmin');
+    const target = createUser('link-nonadmin-target');
+    const memberAgent = await createAuthedAgent(app, member.id);
+    const res = await memberAgent.post(`/api/admin/users/${target.id}/recovery`);
+    expect(res.status).toBe(403);
+    expect(recovery.getRecoveryTokenForUser(target.id)).toBeNull();
+  });
+
+  it('is refused for an anonymous caller', async () => {
+    const target = createUser('link-anon-target');
+    const res = await testRequest(app).post(`/api/admin/users/${target.id}/recovery`);
+    expect(res.status).toBe(401);
+    expect(recovery.getRecoveryTokenForUser(target.id)).toBeNull();
+  });
+
+  it('re-issuing invalidates the previous link', async () => {
+    const u = createUser('link-reissued');
+    const first = await issue(u.id);
+    const second = await issue(u.id);
+    expect(second.token).not.toBe(first.token);
+    const probe = await testRequest(app).get(`/api/auth/recovery/${first.token}`);
+    expect(probe.body.valid).toBe(false);
+    const live = await testRequest(app).get(`/api/auth/recovery/${second.token}`);
+    expect(live.body.valid).toBe(true);
+  });
+});
+
+describe('DELETE /api/admin/users/:id/recovery', () => {
+  it('revokes an outstanding link', async () => {
+    const u = createUser('link-revoked');
+    const { token } = await issue(u.id);
+    const res = await adminAgent.delete(`/api/admin/users/${u.id}/recovery`);
+    expect(res.status).toBe(200);
+    const probe = await testRequest(app).get(`/api/auth/recovery/${token}`);
+    expect(probe.body.valid).toBe(false);
+  });
+
+  it('404s when there is nothing outstanding', async () => {
+    const u = createUser('link-nothing-to-revoke');
+    const res = await adminAgent.delete(`/api/admin/users/${u.id}/recovery`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /api/auth/recovery/:token', () => {
+  it('names the account and reports whether it already has a password', async () => {
+    const u = createUser('probe-target');
+    setPasswordHash(u.id, hashPassword('originalpassword'));
+    const { token } = await issue(u.id);
+    const res = await testRequest(app).get(`/api/auth/recovery/${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ valid: true, username: 'probe-target', hasPassword: true });
+  });
+
+  it('answers an unknown token exactly as it answers an expired one', async () => {
+    const u = createUser('probe-expired');
+    // Backdate the row rather than waiting out the 24h TTL.
+    const { token } = await issue(u.id);
+    const { default: db } = await import('../db/index.js');
+    db.prepare('UPDATE account_recovery_tokens SET expires_at = ? WHERE user_id = ?').run(
+      new Date(Date.now() - 1000).toISOString(),
+      u.id,
+    );
+    const expired = await testRequest(app).get(`/api/auth/recovery/${token}`);
+    const unknown = await testRequest(app).get('/api/auth/recovery/not-a-real-token');
+    expect(expired.body).toEqual({ valid: false });
+    expect(unknown.body).toEqual(expired.body);
+  });
+
+  it('does not spend the link', async () => {
+    const u = createUser('probe-nondestructive');
+    const { token } = await issue(u.id);
+    await testRequest(app).get(`/api/auth/recovery/${token}`);
+    await testRequest(app).get(`/api/auth/recovery/${token}`);
+    const res = await testRequest(app)
+      .post(`/api/auth/recovery/${token}/password`)
+      .send({ password: 'a-fresh-password' });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('POST /api/auth/recovery/:token/password', () => {
+  it('sets the new password and signs the redeeming device in', async () => {
+    const u = createUser('redeem-happy');
+    setPasswordHash(u.id, hashPassword('theoldpassword'));
+    const { token } = await issue(u.id);
+    const res = await testRequest(app)
+      .post(`/api/auth/recovery/${token}/password`)
+      .send({ password: 'thenewpassword' });
+    expect(res.status).toBe(200);
+    expect(res.body.user).toMatchObject({ id: u.id, username: 'redeem-happy' });
+    expect(String(res.headers['set-cookie'])).toContain('lurker_session=');
+    const stored = getPasswordHash(u.id);
+    expect(verifyPassword('thenewpassword', stored)).toBe(true);
+    expect(verifyPassword('theoldpassword', stored)).toBe(false);
+  });
+
+  it('works for an account that had no password at all', async () => {
+    // The passkey-only member who lost their phone: nothing to "reset", so a
+    // password-only reset flow would have stranded them.
+    const u = createUser('redeem-no-password');
+    const { token } = await issue(u.id);
+    const res = await testRequest(app)
+      .post(`/api/auth/recovery/${token}/password`)
+      .send({ password: 'firstpasswordever' });
+    expect(res.status).toBe(200);
+    expect(verifyPassword('firstpasswordever', getPasswordHash(u.id))).toBe(true);
+  });
+
+  it('signs every other device out', async () => {
+    const u = createUser('redeem-revokes');
+    const oldDevice = await createAuthedAgent(app, u.id);
+    expect((await oldDevice.get('/api/auth/me')).status).toBe(200);
+    const { token } = await issue(u.id);
+    await testRequest(app)
+      .post(`/api/auth/recovery/${token}/password`)
+      .send({ password: 'kickeveryoneout' });
+    // The lockout that made recovery necessary is indistinguishable from a
+    // takeover, so a session predating it is assumed hostile.
+    expect((await oldDevice.get('/api/auth/me')).status).toBe(401);
+  });
+
+  it('rejects a too-short password WITHOUT burning the link', async () => {
+    const u = createUser('redeem-short');
+    const { token } = await issue(u.id);
+    const bad = await testRequest(app)
+      .post(`/api/auth/recovery/${token}/password`)
+      .send({ password: 'short' });
+    expect(bad.status).toBe(400);
+    // A single-use link must survive a typo, or the admin has to issue another.
+    const good = await testRequest(app)
+      .post(`/api/auth/recovery/${token}/password`)
+      .send({ password: 'longenoughpassword' });
+    expect(good.status).toBe(200);
+  });
+
+  it('cannot be redeemed twice', async () => {
+    const u = createUser('redeem-twice');
+    const { token } = await issue(u.id);
+    const first = await testRequest(app)
+      .post(`/api/auth/recovery/${token}/password`)
+      .send({ password: 'thefirstpassword' });
+    expect(first.status).toBe(200);
+    const second = await testRequest(app)
+      .post(`/api/auth/recovery/${token}/password`)
+      .send({ password: 'thesecondpassword' });
+    expect(second.status).toBe(400);
+    // The password from the winning redemption is the one that stands.
+    expect(verifyPassword('thefirstpassword', getPasswordHash(u.id))).toBe(true);
+  });
+
+  it('rejects an unknown token', async () => {
+    const res = await testRequest(app)
+      .post('/api/auth/recovery/nope/password')
+      .send({ password: 'longenoughpassword' });
+    expect(res.status).toBe(400);
+  });
+
+  it('leaves existing passkeys alone', async () => {
+    // Recovery restores a way in; it is not a way to strip someone's
+    // credentials out from under them.
+    const u = createUser('redeem-keeps-passkeys');
+    const { insertCredential, countForUser } = await import('../db/webauthnCredentials.js');
+    insertCredential({
+      userId: u.id,
+      credentialId: 'cred-kept-through-recovery',
+      publicKey: Buffer.from('key'),
+      counter: 0,
+      transports: ['internal'],
+      deviceType: 'singleDevice',
+      backedUp: false,
+      label: 'old laptop',
+    });
+    const { token } = await issue(u.id);
+    await testRequest(app)
+      .post(`/api/auth/recovery/${token}/password`)
+      .send({ password: 'passwordalongside' });
+    expect(countForUser(u.id)).toBe(1);
+  });
+});
+
+describe('POST /api/auth/recovery/:token/options', () => {
+  it('returns registration options for the account named by the link', async () => {
+    const u = createUser('passkey-options');
+    const { token } = await issue(u.id);
+    const res = await testRequest(app).post(`/api/auth/recovery/${token}/options`);
+    expect(res.status).toBe(200);
+    expect(res.body.username).toBe('passkey-options');
+    expect(res.body.options.challenge).toBeTruthy();
+    expect(String(res.headers['set-cookie'])).toContain('lurker_webauthn_challenge=');
+  });
+
+  it('excludes passkeys already on the account', async () => {
+    const u = createUser('passkey-options-exclude');
+    const { insertCredential } = await import('../db/webauthnCredentials.js');
+    insertCredential({
+      userId: u.id,
+      credentialId: 'cred-already-enrolled',
+      publicKey: Buffer.from('key'),
+      counter: 0,
+      transports: ['internal'],
+      deviceType: 'singleDevice',
+      backedUp: false,
+      label: null,
+    });
+    const { token } = await issue(u.id);
+    const res = await testRequest(app).post(`/api/auth/recovery/${token}/options`);
+    expect(res.body.options.excludeCredentials).toEqual([
+      { id: 'cred-already-enrolled', transports: ['internal'], type: 'public-key' },
+    ]);
+  });
+
+  it('does not spend the link — the ceremony may still be abandoned', async () => {
+    const u = createUser('passkey-options-nondestructive');
+    const { token } = await issue(u.id);
+    await testRequest(app).post(`/api/auth/recovery/${token}/options`);
+    expect(recovery.findLiveRecoveryToken(token)).toMatchObject({ userId: u.id });
+  });
+
+  it('404s for an invalid link', async () => {
+    const res = await testRequest(app).post('/api/auth/recovery/nope/options');
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/auth/recovery/:token/verify', () => {
+  it('refuses without a pending challenge', async () => {
+    const u = createUser('passkey-verify-nochallenge');
+    const { token } = await issue(u.id);
+    const res = await testRequest(app).post(`/api/auth/recovery/${token}/verify`).send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('no pending recovery');
+    // And the link is untouched, so the member can try again.
+    expect(recovery.findLiveRecoveryToken(token)).toMatchObject({ userId: u.id });
+  });
+
+  it('refuses a challenge issued for a different link', async () => {
+    const u = createUser('passkey-verify-crosslink');
+    const other = createUser('passkey-verify-crosslink-other');
+    const mine = await issue(u.id);
+    const theirs = await issue(other.id);
+    const agent = (await import('../test-utils/testApp.js')).createAnonAgent(app);
+    await agent.post(`/api/auth/recovery/${mine.token}/options`);
+    // Same browser, same challenge cookie, pointed at someone else's link.
+    const res = await agent.post(`/api/auth/recovery/${theirs.token}/verify`).send({});
+    expect(res.status).toBe(400);
+    expect(recovery.findLiveRecoveryToken(theirs.token)).toBeTruthy();
+  });
+
+  it('does not spend the link when the authenticator response fails to verify', async () => {
+    const u = createUser('passkey-verify-badresponse');
+    const { token } = await issue(u.id);
+    const agent = (await import('../test-utils/testApp.js')).createAnonAgent(app);
+    await agent.post(`/api/auth/recovery/${token}/options`);
+    const res = await agent.post(`/api/auth/recovery/${token}/verify`).send({ response: {} });
+    expect(res.status).toBe(400);
+    // A failed ceremony must not cost the member their one link.
+    expect(recovery.findLiveRecoveryToken(token)).toMatchObject({ userId: u.id });
+  });
+});

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -24,6 +24,7 @@ import {
   createRecoveryToken,
   getRecoveryTokenForUser,
   deleteRecoveryTokensForUser,
+  listRecoveryExpiries,
 } from '../db/accountRecovery.js';
 import ircManager from '../services/ircManager.js';
 import { presenceDiagnostics } from '../services/wsHub.js';
@@ -105,6 +106,10 @@ router.get('/users', (_req: Request, res: Response) => {
     const key = effectiveIdent(u).toLowerCase();
     identCounts.set(key, (identCounts.get(key) ?? 0) + 1);
   }
+  // One query for the whole roster rather than one per row — same shape as the
+  // ident tally above. Per-user lookups here meant an instance with 200 accounts
+  // prepared and ran 200 statements on every load of this screen.
+  const recoveryExpiries = listRecoveryExpiries();
   res.json({
     users: all.map((u) => ({
       id: u.id,
@@ -125,7 +130,7 @@ router.get('/users', (_req: Request, res: Response) => {
       // (#855). The token itself is never returned — only its hash is stored,
       // so re-showing a link is impossible by construction; an admin who lost
       // the URL issues a new one, which invalidates the old.
-      recoveryExpiresAt: getRecoveryTokenForUser(u.id)?.expiresAt ?? null,
+      recoveryExpiresAt: recoveryExpiries.get(u.id) ?? null,
     })),
     // Whether either ident mode is running. When neither is, the idents above
     // are inert — the UI says so rather than implying networks see them. (The
@@ -304,12 +309,6 @@ router.post('/users/:id/resume', (req: Request, res: Response) => {
   res.json({ ok: true });
 });
 
-// Read-only presence diagnostic. Surfaces, per connected user, how many WS
-// sockets are open vs. how many the server believes are visible — the value
-// auto-away keys on — plus the persisted away row. An open socket count that
-// stays above visible/away counts, or a visible socket for a user who's
-// plainly gone, is the zombie-socket signature the heartbeat reaps. Safe in
-// both editions: it mutates nothing (unlike pause/resume, which are node-gated).
 // Issue a single-use recovery link for an account (#855). Accounts carry no
 // email address, so this is the whole password-reset story: the admin hands the
 // URL to the member over a channel they already trust, and redeeming it sets a
@@ -317,7 +316,17 @@ router.post('/users/:id/resume', (req: Request, res: Response) => {
 //
 // The response is the ONLY time this URL exists anywhere — only its hash is
 // stored — so an admin who loses it issues a new one, which invalidates the old.
+//
+// Standalone only, like pause/resume. On a hosted cell the control plane owns
+// sign-in (it holds cp_session and injects lurker_session) and has its own
+// email-based reset, so a cell-local password set here is not what hosted login
+// consults — and redeeming would drop CP-injected session rows the control
+// plane still believes are live.
 router.post('/users/:id/recovery', (req: Request, res: Response) => {
+  if (isNodeMode()) {
+    res.status(409).json({ error: 'sign-in is managed by the control plane in node edition' });
+    return;
+  }
   const id = Number(req.params.id);
   if (!Number.isInteger(id)) {
     res.status(400).json({ error: 'invalid id' });
@@ -342,6 +351,10 @@ router.post('/users/:id/recovery', (req: Request, res: Response) => {
 // Revoke an outstanding link — the admin's undo for one sent to the wrong
 // person, or one no longer needed.
 router.delete('/users/:id/recovery', (req: Request, res: Response) => {
+  if (isNodeMode()) {
+    res.status(409).json({ error: 'sign-in is managed by the control plane in node edition' });
+    return;
+  }
   const id = Number(req.params.id);
   if (!Number.isInteger(id)) {
     res.status(400).json({ error: 'invalid id' });
@@ -354,6 +367,12 @@ router.delete('/users/:id/recovery', (req: Request, res: Response) => {
   res.json({ ok: true });
 });
 
+// Read-only presence diagnostic. Surfaces, per connected user, how many WS
+// sockets are open vs. how many the server believes are visible — the value
+// auto-away keys on — plus the persisted away row. An open socket count that
+// stays above visible/away counts, or a visible socket for a user who's
+// plainly gone, is the zombie-socket signature the heartbeat reaps. Safe in
+// both editions: it mutates nothing (unlike pause/resume, which are node-gated).
 router.get('/presence', (_req: Request, res: Response) => {
   const presence = presenceDiagnostics().map((row) => {
     const u = findUserById(row.userId);

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -20,6 +20,11 @@ import {
   getInvite,
   isInviteSpent,
 } from '../db/invites.js';
+import {
+  createRecoveryToken,
+  getRecoveryTokenForUser,
+  deleteRecoveryTokensForUser,
+} from '../db/accountRecovery.js';
 import ircManager from '../services/ircManager.js';
 import { presenceDiagnostics } from '../services/wsHub.js';
 import { isIdentdEnabled, isOidentdFileEnabled } from '../services/identd.js';
@@ -116,6 +121,11 @@ router.get('/users', (_req: Request, res: Response) => {
       // Another account answers this same ident — neither is attributable until
       // the operator assigns one of them something else.
       identConflict: (identCounts.get(effectiveIdent(u).toLowerCase()) ?? 0) > 1,
+      // Whether an unredeemed recovery link is outstanding for this account
+      // (#855). The token itself is never returned — only its hash is stored,
+      // so re-showing a link is impossible by construction; an admin who lost
+      // the URL issues a new one, which invalidates the old.
+      recoveryExpiresAt: getRecoveryTokenForUser(u.id)?.expiresAt ?? null,
     })),
     // Whether either ident mode is running. When neither is, the idents above
     // are inert — the UI says so rather than implying networks see them. (The
@@ -300,6 +310,50 @@ router.post('/users/:id/resume', (req: Request, res: Response) => {
 // stays above visible/away counts, or a visible socket for a user who's
 // plainly gone, is the zombie-socket signature the heartbeat reaps. Safe in
 // both editions: it mutates nothing (unlike pause/resume, which are node-gated).
+// Issue a single-use recovery link for an account (#855). Accounts carry no
+// email address, so this is the whole password-reset story: the admin hands the
+// URL to the member over a channel they already trust, and redeeming it sets a
+// password or enrolls a passkey.
+//
+// The response is the ONLY time this URL exists anywhere — only its hash is
+// stored — so an admin who loses it issues a new one, which invalidates the old.
+router.post('/users/:id/recovery', (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id)) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  const user = findUserById(id);
+  if (!user) {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+  const token = createRecoveryToken(user.id, req.user!.id);
+  const info = getRecoveryTokenForUser(user.id)!;
+  res.json({
+    recovery: {
+      username: user.username,
+      url: `${originFromRequest(req)}/recover/${token}`,
+      expiresAt: info.expiresAt,
+    },
+  });
+});
+
+// Revoke an outstanding link — the admin's undo for one sent to the wrong
+// person, or one no longer needed.
+router.delete('/users/:id/recovery', (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id)) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  if (!deleteRecoveryTokensForUser(id)) {
+    res.status(404).json({ error: 'no outstanding recovery link' });
+    return;
+  }
+  res.json({ ok: true });
+});
+
 router.get('/presence', (_req: Request, res: Response) => {
   const presence = presenceDiagnostics().map((row) => {
     const u = findUserById(row.userId);

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -22,7 +22,6 @@ import {
 } from '../db/invites.js';
 import {
   createRecoveryToken,
-  getRecoveryTokenForUser,
   deleteRecoveryTokensForUser,
   listRecoveryExpiries,
 } from '../db/accountRecovery.js';
@@ -337,13 +336,12 @@ router.post('/users/:id/recovery', (req: Request, res: Response) => {
     res.status(404).json({ error: 'not found' });
     return;
   }
-  const token = createRecoveryToken(user.id, req.user!.id);
-  const info = getRecoveryTokenForUser(user.id)!;
+  const { token, expiresAt } = createRecoveryToken(user.id, req.user!.id);
   res.json({
     recovery: {
       username: user.username,
       url: `${originFromRequest(req)}/recover/${token}`,
-      expiresAt: info.expiresAt,
+      expiresAt,
     },
   });
 });

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -44,6 +44,9 @@ import {
 } from '../db/webauthnCredentials.js';
 import { createSession, deleteSession, deleteSessionsForUser } from '../db/sessions.js';
 import { closeSocketsForUser } from '../services/wsHub.js';
+import { dropSessionsForUser as dropBouncerSessionsForUser } from '../services/bouncer.js';
+import { revokeAllForUser as revokeApiTokensForUser } from '../db/apiTokens.js';
+import { deleteAllForUser as deletePushSubscriptionsForUser } from '../db/pushSubscriptions.js';
 import { SESSION_COOKIE, getCookieOptions, requireAuth, bearerToken } from '../middleware/auth.js';
 import { rpConfig, saveChallenge, consumeChallenge, userIdToHandle } from '../services/webauthn.js';
 import {
@@ -420,19 +423,33 @@ router.post('/invite/:token/password', (req: Request<{ token: string }>, res: Re
 // Every path here ends in finishRecovery(), which signs the account out
 // everywhere before minting the new session: the lockout that made recovery
 // necessary is indistinguishable from a takeover, so any session predating the
-// recovery is assumed hostile — the session rows AND the open sockets, since a
-// socket is only ever checked at upgrade. Existing passkeys are deliberately
-// left alone — recovery restores a way in, it is not a way to strip someone's
-// credentials.
+// recovery is assumed hostile: session rows, open WebSockets, attached bouncer
+// sessions, API tokens, and push registrations all go, because every one of them
+// authenticates once and is never re-checked afterwards. Existing passkeys are
+// the deliberate exception — recovery restores a way in, it is not a way to
+// strip someone's credentials, and a passkey cannot be used without the
+// authenticator itself.
 
 function finishRecovery(res: Response, user: { id: number; username: string; role: string }): void {
+  // "Signed out everywhere" means every door, not just the web session. Each of
+  // these is a credential that authenticates ONCE and is then never re-checked
+  // against the session table, so dropping rows alone leaves all of them open to
+  // whoever held the account — which is precisely who this flow assumes is on
+  // the other end.
   deleteSessionsForUser(user.id);
-  // Rows alone aren't enough: an open socket authenticated at upgrade time and
-  // is never re-checked, so without this an attacker holding the account keeps
-  // reading and sending as them indefinitely — and that is precisely who this
-  // flow assumes is on the other end. Runs before the new session is minted;
-  // the recovering device has no socket yet and reconnects with the new cookie.
+  // Checked at the /ws upgrade and never again; the handler reads its user from
+  // the socket's own closure. Runs before the new session is minted — the
+  // recovering device has no socket yet and reconnects with the new cookie.
   closeSocketsForUser(user.id, 'account recovered');
+  // Same shape one layer down: a bouncer session authenticates at login and then
+  // carries its userId for the life of the TCP connection.
+  dropBouncerSessionsForUser(user.id, 'Account recovered');
+  // Independent bearer credentials that outlive every session — an attacker who
+  // minted one would otherwise keep read-write access straight through recovery.
+  revokeApiTokensForUser(user.id);
+  // Keyed on user_id with no session linkage, so an evicted device would keep
+  // receiving the member's incoming messages as push content.
+  deletePushSubscriptionsForUser(user.id);
   const { token: sessionToken } = createSession(user.id);
   res.cookie(SESSION_COOKIE, sessionToken, getCookieOptions());
   res.json({ user: { id: user.id, username: user.username, role: user.role } });
@@ -589,9 +606,14 @@ router.post('/recovery/:token/verify', async (req: Request<{ token: string }>, r
       backedUp: credentialBackedUp,
       label,
     });
-  } catch (_err) {
-    // The rollback put the link back, so the member can retry with a different
-    // authenticator rather than going back to the admin for a new one.
+  } catch (err) {
+    // ONLY a duplicate credential means what this 409 says. A SQLITE_BUSY or a
+    // full disk would otherwise be reported as "already registered", sending a
+    // locked-out member off to try authenticator after authenticator against
+    // what is actually a server fault. Anything else rethrows to the 500 path,
+    // where it gets logged. The rollback happened either way, so the link
+    // survives and a retry is safe.
+    if ((err as { code?: string }).code !== 'SQLITE_CONSTRAINT_UNIQUE') throw err;
     res.status(409).json({ error: 'that passkey is already registered on this server' });
     return;
   }

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -44,6 +44,7 @@ import {
 } from '../db/webauthnCredentials.js';
 import { createSession, deleteSession, deleteSessionsForUser } from '../db/sessions.js';
 import { closeSocketsForUser } from '../services/wsHub.js';
+import { isNodeMode } from '../utils/edition.js';
 import { dropSessionsForUser as dropBouncerSessionsForUser } from '../services/bouncer.js';
 import { revokeAllForUser as revokeApiTokensForUser } from '../db/apiTokens.js';
 import { deleteAllForUser as deletePushSubscriptionsForUser } from '../db/pushSubscriptions.js';
@@ -430,6 +431,18 @@ router.post('/invite/:token/password', (req: Request<{ token: string }>, res: Re
 // strip someone's credentials, and a passkey cannot be used without the
 // authenticator itself.
 
+// A cell's sign-in is the control plane's: it holds cp_session, injects
+// lurker_session, and has its own email-based reset. Issuing already refuses
+// there (routes/admin.ts), but redemption has to refuse independently — a link
+// minted before an instance became a cell, or by the CLI shipped in the same
+// image, would otherwise be redeemable and would drop CP-injected session rows
+// the control plane still believes are live.
+function recoveryUnavailableInNodeMode(res: Response): boolean {
+  if (!isNodeMode()) return false;
+  res.status(404).json({ error: 'account recovery is managed by the control plane' });
+  return true;
+}
+
 function finishRecovery(res: Response, user: { id: number; username: string; role: string }): void {
   // "Signed out everywhere" means every door, not just the web session. Each of
   // these is a credential that authenticates ONCE and is then never re-checked
@@ -461,6 +474,7 @@ function finishRecovery(res: Response, user: { id: number; username: string; rol
 // comes back because the page needs to name the account being recovered, and
 // whoever holds this link can already take that account over.
 router.get('/recovery/:token', (req: Request<{ token: string }>, res: Response) => {
+  if (recoveryUnavailableInNodeMode(res)) return;
   const info = findLiveRecoveryToken(req.params.token);
   const user = info ? findUserById(info.userId) : null;
   if (!user) {
@@ -489,6 +503,7 @@ router.get('/recovery/:token', (req: Request<{ token: string }>, res: Response) 
 // above already bounds how fast anyone can probe this surface. The passkey half
 // of this flow is unguarded for the same reason; the two now agree.
 router.post('/recovery/:token/password', (req: Request<{ token: string }>, res: Response) => {
+  if (recoveryUnavailableInNodeMode(res)) return;
   const password: unknown = req.body?.password;
   if (!isValidPassword(password)) {
     res.status(400).json({ error: passwordRequirementsMessage() });
@@ -515,6 +530,7 @@ router.post('/recovery/:token/password', (req: Request<{ token: string }>, res: 
 // phone has no password to reset. Mirrors /passkeys/options, but authorized by
 // the link instead of a session.
 router.post('/recovery/:token/options', async (req: Request<{ token: string }>, res: Response) => {
+  if (recoveryUnavailableInNodeMode(res)) return;
   const info = findLiveRecoveryToken(req.params.token);
   const user = info ? findUserById(info.userId) : null;
   if (!user) {
@@ -555,6 +571,7 @@ router.post('/recovery/:token/options', async (req: Request<{ token: string }>, 
 });
 
 router.post('/recovery/:token/verify', async (req: Request<{ token: string }>, res: Response) => {
+  if (recoveryUnavailableInNodeMode(res)) return;
   const challengeToken = req.signedCookies?.[CHALLENGE_COOKIE];
   const entry = consumeChallenge(challengeToken);
   clearChallengeCookie(res);

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -26,6 +26,7 @@ import {
   setPasswordHash,
 } from '../db/users.js';
 import { inviteStatus, consumeInvite } from '../db/invites.js';
+import { findLiveRecoveryToken, consumeRecoveryToken } from '../db/accountRecovery.js';
 import { isValidUsername, isValidLoginUsername } from '../../shared/username.js';
 import {
   listForUser as listCredentialsForUser,
@@ -37,7 +38,7 @@ import {
   updateLabel,
   deleteById as deleteCredentialById,
 } from '../db/webauthnCredentials.js';
-import { createSession, deleteSession } from '../db/sessions.js';
+import { createSession, deleteSession, deleteSessionsForUser } from '../db/sessions.js';
 import { SESSION_COOKIE, getCookieOptions, requireAuth, bearerToken } from '../middleware/auth.js';
 import { rpConfig, saveChallenge, consumeChallenge, userIdToHandle } from '../services/webauthn.js';
 import {
@@ -402,6 +403,179 @@ router.post('/invite/:token/password', (req: Request<{ token: string }>, res: Re
   const { token: sessionToken } = createSession(user.id);
   res.cookie(SESSION_COOKIE, sessionToken, getCookieOptions());
   res.json({ user: { id: user.id, username: user.username, role: user.role } });
+});
+
+// ---------- account recovery ----------
+
+// Redemption of an admin-issued recovery link (#855). An account has no email
+// address, so there is no self-service reset to build: an admin issues a link
+// for one account and hands it over out of band, and redeeming it adds a
+// sign-in method back to an account its owner is locked out of.
+//
+// Every path here ends in finishRecovery(), which signs the account out
+// everywhere before minting the new session: the lockout that made recovery
+// necessary is indistinguishable from a takeover, so any session predating the
+// recovery is assumed hostile. (An already-open WebSocket survives until it
+// disconnects — see deleteSessionsForUser and #567.) Existing passkeys are
+// deliberately left alone — recovery restores a way in, it is not a way to
+// strip someone's credentials.
+
+function finishRecovery(res: Response, user: { id: number; username: string; role: string }): void {
+  deleteSessionsForUser(user.id);
+  const { token: sessionToken } = createSession(user.id);
+  res.cookie(SESSION_COOKIE, sessionToken, getCookieOptions());
+  res.json({ user: { id: user.id, username: user.username, role: user.role } });
+}
+
+// Public status probe for the landing page. An expired link and a token that
+// was never real answer identically — the page is the same dead end either way,
+// and distinguishing them would confirm a token had once existed. The username
+// comes back because the page needs to name the account being recovered, and
+// whoever holds this link can already take that account over.
+router.get('/recovery/:token', (req: Request<{ token: string }>, res: Response) => {
+  const info = findLiveRecoveryToken(req.params.token);
+  const user = info ? findUserById(info.userId) : null;
+  if (!user) {
+    res.json({ valid: false });
+    return;
+  }
+  res.json({
+    valid: true,
+    username: user.username,
+    expiresAt: info!.expiresAt,
+    // Whether the page offers "set a password" or "change your password".
+    hasPassword: userHasPassword(user.id),
+  });
+});
+
+// Set a password with a recovery link. The password is validated BEFORE the
+// token is spent, so a too-short one doesn't burn a single-use link.
+router.post(
+  '/recovery/:token/password',
+  guardCredentialAttempt(loginFailureThrottle),
+  (req: Request<{ token: string }>, res: Response) => {
+    const password: unknown = req.body?.password;
+    if (!isValidPassword(password)) {
+      res.status(400).json({ error: passwordRequirementsMessage() });
+      return;
+    }
+    const userId = consumeRecoveryToken(req.params.token);
+    if (userId === null) {
+      res.status(400).json({ error: 'that recovery link is invalid or has expired' });
+      return;
+    }
+    const user = findUserById(userId);
+    if (!user) {
+      // The row CASCADEs with the account, so this means the account was deleted
+      // between the consume and this read.
+      res.status(404).json({ error: 'that account no longer exists' });
+      return;
+    }
+    setPasswordHash(user.id, hashPassword(password as string));
+    finishRecovery(res, user);
+  },
+);
+
+// Enroll a fresh passkey with a recovery link — the half of this feature a
+// password-only reset would miss, since a passkey-only member who lost their
+// phone has no password to reset. Mirrors /passkeys/options, but authorized by
+// the link instead of a session.
+router.post('/recovery/:token/options', async (req: Request<{ token: string }>, res: Response) => {
+  const info = findLiveRecoveryToken(req.params.token);
+  const user = info ? findUserById(info.userId) : null;
+  if (!user) {
+    res.status(404).json({ error: 'invalid or expired recovery link' });
+    return;
+  }
+  const { rpID, rpName } = rpConfig();
+  // listCredentialsForUser is untyped — credentials are any[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const existing = listCredentialsForUser(user.id) as any[];
+  const options = await generateRegistrationOptions({
+    rpName,
+    rpID,
+    userName: user.username,
+    userID: new Uint8Array(userIdToHandle(user.id)),
+    userDisplayName: user.username,
+    attestationType: 'none',
+    authenticatorSelection: {
+      residentKey: 'required',
+      userVerification: 'preferred',
+    },
+    // The authenticators already on the account. Usually none of them are the
+    // one in the member's hand — that's why they're here — but excluding them
+    // keeps a still-enrolled device from silently registering itself twice.
+    excludeCredentials: existing.map((c) => ({
+      id: c.credentialId,
+      transports: c.transports,
+    })),
+  });
+  const token = saveChallenge({
+    purpose: 'recovery',
+    challenge: options.challenge,
+    userId: user.id,
+    recoveryToken: req.params.token,
+  });
+  setChallengeCookie(res, token);
+  res.json({ options, username: user.username });
+});
+
+router.post('/recovery/:token/verify', async (req: Request<{ token: string }>, res: Response) => {
+  const challengeToken = req.signedCookies?.[CHALLENGE_COOKIE];
+  const entry = consumeChallenge(challengeToken);
+  clearChallengeCookie(res);
+  if (!entry || entry.purpose !== 'recovery' || entry.recoveryToken !== req.params.token) {
+    res.status(400).json({ error: 'no pending recovery' });
+    return;
+  }
+  const { rpID, expectedOrigin } = rpConfig();
+  let verification: VerifiedRegistrationResponse;
+  try {
+    verification = await verifyRegistrationResponse({
+      response: req.body?.response,
+      expectedChallenge: entry.challenge as string,
+      expectedOrigin,
+      expectedRPID: rpID,
+      requireUserVerification: false,
+    });
+  } catch (err) {
+    const e = err as { message?: string };
+    res.status(400).json({ error: e.message || 'verification failed' });
+    return;
+  }
+  if (!verification.verified || !verification.registrationInfo) {
+    res.status(400).json({ error: 'verification failed' });
+    return;
+  }
+
+  // Spend the link only once the authenticator has answered, so a failed or
+  // abandoned ceremony leaves it usable. Nothing has been written yet, so losing
+  // this race needs no cleanup — unlike the invite flow, which has a
+  // speculatively-created account to tear down.
+  const userId = consumeRecoveryToken(req.params.token);
+  if (userId === null || userId !== (entry.userId as number)) {
+    res.status(409).json({ error: 'that recovery link is no longer valid' });
+    return;
+  }
+  const user = findUserById(userId);
+  if (!user) {
+    res.status(404).json({ error: 'that account no longer exists' });
+    return;
+  }
+
+  const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
+  const label = (req.body?.label || '').toString().trim().slice(0, 64) || null;
+  insertCredential({
+    userId: user.id,
+    credentialId: credential.id,
+    publicKey: Buffer.from(credential.publicKey),
+    counter: credential.counter,
+    transports: credential.transports || [],
+    deviceType: credentialDeviceType,
+    backedUp: credentialBackedUp,
+    label,
+  });
+  finishRecovery(res, user);
 });
 
 // ---------- login ----------

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -26,7 +26,11 @@ import {
   setPasswordHash,
 } from '../db/users.js';
 import { inviteStatus, consumeInvite } from '../db/invites.js';
-import { findLiveRecoveryToken, consumeRecoveryToken } from '../db/accountRecovery.js';
+import {
+  findLiveRecoveryToken,
+  consumeRecoveryToken,
+  spendRecoveryAndEnroll,
+} from '../db/accountRecovery.js';
 import { isValidUsername, isValidLoginUsername } from '../../shared/username.js';
 import {
   listForUser as listCredentialsForUser,
@@ -39,6 +43,7 @@ import {
   deleteById as deleteCredentialById,
 } from '../db/webauthnCredentials.js';
 import { createSession, deleteSession, deleteSessionsForUser } from '../db/sessions.js';
+import { closeSocketsForUser } from '../services/wsHub.js';
 import { SESSION_COOKIE, getCookieOptions, requireAuth, bearerToken } from '../middleware/auth.js';
 import { rpConfig, saveChallenge, consumeChallenge, userIdToHandle } from '../services/webauthn.js';
 import {
@@ -415,13 +420,19 @@ router.post('/invite/:token/password', (req: Request<{ token: string }>, res: Re
 // Every path here ends in finishRecovery(), which signs the account out
 // everywhere before minting the new session: the lockout that made recovery
 // necessary is indistinguishable from a takeover, so any session predating the
-// recovery is assumed hostile. (An already-open WebSocket survives until it
-// disconnects — see deleteSessionsForUser and #567.) Existing passkeys are
-// deliberately left alone — recovery restores a way in, it is not a way to
-// strip someone's credentials.
+// recovery is assumed hostile — the session rows AND the open sockets, since a
+// socket is only ever checked at upgrade. Existing passkeys are deliberately
+// left alone — recovery restores a way in, it is not a way to strip someone's
+// credentials.
 
 function finishRecovery(res: Response, user: { id: number; username: string; role: string }): void {
   deleteSessionsForUser(user.id);
+  // Rows alone aren't enough: an open socket authenticated at upgrade time and
+  // is never re-checked, so without this an attacker holding the account keeps
+  // reading and sending as them indefinitely — and that is precisely who this
+  // flow assumes is on the other end. Runs before the new session is minted;
+  // the recovering device has no socket yet and reconnects with the new cookie.
+  closeSocketsForUser(user.id, 'account recovered');
   const { token: sessionToken } = createSession(user.id);
   res.cookie(SESSION_COOKIE, sessionToken, getCookieOptions());
   res.json({ user: { id: user.id, username: user.username, role: user.role } });
@@ -451,38 +462,36 @@ router.get('/recovery/:token', (req: Request<{ token: string }>, res: Response) 
 // Set a password with a recovery link. The password is validated BEFORE the
 // token is spent, so a too-short one doesn't burn a single-use link.
 //
-// guardCredentialAttempt shares this IP's login backoff — it turns away a
-// caller already being throttled, and clears that state on success. It does NOT
-// count failures here: it records only on 401, and a dead link answers 400.
-// That's deliberate rather than an oversight. Nothing on this route is
-// guessable — the token is 32 random bytes — so failure backoff would buy
-// nothing, while the router-wide limitRequests(authRequestThrottle) above
-// already caps how fast anyone can probe the auth surface at all.
-router.post(
-  '/recovery/:token/password',
-  guardCredentialAttempt(loginFailureThrottle),
-  (req: Request<{ token: string }>, res: Response) => {
-    const password: unknown = req.body?.password;
-    if (!isValidPassword(password)) {
-      res.status(400).json({ error: passwordRequirementsMessage() });
-      return;
-    }
-    const userId = consumeRecoveryToken(req.params.token);
-    if (userId === null) {
-      res.status(400).json({ error: 'that recovery link is invalid or has expired' });
-      return;
-    }
-    const user = findUserById(userId);
-    if (!user) {
-      // The row CASCADEs with the account, so this means the account was deleted
-      // between the consume and this read.
-      res.status(404).json({ error: 'that account no longer exists' });
-      return;
-    }
-    setPasswordHash(user.id, hashPassword(password as string));
-    finishRecovery(res, user);
-  },
-);
+// NO guardCredentialAttempt here, unlike the login routes, and that is the
+// point: its 429 pre-check turns away an IP already in login backoff — which is
+// exactly the person recovering, since failing at sign-in is how they got here.
+// (Behind a proxy without LURKER_TRUST_PROXY the key is the proxy's address, so
+// one member's failed logins would lock everyone else out of recovery too.) It
+// would buy nothing either way: the token is 32 random bytes, so there is
+// nothing to brute-force, and the router-wide limitRequests(authRequestThrottle)
+// above already bounds how fast anyone can probe this surface. The passkey half
+// of this flow is unguarded for the same reason; the two now agree.
+router.post('/recovery/:token/password', (req: Request<{ token: string }>, res: Response) => {
+  const password: unknown = req.body?.password;
+  if (!isValidPassword(password)) {
+    res.status(400).json({ error: passwordRequirementsMessage() });
+    return;
+  }
+  const userId = consumeRecoveryToken(req.params.token);
+  if (userId === null) {
+    res.status(400).json({ error: 'that recovery link is invalid or has expired' });
+    return;
+  }
+  const user = findUserById(userId);
+  if (!user) {
+    // The row CASCADEs with the account, so this means the account was deleted
+    // between the consume and this read.
+    res.status(404).json({ error: 'that account no longer exists' });
+    return;
+  }
+  setPasswordHash(user.id, hashPassword(password as string));
+  finishRecovery(res, user);
+});
 
 // Enroll a fresh passkey with a recovery link — the half of this feature a
 // password-only reset would miss, since a passkey-only member who lost their
@@ -557,11 +566,36 @@ router.post('/recovery/:token/verify', async (req: Request<{ token: string }>, r
   }
 
   // Spend the link only once the authenticator has answered, so a failed or
-  // abandoned ceremony leaves it usable. Nothing has been written yet, so losing
-  // this race needs no cleanup — unlike the invite flow, which has a
-  // speculatively-created account to tear down.
-  const userId = consumeRecoveryToken(req.params.token);
-  if (userId === null || userId !== (entry.userId as number)) {
+  // abandoned ceremony leaves it usable.
+  //
+  // Spend and enroll go in ONE transaction. webauthn_credentials.credential_id
+  // is globally UNIQUE while excludeCredentials only excludes THIS account's
+  // keys, so an authenticator already enrolled on a different account of the
+  // same instance (a shared machine, or one person with two accounts) clears the
+  // ceremony and then fails the insert. Outside a transaction that 500s with the
+  // token already deleted: no credential written, one link burned, member still
+  // locked out.
+  const entryUserId = entry.userId as number;
+  let userId: number | null = null;
+  const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
+  const label = (req.body?.label || '').toString().trim().slice(0, 64) || null;
+  try {
+    userId = spendRecoveryAndEnroll(req.params.token, entryUserId, {
+      credentialId: credential.id,
+      publicKey: Buffer.from(credential.publicKey),
+      counter: credential.counter,
+      transports: credential.transports || [],
+      deviceType: credentialDeviceType,
+      backedUp: credentialBackedUp,
+      label,
+    });
+  } catch (_err) {
+    // The rollback put the link back, so the member can retry with a different
+    // authenticator rather than going back to the admin for a new one.
+    res.status(409).json({ error: 'that passkey is already registered on this server' });
+    return;
+  }
+  if (userId === null) {
     res.status(409).json({ error: 'that recovery link is no longer valid' });
     return;
   }
@@ -570,19 +604,6 @@ router.post('/recovery/:token/verify', async (req: Request<{ token: string }>, r
     res.status(404).json({ error: 'that account no longer exists' });
     return;
   }
-
-  const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
-  const label = (req.body?.label || '').toString().trim().slice(0, 64) || null;
-  insertCredential({
-    userId: user.id,
-    credentialId: credential.id,
-    publicKey: Buffer.from(credential.publicKey),
-    counter: credential.counter,
-    transports: credential.transports || [],
-    deviceType: credentialDeviceType,
-    backedUp: credentialBackedUp,
-    label,
-  });
   finishRecovery(res, user);
 });
 

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -28,8 +28,8 @@ import {
 import { inviteStatus, consumeInvite } from '../db/invites.js';
 import {
   findLiveRecoveryToken,
-  consumeRecoveryToken,
   spendRecoveryAndEnroll,
+  spendRecoveryAndSetPassword,
 } from '../db/accountRecovery.js';
 import { isValidUsername, isValidLoginUsername } from '../../shared/username.js';
 import {
@@ -424,12 +424,14 @@ router.post('/invite/:token/password', (req: Request<{ token: string }>, res: Re
 // Every path here ends in finishRecovery(), which signs the account out
 // everywhere before minting the new session: the lockout that made recovery
 // necessary is indistinguishable from a takeover, so any session predating the
-// recovery is assumed hostile: session rows, open WebSockets, attached bouncer
-// sessions, API tokens, and push registrations all go, because every one of them
-// authenticates once and is never re-checked afterwards. Existing passkeys are
-// the deliberate exception — recovery restores a way in, it is not a way to
-// strip someone's credentials, and a passkey cannot be used without the
-// authenticator itself.
+// recovery is assumed hostile, so redeeming leaves exactly ONE way into the
+// account: the credential just established. Everything else goes — session rows,
+// open WebSockets, attached bouncer sessions, API tokens, push registrations,
+// the old password, and every previously enrolled passkey. Each of those either
+// authenticates once and is never re-checked, or is a credential an attacker
+// could have planted; changing a password is worthless while a passkey they
+// enrolled still opens the door, and clearing passkeys is worthless while they
+// still know a password.
 
 // A cell's sign-in is the control plane's: it holds cp_session, injects
 // lurker_session, and has its own email-based reset. Issuing already refuses
@@ -509,7 +511,10 @@ router.post('/recovery/:token/password', (req: Request<{ token: string }>, res: 
     res.status(400).json({ error: passwordRequirementsMessage() });
     return;
   }
-  const userId = consumeRecoveryToken(req.params.token);
+  // Spend, wipe every other credential, and set the new password in one
+  // transaction — a half-applied recovery would leave the account either
+  // unreachable or still open to whoever held it.
+  const userId = spendRecoveryAndSetPassword(req.params.token, hashPassword(password as string));
   if (userId === null) {
     res.status(400).json({ error: 'that recovery link is invalid or has expired' });
     return;
@@ -521,7 +526,6 @@ router.post('/recovery/:token/password', (req: Request<{ token: string }>, res: 
     res.status(404).json({ error: 'that account no longer exists' });
     return;
   }
-  setPasswordHash(user.id, hashPassword(password as string));
   finishRecovery(res, user);
 });
 
@@ -552,9 +556,10 @@ router.post('/recovery/:token/options', async (req: Request<{ token: string }>, 
       residentKey: 'required',
       userVerification: 'preferred',
     },
-    // The authenticators already on the account. Usually none of them are the
-    // one in the member's hand — that's why they're here — but excluding them
-    // keeps a still-enrolled device from silently registering itself twice.
+    // The authenticators already on the account. Redeeming removes all of them
+    // anyway, so this is not a security boundary — it just stops a browser from
+    // silently re-registering a key it can see is already enrolled, which would
+    // be a confusing no-op prompt rather than an error.
     excludeCredentials: existing.map((c) => ({
       id: c.credentialId,
       transports: c.transports,

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -450,6 +450,14 @@ router.get('/recovery/:token', (req: Request<{ token: string }>, res: Response) 
 
 // Set a password with a recovery link. The password is validated BEFORE the
 // token is spent, so a too-short one doesn't burn a single-use link.
+//
+// guardCredentialAttempt shares this IP's login backoff — it turns away a
+// caller already being throttled, and clears that state on success. It does NOT
+// count failures here: it records only on 401, and a dead link answers 400.
+// That's deliberate rather than an oversight. Nothing on this route is
+// guessable — the token is 32 random bytes — so failure backoff would buy
+// nothing, while the router-wide limitRequests(authRequestThrottle) above
+// already caps how fast anyone can probe the auth surface at all.
 router.post(
   '/recovery/:token/password',
   guardCredentialAttempt(loginFailureThrottle),

--- a/server/server.ts
+++ b/server/server.ts
@@ -25,6 +25,7 @@ import { getNodeSecret } from './middleware/nodeAuth.js';
 import { nodeUploadConfigured } from './services/uploadProviders/nodeUpload.js';
 import * as systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
+import { purgeExpiredRecoveryTokens } from './db/accountRecovery.js';
 import { sweepExpiredPreviews } from './db/linkPreviews.js';
 import { sweepPreviewCache } from './services/previewCache/index.js';
 import { startRetentionSweeper } from './services/retentionSweeper.js';
@@ -143,6 +144,11 @@ attachWsHub(server, SESSION_SECRET);
 
 purgeExpiredSessions();
 setInterval(purgeExpiredSessions, 60 * 60 * 1000).unref();
+// Same cadence for expired recovery links. Nothing reads a stale row — every
+// query filters on expires_at — this just keeps one from holding an account's
+// single slot and looking live in a table dump.
+purgeExpiredRecoveryTokens();
+setInterval(() => purgeExpiredRecoveryTokens(), 60 * 60 * 1000).unref();
 
 // link_previews is a cache with a TTL, so lapsed rows have to actually go — without this it
 // only ever grows. Deliberately NOT gated on previewsEnabled(): an operator who turns the

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -1989,7 +1989,13 @@ function dispatchIrcEvent(event: Record<string, unknown>): void {
  */
 export function dropSessionsForUser(userId: number, reason: string): void {
   for (const session of sessions) {
-    if (session.userId === userId && session.isRegistered()) session.closeWithError(reason);
+    // Deliberately NOT gated on isRegistered(). userId is assigned at PASS-time
+    // auth, but a session isn't "registered" until NICK/USER completes — and it
+    // gets a 60s grace to get there. Skipping those left a hole: authenticate,
+    // stall before NICK/USER, wait out the recovery, then finish registering and
+    // arrive attached to an account that was just recovered. The isRegistered()
+    // filter belongs to the count/dispatch callers, not to revocation.
+    if (session.userId === userId) session.closeWithError(reason);
   }
 }
 

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -1977,7 +1977,17 @@ function dispatchIrcEvent(event: Record<string, unknown>): void {
   for (const session of set) session.deliverSelfEcho(type, target, text, time);
 }
 
-function dropSessionsForUser(userId: number, reason: string): void {
+/**
+ * Close every attached bouncer session for a user.
+ *
+ * Exported for account recovery (#855), which has to reach past the web client:
+ * a bouncer session authenticates once at login and then carries its userId in
+ * the session object — the same "checked once, never re-checked" shape as a
+ * WebSocket. Without this, an attached IRC client keeps receiving playback and
+ * sending as the member after the account has been recovered. A no-op when the
+ * bouncer isn't running, since `sessions` is then empty.
+ */
+export function dropSessionsForUser(userId: number, reason: string): void {
   for (const session of sessions) {
     if (session.userId === userId && session.isRegistered()) session.closeWithError(reason);
   }

--- a/server/services/wsHub.revoke.test.ts
+++ b/server/services/wsHub.revoke.test.ts
@@ -7,6 +7,17 @@
 // its user in its own closure, so nothing about deleting session rows can be
 // observed from inside the hub. A function-level assertion would pass even if
 // the socket kept streaming, which is the exact failure it exists to rule out.
+//
+// NOT covered here: a peer that refuses the close handshake. `ws.close()` sends
+// a frame and moves to CLOSING while inbound frames keep dispatching, so a
+// hostile client could act as the account until ws's 30s CLOSE_TIMEOUT — which
+// is why the message handler drops everything once `ws.revoked` is set, and why
+// closeSocketsForUser follows the close with a terminate. Every attempt to test
+// it from out here failed to DISCRIMINATE rather than failing to pass: a client
+// whose socket is paused (the only way to make it non-cooperative) observes
+// neither the close frame nor the FIN, so it looks identical whether the server
+// terminated or not. The guard is the first statement in the handler, ahead of
+// any parsing, so it holds by construction.
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import http from 'http';

--- a/server/services/wsHub.revoke.test.ts
+++ b/server/services/wsHub.revoke.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Cover for closeSocketsForUser (#855). Drives a REAL socket against a real
+// attachWsHub, because the property being claimed is that an already-open
+// connection actually goes away: the socket authenticated at upgrade and holds
+// its user in its own closure, so nothing about deleting session rows can be
+// observed from inside the hub. A function-level assertion would pass even if
+// the socket kept streaming, which is the exact failure it exists to rule out.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'http';
+import request from 'supertest';
+import { WebSocket } from 'ws';
+import { createTestApp, setupTestDb, TEST_SESSION_SECRET } from '../test-utils/testApp.js';
+
+const testDb = setupTestDb('wshub-revoke');
+
+let server: http.Server;
+let url: string;
+let createUser: typeof import('../db/users.js').createUser;
+let createSession: typeof import('../db/sessions.js').createSession;
+let closeSocketsForUser: typeof import('./wsHub.js').closeSocketsForUser;
+let createRecoveryToken: typeof import('../db/accountRecovery.js').createRecoveryToken;
+
+beforeAll(async () => {
+  ({ createUser } = await import('../db/users.js'));
+  ({ createSession } = await import('../db/sessions.js'));
+  ({ createRecoveryToken } = await import('../db/accountRecovery.js'));
+  const wsHub = await import('./wsHub.js');
+  closeSocketsForUser = wsHub.closeSocketsForUser;
+
+  // The auth router rides the SAME http server as the hub, so redeeming a link
+  // over HTTP and the socket it has to evict are genuinely the same process —
+  // which is the only way to prove the route is wired to the eviction at all.
+  const authRouter = (await import('../routes/auth.js')).default;
+  server = http.createServer(createTestApp({ '/api/auth': authRouter }));
+  wsHub.attachWsHub(server, TEST_SESSION_SECRET);
+  server.listen(0);
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('test server did not bind synchronously to a TCP port');
+  }
+  server.unref();
+  url = `ws://127.0.0.1:${address.port}/ws`;
+});
+
+afterAll(() => {
+  server.close();
+  testDb.cleanup();
+});
+
+// Open a socket and resolve once it has received its first frame, so the server
+// has definitely registered it before the test tries to close it.
+function connect(userId: number): Promise<WebSocket> {
+  const { token } = createSession(userId);
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url, { headers: { Authorization: `Bearer ${token}` } });
+    const timer = setTimeout(() => {
+      ws.close();
+      reject(new Error('timed out waiting for the first frame'));
+    }, 5000);
+    ws.once('message', () => {
+      clearTimeout(timer);
+      resolve(ws);
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+function closed(ws: WebSocket): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('socket was never closed')), 5000);
+    ws.on('close', (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+}
+
+describe('closeSocketsForUser', () => {
+  it('closes every open socket for the account', async () => {
+    const user = createUser('revoke-target');
+    const [a, b] = await Promise.all([connect(user.id), connect(user.id)]);
+    const bothClosed = Promise.all([closed(a), closed(b)]);
+    expect(closeSocketsForUser(user.id, 'account recovered')).toBe(2);
+    expect(await bothClosed).toEqual([1000, 1000]);
+  });
+
+  it('leaves other accounts connected', async () => {
+    const mine = createUser('revoke-mine');
+    const theirs = createUser('revoke-theirs');
+    const ours = await connect(mine.id);
+    const bystander = await connect(theirs.id);
+    const mineClosed = closed(ours);
+    closeSocketsForUser(mine.id);
+    await mineClosed;
+    expect(bystander.readyState).toBe(WebSocket.OPEN);
+    bystander.close();
+  });
+
+  it('is a no-op for an account with nothing open', () => {
+    const user = createUser('revoke-nothing-open');
+    expect(closeSocketsForUser(user.id)).toBe(0);
+  });
+});
+
+describe('account recovery evicts live sockets', () => {
+  it('closes the attacker socket when the member redeems their link', async () => {
+    // The scenario the feature is FOR: someone else holds the account with an
+    // open connection. Dropping session rows alone would leave them reading
+    // backlog and sending as the member for as long as they cared to stay
+    // connected, because a socket is only ever checked at upgrade.
+    const user = createUser('revoke-via-route');
+    const attacker = await connect(user.id);
+    const evicted = closed(attacker);
+    const token = createRecoveryToken(user.id, null);
+
+    const res = await request(server)
+      .post(`/api/auth/recovery/${token}/password`)
+      .send({ password: 'themembersnewpassword' });
+    expect(res.status).toBe(200);
+
+    expect(await evicted).toBe(1000);
+  });
+});

--- a/server/services/wsHub.revoke.test.ts
+++ b/server/services/wsHub.revoke.test.ts
@@ -13,6 +13,7 @@ import http from 'http';
 import request from 'supertest';
 import { WebSocket } from 'ws';
 import { createTestApp, setupTestDb, TEST_SESSION_SECRET } from '../test-utils/testApp.js';
+import { WS_CLOSE_SESSION_REVOKED } from '../../shared/wsCloseCodes.js';
 
 const testDb = setupTestDb('wshub-revoke');
 
@@ -87,7 +88,10 @@ describe('closeSocketsForUser', () => {
     const [a, b] = await Promise.all([connect(user.id), connect(user.id)]);
     const bothClosed = Promise.all([closed(a), closed(b)]);
     expect(closeSocketsForUser(user.id, 'account recovered')).toBe(2);
-    expect(await bothClosed).toEqual([1000, 1000]);
+    // The dedicated code, not a plain 1000: the client can only tell an eviction
+    // from an ordinary drop by the code, and reconnecting after this one can
+    // never succeed.
+    expect(await bothClosed).toEqual([WS_CLOSE_SESSION_REVOKED, WS_CLOSE_SESSION_REVOKED]);
   });
 
   it('leaves other accounts connected', async () => {
@@ -124,6 +128,6 @@ describe('account recovery evicts live sockets', () => {
       .send({ password: 'themembersnewpassword' });
     expect(res.status).toBe(200);
 
-    expect(await evicted).toBe(1000);
+    expect(await evicted).toBe(WS_CLOSE_SESSION_REVOKED);
   });
 });

--- a/server/services/wsHub.revoke.test.ts
+++ b/server/services/wsHub.revoke.test.ts
@@ -117,7 +117,7 @@ describe('account recovery evicts live sockets', () => {
     const user = createUser('revoke-via-route');
     const attacker = await connect(user.id);
     const evicted = closed(attacker);
-    const token = createRecoveryToken(user.id, null);
+    const { token } = createRecoveryToken(user.id, null);
 
     const res = await request(server)
       .post(`/api/auth/recovery/${token}/password`)

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1586,6 +1586,42 @@ export function fanOutToUser(userId: number, payload: WsPayload, opts: FanOutOpt
   fanOut(userId, payload, opts);
 }
 
+/**
+ * Close every open socket for a user, so a revoked session stops streaming.
+ *
+ * Session checks happen at the /ws upgrade and nowhere after it — the handler
+ * reads its user off the socket's own closure — so deleting the session rows
+ * alone leaves an ALREADY-OPEN socket reading backlog and sending messages as
+ * that account for as long as its holder cares to keep it open. Account
+ * recovery (#855) is exactly the case where that matters: the lockout it
+ * answers is indistinguishable from a takeover, so "signed out everywhere" has
+ * to mean the sockets too, not just the rows behind future requests.
+ *
+ * Deliberately NOT the 'user-disposed' path, which is for a deleted account: it
+ * also tears down IRC connections and drops the system log. Here the account
+ * lives on and is expected to reconnect immediately.
+ *
+ * Returns the number of sockets closed.
+ */
+export function closeSocketsForUser(userId: number, reason = 'session revoked'): number {
+  const set = socketsByUser.get(userId);
+  if (!set) return 0;
+  let closed = 0;
+  for (const ws of set) {
+    try {
+      ws.close(1000, reason);
+      closed++;
+    } catch (_) {
+      /* already tearing down; the close handler prunes it either way */
+    }
+  }
+  // The close handlers prune the set themselves, but a socket that never fires
+  // one (already-dead transport) would otherwise linger and keep receiving
+  // fan-out. Dropping the whole entry is safe: a reconnect re-adds it.
+  socketsByUser.delete(userId);
+  return closed;
+}
+
 // Push the user's current ignore list for one scope to all their open tabs.
 // networkId null targets the global bucket; a number targets that network's own
 // rules. The client replaces the matching bucket and re-unions at match time.

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1451,9 +1451,11 @@ function announceOpen(
 }
 
 // Per-user socket bookkeeping lives at module scope so the verb registry can
-// reach into fanOut without importing the WSS instance. The state is still
-// owned by attachWsHub at runtime (it's the only writer to socketsByUser via
-// addSocket/removeSocket); the registry just reads through it.
+// reach into fanOut without importing the WSS instance. attachWsHub owns the
+// state at runtime — addSocket/removeSocket are the only mutators — and
+// everything else reads through it. closeSocketsForUser is the one outside
+// caller that acts on the sockets themselves, and it deliberately mutates
+// nothing: it closes them and lets removeSocket do the bookkeeping.
 const socketsByUser = new Map<number, Set<LurkerWebSocket>>();
 
 // How many bytes of un-drained outbound frames a socket may hold before it
@@ -1615,10 +1617,14 @@ export function closeSocketsForUser(userId: number, reason = 'session revoked'):
       /* already tearing down; the close handler prunes it either way */
     }
   }
-  // The close handlers prune the set themselves, but a socket that never fires
-  // one (already-dead transport) would otherwise linger and keep receiving
-  // fan-out. Dropping the whole entry is safe: a reconnect re-adds it.
-  socketsByUser.delete(userId);
+  // Deliberately NOT socketsByUser.delete(userId) here. removeSocket() bails out
+  // early when the entry is already gone, so deleting it first makes every close
+  // handler a no-op and evaluatePresence() never runs: the account would sit
+  // with nobody connected and auto-away never armed, so its IRC connections
+  // would stay non-away indefinitely. Letting each close handler prune normally
+  // keeps presence honest, and the heartbeat reaps any socket whose close never
+  // fires. ('user-disposed' can afford the eager delete because it clears the
+  // auto-away timer itself and the account is going away regardless.)
   return closed;
 }
 

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -128,6 +128,14 @@ interface LurkerWebSocket extends WebSocket {
   // visible=true) and userHasVisibleClient() stays true forever, permanently
   // suppressing auto-away.
   isAlive?: boolean;
+  // Set by closeSocketsForUser. `ws.close()` only sends a close FRAME and moves
+  // to CLOSING; the `ws` library keeps dispatching inbound frames until the peer
+  // echoes it (or its 30s CLOSE_TIMEOUT fires), and neither the library nor our
+  // message handler checks readyState. A revoked socket is assumed to be held by
+  // an attacker, and one that simply never replies to the close would otherwise
+  // keep sending messages as the recovered account for that whole window. The
+  // message handler drops everything once this is set.
+  revoked?: boolean;
   // The current no-progress streak on this socket's outbound queue, or undefined
   // when it isn't over MAX_BUFFERED_BYTES. `since` is when the streak began,
   // `at` when we last looked, `floor` the lowest bufferedAmount seen during it.
@@ -1612,13 +1620,32 @@ export function fanOutToUser(userId: number, payload: WsPayload, opts: FanOutOpt
  *
  * Returns the number of sockets closed.
  */
+// Grace for a cooperative client to acknowledge the close frame before the
+// socket is torn down under it. Long enough that a normal browser closes itself
+// first, short enough that a peer refusing to answer isn't left holding a
+// half-open connection to a recovered account.
+const REVOKED_TERMINATE_MS = 2000;
+
 export function closeSocketsForUser(userId: number, reason = 'session revoked'): number {
   const set = socketsByUser.get(userId);
   if (!set) return 0;
   let closed = 0;
   for (const ws of set) {
     try {
+      // Flag BEFORE closing: from here on the message handler drops anything
+      // this socket sends, so the close handshake window is not an authenticated
+      // one. A cooperative client goes away on the frame; a hostile one is cut
+      // off by the terminate below rather than waiting out ws's 30s timeout.
+      ws.revoked = true;
       ws.close(WS_CLOSE_SESSION_REVOKED, reason);
+      const kill = setTimeout(() => {
+        try {
+          ws.terminate();
+        } catch (_) {
+          /* already gone */
+        }
+      }, REVOKED_TERMINATE_MS);
+      kill.unref?.();
       closed++;
     } catch (_) {
       /* already tearing down; the close handler prunes it either way */
@@ -2384,6 +2411,11 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     sendSnapshot(ws, user.id);
 
     ws.on('message', (raw) => {
+      // This socket's session was revoked mid-connection (account recovery).
+      // `ws.close()` does not stop inbound dispatch — it only sends a frame —
+      // so without this, a peer that declines to answer keeps acting as the
+      // account for the whole close-handshake window.
+      if (ws.revoked) return;
       // #574: per-socket flood control, checked before JSON.parse so a flood
       // pays no parse cost. Exhausting the bucket closes the socket (1008 policy
       // violation) rather than dropping silently — a client at this rate is

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -10,6 +10,7 @@ import type { MessageEvent } from '../db/messages.js';
 import type { PageUnit } from '../../shared/eventFilter.js';
 import { asPageUnit } from '../../shared/eventFilter.js';
 import { isChannelTarget } from '../../shared/channels.js';
+import { WS_CLOSE_SESSION_REVOKED } from '../../shared/wsCloseCodes.js';
 import { WebSocketServer } from 'ws';
 import cookie from 'cookie';
 import cookieParser from 'cookie-parser';
@@ -1603,6 +1604,12 @@ export function fanOutToUser(userId: number, payload: WsPayload, opts: FanOutOpt
  * also tears down IRC connections and drops the system log. Here the account
  * lives on and is expected to reconnect immediately.
  *
+ * Closes with WS_CLOSE_SESSION_REVOKED rather than a plain 1000 so the client
+ * can tell this apart from an ordinary drop. It cannot infer the difference, and
+ * reconnecting is futile — the session row is gone, so /ws will 401 forever —
+ * so a 1000 leaves the evicted tab in an endless backoff loop showing stale
+ * content with nothing telling the user they've been signed out.
+ *
  * Returns the number of sockets closed.
  */
 export function closeSocketsForUser(userId: number, reason = 'session revoked'): number {
@@ -1611,7 +1618,7 @@ export function closeSocketsForUser(userId: number, reason = 'session revoked'):
   let closed = 0;
   for (const ws of set) {
     try {
-      ws.close(1000, reason);
+      ws.close(WS_CLOSE_SESSION_REVOKED, reason);
       closed++;
     } catch (_) {
       /* already tearing down; the close handler prunes it either way */

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1463,8 +1463,11 @@ function announceOpen(
 // reach into fanOut without importing the WSS instance. attachWsHub owns the
 // state at runtime — addSocket/removeSocket are the only mutators — and
 // everything else reads through it. closeSocketsForUser is the one outside
-// caller that acts on the sockets themselves, and it deliberately mutates
-// nothing: it closes them and lets removeSocket do the bookkeeping.
+// caller that acts on the sockets themselves: it does NOT touch this map — it
+// closes the sockets and lets removeSocket do the bookkeeping — but it does set
+// `ws.revoked` on each, which the message handler checks. That flag is what
+// closes the close-handshake window, so it is load-bearing rather than
+// incidental; don't drop it while tidying.
 const socketsByUser = new Map<number, Set<LurkerWebSocket>>();
 
 // How many bytes of un-drained outbound frames a socket may hold before it

--- a/shared/wsCloseCodes.ts
+++ b/shared/wsCloseCodes.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// WebSocket close codes Lurker defines for itself. 4000–4999 is the range the
+// RFC reserves for applications, so these can never collide with a protocol or
+// browser-generated code.
+//
+// Shared because a close code is only useful if both ends agree on it: the
+// server states WHY it closed, and the client decides what to do about it. An
+// ordinary drop and a deliberate eviction look identical otherwise, which is
+// how an evicted tab ends up reconnecting forever against a /ws that will
+// answer 401 for the rest of its life.
+
+/**
+ * The account's sessions were revoked while this socket was open — account
+ * recovery (#855). The session row behind this socket is gone, so reconnecting
+ * can only 401: the client must stop trying and send the user to sign in.
+ */
+export const WS_CLOSE_SESSION_REVOKED = 4001;

--- a/tools/recovery-link.ts
+++ b/tools/recovery-link.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Operator escape hatch for account recovery (#855).
+//
+// Recovery links are normally issued from Admin → Users, which covers everyone
+// except the person who would have to click the button: an instance's only
+// admin, locked out of their own account. This is the same link, minted from a
+// shell on the box. Self-hosters have that shell by definition, and holding it
+// is already equivalent to holding the database.
+//
+// Usage (inside the container, or wherever the server runs):
+//   tsx tools/recovery-link.ts alice
+//   tsx tools/recovery-link.ts alice --url https://lurker.example.com
+//   npm run recovery-link -- alice
+//
+// The URL is printed once and nowhere else — only its SHA-256 is stored — so
+// losing it means minting another, which invalidates the first. The link is
+// single-use and expires in 24 hours.
+//
+// DATABASE_PATH selects the database (same env the server uses); the base URL
+// defaults to the first entry in WEBAUTHN_ORIGIN, which is already the public
+// origin on any instance where passkeys work.
+
+import path from 'path';
+
+const argv = process.argv.slice(2);
+
+function usage(): never {
+  console.log(
+    [
+      'Mint a single-use account recovery link.',
+      '',
+      'Usage: tsx tools/recovery-link.ts <username> [--url <origin>]',
+      '',
+      '  <username>      The account to recover. Matched case-insensitively.',
+      '  --url <origin>  Public origin for the link (e.g. https://lurker.example.com).',
+      '                  Defaults to the first entry in WEBAUTHN_ORIGIN.',
+      '',
+      'DATABASE_PATH selects the database.',
+    ].join('\n'),
+  );
+  process.exit(0);
+}
+
+if (argv.length === 0 || argv.includes('--help') || argv.includes('-h')) usage();
+
+const urlIndex = argv.indexOf('--url');
+const originArg = urlIndex === -1 ? null : argv[urlIndex + 1];
+if (urlIndex !== -1 && !originArg) {
+  console.error('--url needs a value, e.g. --url https://lurker.example.com');
+  process.exit(1);
+}
+const skipIndex = urlIndex === -1 ? -1 : urlIndex + 1;
+const username = argv.filter((a, i) => !a.startsWith('--') && i !== skipIndex)[0];
+if (!username) usage();
+
+const origin = (originArg || (process.env.WEBAUTHN_ORIGIN || '').split(',')[0] || '').trim();
+if (!origin) {
+  console.error(
+    'No base URL: pass --url https://lurker.example.com, or set WEBAUTHN_ORIGIN in the environment.',
+  );
+  process.exit(1);
+}
+
+// db/index.ts resolves DATABASE_PATH at import time, so the default has to be in
+// place before anything below it loads.
+process.env.DATABASE_PATH =
+  process.env.DATABASE_PATH || path.join(import.meta.dirname, '../data/lurker.db');
+
+const { findUserByUsername } = await import('../server/db/users.js');
+const { createRecoveryToken } = await import('../server/db/accountRecovery.js');
+
+const user = findUserByUsername(username);
+if (!user) {
+  console.error(`No account named '${username}' in ${process.env.DATABASE_PATH}.`);
+  process.exit(1);
+}
+
+// createdBy is null: nobody in the users table issued this one, and recording a
+// stand-in admin would misattribute it in the panel.
+const token = createRecoveryToken(user.id, null);
+
+console.log('');
+console.log(`Recovery link for ${user.username} (expires in 24 hours, single use):`);
+console.log('');
+console.log(`  ${origin.replace(/\/+$/, '')}/recover/${token}`);
+console.log('');
+console.log('This is the only time it is shown. Any previous link for this account is now dead.');

--- a/tools/recovery-link.ts
+++ b/tools/recovery-link.ts
@@ -38,6 +38,7 @@ import {
   hashRecoveryToken,
   recoveryExpiresAt,
 } from '../server/db/accountRecoveryToken.js';
+import { parseRecoveryLinkArgs } from './recoveryLinkArgs.js';
 
 const argv = process.argv.slice(2);
 
@@ -61,21 +62,14 @@ function usage(): never {
 
 if (argv.length === 0 || argv.includes('--help') || argv.includes('-h')) usage();
 
-// Both spellings. Accepting only the space-separated form meant `--url=https://x`
-// fell through the flag filter, silently fell back to WEBAUTHN_ORIGIN, and
-// handed a locked-out admin a link pointing at the wrong host — after the token
-// was already written, so recovering from it costs a reissue.
-const inlineUrl = argv.find((a) => a.startsWith('--url='));
-const urlIndex = argv.indexOf('--url');
-const originArg = inlineUrl ? inlineUrl.slice('--url='.length) : (argv[urlIndex + 1] ?? null);
-if ((urlIndex !== -1 || inlineUrl) && !originArg) {
-  console.error('--url needs a value, e.g. --url https://lurker.example.com');
+const { username, origin, error } = parseRecoveryLinkArgs(argv, process.env);
+// Error first: a malformed flag deserves the specific complaint, not the usage
+// dump. `--url` with nothing after it yields no username either, so checking
+// username first would swallow the useful message.
+if (error) {
+  console.error(error);
   process.exit(1);
 }
-// Only skip the NEXT argv slot when --url took a separate value; with --url=…
-// there is no separate slot, and urlIndex + 1 would otherwise eat the username.
-const skipIndex = urlIndex === -1 ? -1 : urlIndex + 1;
-const username = argv.filter((a, i) => !a.startsWith('--') && i !== skipIndex)[0];
 if (!username) usage();
 
 // A cell's sign-in belongs to the control plane, which has its own email-based
@@ -85,14 +79,6 @@ if (!username) usage();
 if ((process.env.LURKER_EDITION || '').trim().toLowerCase() === 'node') {
   console.error(
     'This is a hosted cell — sign-in is managed by the control plane, which has its own password reset.',
-  );
-  process.exit(1);
-}
-
-const origin = (originArg || (process.env.WEBAUTHN_ORIGIN || '').split(',')[0] || '').trim();
-if (!origin) {
-  console.error(
-    'No base URL: pass --url https://lurker.example.com, or set WEBAUTHN_ORIGIN in the environment.',
   );
   process.exit(1);
 }
@@ -142,6 +128,6 @@ db.prepare(
 console.log('');
 console.log(`Recovery link for ${user.username} (expires in 24 hours, single use):`);
 console.log('');
-console.log(`  ${origin.replace(/\/+$/, '')}/recover/${token}`);
+console.log(`  ${origin}/recover/${token}`);
 console.log('');
 console.log('This is the only time it is shown. Any previous link for this account is now dead.');

--- a/tools/recovery-link.ts
+++ b/tools/recovery-link.ts
@@ -21,8 +21,23 @@
 // DATABASE_PATH selects the database (same env the server uses); the base URL
 // defaults to the first entry in WEBAUTHN_ORIGIN, which is already the public
 // origin on any instance where passkeys work.
+//
+// ⚠ Opens its OWN bare connection rather than importing server/db/index.ts, the
+// same way tools/fold-buffer-case.ts does. That module's body runs the entire
+// migration + seed pipeline, and this tool is documented as `docker compose
+// exec` against a RUNNING server — importing it would make this a second
+// process migrating a database the server is actively writing, risking
+// SQLITE_BUSY at precisely the moment (sole admin locked out) when this has to
+// work. The token rules are shared through server/db/accountRecoveryToken.ts,
+// which is db-free, so there is still exactly one definition of them.
 
+import Database from 'better-sqlite3';
 import path from 'path';
+import {
+  generateRecoveryToken,
+  hashRecoveryToken,
+  recoveryExpiresAt,
+} from '../server/db/accountRecoveryToken.js';
 
 const argv = process.argv.slice(2);
 
@@ -63,23 +78,47 @@ if (!origin) {
   process.exit(1);
 }
 
-// db/index.ts resolves DATABASE_PATH at import time, so the default has to be in
-// place before anything below it loads.
-process.env.DATABASE_PATH =
-  process.env.DATABASE_PATH || path.join(import.meta.dirname, '../data/lurker.db');
+// Same default as db/index.ts, so `DATABASE_PATH` unset means the same file the
+// server would open.
+const dbPath = process.env.DATABASE_PATH || path.join(import.meta.dirname, '../data/lurker.db');
 
-const { findUserByUsername } = await import('../server/db/users.js');
-const { createRecoveryToken } = await import('../server/db/accountRecovery.js');
+const db = new Database(dbPath);
+db.pragma('busy_timeout = 5000');
+db.pragma('foreign_keys = ON');
 
-const user = findUserByUsername(username);
-if (!user) {
-  console.error(`No account named '${username}' in ${process.env.DATABASE_PATH}.`);
+// The table is created by the server's migration, not here — a tool that runs
+// before the server has ever started has nothing to recover anyway.
+const hasTable = db
+  .prepare(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'account_recovery_tokens'`)
+  .get();
+if (!hasTable) {
+  console.error(
+    `${dbPath} has no account_recovery_tokens table — start the server once to migrate it.`,
+  );
   process.exit(1);
 }
 
-// createdBy is null: nobody in the users table issued this one, and recording a
+// Case-insensitive, matching findUserByUsername.
+const user = db
+  .prepare('SELECT id, username FROM users WHERE username = ? COLLATE NOCASE')
+  .get(username) as { id: number; username: string } | undefined;
+if (!user) {
+  console.error(`No account named '${username}' in ${dbPath}.`);
+  process.exit(1);
+}
+
+// created_by is null: nobody in the users table issued this one, and recording a
 // stand-in admin would misattribute it in the panel.
-const token = createRecoveryToken(user.id, null);
+const token = generateRecoveryToken();
+db.prepare(
+  `INSERT INTO account_recovery_tokens (token_hash, user_id, created_by, expires_at)
+   VALUES (?, ?, NULL, ?)
+   ON CONFLICT(user_id) DO UPDATE SET
+     token_hash = excluded.token_hash,
+     created_by = excluded.created_by,
+     expires_at = excluded.expires_at,
+     created_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')`,
+).run(hashRecoveryToken(token), user.id, recoveryExpiresAt());
 
 console.log('');
 console.log(`Recovery link for ${user.username} (expires in 24 hours, single use):`);

--- a/tools/recovery-link.ts
+++ b/tools/recovery-link.ts
@@ -42,7 +42,9 @@ import { parseRecoveryLinkArgs } from './recoveryLinkArgs.js';
 
 const argv = process.argv.slice(2);
 
-function usage(): never {
+// exitCode 0 for an explicit --help, 1 when the invocation was simply wrong —
+// a script or an operator checking $? has to be able to tell those apart.
+function usage(exitCode = 0): never {
   console.log(
     [
       'Mint a single-use account recovery link.',
@@ -57,10 +59,13 @@ function usage(): never {
       'DATABASE_PATH selects the database.',
     ].join('\n'),
   );
-  process.exit(0);
+  process.exit(exitCode);
 }
 
-if (argv.length === 0 || argv.includes('--help') || argv.includes('-h')) usage();
+if (argv.includes('--help') || argv.includes('-h')) usage(0);
+// No arguments is the same class of mistake as a flag with no username: the tool
+// cannot do anything without one, so $? has to say so.
+if (argv.length === 0) usage(1);
 
 const { username, origin, error } = parseRecoveryLinkArgs(argv, process.env);
 // Error first: a malformed flag deserves the specific complaint, not the usage
@@ -70,7 +75,7 @@ if (error) {
   console.error(error);
   process.exit(1);
 }
-if (!username) usage();
+if (!username) usage(1);
 
 // A cell's sign-in belongs to the control plane, which has its own email-based
 // reset — the admin routes refuse there for the same reason. The CLI ships in

--- a/tools/recovery-link.ts
+++ b/tools/recovery-link.ts
@@ -87,7 +87,19 @@ if ((process.env.LURKER_EDITION || '').trim().toLowerCase() === 'node') {
 // server would open.
 const dbPath = process.env.DATABASE_PATH || path.join(import.meta.dirname, '../data/lurker.db');
 
-const db = new Database(dbPath);
+// fileMustExist: a bare `new Database(path)` CREATES the file, so a wrong or
+// stale DATABASE_PATH silently produced an empty database, failed the table
+// probe below, and told the operator to "start the server once to migrate it" —
+// pointing at a migration problem when the real one is the path, and leaving a
+// stray file behind. On the sole-admin-locked-out path a misleading diagnosis
+// costs the most.
+let db: Database.Database;
+try {
+  db = new Database(dbPath, { fileMustExist: true });
+} catch (_err) {
+  console.error(`No database at ${dbPath}. Set DATABASE_PATH, or run this where the server runs.`);
+  process.exit(1);
+}
 db.pragma('busy_timeout = 5000');
 db.pragma('foreign_keys = ON');
 

--- a/tools/recovery-link.ts
+++ b/tools/recovery-link.ts
@@ -50,7 +50,8 @@ function usage(): never {
       '',
       '  <username>      The account to recover. Matched case-insensitively.',
       '  --url <origin>  Public origin for the link (e.g. https://lurker.example.com).',
-      '                  Defaults to the first entry in WEBAUTHN_ORIGIN.',
+      '                  --url=<origin> works too. Defaults to the first entry',
+      '                  in WEBAUTHN_ORIGIN.',
       '',
       'DATABASE_PATH selects the database.',
     ].join('\n'),
@@ -60,15 +61,33 @@ function usage(): never {
 
 if (argv.length === 0 || argv.includes('--help') || argv.includes('-h')) usage();
 
+// Both spellings. Accepting only the space-separated form meant `--url=https://x`
+// fell through the flag filter, silently fell back to WEBAUTHN_ORIGIN, and
+// handed a locked-out admin a link pointing at the wrong host — after the token
+// was already written, so recovering from it costs a reissue.
+const inlineUrl = argv.find((a) => a.startsWith('--url='));
 const urlIndex = argv.indexOf('--url');
-const originArg = urlIndex === -1 ? null : argv[urlIndex + 1];
-if (urlIndex !== -1 && !originArg) {
+const originArg = inlineUrl ? inlineUrl.slice('--url='.length) : (argv[urlIndex + 1] ?? null);
+if ((urlIndex !== -1 || inlineUrl) && !originArg) {
   console.error('--url needs a value, e.g. --url https://lurker.example.com');
   process.exit(1);
 }
+// Only skip the NEXT argv slot when --url took a separate value; with --url=…
+// there is no separate slot, and urlIndex + 1 would otherwise eat the username.
 const skipIndex = urlIndex === -1 ? -1 : urlIndex + 1;
 const username = argv.filter((a, i) => !a.startsWith('--') && i !== skipIndex)[0];
 if (!username) usage();
+
+// A cell's sign-in belongs to the control plane, which has its own email-based
+// reset — the admin routes refuse there for the same reason. The CLI ships in
+// the same image cells run, so it has to refuse too, rather than minting a link
+// whose redemption would drop CP-injected sessions the CP still believes live.
+if ((process.env.LURKER_EDITION || '').trim().toLowerCase() === 'node') {
+  console.error(
+    'This is a hosted cell — sign-in is managed by the control plane, which has its own password reset.',
+  );
+  process.exit(1);
+}
 
 const origin = (originArg || (process.env.WEBAUTHN_ORIGIN || '').split(',')[0] || '').trim();
 if (!origin) {

--- a/tools/recoveryLinkArgs.test.ts
+++ b/tools/recoveryLinkArgs.test.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { parseRecoveryLinkArgs } from './recoveryLinkArgs.js';
+
+const ENV = { WEBAUTHN_ORIGIN: 'https://lurker.example.com' };
+
+describe('parseRecoveryLinkArgs', () => {
+  it('falls back to WEBAUTHN_ORIGIN for the documented default invocation', () => {
+    // `npm run recovery-link -- your-username`, exactly as SELF_HOSTING.md says.
+    // This is the form that broke: with no --url, argv[urlIndex + 1] read argv[0]
+    // and the username became the origin.
+    expect(parseRecoveryLinkArgs(['alice'], ENV)).toEqual({
+      username: 'alice',
+      origin: 'https://lurker.example.com',
+      error: null,
+    });
+  });
+
+  it('takes the first entry of a comma-separated WEBAUTHN_ORIGIN', () => {
+    const env = { WEBAUTHN_ORIGIN: 'https://a.example,https://b.example' };
+    expect(parseRecoveryLinkArgs(['alice'], env).origin).toBe('https://a.example');
+  });
+
+  it.each([
+    [['alice', '--url', 'https://x.example']],
+    [['--url', 'https://x.example', 'alice']],
+    [['alice', '--url=https://x.example']],
+    [['--url=https://x.example', 'alice']],
+  ])('accepts %j', (argv) => {
+    expect(parseRecoveryLinkArgs(argv, ENV)).toEqual({
+      username: 'alice',
+      origin: 'https://x.example',
+      error: null,
+    });
+  });
+
+  it('prefers an explicit --url over the environment', () => {
+    expect(parseRecoveryLinkArgs(['alice', '--url', 'https://override.example'], ENV).origin).toBe(
+      'https://override.example',
+    );
+  });
+
+  it('trims a trailing slash so the path does not double up', () => {
+    expect(parseRecoveryLinkArgs(['alice', '--url', 'https://x.example/'], ENV).origin).toBe(
+      'https://x.example',
+    );
+  });
+
+  it('reports a --url with no value', () => {
+    expect(parseRecoveryLinkArgs(['alice', '--url'], ENV).error).toMatch(/--url needs a value/);
+  });
+
+  it('reports having no origin at all', () => {
+    const result = parseRecoveryLinkArgs(['alice'], {});
+    expect(result.error).toMatch(/No base URL/);
+  });
+
+  it('returns a null username when only flags were given', () => {
+    expect(parseRecoveryLinkArgs(['--url', 'https://x.example'], ENV).username).toBeNull();
+  });
+});

--- a/tools/recoveryLinkArgs.ts
+++ b/tools/recoveryLinkArgs.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Argument parsing for tools/recovery-link.ts, split out as a pure function so
+// it can be tested.
+//
+// It earns its own module: this is index arithmetic over argv, and it has been
+// wrong twice. First `urlIndex + 1` was used as a skip index when no --url was
+// present, so it swallowed the username (argv[0]). Then, fixing that, the same
+// `urlIndex + 1` was READ with no --url present, so the username became the
+// origin and the WEBAUTHN_ORIGIN fallback went dead — printing a link like
+// `alice/recover/<token>` for the documented default invocation, on the
+// sole-admin-locked-out path this tool exists for, after the token was already
+// written. Both were invisible to typecheck and to every other test.
+
+export interface RecoveryLinkArgs {
+  username: string | null;
+  origin: string;
+  /** Set when the arguments are unusable; the caller prints it and exits 1. */
+  error: string | null;
+}
+
+export function parseRecoveryLinkArgs(
+  argv: readonly string[],
+  env: { WEBAUTHN_ORIGIN?: string } = {},
+): RecoveryLinkArgs {
+  const inlineUrl = argv.find((a) => a.startsWith('--url='));
+  const urlIndex = argv.indexOf('--url');
+
+  // Read the following slot ONLY when --url actually appeared as its own token.
+  // Without this guard urlIndex is -1 and argv[0] — the username — is read as
+  // the origin.
+  const spacedValue = urlIndex === -1 ? null : (argv[urlIndex + 1] ?? null);
+  const originArg = inlineUrl ? inlineUrl.slice('--url='.length) : spacedValue;
+
+  if ((inlineUrl || urlIndex !== -1) && !originArg) {
+    return {
+      username: null,
+      origin: '',
+      error: '--url needs a value, e.g. --url https://lurker.example.com',
+    };
+  }
+
+  // Skip the value slot only when --url took a separate one; with --url=… there
+  // is no separate slot and skipping would eat the username.
+  const skipIndex = urlIndex === -1 ? -1 : urlIndex + 1;
+  const username = argv.filter((a, i) => !a.startsWith('--') && i !== skipIndex)[0] ?? null;
+
+  const origin = (originArg || (env.WEBAUTHN_ORIGIN || '').split(',')[0] || '').trim();
+  if (username && !origin) {
+    return {
+      username,
+      origin: '',
+      error:
+        'No base URL: pass --url https://lurker.example.com, or set WEBAUTHN_ORIGIN in the environment.',
+    };
+  }
+  // Trailing slashes would double up against the /recover/ path below.
+  return { username, origin: origin.replace(/\/+$/, ''), error: null };
+}

--- a/vue_client/src/api.test.ts
+++ b/vue_client/src/api.test.ts
@@ -33,6 +33,11 @@ describe('shouldBounceToLogin', () => {
       false,
     );
     expect(shouldBounceToLogin('/api/settings/bootstrap', 401, false, '/login')).toBe(false);
+    // Same shape for a recovery link (#855): its whole audience is a logged-out
+    // visitor, so an ejection here strands the one person the link exists for.
+    expect(shouldBounceToLogin('/api/settings/bootstrap', 401, false, '/recover/abc123')).toBe(
+      false,
+    );
   });
 });
 

--- a/vue_client/src/api.ts
+++ b/vue_client/src/api.ts
@@ -28,10 +28,12 @@ const AUTH_RECOVERY_FLAG = 'lurker:authRecoveryAttempted';
 
 // Public routes that render without a session (mirror router.ts). A background
 // 401 while sitting on one of these is the expected "not signed in yet" state,
-// NOT a stale session — bouncing would eject an invite/sign-in visitor to
-// `/login?next=/` before their page can even mount.
+// NOT a stale session — bouncing would eject an invite/recovery/sign-in visitor
+// to `/login?next=/` before their page can even mount.
 function isPublicPath(pathname: string): boolean {
-  return pathname === '/login' || pathname.startsWith('/invite/');
+  return (
+    pathname === '/login' || pathname.startsWith('/invite/') || pathname.startsWith('/recover/')
+  );
 }
 
 // Pure decision (exported for tests): a 401 from a normal authed call means the

--- a/vue_client/src/components/admin-panes/UsersPane.vue
+++ b/vue_client/src/components/admin-panes/UsersPane.vue
@@ -56,6 +56,13 @@
             duplicate
           </span>
           <span
+            v-if="u.recoveryExpiresAt"
+            class="recovery-tag"
+            :title="`recovery link issued, unused, expires ${u.recoveryExpiresAt}`"
+          >
+            recovery pending
+          </span>
+          <span
             class="last-seen"
             :title="`joined ${u.createdAt}${u.lastSeenAt ? ` · last seen ${u.lastSeenAt}` : ''}`"
           >
@@ -97,6 +104,18 @@
           </small>
         </form>
 
+        <!-- Shown once, under the row it belongs to. Only the hash is stored, so
+             there is no later screen that can show this URL again — an admin who
+             loses it issues another, which kills this one. -->
+        <div v-if="freshRecovery && freshRecovery.userId === u.id" class="recovery-fresh">
+          <code>{{ freshRecovery.url }}</code>
+          <button class="link" @click="copyUrl(freshRecovery.url)">copy</button>
+          <small class="muted">
+            Send this to {{ u.username }} over a channel you trust. Single use, expires in 24 hours,
+            and shown only now.
+          </small>
+        </div>
+
         <div class="row-actions">
           <button
             v-if="canAssignIdents"
@@ -121,6 +140,23 @@
             @click="u.isPaused ? onResumeUser(u) : onPauseUser(u)"
           >
             {{ u.isPaused ? 'resume' : 'pause' }}
+          </button>
+          <button
+            class="link"
+            :disabled="adminBusy"
+            title="issue a single-use link that lets this member set a password or add a passkey"
+            @click="onIssueRecovery(u)"
+          >
+            {{ u.recoveryExpiresAt ? 'reissue recovery' : 'recovery link' }}
+          </button>
+          <button
+            v-if="u.recoveryExpiresAt"
+            class="link"
+            :disabled="adminBusy"
+            title="revoke the outstanding recovery link"
+            @click="onRevokeRecovery(u)"
+          >
+            revoke recovery
           </button>
           <button
             class="link danger"
@@ -172,6 +208,11 @@ const adminBusy = ref(false);
 const editingIdentFor = ref<number | null>(null);
 const identDraft = ref('');
 
+// The one recovery link minted this session, if any. Held in the component
+// rather than the store because it is not state — it is a value that exists for
+// exactly as long as this screen is open, and nothing can fetch it back.
+const freshRecovery = ref<{ userId: number; url: string } | null>(null);
+
 function onEditIdent(user: AdminUser) {
   adminError.value = '';
   // Seed with the override only — showing the derived value would make "save"
@@ -203,6 +244,52 @@ onMounted(() => {
     adminError.value = e.message;
   });
 });
+
+async function onIssueRecovery(user: AdminUser) {
+  // Reissuing is destructive to a link that may already be in the member's
+  // hands, so say so — the copy names what breaks rather than asking "are you
+  // sure".
+  if (
+    user.recoveryExpiresAt &&
+    !confirm(`Issue a new recovery link for ${user.username}? The one already sent stops working.`)
+  )
+    return;
+  adminError.value = '';
+  adminBusy.value = true;
+  freshRecovery.value = null;
+  try {
+    const recovery = await adminStore.createRecoveryLink(user.id);
+    freshRecovery.value = { userId: user.id, url: recovery.url };
+    copyUrl(recovery.url);
+  } catch (e: any) {
+    adminError.value = e.message || 'failed to issue recovery link';
+  } finally {
+    adminBusy.value = false;
+  }
+}
+
+async function onRevokeRecovery(user: AdminUser) {
+  if (!confirm(`Revoke ${user.username}'s recovery link? Anyone holding it can no longer use it.`))
+    return;
+  adminError.value = '';
+  adminBusy.value = true;
+  try {
+    await adminStore.revokeRecoveryLink(user.id);
+    if (freshRecovery.value?.userId === user.id) freshRecovery.value = null;
+  } catch (e: any) {
+    adminError.value = e.message || 'failed to revoke recovery link';
+  } finally {
+    adminBusy.value = false;
+  }
+}
+
+function copyUrl(url: string) {
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(url).catch(() => {
+      /* clipboard is best-effort */
+    });
+  }
+}
 
 async function onDeleteUser(user: AdminUser) {
   if (!confirm(`Delete user ${user.username}? This is irreversible.`)) return;
@@ -280,6 +367,21 @@ async function onResumeUser(user: AdminUser) {
   border: 1px solid currentcolor;
   padding: 0 var(--space-2);
   text-transform: uppercase;
+}
+.user-row .recovery-tag {
+  color: var(--warn);
+  border: 1px solid var(--warn);
+  padding: 0 var(--space-2);
+  text-transform: uppercase;
+}
+.user-row .recovery-fresh {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+.user-row .recovery-fresh code {
+  overflow-wrap: anywhere;
 }
 .user-row .paused-tag {
   color: var(--warn);

--- a/vue_client/src/components/admin-panes/UsersPane.vue
+++ b/vue_client/src/components/admin-panes/UsersPane.vue
@@ -275,7 +275,13 @@ async function onIssueRecovery(user: AdminUser) {
   try {
     const recovery = await adminStore.createRecoveryLink(user.id);
     freshRecovery.value = { userId: user.id, url: recovery.url, copied: false, copyFailed: false };
-    await onCopyRecovery(recovery.url);
+    // Speculative: `reportFailure: false` because this copy runs after an
+    // awaited network call, and Safari (and anything else enforcing transient
+    // user activation) revokes activation across that await — writeText rejects
+    // with NotAllowedError even though the clipboard is perfectly available. A
+    // scary "clipboard unavailable" here would be wrong, and the copy button
+    // below, which calls writeText synchronously inside its own click, works.
+    await onCopyRecovery(recovery.url, false);
   } catch (e: any) {
     adminError.value = e.message || 'failed to issue recovery link';
   } finally {
@@ -298,7 +304,7 @@ async function onRevokeRecovery(user: AdminUser) {
   }
 }
 
-async function onCopyRecovery(url: string) {
+async function onCopyRecovery(url: string, reportFailure = true) {
   if (!freshRecovery.value) return;
   try {
     await navigator.clipboard.writeText(url);
@@ -306,7 +312,9 @@ async function onCopyRecovery(url: string) {
     freshRecovery.value.copyFailed = false;
   } catch (_) {
     freshRecovery.value.copied = false;
-    freshRecovery.value.copyFailed = true;
+    // Only a copy the admin actually clicked is worth an error. That one is a
+    // real signal — no activation excuse, and this URL cannot be re-fetched.
+    if (reportFailure) freshRecovery.value.copyFailed = true;
   }
 }
 

--- a/vue_client/src/components/admin-panes/UsersPane.vue
+++ b/vue_client/src/components/admin-panes/UsersPane.vue
@@ -109,10 +109,19 @@
              loses it issues another, which kills this one. -->
         <div v-if="freshRecovery && freshRecovery.userId === u.id" class="recovery-fresh">
           <code>{{ freshRecovery.url }}</code>
-          <button class="link" @click="copyUrl(freshRecovery.url)">copy</button>
+          <button class="link" @click="onCopyRecovery(freshRecovery.url)">
+            {{ freshRecovery.copied ? 'copied' : 'copy' }}
+          </button>
           <small class="muted">
             Send this to {{ u.username }} over a channel you trust. Single use, expires in 24 hours,
             and shown only now.
+          </small>
+          <!-- Said out loud rather than swallowed: the clipboard API is absent
+               outside a secure context, which includes plain-HTTP LAN installs.
+               Elsewhere a failed copy costs a convenience; here it is the only
+               copy of a value nothing can re-fetch. -->
+          <small v-if="freshRecovery.copyFailed" class="error">
+            clipboard unavailable — select and copy the link above manually
           </small>
         </div>
 
@@ -142,6 +151,7 @@
             {{ u.isPaused ? 'resume' : 'pause' }}
           </button>
           <button
+            v-if="!config.isNode"
             class="link"
             :disabled="adminBusy"
             title="issue a single-use link that lets this member set a password or add a passkey"
@@ -150,7 +160,7 @@
             {{ u.recoveryExpiresAt ? 'reissue recovery' : 'recovery link' }}
           </button>
           <button
-            v-if="u.recoveryExpiresAt"
+            v-if="!config.isNode && u.recoveryExpiresAt"
             class="link"
             :disabled="adminBusy"
             title="revoke the outstanding recovery link"
@@ -211,7 +221,12 @@ const identDraft = ref('');
 // The one recovery link minted this session, if any. Held in the component
 // rather than the store because it is not state — it is a value that exists for
 // exactly as long as this screen is open, and nothing can fetch it back.
-const freshRecovery = ref<{ userId: number; url: string } | null>(null);
+const freshRecovery = ref<{
+  userId: number;
+  url: string;
+  copied: boolean;
+  copyFailed: boolean;
+} | null>(null);
 
 function onEditIdent(user: AdminUser) {
   adminError.value = '';
@@ -259,8 +274,8 @@ async function onIssueRecovery(user: AdminUser) {
   freshRecovery.value = null;
   try {
     const recovery = await adminStore.createRecoveryLink(user.id);
-    freshRecovery.value = { userId: user.id, url: recovery.url };
-    copyUrl(recovery.url);
+    freshRecovery.value = { userId: user.id, url: recovery.url, copied: false, copyFailed: false };
+    await onCopyRecovery(recovery.url);
   } catch (e: any) {
     adminError.value = e.message || 'failed to issue recovery link';
   } finally {
@@ -283,11 +298,15 @@ async function onRevokeRecovery(user: AdminUser) {
   }
 }
 
-function copyUrl(url: string) {
-  if (navigator.clipboard?.writeText) {
-    navigator.clipboard.writeText(url).catch(() => {
-      /* clipboard is best-effort */
-    });
+async function onCopyRecovery(url: string) {
+  if (!freshRecovery.value) return;
+  try {
+    await navigator.clipboard.writeText(url);
+    freshRecovery.value.copied = true;
+    freshRecovery.value.copyFailed = false;
+  } catch (_) {
+    freshRecovery.value.copied = false;
+    freshRecovery.value.copyFailed = true;
   }
 }
 

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -9,6 +9,7 @@ import { useAuthStore } from '../stores/auth.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useThemesStore } from '../stores/themes.js';
 import { THEME_POINTER_KEYS } from '../../../shared/themePresets.js';
+import { WS_CLOSE_SESSION_REVOKED } from '../../../shared/wsCloseCodes.js';
 import { primePreviews } from './useLinkPreview.js';
 import { previewableEventTexts } from '../utils/previewEvents.js';
 import { useConfigStore } from '../stores/config.js';
@@ -1010,7 +1011,7 @@ function open() {
   );
   socket.addEventListener(
     'close',
-    () => {
+    (ev) => {
       connected.value = false;
       socket = null;
       // A probe armed against the socket that just died must not survive into
@@ -1035,6 +1036,24 @@ function open() {
         /* store not yet initialized; nothing in flight */
       }
       const auth = useAuthStore();
+      // The server evicted this device: the session behind this socket was
+      // revoked mid-connection by an account recovery. Reconnecting is futile —
+      // /ws will 401 for the rest of this tab's life — and an ordinary drop is
+      // indistinguishable without the code, which is why the server sends one.
+      //
+      // Clearing the user first is what stops the reconnect arm below (the same
+      // ordering the logout path relies on), then a full navigation to `/`
+      // rebuilds the app against the dead cookie and lands on sign-in. That's
+      // the mechanism api.ts already uses for a session that died under a REST
+      // call; here it's the WS noticing first. A reload rather than an in-app
+      // route change on purpose: every store still holds the evicted account's
+      // data, and resetSession() can't be called from here without an import
+      // cycle (useSessionReset imports resetSocket from this module).
+      if (ev.code === WS_CLOSE_SESSION_REVOKED) {
+        auth.user = null;
+        window.location.assign('/');
+        return;
+      }
       if (auth.user) {
         // A socket that lived a while proves the server is healthy and this was
         // an ordinary drop — start over at the base delay. One that died young

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -1051,7 +1051,14 @@ function open() {
       // cycle (useSessionReset imports resetSocket from this module).
       if (ev.code === WS_CLOSE_SESSION_REVOKED) {
         auth.user = null;
-        window.location.assign('/');
+        // ...except in the tab doing the recovering. The server closes sockets
+        // BEFORE it mints the new session, so on a browser that was still signed
+        // in to this account the close frame beats the redemption response —
+        // navigating here would cancel that in-flight fetch and throw away the
+        // Set-Cookie, dumping the member at /login with their single-use link
+        // already spent. That tab routes itself to `/` on success anyway, so
+        // leaving it alone costs nothing.
+        if (!window.location.pathname.startsWith('/recover/')) window.location.assign('/');
         return;
       }
       if (auth.user) {

--- a/vue_client/src/router.test.ts
+++ b/vue_client/src/router.test.ts
@@ -16,6 +16,17 @@ import router from './router.js';
 // vue-router warned (R0102) and navigation misbehaved — pushes landed back on
 // `/` — but resolve() still worked, so a hand-copied table looked fine.
 
+describe('public routes', () => {
+  it('serves account recovery without an auth requirement', () => {
+    // A recovery link is redeemed by someone who by definition cannot sign in,
+    // so a requiresAuth here would bounce every visitor to /login.
+    const recover = router.getRoutes().find((r) => r.name === 'recover');
+    expect(recover?.path).toBe('/recover/:token');
+    expect(recover?.meta?.requiresAuth).toBeUndefined();
+    expect(router.resolve('/recover/tok123').params).toEqual({ token: 'tok123' });
+  });
+});
+
 describe('chat routes', () => {
   it('gives each chat screen its own named record', () => {
     const byName = new Map(router.getRoutes().map((r) => [r.name, r.path]));

--- a/vue_client/src/router.ts
+++ b/vue_client/src/router.ts
@@ -16,6 +16,11 @@ const chatShell = () => import('./views/Chat.vue');
 const routes: RouteRecordRaw[] = [
   { path: '/login', name: 'login', component: () => import('./views/Login.vue') },
   { path: '/invite/:token', name: 'invite', component: () => import('./views/InviteAccept.vue') },
+  {
+    path: '/recover/:token',
+    name: 'recover',
+    component: () => import('./views/AccountRecovery.vue'),
+  },
   // The three chat locations. All render the same shell; only the params differ.
   //
   // `/buffer/:id` names ONE buffer by its SERVER ID (#744) — never by name. The

--- a/vue_client/src/stores/admin.ts
+++ b/vue_client/src/stores/admin.ts
@@ -18,6 +18,19 @@ export interface AdminUser {
   effectiveIdent?: string;
   /** Another account answers this same ident — neither one attributes anything. */
   identConflict?: boolean;
+  /**
+   * Expiry of this account's outstanding recovery link, or null for none (#855).
+   * The link itself is never returned — only its hash is stored — so this can
+   * say one exists but can never re-show it.
+   */
+  recoveryExpiresAt?: string | null;
+}
+
+/** A freshly minted recovery link. The URL is shown once and never again. */
+export interface AdminRecoveryLink {
+  username: string;
+  url: string;
+  expiresAt: string;
 }
 
 export interface AdminInvite {
@@ -140,6 +153,22 @@ export const useAdminStore = defineStore('admin', {
         this.error = '';
       });
       return res as { ident: string | null; effectiveIdent: string };
+    },
+    // Mint a single-use recovery link for an account (#855). The response is the
+    // only place the URL exists, so the caller must surface it immediately —
+    // re-reading the store later can only tell you that one is outstanding.
+    async createRecoveryLink(id: number) {
+      const { recovery } = await api(`/api/admin/users/${id}/recovery`, { method: 'POST' });
+      this.usersFetchSeq++;
+      const u = this.users.find((x) => x.id === id);
+      if (u) u.recoveryExpiresAt = recovery.expiresAt;
+      return recovery as AdminRecoveryLink;
+    },
+    async revokeRecoveryLink(id: number) {
+      await api(`/api/admin/users/${id}/recovery`, { method: 'DELETE' });
+      this.usersFetchSeq++;
+      const u = this.users.find((x) => x.id === id);
+      if (u) u.recoveryExpiresAt = null;
     },
     async fetchInvites() {
       const seq = ++this.invitesFetchSeq;

--- a/vue_client/src/stores/auth.ts
+++ b/vue_client/src/stores/auth.ts
@@ -249,6 +249,53 @@ export const useAuthStore = defineStore('auth', {
         throw err;
       }
     },
+    // --- account recovery (#855) ---
+    // An admin-issued link for an account its owner is locked out of. Both
+    // redemption paths mint a fresh session and, server-side, sign every other
+    // device out.
+    async fetchRecoveryStatus(token: string) {
+      // Public endpoint, never throws on a dead token — { valid: false } covers
+      // "expired", "already used" and "never existed" alike.
+      return await api(`/api/auth/recovery/${encodeURIComponent(token)}`);
+    },
+    async recoverWithPassword({ token, password }: { token?: string; password?: string } = {}) {
+      this.error = null;
+      try {
+        const { user } = await api(`/api/auth/recovery/${encodeURIComponent(token!)}/password`, {
+          method: 'POST',
+          body: { password },
+        });
+        // A different account may have been signed in on this browser — wipe
+        // its state before the new session takes over, as invite redemption does.
+        this.user = null;
+        resetSession();
+        this.adoptSession(user);
+        return user as AuthUser;
+      } catch (err: any) {
+        this.error = friendlyError(err, 'account recovery failed');
+        throw err;
+      }
+    },
+    async recoverWithPasskey({ token, label }: { token?: string; label?: string } = {}) {
+      this.error = null;
+      try {
+        const { options } = await api(`/api/auth/recovery/${encodeURIComponent(token!)}/options`, {
+          method: 'POST',
+        });
+        const response = await startRegistration({ optionsJSON: options });
+        const { user } = await api(`/api/auth/recovery/${encodeURIComponent(token!)}/verify`, {
+          method: 'POST',
+          body: { response, label },
+        });
+        this.user = null;
+        resetSession();
+        this.adoptSession(user);
+        return user as AuthUser;
+      } catch (err: any) {
+        this.error = friendlyError(err, 'account recovery failed');
+        throw err;
+      }
+    },
     async addPasskey({ label }: { label?: string } = {}) {
       const { options } = await api('/api/auth/passkeys/options', { method: 'POST' });
       const response = await startRegistration({ optionsJSON: options });

--- a/vue_client/src/views/AccountRecovery.vue
+++ b/vue_client/src/views/AccountRecovery.vue
@@ -1,0 +1,233 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<!--
+  Redemption page for an admin-issued account recovery link (#855). Reached only
+  by URL, and the token in that URL is the whole authorization — there is no
+  account to sign into first, which is the point.
+
+  Two ways out, because there are two ways in: set a password, or enroll a
+  passkey. A member whose only credential was a passkey on a lost phone has no
+  password to reset, so offering only the password half would strand exactly the
+  case this exists for.
+-->
+
+<template>
+  <div class="recover">
+    <WordBackdrop word="recover" />
+    <div class="card">
+      <h1>lurker</h1>
+
+      <template v-if="checking">
+        <p class="subtitle">Checking link…</p>
+      </template>
+
+      <template v-else-if="!status?.valid">
+        <p class="subtitle">This recovery link is no longer valid.</p>
+        <p class="muted">
+          Links are single-use and expire after 24 hours. Ask your instance admin for a fresh one.
+        </p>
+        <RouterLink to="/login" class="link">go to sign-in</RouterLink>
+      </template>
+
+      <template v-else>
+        <p class="subtitle">
+          Recovering <strong>{{ status.username }}</strong
+          >.
+        </p>
+        <p class="warning">Signing back in here signs that account out on every other device.</p>
+
+        <form @submit.prevent="onSetPassword">
+          <label>
+            <span>{{ status.hasPassword ? 'New password' : 'Password' }}</span>
+            <input
+              v-model="password"
+              type="password"
+              autocomplete="new-password"
+              autofocus
+              required
+              minlength="8"
+            />
+          </label>
+          <p class="hint">8+ characters.</p>
+          <button type="submit" class="btn-primary" :disabled="working || !password">
+            {{ passwordLabel }}
+          </button>
+        </form>
+
+        <div class="divider"><span>or</span></div>
+
+        <button class="btn-primary" :disabled="working" @click="onAddPasskey">
+          {{ mode === 'passkey' && working ? 'Waiting for passkey…' : 'Register a passkey' }}
+        </button>
+        <p class="hint">
+          Adds a new passkey to the account. Any passkeys already on it are left alone.
+        </p>
+
+        <p v-if="auth.error" class="error">{{ auth.error }}</p>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useAuthStore } from '../stores/auth.js';
+import WordBackdrop from '../components/WordBackdrop.vue';
+
+const route = useRoute();
+const router = useRouter();
+const auth = useAuthStore();
+
+interface RecoveryStatus {
+  valid: boolean;
+  username?: string;
+  hasPassword?: boolean;
+  expiresAt?: string;
+}
+
+const status = ref<RecoveryStatus | null>(null);
+const checking = ref(true);
+const password = ref('');
+const working = ref(false);
+const mode = ref<'password' | 'passkey' | null>(null);
+
+const token = computed(() => route.params.token as string);
+
+const passwordLabel = computed(() => {
+  if (mode.value === 'password' && working.value) return 'Signing in…';
+  return status.value?.hasPassword ? 'Set new password' : 'Set password';
+});
+
+onMounted(async () => {
+  try {
+    status.value = await auth.fetchRecoveryStatus(token.value);
+  } catch (_) {
+    status.value = { valid: false };
+  } finally {
+    checking.value = false;
+  }
+});
+
+async function onSetPassword() {
+  if (!password.value || working.value) return;
+  working.value = true;
+  mode.value = 'password';
+  try {
+    await auth.recoverWithPassword({ token: token.value, password: password.value });
+    router.replace('/');
+  } catch (_) {
+    // surfaced via auth.error
+  } finally {
+    working.value = false;
+    mode.value = null;
+  }
+}
+
+async function onAddPasskey() {
+  if (working.value) return;
+  working.value = true;
+  mode.value = 'passkey';
+  try {
+    await auth.recoverWithPasskey({ token: token.value });
+    router.replace('/');
+  } catch (_) {
+    // surfaced via auth.error
+  } finally {
+    working.value = false;
+    mode.value = null;
+  }
+}
+</script>
+
+<style scoped>
+.recover {
+  position: relative;
+  min-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+.card {
+  position: relative;
+  z-index: var(--z-base);
+  width: min(380px, 92vw);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-popover);
+  padding: var(--space-9);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+h1 {
+  margin: 0 0 var(--space-2);
+  color: var(--accent);
+  font-weight: 700;
+  text-transform: lowercase;
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+}
+.subtitle {
+  margin: 0;
+  color: var(--fg-muted);
+}
+.muted {
+  margin: 0;
+  color: var(--fg-muted);
+  font-style: italic;
+}
+.warning {
+  margin: 0;
+  padding: var(--space-4) var(--space-5);
+  border: 1px solid var(--warn, var(--accent));
+  color: var(--warn, var(--accent));
+  background: transparent;
+}
+form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  margin: 0;
+}
+label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  color: var(--fg-muted);
+}
+label span {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+/* Two equal ways in, not a primary and a fallback — the rule says so out loud. */
+.divider {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  color: var(--fg-muted);
+}
+.divider::before,
+.divider::after {
+  content: '';
+  flex: 1;
+  border-top: 1px solid var(--border);
+}
+.error {
+  margin: 0;
+  color: var(--bad);
+}
+.link {
+  color: var(--accent);
+}
+.hint {
+  margin: 0;
+  color: var(--fg-muted);
+}
+</style>

--- a/vue_client/src/views/AccountRecovery.vue
+++ b/vue_client/src/views/AccountRecovery.vue
@@ -108,6 +108,14 @@ const passwordLabel = computed(() => {
 });
 
 onMounted(async () => {
+  // auth.error is shared store state that survives in-app navigation, and this
+  // page renders it unconditionally. Reachable: a dead link sends you to sign-in
+  // via the link below, a failed login sets the error, and the browser Back
+  // button returns here — greeting you with "invalid username or password" on a
+  // page you haven't touched yet. The store's actions each clear it when they
+  // run, so the stale window is only between mount and the first attempt; this
+  // closes it.
+  auth.error = null;
   try {
     status.value = await auth.fetchRecoveryStatus(token.value);
   } catch (_) {

--- a/vue_client/src/views/AccountRecovery.vue
+++ b/vue_client/src/views/AccountRecovery.vue
@@ -12,6 +12,10 @@
   passkey. A member whose only credential was a passkey on a lost phone has no
   password to reset, so offering only the password half would strand exactly the
   case this exists for.
+
+  Either way the account ends up with exactly ONE credential — the one chosen
+  here. Recovery assumes the account may have been taken over, and a password an
+  attacker set or a passkey they enrolled would otherwise outlive it.
 -->
 
 <template>
@@ -37,7 +41,10 @@
           Recovering <strong>{{ status.username }}</strong
           >.
         </p>
-        <p class="warning">Signing back in here signs that account out on every other device.</p>
+        <p class="warning">
+          This replaces every way into the account. Other devices are signed out, and any existing
+          password and passkeys stop working.
+        </p>
 
         <form @submit.prevent="onSetPassword">
           <label>
@@ -62,9 +69,7 @@
         <button class="btn-primary" :disabled="working" @click="onAddPasskey">
           {{ mode === 'passkey' && working ? 'Waiting for passkey…' : 'Register a passkey' }}
         </button>
-        <p class="hint">
-          Adds a new passkey to the account. Any passkeys already on it are left alone.
-        </p>
+        <p class="hint">This becomes the account's only sign-in method.</p>
 
         <p v-if="auth.error" class="error">{{ auth.error }}</p>
       </template>

--- a/vue_client/src/views/Login.vue
+++ b/vue_client/src/views/Login.vue
@@ -76,8 +76,13 @@
 
         <!-- There is no self-service reset to link to: accounts here carry no
              email address, so nothing could verify the request. Recovery runs
-             through the admin (#855). Hidden on a hosted cell, where the control
-             plane holds an email and does have its own reset. -->
+             through the admin (#855).
+             Shown by DEFAULT and hidden once /api/config resolves as node, not
+             the other way round: `edition` defaults to 'standalone', so a cell
+             flashes this line for the length of that fetch. Deliberate — gating
+             on config.checked would instead hide it on every standalone login,
+             which is the common case and the one that needs it. A hosted cell
+             signs in through the control plane anyway. -->
         <p v-if="!config.isNode" class="hint">
           Locked out? Accounts here have no email address — ask your instance admin for a recovery
           link.

--- a/vue_client/src/views/Login.vue
+++ b/vue_client/src/views/Login.vue
@@ -73,6 +73,15 @@
             {{ working && loginMode === 'password' ? 'Signing in…' : 'Sign in with password' }}
           </button>
         </form>
+
+        <!-- There is no self-service reset to link to: accounts here carry no
+             email address, so nothing could verify the request. Recovery runs
+             through the admin (#855). Hidden on a hosted cell, where the control
+             plane holds an email and does have its own reset. -->
+        <p v-if="!config.isNode" class="hint">
+          Locked out? Accounts here have no email address — ask your instance admin for a recovery
+          link.
+        </p>
       </template>
 
       <p v-if="auth.error" class="error">{{ auth.error }}</p>
@@ -85,6 +94,7 @@ import { ref, computed, onMounted } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 import type { SetupStatus } from '../stores/auth.js';
 import { useAuthStore } from '../stores/auth.js';
+import { useConfigStore } from '../stores/config.js';
 import WordBackdrop from '../components/WordBackdrop.vue';
 import { USERNAME_PATTERN, MAX_USERNAME_LENGTH } from '../../../shared/username.js';
 
@@ -97,6 +107,9 @@ const password = ref('');
 const working = ref(false);
 const loadingStatus = ref(true);
 const auth = useAuthStore();
+// Defaults to standalone, so a config fetch that hasn't landed shows the line —
+// the right default, since standalone is the only edition that self-hosts.
+const config = useConfigStore();
 const router = useRouter();
 const route = useRoute();
 const setup = ref<SetupStatus | null>(null);


### PR DESCRIPTION
Closes #855.

Lurker accounts carry no email address, so there is nothing a self-service "forgot password" flow could verify a request against — a public form would only be an account-enumeration oracle. The admin issues a link instead, from **Admin → Users**, and hands it to the member over a channel they already trust.

Framed as **recovery**, not a password reset: the landing page offers *set a password* **and** *register a passkey*. A member whose only credential was a passkey on a lost phone has no password to reset, so a password-only flow would strand exactly the case this exists for.

## Token rules

Mechanics mirror `invite_tokens`, with the differences a token that takes over an **existing** account earns:

- **SHA-256 only.** `invite_tokens` stores its token raw because an invite merely *creates* an account; this one *takes one over*, so a read of the table must not be enough to use it. The URL in the admin's response is the only place it ever exists — losing it means issuing another, which kills the first.
- **Single use** via one guarded `DELETE … RETURNING`. The row vanishing *is* the rule: no spent-but-present state for a later read to misjudge (the #590 trap).
- **24h TTL**, not the control plane's 1h — this link is hand-delivered, not emailed.
- `user_id` is UNIQUE, so issuing replaces any outstanding link.
- Validation runs **before** the spend, so a short password or a failed WebAuthn ceremony never burns the link.

## Redeeming leaves exactly one way in

A lockout is indistinguishable from a takeover, so recovery assumes one. Everything that authenticates once and is never re-checked afterwards goes: session rows, open WebSockets, attached bouncer sessions, API tokens, push registrations — plus the old password and every previously enrolled passkey. What remains is the single credential just established.

That last part was a deliberate call (see the review history below): changing a password is worthless while a passkey an attacker enrolled still opens the door, and clearing passkeys is worthless while they still know a password. The cost is stated on the recovery page and in the docs — a member with several passkeys re-enrolls the ones they still have.

## Also here

- `npm run recovery-link -- <username>` for the one case an admin-mediated flow can't cover: an instance's only admin, locked out of their own account. Arg parsing is a pure, table-tested function.
- **The Dockerfile never shipped `tools/`** — so the documented `docker compose exec` line for the existing `fold-buffer-case.ts` couldn't have worked either. Fixed, and `.dockerignore` now keeps test files out of the runtime image (it was shipping every server test).
- A "locked out?" line on the login page, hidden on a hosted cell.
- All admin *and* redemption routes refuse in node edition — the control plane owns hosted sign-in and has its own email reset.
- `docs/SELF_HOSTING.md`'s "Forgot the admin password" section — which told operators to `DELETE FROM users` with sqlite3 and noted a reset CLI was "on the roadmap" — is replaced by the real thing.

## Review

Five `/code-review high` passes, 17 findings, all addressed. The recurring shape was worth the repetition: **a credential that authenticates once and is never re-checked**. I kept fixing it at the one door I happened to be looking at, and each pass found the same defect somewhere new — WebSockets, then bouncer sessions and API tokens and push, then the credentials themselves, then the close-handshake window where a socket is "closed" but still accepting inbound frames.

Two of the findings were regressions I introduced while fixing others, including one that broke the CLI's documented invocation. That one is now covered by a test rather than by my having smoke-tested it once.

A review pass flagged "any admin can mint a link for any account, so an admin can now read anyone's DMs" as a new capability. It isn't. `role: 'admin'` is set in exactly two places, both first-run setup; invite redemption always creates `role: 'user'` and there is no promote-to-admin path — so a standalone instance has one admin, the operator, and a second could only be made by editing the database. Anyone who can do that can already read `messages.text` (plaintext; E2E is a separate opt-in layer) and take over any account with one `UPDATE users SET password_hash = …`. This adds a convenient, revocable, visibly-badged path to something the box owner could always do.

`npm run check` clean; 4354 server tests, 1105 client tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVvboF5wi8psQQEursyoUr
