### PR TITLE
Bump Lurker version to 2.2.0 — retention, account recovery, nick-completion suffix

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -93,6 +93,7 @@ jobs:
               changed=true
             elif ! git diff --quiet "$prev" "$GITHUB_REF_NAME" -- \
                 server/engine ':(exclude)server/engine/*.test.ts' \
+                ':(exclude)server/engine/*.spec.ts' \
                 server/engine.ts server/services/identd.ts \
                 server/utils/processGuards.ts server/utils/userAgent.ts \
                 Dockerfile 'tsconfig*.json'; then
@@ -102,9 +103,13 @@ jobs:
               [ "$(dep "$prev")" = "$(dep "$GITHUB_REF_NAME")" ] || changed=true
             fi
             echo "engine files changed since ${prev:-<none>}: $changed"
-            # Match on whole words so `v2.2.0` in the list cannot pin `v2.2.01`.
+            # Match whole ENTRIES, not substrings or words: `grep -w` treats `-`
+            # and `.` as word boundaries, so a `v2.2.0-rc1` entry would also pin
+            # `v2.2.0` — failing in the direction that leaves a genuinely changed
+            # engine unpublished, with nothing but a misleading log line to say so.
             if [ "$changed" = "true" ] && \
-               grep -qwF -- "$GITHUB_REF_NAME" <<<"${ENGINE_TAG_PINNED_RELEASES:-}"; then
+               tr ' \t' '\n\n' <<<"${ENGINE_TAG_PINNED_RELEASES:-}" \
+                 | grep -qxF -- "$GITHUB_REF_NAME"; then
               changed=false
               echo "engine tag PINNED for ${GITHUB_REF_NAME} by ENGINE_TAG_PINNED_RELEASES"
             fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,6 +26,15 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/lurker
+  # Releases that must NOT move the engine tag, whitespace-separated, `v`-prefixed.
+  # An escape hatch for when the path diff below says the engine image changed but
+  # the engine's behaviour did not, so self-hosters keep the engine they are running
+  # instead of having `docker compose pull` recreate it — and drop their IRC
+  # connections — for nothing. Entries are one-shot: drop them once released.
+  #
+  # v2.2.0: the only matches were a `COPY tools/` line the engine never executes
+  # (the recovery-link CLI) and a test-only refactor.
+  ENGINE_TAG_PINNED_RELEASES: 'v2.2.0'
 
 jobs:
   build-and-push:
@@ -83,7 +92,8 @@ jobs:
             if [ -z "$prev" ]; then
               changed=true
             elif ! git diff --quiet "$prev" "$GITHUB_REF_NAME" -- \
-                server/engine server/engine.ts server/services/identd.ts \
+                server/engine ':(exclude)server/engine/*.test.ts' \
+                server/engine.ts server/services/identd.ts \
                 server/utils/processGuards.ts server/utils/userAgent.ts \
                 Dockerfile 'tsconfig*.json'; then
               changed=true
@@ -92,6 +102,12 @@ jobs:
               [ "$(dep "$prev")" = "$(dep "$GITHUB_REF_NAME")" ] || changed=true
             fi
             echo "engine files changed since ${prev:-<none>}: $changed"
+            # Match on whole words so `v2.2.0` in the list cannot pin `v2.2.01`.
+            if [ "$changed" = "true" ] && \
+               grep -qwF -- "$GITHUB_REF_NAME" <<<"${ENGINE_TAG_PINNED_RELEASES:-}"; then
+              changed=false
+              echo "engine tag PINNED for ${GITHUB_REF_NAME} by ENGINE_TAG_PINNED_RELEASES"
+            fi
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish_engine }}" = "true" ]; then
             changed=true
             version="manual-$(git rev-parse --short HEAD)"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "2.1.5",
+      "version": "2.2.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "2.1.5",
+      "version": "2.2.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "2.1.5",
+  "version": "2.2.0",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Version bump for the 2.2.0 release: `2.1.5` → `2.2.0` across the root and `vue_client` manifests and lockfiles.

## Also: pin the engine tag for this release

The path diff that decides whether `engine-1` moves matched two changes since v2.1.5 that the engine never runs:

- `Dockerfile` — a `COPY tools/` line added for the `recovery-link` CLI
- `server/engine/engine.test.ts` — a test-only refactor

Letting the tag move on those would recreate every self-hosted engine container — dropping its IRC connections — for no behaviour change, which is the one thing that mechanism exists to prevent.

Two changes:

1. **Test files are excluded from the engine diff outright** (`':(exclude)server/engine/*.test.ts'`). They never ship, so they should never have moved the tag.
2. **A one-shot `ENGINE_TAG_PINNED_RELEASES` list** in the workflow `env`, covering the `Dockerfile` match. `v2.2.0` is its first entry; entries are dropped once released.

### Verification

The `Decide whether the engine tag moves` step was extracted verbatim from the workflow and run against real history with a real tag on this commit:

| pin list | result |
|---|---|
| contains this release | `changed=false` — engine tag stays put |
| **empty** | `changed=true` — **control: the pin is what stops it** |
| names a different release | `changed=true` — no leakage |

The empty-list run is the control: without the pin the tag *would* move, so this is not a no-op.

Word-boundary matching (`grep -qwF`) was checked so `v2.2.0` cannot pin `v2.2.01`, `v2.2.1`, or `av2.2.0`. The pathspec exclusion was confirmed to actually filter the test file against `v2.1.5..HEAD`. YAML re-parsed after editing.

### Release base

`npm run check` clean (pre-existing warnings only) and the full suite green on the release base: **306 files, 4359 tests passed**.