### PR TITLE
Retention sweep: pace by what a statement costs, not how many there are

### DIFF
--- a/server/services/retentionSweeper.test.ts
+++ b/server/services/retentionSweeper.test.ts
@@ -7,7 +7,7 @@
 // tables. Batch/budget constants are INJECTED tiny — test cost must never
 // scale with the production constants.
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -23,6 +23,8 @@ let addBookmark: typeof import('../db/bookmarks.js').addBookmark;
 let setUserSetting: typeof import('../db/settings.js').setUserSetting;
 let runRetentionTick: typeof import('./retentionSweeper.js').runRetentionTick;
 let takeDirtyBuffers: typeof import('../db/retention.js').takeDirtyBuffers;
+let retentionDb: typeof import('../db/retention.js');
+let __resetSweepPacing: typeof import('./retentionSweeper.js').__resetSweepPacing;
 
 beforeAll(async () => {
   ({ default: db } = await import('../db/index.js'));
@@ -33,6 +35,8 @@ beforeAll(async () => {
   ({ setUserSetting } = await import('../db/settings.js'));
   ({ runRetentionTick } = await import('./retentionSweeper.js'));
   ({ takeDirtyBuffers } = await import('../db/retention.js'));
+  retentionDb = await import('../db/retention.js');
+  ({ __resetSweepPacing } = await import('./retentionSweeper.js'));
 });
 
 afterAll(() => {
@@ -42,8 +46,14 @@ afterAll(() => {
 // Tiny knobs so the budget/backlog behavior is exercised with dozens of rows,
 // not hundreds of thousands. noiseIntervalMs Infinity keeps the noise clock
 // out of the count-sweep tests; the noise tests pass 0 to force it.
+// Pacing is OFF here on purpose: these tests assert the statement-count budget,
+// and a wall-clock budget would make them depend on how fast the box is. The
+// pacing behaviour has its own describe block, which sets the knobs it needs.
 const OPTS = {
   batchRows: 4,
+  minBatchRows: 1,
+  targetStatementMs: Infinity,
+  maxTickMs: Infinity,
   maxBatchesPerTick: 100,
   idleDelayMs: 0,
   busyDelayMs: 0,
@@ -618,5 +628,104 @@ describe('runRetentionTick', () => {
     deleteJob(job.id);
     await runRetentionTick(OPTS);
     expect(rowIds(bufferId)).toEqual(ids.slice(7));
+  });
+});
+
+// The 2026-08-28 incident: the statement-count budget assumes each statement is
+// cheap, and on a cold start it is not — one 500-row delete cascading into the
+// FTS triggers blocked the loop for ~800ms a second. These pin the two things
+// that stop a statement count from being the only guard.
+describe('pacing', () => {
+  /** Replace a delete with one that reports a FULL batch (so the loop keeps
+   *  going) and burns `ms` of real synchronous time, recording the batch size
+   *  it was handed. Burning wall-clock is the point: it is what the sweeper
+   *  measures, and a mock that returned instantly would prove nothing. */
+  function slowDelete(ms: number): number[] {
+    const seen: number[] = [];
+    vi.spyOn(retentionDb, 'deleteRetentionBatch').mockImplementation(
+      (_b: number, _bound: number, _owner: number, limit: number) => {
+        seen.push(limit);
+        const end = performance.now() + ms;
+        while (performance.now() < end) {
+          /* block the loop the way a real slow statement does */
+        }
+        return limit; // a full batch — the tail is never "done"
+      },
+    );
+    return seen;
+  }
+
+  beforeEach(() => {
+    __resetSweepPacing();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('halves the batch size while statements overrun the target', async () => {
+    const { userId } = seedBuffer('pace-shrink', 30);
+    setUserSetting(userId, 'data.retention.lines', 10);
+    const seen = slowDelete(30);
+
+    await runRetentionTick({
+      ...OPTS,
+      batchRows: 64,
+      minBatchRows: 1,
+      targetStatementMs: 10, // every mocked statement overruns this
+      maxBatchesPerTick: 6,
+    });
+
+    expect(seen.length).toBeGreaterThan(2);
+    expect(seen[0]).toBe(64);
+    // Strictly decreasing, and it actually got small — not merely "not larger".
+    for (let i = 1; i < seen.length; i++) expect(seen[i]).toBeLessThan(seen[i - 1]);
+    expect(seen.at(-1)!).toBeLessThanOrEqual(16);
+  });
+
+  it('never shrinks below minBatchRows', async () => {
+    const { userId } = seedBuffer('pace-floor', 30);
+    setUserSetting(userId, 'data.retention.lines', 10);
+    const seen = slowDelete(30);
+
+    await runRetentionTick({
+      ...OPTS,
+      batchRows: 64,
+      minBatchRows: 8,
+      targetStatementMs: 10,
+      maxBatchesPerTick: 12,
+    });
+
+    expect(Math.min(...seen)).toBe(8);
+  });
+
+  it('holds the batch size when targetStatementMs is Infinity', async () => {
+    const { userId } = seedBuffer('pace-off', 30);
+    setUserSetting(userId, 'data.retention.lines', 10);
+    const seen = slowDelete(30);
+
+    await runRetentionTick({ ...OPTS, batchRows: 64, maxBatchesPerTick: 5 });
+
+    expect(new Set(seen)).toEqual(new Set([64]));
+  });
+
+  it('ends a tick on elapsed statement time even with batches to spare', async () => {
+    const { userId } = seedBuffer('pace-tick', 30);
+    setUserSetting(userId, 'data.retention.lines', 10);
+    const seen = slowDelete(30);
+
+    // 500 batches available, but only ~90ms of statement time allowed: the
+    // statement COUNT cannot end this tick, so only the time budget can.
+    const result = await runRetentionTick({
+      ...OPTS,
+      batchRows: 4,
+      minBatchRows: 4,
+      targetStatementMs: Infinity,
+      maxTickMs: 90,
+      maxBatchesPerTick: 500,
+    });
+
+    expect(seen.length).toBeLessThan(10); // ~3 x 30ms, nowhere near 500
+    expect(result.backlog).toBe(true);
   });
 });

--- a/server/services/retentionSweeper.test.ts
+++ b/server/services/retentionSweeper.test.ts
@@ -24,7 +24,7 @@ let setUserSetting: typeof import('../db/settings.js').setUserSetting;
 let runRetentionTick: typeof import('./retentionSweeper.js').runRetentionTick;
 let takeDirtyBuffers: typeof import('../db/retention.js').takeDirtyBuffers;
 let retentionDb: typeof import('../db/retention.js');
-let __resetSweepPacing: typeof import('./retentionSweeper.js').__resetSweepPacing;
+let resetSweepPacingForTests: typeof import('./retentionSweeper.js').resetSweepPacingForTests;
 
 beforeAll(async () => {
   ({ default: db } = await import('../db/index.js'));
@@ -36,7 +36,7 @@ beforeAll(async () => {
   ({ runRetentionTick } = await import('./retentionSweeper.js'));
   ({ takeDirtyBuffers } = await import('../db/retention.js'));
   retentionDb = await import('../db/retention.js');
-  ({ __resetSweepPacing } = await import('./retentionSweeper.js'));
+  ({ resetSweepPacingForTests } = await import('./retentionSweeper.js'));
 });
 
 afterAll(() => {
@@ -47,7 +47,7 @@ afterAll(() => {
 // so without this a test inherits whatever size the previous one settled on —
 // silently running at someone else's batch size rather than its own.
 beforeEach(() => {
-  __resetSweepPacing();
+  resetSweepPacingForTests();
 });
 
 // Tiny knobs so the budget/backlog behavior is exercised with dozens of rows,
@@ -58,7 +58,7 @@ beforeEach(() => {
 // pacing behaviour has its own describe block, which sets the knobs it needs.
 const OPTS = {
   batchRows: 4,
-  minBatchRows: 1,
+  minBatchRows: 4, // == batchRows: pacing fully inert for the legacy tests
   targetStatementMs: Infinity,
   maxTickMs: Infinity,
   maxBatchesPerTick: 100,
@@ -642,29 +642,60 @@ describe('runRetentionTick', () => {
 // cheap, and on a cold start it is not — one 500-row delete cascading into the
 // FTS triggers blocked the loop for ~800ms a second. These pin the two things
 // that stop a statement count from being the only guard.
+// The 2026-08-28 incident: the statement-count budget assumes each statement is
+// cheap, and on a cold start it is not — one 500-row delete cascading into the
+// FTS triggers blocked the loop for ~800ms a second on a 2.1 GB database.
 describe('pacing', () => {
-  /** Replace a delete with one that reports a FULL batch (so the loop keeps
-   *  going) and burns `ms` of real synchronous time, recording the batch size
-   *  it was handed. Burning wall-clock is the point: it is what the sweeper
-   *  measures, and a mock that returned instantly would prove nothing. */
-  function slowDelete(ms: number): number[] {
+  /**
+   * Replace the delete with one that blocks for `ms(rows)` of REAL synchronous
+   * time and records the size it was handed. Burning wall-clock is the point —
+   * it is what the sweeper measures. `full` decides whether it reports a full
+   * batch (the loop continues) or a short one (the buffer's tail is done).
+   * The boundary probe is pinned cheap and constant so these assertions are
+   * about the DELETE path and cannot flake on a loaded box.
+   */
+  function mockDelete(ms: (rows: number) => number, full = true): number[] {
     const seen: number[] = [];
-    // The first charged statement of a tick is the real boundary probe. Pin it
-    // cheap and constant: otherwise a probe that happens to exceed
-    // targetStatementMs on a loaded CI box halves the batch before the first
-    // delete, and these assertions are about the DELETE path.
     vi.spyOn(retentionDb, 'retentionBoundaryId').mockReturnValue(1);
     vi.spyOn(retentionDb, 'deleteRetentionBatch').mockImplementation(
       (_b: number, _bound: number, _owner: number, limit: number) => {
         seen.push(limit);
-        const end = performance.now() + ms;
+        const end = performance.now() + ms(limit);
         while (performance.now() < end) {
           /* block the loop the way a real slow statement does */
         }
-        return limit; // a full batch — the tail is never "done"
+        return full ? limit : Math.max(0, limit - 1);
       },
     );
     return seen;
+  }
+
+  const PACED = {
+    ...OPTS,
+    batchRows: 64,
+    minBatchRows: 1,
+    targetStatementMs: 10,
+    maxBatchesPerTick: 60,
+  };
+
+  /** A capped, over-cap buffer that stays dirty under a full-batch mock. */
+  function capped(name: string, rows = 40): number {
+    const b = seedBuffer(name, rows);
+    setUserSetting(b.userId, 'data.retention.lines', 10);
+    return b.bufferId;
+  }
+
+  /** Run cheap full batches until the size has climbed to `batchRows`. */
+  async function warmUpToMax(): Promise<void> {
+    mockDelete(() => 0);
+    await runRetentionTick(PACED);
+    vi.restoreAllMocks();
+  }
+
+  /** Seed a capped buffer, then warm the size up to `batchRows` on it. */
+  async function warmUpToMaxOn(name: string): Promise<void> {
+    capped(name);
+    await warmUpToMax();
   }
 
   beforeEach(() => {
@@ -677,118 +708,103 @@ describe('pacing', () => {
     vi.restoreAllMocks();
   });
 
-  it('halves the batch size while statements overrun the target', async () => {
-    const { userId } = seedBuffer('pace-shrink', 30);
-    setUserSetting(userId, 'data.retention.lines', 10);
-    const seen = slowDelete(30);
+  it('starts at the floor and earns its way up', async () => {
+    capped('pace-floorstart');
+    const seen = mockDelete(() => 0);
 
-    await runRetentionTick({
-      ...OPTS,
-      batchRows: 64,
-      minBatchRows: 1,
-      targetStatementMs: 10, // every mocked statement overruns this
-      maxBatchesPerTick: 6,
-    });
+    await runRetentionTick(PACED);
 
-    expect(seen.length).toBeGreaterThan(2);
+    // Nothing has been measured yet, so the first statement must NOT assume the
+    // maximum works — that assumption is what this file exists to stop making,
+    // and boot re-marks every buffer dirty so it would be re-paid every restart.
+    expect(seen[0]).toBe(PACED.minBatchRows);
+    expect(seen.at(-1)!).toBeGreaterThan(seen[0]);
+    expect(Math.max(...seen)).toBeLessThanOrEqual(PACED.batchRows);
+  });
+
+  it('halves a full batch that overruns the target', async () => {
+    capped('pace-shrink');
+    await warmUpToMax();
+
+    const seen = mockDelete(() => 30); // every full batch overruns 10ms
+    await runRetentionTick({ ...PACED, maxBatchesPerTick: 6 });
+
     expect(seen[0]).toBe(64);
-    // Strictly decreasing, and it actually got small — not merely "not larger".
     for (let i = 1; i < seen.length; i++) expect(seen[i]).toBeLessThan(seen[i - 1]);
     expect(seen.at(-1)!).toBeLessThanOrEqual(16);
   });
 
   it('never shrinks below minBatchRows', async () => {
-    const { userId } = seedBuffer('pace-floor', 30);
-    setUserSetting(userId, 'data.retention.lines', 10);
-    const seen = slowDelete(30);
+    capped('pace-floor');
+    await warmUpToMax();
 
-    await runRetentionTick({
-      ...OPTS,
-      batchRows: 64,
-      minBatchRows: 8,
-      targetStatementMs: 10,
-      maxBatchesPerTick: 12,
-    });
+    const seen = mockDelete(() => 30);
+    await runRetentionTick({ ...PACED, minBatchRows: 8, maxBatchesPerTick: 30 });
 
     expect(Math.min(...seen)).toBe(8);
   });
 
-  it('holds the batch size when targetStatementMs is Infinity', async () => {
-    const { userId } = seedBuffer('pace-off', 30);
-    setUserSetting(userId, 'data.retention.lines', 10);
-    const seen = slowDelete(30);
+  it('pins at batchRows when targetStatementMs is Infinity', async () => {
+    capped('pace-off');
+    const seen = mockDelete(() => 30);
 
-    await runRetentionTick({ ...OPTS, batchRows: 64, maxBatchesPerTick: 5 });
+    await runRetentionTick({ ...PACED, targetStatementMs: Infinity });
 
-    expect(new Set(seen)).toEqual(new Set([64]));
+    // Nothing can overrun Infinity, so it only ever grows — up to the ceiling.
+    expect(seen.at(-1)).toBe(64);
+    expect(Math.max(...seen)).toBe(64);
   });
 
-  /** Deletes that return one row SHORT of the batch — the shape that ends a
-   *  buffer's loop — instantly. Records the size each was handed. */
-  function shortDelete(): number[] {
-    const seen: number[] = [];
-    vi.spyOn(retentionDb, 'retentionBoundaryId').mockReturnValue(1);
-    vi.spyOn(retentionDb, 'deleteRetentionBatch').mockImplementation(
-      (_b: number, _bound: number, _owner: number, limit: number) => {
-        seen.push(limit);
-        return Math.max(0, limit - 1); // short: the tail is "done"
-      },
-    );
-    return seen;
-  }
-
-  it('does not let a short batch grow the size back', async () => {
-    const PACED = {
-      ...OPTS,
-      batchRows: 64,
-      minBatchRows: 1,
-      targetStatementMs: 10,
-      maxBatchesPerTick: 4,
-    };
-    const big = seedBuffer('pace-short-big', 60);
-    setUserSetting(big.userId, 'data.retention.lines', 10);
-
-    slowDelete(30);
-    await runRetentionTick(PACED); // full+slow batches shrink the size
-
-    // Now a tickful of buffers that each end on ONE cheap short batch. A short
-    // batch is cheap because it deleted almost nothing, so it proves nothing
-    // about the size — if it grew it, boot (every buffer dirty, most over cap
-    // by a handful of rows) would ratchet straight back to the maximum.
+  it('does not let a short batch grow the size', async () => {
+    capped('pace-short-seed');
+    await warmUpToMax();
+    // Shrink off the ceiling so growth would be visible.
+    mockDelete(() => 30);
+    await runRetentionTick({ ...PACED, maxBatchesPerTick: 4 });
     vi.restoreAllMocks();
-    const seen = shortDelete();
-    for (let i = 0; i < 6; i++) {
-      const b = seedBuffer(`pace-short-${i}`, 30);
-      setUserSetting(b.userId, 'data.retention.lines', 10);
-    }
-    await runRetentionTick({ ...PACED, maxBatchesPerTick: 100 });
+
+    // A tickful of buffers that each end on ONE cheap short batch. Short means
+    // it deleted almost nothing, so it proves nothing about the size — if it
+    // grew it, boot (every buffer dirty, most over cap by a handful of rows)
+    // would ratchet straight back to the maximum.
+    const seen = mockDelete(() => 0, false);
+    for (let i = 0; i < 6; i++) capped(`pace-short-${i}`, 30);
+    await runRetentionTick(PACED);
 
     expect(seen.length).toBeGreaterThanOrEqual(6);
-    expect(new Set(seen).size).toBe(1); // every buffer used the same size
+    expect(new Set(seen).size).toBe(1);
   });
 
-  it('does not let a cheap unsized statement grow the batch back', async () => {
-    const { userId } = seedBuffer('pace-nogrow', 60);
-    setUserSetting(userId, 'data.retention.lines', 10);
-    const seen = slowDelete(30);
-    const PACED = {
-      ...OPTS,
-      batchRows: 64,
-      minBatchRows: 1,
-      targetStatementMs: 10,
-      maxBatchesPerTick: 4,
-    };
+  it('does not let a SLOW short batch shrink the size', async () => {
+    await warmUpToMaxOn('pace-slowshort-seed');
 
-    await runRetentionTick(PACED); // slow deletes shrink the batch
+    // The terminal deleteNoiseBatch of a user's window matches nothing, so its
+    // LIMIT never trips and it scans the whole time range of an index that has
+    // no user_id — slow for reasons no batch size can change. Shrinking on it
+    // would walk the line-cap sweep down to the floor for free.
+    const seen = mockDelete(() => 30, false);
+    for (let i = 0; i < 6; i++) capped(`pace-slowshort-${i}`, 30);
+    await runRetentionTick(PACED);
+
+    expect(seen.length).toBeGreaterThanOrEqual(6);
+    expect(new Set(seen).size).toBe(1);
+    expect(seen[0]).toBe(64);
+  });
+
+  it('does not let a cheap unsized statement grow the size', async () => {
+    capped('pace-nogrow', 60);
+    await warmUpToMax();
+
+    const seen = mockDelete(() => 30);
+    await runRetentionTick({ ...PACED, maxBatchesPerTick: 4 });
     const shrunk = seen.at(-1)!;
     expect(shrunk).toBeLessThan(64);
 
     // The mocked delete always reports a full batch, so the buffer is still
     // dirty and the next tick re-probes it. That probe is instant and takes no
-    // row limit — it must teach the controller NOTHING, or boot (which seeds
-    // every buffer dirty) re-inflates the batch and the ~800ms block returns.
+    // row limit — it must teach the controller NOTHING.
     seen.length = 0;
-    await runRetentionTick(PACED);
+    await runRetentionTick({ ...PACED, maxBatchesPerTick: 4 });
 
     // Not `shrunk`: the controller halved again after that last statement.
     // A probe that grew it would land ABOVE this, which is the regression.
@@ -796,19 +812,19 @@ describe('pacing', () => {
   });
 
   it('still deletes when the boundary probe alone exhausts the tick budget', async () => {
-    const { userId, bufferId } = seedBuffer('pace-livelock', 30);
-    setUserSetting(userId, 'data.retention.lines', 10);
-    // The probe is O(cap) and cannot be batched. If it can spend the whole
-    // tick budget by itself, a pre-test delete loop runs ZERO times, the
-    // buffer is re-marked dirty, and the next tick repeats it — pruning stops
-    // forever while still blocking the loop every busyDelayMs.
+    const b = seedBuffer('pace-livelock', 30);
+    setUserSetting(b.userId, 'data.retention.lines', 10);
+    // The probe is O(cap) and cannot be batched. If it can spend the whole tick
+    // budget by itself, a pre-test delete loop runs ZERO times, the buffer is
+    // re-marked dirty, and the next tick repeats it — pruning stops forever
+    // while still blocking the loop every busyDelayMs.
     const realBoundary = retentionDb.retentionBoundaryId;
-    vi.spyOn(retentionDb, 'retentionBoundaryId').mockImplementation((b: number, cap: number) => {
+    vi.spyOn(retentionDb, 'retentionBoundaryId').mockImplementation((buf: number, cap: number) => {
       const end = performance.now() + 60;
       while (performance.now() < end) {
         /* a probe that costs more than the whole tick */
       }
-      return realBoundary(b, cap);
+      return realBoundary(buf, cap);
     });
 
     const r = await runRetentionTick({
@@ -821,14 +837,13 @@ describe('pacing', () => {
     });
 
     expect(r.rowsDeleted).toBeGreaterThan(0);
-    expect(rowIds(bufferId).length).toBeLessThan(30);
+    expect(rowIds(b.bufferId).length).toBeLessThan(30);
     expect(r.backlog).toBe(true); // still more to do, but it MOVED
   });
 
   it('ends a tick on elapsed statement time even with batches to spare', async () => {
-    const { userId } = seedBuffer('pace-tick', 30);
-    setUserSetting(userId, 'data.retention.lines', 10);
-    const seen = slowDelete(30);
+    capped('pace-tick', 30);
+    const seen = mockDelete(() => 30);
 
     // 500 batches available, but only ~90ms of statement time allowed: the
     // statement COUNT cannot end this tick, so only the time budget can.

--- a/server/services/retentionSweeper.test.ts
+++ b/server/services/retentionSweeper.test.ts
@@ -43,6 +43,13 @@ afterAll(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
+// The pacing controller is module-global and carried across ticks on purpose,
+// so without this a test inherits whatever size the previous one settled on —
+// silently running at someone else's batch size rather than its own.
+beforeEach(() => {
+  __resetSweepPacing();
+});
+
 // Tiny knobs so the budget/backlog behavior is exercised with dozens of rows,
 // not hundreds of thousands. noiseIntervalMs Infinity keeps the noise clock
 // out of the count-sweep tests; the noise tests pass 0 to force it.
@@ -642,6 +649,11 @@ describe('pacing', () => {
    *  measures, and a mock that returned instantly would prove nothing. */
   function slowDelete(ms: number): number[] {
     const seen: number[] = [];
+    // The first charged statement of a tick is the real boundary probe. Pin it
+    // cheap and constant: otherwise a probe that happens to exceed
+    // targetStatementMs on a loaded CI box halves the batch before the first
+    // delete, and these assertions are about the DELETE path.
+    vi.spyOn(retentionDb, 'retentionBoundaryId').mockReturnValue(1);
     vi.spyOn(retentionDb, 'deleteRetentionBatch').mockImplementation(
       (_b: number, _bound: number, _owner: number, limit: number) => {
         seen.push(limit);
@@ -656,7 +668,9 @@ describe('pacing', () => {
   }
 
   beforeEach(() => {
-    __resetSweepPacing();
+    // Drop dirty buffers left by earlier tests BEFORE seeding this one, so the
+    // deliberately tiny budgets below are spent on the buffer under test.
+    takeDirtyBuffers();
   });
 
   afterEach(() => {
@@ -707,6 +721,64 @@ describe('pacing', () => {
     await runRetentionTick({ ...OPTS, batchRows: 64, maxBatchesPerTick: 5 });
 
     expect(new Set(seen)).toEqual(new Set([64]));
+  });
+
+  it('does not let a cheap unsized statement grow the batch back', async () => {
+    const { userId } = seedBuffer('pace-nogrow', 60);
+    setUserSetting(userId, 'data.retention.lines', 10);
+    const seen = slowDelete(30);
+    const PACED = {
+      ...OPTS,
+      batchRows: 64,
+      minBatchRows: 1,
+      targetStatementMs: 10,
+      maxBatchesPerTick: 4,
+    };
+
+    await runRetentionTick(PACED); // slow deletes shrink the batch
+    const shrunk = seen.at(-1)!;
+    expect(shrunk).toBeLessThan(64);
+
+    // The mocked delete always reports a full batch, so the buffer is still
+    // dirty and the next tick re-probes it. That probe is instant and takes no
+    // row limit — it must teach the controller NOTHING, or boot (which seeds
+    // every buffer dirty) re-inflates the batch and the ~800ms block returns.
+    seen.length = 0;
+    await runRetentionTick(PACED);
+
+    // Not `shrunk`: the controller halved again after that last statement.
+    // A probe that grew it would land ABOVE this, which is the regression.
+    expect(seen[0]).toBe(shrunk / 2);
+  });
+
+  it('still deletes when the boundary probe alone exhausts the tick budget', async () => {
+    const { userId, bufferId } = seedBuffer('pace-livelock', 30);
+    setUserSetting(userId, 'data.retention.lines', 10);
+    // The probe is O(cap) and cannot be batched. If it can spend the whole
+    // tick budget by itself, a pre-test delete loop runs ZERO times, the
+    // buffer is re-marked dirty, and the next tick repeats it — pruning stops
+    // forever while still blocking the loop every busyDelayMs.
+    const realBoundary = retentionDb.retentionBoundaryId;
+    vi.spyOn(retentionDb, 'retentionBoundaryId').mockImplementation((b: number, cap: number) => {
+      const end = performance.now() + 60;
+      while (performance.now() < end) {
+        /* a probe that costs more than the whole tick */
+      }
+      return realBoundary(b, cap);
+    });
+
+    const r = await runRetentionTick({
+      ...OPTS,
+      batchRows: 4,
+      minBatchRows: 4,
+      targetStatementMs: Infinity,
+      maxTickMs: 50, // less than the probe above
+      maxBatchesPerTick: 500,
+    });
+
+    expect(r.rowsDeleted).toBeGreaterThan(0);
+    expect(rowIds(bufferId).length).toBeLessThan(30);
+    expect(r.backlog).toBe(true); // still more to do, but it MOVED
   });
 
   it('ends a tick on elapsed statement time even with batches to spare', async () => {

--- a/server/services/retentionSweeper.test.ts
+++ b/server/services/retentionSweeper.test.ts
@@ -640,11 +640,10 @@ describe('runRetentionTick', () => {
 
 // The 2026-08-28 incident: the statement-count budget assumes each statement is
 // cheap, and on a cold start it is not — one 500-row delete cascading into the
-// FTS triggers blocked the loop for ~800ms a second. These pin the two things
-// that stop a statement count from being the only guard.
-// The 2026-08-28 incident: the statement-count budget assumes each statement is
-// cheap, and on a cold start it is not — one 500-row delete cascading into the
-// FTS triggers blocked the loop for ~800ms a second on a 2.1 GB database.
+// FTS triggers blocked the loop for ~800ms a second on a 2.1 GB database. These
+// pin what makes the measured budget hold: which statements may size the batch,
+// in which direction, and that neither an unbatchable probe nor a finished
+// noise window can spend a tick's time budget on something else.
 describe('pacing', () => {
   /**
    * Replace the delete with one that blocks for `ms(rows)` of REAL synchronous

--- a/server/services/retentionSweeper.test.ts
+++ b/server/services/retentionSweeper.test.ts
@@ -723,6 +723,50 @@ describe('pacing', () => {
     expect(new Set(seen)).toEqual(new Set([64]));
   });
 
+  /** Deletes that return one row SHORT of the batch — the shape that ends a
+   *  buffer's loop — instantly. Records the size each was handed. */
+  function shortDelete(): number[] {
+    const seen: number[] = [];
+    vi.spyOn(retentionDb, 'retentionBoundaryId').mockReturnValue(1);
+    vi.spyOn(retentionDb, 'deleteRetentionBatch').mockImplementation(
+      (_b: number, _bound: number, _owner: number, limit: number) => {
+        seen.push(limit);
+        return Math.max(0, limit - 1); // short: the tail is "done"
+      },
+    );
+    return seen;
+  }
+
+  it('does not let a short batch grow the size back', async () => {
+    const PACED = {
+      ...OPTS,
+      batchRows: 64,
+      minBatchRows: 1,
+      targetStatementMs: 10,
+      maxBatchesPerTick: 4,
+    };
+    const big = seedBuffer('pace-short-big', 60);
+    setUserSetting(big.userId, 'data.retention.lines', 10);
+
+    slowDelete(30);
+    await runRetentionTick(PACED); // full+slow batches shrink the size
+
+    // Now a tickful of buffers that each end on ONE cheap short batch. A short
+    // batch is cheap because it deleted almost nothing, so it proves nothing
+    // about the size — if it grew it, boot (every buffer dirty, most over cap
+    // by a handful of rows) would ratchet straight back to the maximum.
+    vi.restoreAllMocks();
+    const seen = shortDelete();
+    for (let i = 0; i < 6; i++) {
+      const b = seedBuffer(`pace-short-${i}`, 30);
+      setUserSetting(b.userId, 'data.retention.lines', 10);
+    }
+    await runRetentionTick({ ...PACED, maxBatchesPerTick: 100 });
+
+    expect(seen.length).toBeGreaterThanOrEqual(6);
+    expect(new Set(seen).size).toBe(1); // every buffer used the same size
+  });
+
   it('does not let a cheap unsized statement grow the batch back', async () => {
     const { userId } = seedBuffer('pace-nogrow', 60);
     setUserSetting(userId, 'data.retention.lines', 10);

--- a/server/services/retentionSweeper.test.ts
+++ b/server/services/retentionSweeper.test.ts
@@ -811,6 +811,51 @@ describe('pacing', () => {
     expect(seen[0]).toBe(shrunk / 2);
   });
 
+  it('does not enter closed-buffer GC on a tick the noise clock already exhausted', async () => {
+    // outOfBudget() is only consulted at the TOP of the per-user queue loop, so
+    // a noiseStep that finishes its window while blowing maxTickMs would still
+    // be followed by gcStep — whose listing, guaranteed drain and row delete
+    // are exactly the synchronous work the backstop exists to stop.
+    const user = createUser('gc-after-noise');
+    const net = createNetwork(user.id, {
+      name: 'gc-after-noise',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'gc-after-noise',
+    })!;
+    insertMessage({
+      networkId: net.id,
+      target: '#chan',
+      time: new Date(Date.now() - 10 * 24 * 3_600_000).toISOString(),
+      type: 'join',
+      nick: 'someone',
+      text: null,
+      self: false,
+    });
+    setUserSetting(user.id, 'data.retention.event_hours', 24);
+    setUserSetting(user.id, 'data.retention.closed_buffer_days', 7); // GC ON
+
+    // One slow noise statement that returns SHORT: the window is finished (so
+    // noiseStep returns true) but the tick's time budget is gone.
+    vi.spyOn(retentionDb, 'deleteNoiseBatch').mockImplementation(() => {
+      const end = performance.now() + 60;
+      while (performance.now() < end) {
+        /* blow the budget */
+      }
+      return 0;
+    });
+    const gcListing = vi.spyOn(retentionDb, 'listGcEligibleBuffers');
+
+    await runRetentionTick({
+      ...OPTS,
+      noiseIntervalMs: 0,
+      maxTickMs: 20, // less than the noise statement above
+    });
+
+    expect(gcListing).not.toHaveBeenCalled();
+  });
+
   it('still deletes when the boundary probe alone exhausts the tick budget', async () => {
     const b = seedBuffer('pace-livelock', 30);
     setUserSetting(b.userId, 'data.retention.lines', 10);

--- a/server/services/retentionSweeper.ts
+++ b/server/services/retentionSweeper.ts
@@ -121,12 +121,21 @@ const yieldToLoop = () => new Promise<void>((resolve) => setImmediate(resolve));
 //
 // Deliberately module-level, i.e. carried ACROSS ticks: the whole point is
 // that a tick which found the work expensive hands that knowledge to the next
-// one. Reset between tests with `__resetSweepPacing`.
-let adaptedBatchRows = Number.POSITIVE_INFINITY;
+// one. Reset between tests with `resetSweepPacingForTests`.
+//
+// 0 means "nothing measured yet", which pacedBatchRows floors to minBatchRows:
+// start at the FLOOR and earn the way up. Starting at `batchRows` would assume
+// the maximum works, which is the assumption this whole file exists to stop
+// making — and boot re-marks every buffer dirty, so that assumption would be
+// re-made, and paid for, on every single restart.
+// One constant for both the initial value and the reset, so a process start
+// and a test reset can never disagree about what "nothing measured" means.
+const UNMEASURED = 0;
+let adaptedBatchRows = UNMEASURED;
 
 /** Test-only: forget what the last tick learned about statement cost. */
-export function __resetSweepPacing(): void {
-  adaptedBatchRows = Number.POSITIVE_INFINITY;
+export function resetSweepPacingForTests(): void {
+  adaptedBatchRows = UNMEASURED;
 }
 
 /** The batch size to use right now, clamped into the option's own range. */
@@ -167,12 +176,23 @@ function measure<T>(run: () => T): { value: T; ms: number } {
  * it, so the size only grows and pins to `batchRows`.
  */
 function adaptToStatement(opts: RetentionSweepOptions, ms: number, full: boolean): void {
+  // ONLY a full batch says anything about per-row cost, in EITHER direction —
+  // a full batch is row-bound by construction, because the LIMIT is what
+  // stopped the walk.
+  //
+  // A short one is not, and shrinking on it is actively wrong: the terminal
+  // `deleteNoiseBatch` of a user's window matches nothing, so the LIMIT never
+  // trips and it scans the whole [since, cutoff) range of
+  // `idx_messages_noise_time` — an index on (time, buffer_id) with no user_id,
+  // so that range is every OTHER user's noise, the bookmarked rows, and the
+  // entire backlog of anyone with event_hours = 0. It is slow for reasons no
+  // batch size can change, once per user per pass, and letting it shrink would
+  // walk the line-cap sweep down to the floor for free.
+  if (!full) return;
   const current = pacedBatchRows(opts);
   if (ms > opts.targetStatementMs) {
-    // An overrun shrinks whatever the batch was: a SHORT statement that still
-    // blew the budget is the worst news there is about the size.
     adaptedBatchRows = Math.floor(current / 2);
-  } else if (full && ms < opts.targetStatementMs / 2) {
+  } else if (ms < opts.targetStatementMs / 2) {
     // Growth requires a FULL batch. A short one is the last of a buffer or
     // user and is cheap because it deleted almost nothing — it never showed
     // that `rows` rows fit in the budget. Boot seeds every buffer dirty and
@@ -361,8 +381,11 @@ export async function runRetentionTick(
   // trigger per row synchronously. Every statement re-checks the world
   // (state, age, bookmarks — see db/retention.ts), and the user's setting is
   // re-read per buffer so switching GC off mid-tick stops it at the next
-  // buffer. Progress is GUARANTEED per step: the listing and the first drain
-  // batch run even on an exhausted budget (overshooting by ≤2 statements),
+  // buffer. Progress is GUARANTEED per step: the listing, the first drain
+  // batch and the row delete run even on an exhausted budget — an overshoot of
+  // 3 statements, and of maxTickMs by their duration, since the budget is only
+  // consulted between statements. Bounded in practice because the drain uses
+  // the paced batch size, which by then reflects what a statement costs here.
   // otherwise a small budget could be spent entirely on the noise probe and
   // the listing every tick and never reach a drain — a busy-cadence livelock.
   const GC_LIST_LIMIT = 50;

--- a/server/services/retentionSweeper.ts
+++ b/server/services/retentionSweeper.ts
@@ -53,8 +53,22 @@ import settingsService from './settingsService.js';
 import * as systemLog from './systemLog.js';
 
 export interface RetentionSweepOptions {
-  /** Rows per DELETE statement. */
+  /** MAXIMUM rows per DELETE statement. The batch actually used is adapted
+   *  down from here toward `minBatchRows` whenever a statement blocks the loop
+   *  for longer than `targetStatementMs` — see `pacedBatchRows`. */
   batchRows: number;
+  /** Floor for the adapted batch size. Below this the per-statement overhead
+   *  dominates and the sweep stops making useful progress. */
+  minBatchRows: number;
+  /** How long ONE bounded statement may block the event loop before the batch
+   *  size is cut. Infinity disables adaptation (tests, and anyone who wants
+   *  the old fixed-size behaviour). */
+  targetStatementMs: number;
+  /** Total time a tick may spend INSIDE synchronous statements before handing
+   *  the rest to the next one. A backstop on top of `maxBatchesPerTick`, which
+   *  counts statements and so cannot bound a tick whose statements are slow.
+   *  Infinity disables it. */
+  maxTickMs: number;
   /** Bounded statements (boundary probes + delete batches) a single tick may
    *  spend before handing the rest to the next one. */
   maxBatchesPerTick: number;
@@ -70,6 +84,13 @@ export interface RetentionSweepOptions {
 
 export const RETENTION_SWEEP_DEFAULTS: RetentionSweepOptions = {
   batchRows: 500,
+  minBatchRows: 25,
+  // 50ms is the budget for ONE statement, not for the tick: the yields between
+  // statements are what keep sockets breathing, so many short blocks are fine
+  // where one long one is not. Sized against the ~120s IRC ping timeout with
+  // three orders of magnitude to spare.
+  targetStatementMs: 50,
+  maxTickMs: 1000,
   maxBatchesPerTick: 20,
   idleDelayMs: 60 * 1000,
   busyDelayMs: 5 * 1000,
@@ -89,6 +110,53 @@ export interface RetentionTickResult {
 }
 
 const yieldToLoop = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+// ─── Pacing ────────────────────────────────────────────────────────────────
+// The budget above counts STATEMENTS, which silently assumes each one is
+// cheap. On a cold start it is not: a first noise pass walks a user's history
+// from epoch, and a 500-row delete cascading into the FTS triggers blocked the
+// loop for ~800ms a second on a 2.1 GB hosted database (2026-08-28). The
+// statement count cannot express that — so measure the block and shrink the
+// batch until it fits, then grow back while it does.
+//
+// Deliberately module-level, i.e. carried ACROSS ticks: the whole point is
+// that a tick which found the work expensive hands that knowledge to the next
+// one. Reset between tests with `__resetSweepPacing`.
+let adaptedBatchRows = Number.POSITIVE_INFINITY;
+
+/** Test-only: forget what the last tick learned about statement cost. */
+export function __resetSweepPacing(): void {
+  adaptedBatchRows = Number.POSITIVE_INFINITY;
+}
+
+/** The batch size to use right now, clamped into the option's own range. */
+function pacedBatchRows(opts: RetentionSweepOptions): number {
+  return Math.max(opts.minBatchRows, Math.min(opts.batchRows, adaptedBatchRows));
+}
+
+/**
+ * Run one bounded statement, charging what it cost to the tick and feeding the
+ * measurement back into the batch size. Halve on an overrun, step back up
+ * gently when we are inside budget — slow to trust, quick to back off, so a
+ * single expensive buffer cannot re-saturate the loop for a whole tick.
+ */
+function timedStatement<T>(opts: RetentionSweepOptions, run: () => T): { value: T; ms: number } {
+  const started = performance.now();
+  const value = run();
+  const ms = performance.now() - started;
+  // Both bounds live in pacedBatchRows, which is the only reader — clamping
+  // here too would mean two places to get the range right, and a mutation to
+  // either one would leave the behaviour unchanged and untestable.
+  // A targetStatementMs of Infinity needs no special case: nothing can overrun
+  // it, so the size only ever grows and pins to `batchRows`.
+  const current = pacedBatchRows(opts);
+  if (ms > opts.targetStatementMs) {
+    adaptedBatchRows = Math.floor(current / 2);
+  } else if (ms < opts.targetStatementMs / 2) {
+    adaptedBatchRows = Math.max(current + 1, Math.ceil(current * 1.25));
+  }
+  return { value, ms };
+}
 
 // Noise-clock scheduling state. `lastNoiseSweepMs = 0` makes the first tick
 // after boot start a pass; the settings listener forces one with -Infinity
@@ -139,12 +207,23 @@ export async function runRetentionTick(
   // Per-tick cap cache: one settings read per owner, not per buffer.
   const capByUser = new Map<number, number>();
   let batchesSpent = 0;
+  // Time spent INSIDE statements, not wall-clock: the awaits between them are
+  // exactly what we are trying to leave room for, so they must not count.
+  let syncMsSpent = 0;
+  const outOfBudget = (): boolean =>
+    batchesSpent >= opts.maxBatchesPerTick || syncMsSpent >= opts.maxTickMs;
+  const charge = <T>(run: () => T): T => {
+    const { value, ms } = timedStatement(opts, run);
+    syncMsSpent += ms;
+    batchesSpent++;
+    return value;
+  };
 
   const pending = takeDirtyBuffers();
   for (let i = 0; i < pending.length; i++) {
     const bufferId = pending[i];
     try {
-      if (batchesSpent >= opts.maxBatchesPerTick) {
+      if (outOfBudget()) {
         // Out of budget — put the rest back for the (soon) next tick.
         markBufferDirty(bufferId);
         result.backlog = true;
@@ -168,19 +247,18 @@ export async function runRetentionTick(
 
       // The OFFSET walk is O(cap) index entries — real work, charged like a
       // delete batch.
-      const boundaryId = retentionBoundaryId(bufferId, cap);
-      batchesSpent++;
+      const boundaryId = charge(() => retentionBoundaryId(bufferId, cap));
       if (boundaryId === undefined) continue; // within cap
 
       // "Done" is a short delete batch, NOT an exhausted budget: keying the
       // re-mark on the budget livelocks — with a small budget every capped
       // buffer ends its visit at the limit and reports a backlog forever.
       let tailDone = false;
-      while (batchesSpent < opts.maxBatchesPerTick) {
-        const deleted = deleteRetentionBatch(bufferId, boundaryId, ownerId, opts.batchRows);
-        batchesSpent++;
+      while (!outOfBudget()) {
+        const rows = pacedBatchRows(opts);
+        const deleted = charge(() => deleteRetentionBatch(bufferId, boundaryId, ownerId, rows));
         result.rowsDeleted += deleted;
-        if (deleted < opts.batchRows) {
+        if (deleted < rows) {
           tailDone = true; // (or only bookmarks left below the boundary)
           break;
         }
@@ -217,12 +295,12 @@ export async function runRetentionTick(
     const cutoffIso = new Date(Date.now() - hours * 3_600_000).toISOString();
     const sinceIso = getNoiseCursor(userId);
     if (sinceIso >= cutoffIso) return true; // nothing has aged past the cutoff since last pass
-    while (batchesSpent < opts.maxBatchesPerTick) {
+    while (!outOfBudget()) {
       await yieldToLoop();
-      const deleted = deleteNoiseBatch(userId, sinceIso, cutoffIso, opts.batchRows);
-      batchesSpent++;
+      const rows = pacedBatchRows(opts);
+      const deleted = charge(() => deleteNoiseBatch(userId, sinceIso, cutoffIso, rows));
       result.noiseRowsDeleted += deleted;
-      if (deleted < opts.batchRows) {
+      if (deleted < rows) {
         // Window clear (survivors are bookmarked). Compare-and-advance, not a
         // blind set: an insert-side rewind can land during the awaits above,
         // and this pass's window never covered it.
@@ -248,8 +326,8 @@ export async function runRetentionTick(
     for (;;) {
       const days = effectiveClosedBufferDays(userId);
       if (days <= 0) return true; // GC off for this user
-      const eligible = listGcEligibleBuffers(userId, days, GC_LIST_LIMIT);
-      batchesSpent++; // the listing (with its bookmark subquery) is a real statement
+      // the listing (with its bookmark subquery) is a real statement
+      const eligible = charge(() => listGcEligibleBuffers(userId, days, GC_LIST_LIMIT));
       if (eligible.length === 0) return true;
       for (const bufferId of eligible) {
         const daysNow = effectiveClosedBufferDays(userId);
@@ -257,20 +335,21 @@ export async function runRetentionTick(
         let drained = false;
         do {
           await yieldToLoop();
-          const deleted = drainBufferBatch(userId, bufferId, daysNow, opts.batchRows);
-          batchesSpent++;
+          const rows = pacedBatchRows(opts);
+          const deleted = charge(() => drainBufferBatch(userId, bufferId, daysNow, rows));
           result.gcRowsDeleted += deleted;
-          if (deleted < opts.batchRows) {
+          if (deleted < rows) {
             drained = true; // empty — or reopened / re-closed / bookmarked, all refused below
             break;
           }
-        } while (batchesSpent < opts.maxBatchesPerTick);
+        } while (!outOfBudget());
         if (!drained) return false; // budget died mid-drain; re-listed next pass
-        batchesSpent++; // the row delete cascades into eight tables — real work
-        if (gcDeleteClosedBuffer(userId, bufferId, daysNow)) result.buffersCollected++;
+        // the row delete cascades into eight tables — real work
+        if (charge(() => gcDeleteClosedBuffer(userId, bufferId, daysNow)))
+          result.buffersCollected++;
         // A refusal (reopened, re-closed recently, or a bookmark landed) is
         // simply left alone; the next pass re-derives eligibility from scratch.
-        if (batchesSpent >= opts.maxBatchesPerTick) return false; // user stays at head
+        if (outOfBudget()) return false; // user stays at head
       }
       if (eligible.length < GC_LIST_LIMIT) return true; // that was everything
     }
@@ -278,7 +357,7 @@ export async function runRetentionTick(
 
   if (noisePendingUsers !== null || Date.now() - lastNoiseSweepMs >= opts.noiseIntervalMs) {
     if (noisePendingUsers === null) noisePendingUsers = listUserIds();
-    while (noisePendingUsers.length > 0 && batchesSpent < opts.maxBatchesPerTick) {
+    while (noisePendingUsers.length > 0 && !outOfBudget()) {
       const userId = noisePendingUsers[0];
       if (!(await noiseStep(userId))) break;
       if (!(await gcStep(userId))) break;

--- a/server/services/retentionSweeper.ts
+++ b/server/services/retentionSweeper.ts
@@ -429,6 +429,13 @@ export async function runRetentionTick(
     while (noisePendingUsers.length > 0 && !outOfBudget()) {
       const userId = noisePendingUsers[0];
       if (!(await noiseStep(userId))) break;
+      // Re-check between the two: noiseStep can finish its window (returning
+      // true) on the statement that spent the rest of the budget, and gcStep's
+      // listing + guaranteed drain + row delete is exactly the synchronous work
+      // maxTickMs exists to stop. The user stays at the head, so their GC runs
+      // first thing next tick — by which point their noise window is clear and
+      // noiseStep is cheap.
+      if (outOfBudget()) break;
       if (!(await gcStep(userId))) break;
       noisePendingUsers.shift();
     }

--- a/server/services/retentionSweeper.ts
+++ b/server/services/retentionSweeper.ts
@@ -166,11 +166,19 @@ function measure<T>(run: () => T): { value: T; ms: number } {
  * A targetStatementMs of Infinity needs no special case: nothing can overrun
  * it, so the size only grows and pins to `batchRows`.
  */
-function adaptToStatement(opts: RetentionSweepOptions, ms: number): void {
+function adaptToStatement(opts: RetentionSweepOptions, ms: number, full: boolean): void {
   const current = pacedBatchRows(opts);
   if (ms > opts.targetStatementMs) {
+    // An overrun shrinks whatever the batch was: a SHORT statement that still
+    // blew the budget is the worst news there is about the size.
     adaptedBatchRows = Math.floor(current / 2);
-  } else if (ms < opts.targetStatementMs / 2) {
+  } else if (full && ms < opts.targetStatementMs / 2) {
+    // Growth requires a FULL batch. A short one is the last of a buffer or
+    // user and is cheap because it deleted almost nothing — it never showed
+    // that `rows` rows fit in the budget. Boot seeds every buffer dirty and
+    // most are over cap by a handful of rows, so counting those would be one
+    // growth step each and no shrink steps: ~14 small buffers would ratchet
+    // 25 back to 500 and hand the next big buffer the ~800ms block again.
     adaptedBatchRows = Math.max(current + 1, Math.ceil(current * 1.25));
   }
 }
@@ -227,12 +235,14 @@ export async function runRetentionTick(
     batchesSpent++;
     return value;
   };
-  // Charge the tick AND size the next batch from what this one cost.
-  const chargeSized = <T>(run: () => T): T => {
+  // Charge the tick AND size the next batch from what this one cost. Every
+  // caller is a row-limited delete returning how many rows it removed, so
+  // `deleted >= rows` is what "the batch was full" means.
+  const chargeSized = (rows: number, run: () => number): number => {
     const { value, ms } = measure(run);
     syncMsSpent += ms;
     batchesSpent++;
-    adaptToStatement(opts, ms);
+    adaptToStatement(opts, ms, value >= rows);
     return value;
   };
 
@@ -278,8 +288,14 @@ export async function runRetentionTick(
       // overshoot of one statement (the same trade gcStep's drain makes).
       let tailDone = false;
       do {
+        // Yield FIRST, like every other guaranteed-progress loop here. The
+        // probe above is the one statement the batch size cannot shrink, and
+        // the delete below now runs even when that probe alone spent the whole
+        // budget — without this the two are one unbroken block, and maxTickMs
+        // cannot help because it is only consulted between statements.
+        await yieldToLoop();
         const rows = pacedBatchRows(opts);
-        const deleted = chargeSized(() =>
+        const deleted = chargeSized(rows, () =>
           deleteRetentionBatch(bufferId, boundaryId, ownerId, rows),
         );
         result.rowsDeleted += deleted;
@@ -287,7 +303,6 @@ export async function runRetentionTick(
           tailDone = true; // (or only bookmarks left below the boundary)
           break;
         }
-        await yieldToLoop();
       } while (!outOfBudget());
       if (!tailDone) {
         // Budget died mid-buffer — re-check soon.
@@ -327,7 +342,7 @@ export async function runRetentionTick(
     do {
       await yieldToLoop();
       const rows = pacedBatchRows(opts);
-      const deleted = chargeSized(() => deleteNoiseBatch(userId, sinceIso, cutoffIso, rows));
+      const deleted = chargeSized(rows, () => deleteNoiseBatch(userId, sinceIso, cutoffIso, rows));
       result.noiseRowsDeleted += deleted;
       if (deleted < rows) {
         // Window clear (survivors are bookmarked). Compare-and-advance, not a
@@ -365,7 +380,9 @@ export async function runRetentionTick(
         do {
           await yieldToLoop();
           const rows = pacedBatchRows(opts);
-          const deleted = chargeSized(() => drainBufferBatch(userId, bufferId, daysNow, rows));
+          const deleted = chargeSized(rows, () =>
+            drainBufferBatch(userId, bufferId, daysNow, rows),
+          );
           result.gcRowsDeleted += deleted;
           if (deleted < rows) {
             drained = true; // empty — or reopened / re-closed / bookmarked, all refused below

--- a/server/services/retentionSweeper.ts
+++ b/server/services/retentionSweeper.ts
@@ -53,16 +53,19 @@ import settingsService from './settingsService.js';
 import * as systemLog from './systemLog.js';
 
 export interface RetentionSweepOptions {
-  /** MAXIMUM rows per DELETE statement. The batch actually used is adapted
-   *  down from here toward `minBatchRows` whenever a statement blocks the loop
-   *  for longer than `targetStatementMs` — see `pacedBatchRows`. */
+  /** CEILING on the rows per DELETE statement — not the size used. The sweep
+   *  starts at `minBatchRows` and climbs toward this while full batches stay
+   *  inside `targetStatementMs`, halving back down when one does not. See
+   *  `pacedBatchRows`. */
   batchRows: number;
-  /** Floor for the adapted batch size. Below this the per-statement overhead
-   *  dominates and the sweep stops making useful progress. */
+  /** Both the floor for the adapted size AND where a cold process starts:
+   *  nothing has been measured yet, so assume the least. Below this the
+   *  per-statement overhead dominates and the sweep stops making progress. */
   minBatchRows: number;
-  /** How long ONE bounded statement may block the event loop before the batch
-   *  size is cut. Infinity disables adaptation (tests, and anyone who wants
-   *  the old fixed-size behaviour). */
+  /** How long one FULL batch may block the event loop before the size is
+   *  halved. Only full batches count, in either direction — see
+   *  `adaptToStatement`. Infinity means nothing can ever overrun, so the size
+   *  only climbs and pins at `batchRows`. */
   targetStatementMs: number;
   /** Total time a tick may spend INSIDE synchronous statements before handing
    *  the rest to the next one. A backstop on top of `maxBatchesPerTick`, which

--- a/server/services/retentionSweeper.ts
+++ b/server/services/retentionSweeper.ts
@@ -131,42 +131,50 @@ export function __resetSweepPacing(): void {
 
 /** The batch size to use right now, clamped into the option's own range. */
 function pacedBatchRows(opts: RetentionSweepOptions): number {
-  return Math.max(opts.minBatchRows, Math.min(opts.batchRows, adaptedBatchRows));
+  // The ceiling wins a contradictory pair: `batchRows` is documented as the
+  // MAXIMUM, so a floor above it must not silently raise the batch past it.
+  // And never 0 — a zero-row delete removes nothing while still costing a
+  // charged statement, and `deleted < rows` (0 < 0) is false, so the loop
+  // would not even recognise it as a short batch.
+  const floor = Math.max(1, Math.min(opts.minBatchRows, opts.batchRows));
+  return Math.max(floor, Math.min(opts.batchRows, adaptedBatchRows));
+}
+
+/** Run a statement, reporting how long it blocked the loop. */
+function measure<T>(run: () => T): { value: T; ms: number } {
+  const started = performance.now();
+  const value = run();
+  return { value, ms: performance.now() - started };
 }
 
 /**
- * Run one bounded statement, charging what it cost to the tick and feeding the
- * measurement back into the batch size. Halve on an overrun, step back up
- * gently when we are inside budget — slow to trust, quick to back off, so a
- * single expensive buffer cannot re-saturate the loop for a whole tick.
+ * Feed ONE row-limited statement's cost back into the batch size. Halve on an
+ * overrun, step back up gently when inside budget — slow to trust, quick to
+ * back off, so a single expensive buffer cannot re-saturate the loop.
+ *
+ * Only ever called for statements whose cost is a function of `rows`. The
+ * boundary probe (O(cap)), the GC listing (fixed limit) and the closed-buffer
+ * delete take no row limit, so shrinking the batch cannot make them cheaper:
+ * letting them shrink it punishes the delete path for a cost it cannot
+ * reduce, and — the one that defeats the whole fix — letting a FAST one grow
+ * it proves nothing about delete cost. Boot seeds every buffer dirty, so a
+ * handful of quick within-cap probes would otherwise re-inflate the batch to
+ * the maximum before the noise pass ran, and the ~800ms block would be back.
+ *
+ * Both bounds live in pacedBatchRows, the only reader — clamping here too
+ * would leave a mutation to either one behaviour-neutral, i.e. untestable.
+ * A targetStatementMs of Infinity needs no special case: nothing can overrun
+ * it, so the size only grows and pins to `batchRows`.
  */
-function timedStatement<T>(opts: RetentionSweepOptions, run: () => T): { value: T; ms: number } {
-  const started = performance.now();
-  const value = run();
-  const ms = performance.now() - started;
-  // Both bounds live in pacedBatchRows, which is the only reader — clamping
-  // here too would mean two places to get the range right, and a mutation to
-  // either one would leave the behaviour unchanged and untestable.
-  // A targetStatementMs of Infinity needs no special case: nothing can overrun
-  // it, so the size only ever grows and pins to `batchRows`.
+function adaptToStatement(opts: RetentionSweepOptions, ms: number): void {
   const current = pacedBatchRows(opts);
   if (ms > opts.targetStatementMs) {
     adaptedBatchRows = Math.floor(current / 2);
   } else if (ms < opts.targetStatementMs / 2) {
     adaptedBatchRows = Math.max(current + 1, Math.ceil(current * 1.25));
   }
-  return { value, ms };
 }
 
-// Noise-clock scheduling state. `lastNoiseSweepMs = 0` makes the first tick
-// after boot start a pass; the settings listener forces one with -Infinity
-// (due under ANY interval, Infinity included). `noisePendingUsers` is the
-// pass's cursor ACROSS ticks: a budget-exhausted tick leaves the unfinished
-// user at the head and the next tick resumes there — without it the pass
-// restarts from the first user every tick, and once noise-enabled users
-// outnumber the budget the tail is never reached and the sweeper busy-loops
-// forever (the same livelock class the count sweep's drained dirty set
-// exists to prevent).
 let lastNoiseSweepMs = 0;
 let noisePendingUsers: number[] | null = null;
 // A settings change that lands while a pass is mid-flight asks for a fresh
@@ -212,10 +220,19 @@ export async function runRetentionTick(
   let syncMsSpent = 0;
   const outOfBudget = (): boolean =>
     batchesSpent >= opts.maxBatchesPerTick || syncMsSpent >= opts.maxTickMs;
+  // Charge the tick, but teach the controller nothing: see adaptToStatement.
   const charge = <T>(run: () => T): T => {
-    const { value, ms } = timedStatement(opts, run);
+    const { value, ms } = measure(run);
     syncMsSpent += ms;
     batchesSpent++;
+    return value;
+  };
+  // Charge the tick AND size the next batch from what this one cost.
+  const chargeSized = <T>(run: () => T): T => {
+    const { value, ms } = measure(run);
+    syncMsSpent += ms;
+    batchesSpent++;
+    adaptToStatement(opts, ms);
     return value;
   };
 
@@ -253,17 +270,25 @@ export async function runRetentionTick(
       // "Done" is a short delete batch, NOT an exhausted budget: keying the
       // re-mark on the budget livelocks — with a small budget every capped
       // buffer ends its visit at the limit and reports a backlog forever.
+      // do/while, NOT while: the probe above is O(cap) and unbatchable, so on
+      // a large cap it can spend the whole tick budget by itself. A pre-test
+      // loop would then run zero times, re-mark the buffer dirty and repeat
+      // the same probe every busyDelayMs — blocking the loop forever while
+      // deleting nothing. Progress per visit is guaranteed instead, at an
+      // overshoot of one statement (the same trade gcStep's drain makes).
       let tailDone = false;
-      while (!outOfBudget()) {
+      do {
         const rows = pacedBatchRows(opts);
-        const deleted = charge(() => deleteRetentionBatch(bufferId, boundaryId, ownerId, rows));
+        const deleted = chargeSized(() =>
+          deleteRetentionBatch(bufferId, boundaryId, ownerId, rows),
+        );
         result.rowsDeleted += deleted;
         if (deleted < rows) {
           tailDone = true; // (or only bookmarks left below the boundary)
           break;
         }
         await yieldToLoop();
-      }
+      } while (!outOfBudget());
       if (!tailDone) {
         // Budget died mid-buffer — re-check soon.
         markBufferDirty(bufferId);
@@ -295,10 +320,14 @@ export async function runRetentionTick(
     const cutoffIso = new Date(Date.now() - hours * 3_600_000).toISOString();
     const sinceIso = getNoiseCursor(userId);
     if (sinceIso >= cutoffIso) return true; // nothing has aged past the cutoff since last pass
-    while (!outOfBudget()) {
+    // do/while for the same reason as the count sweep above: this step is
+    // only entered with budget left, and it must delete at least one batch
+    // when it is, or a user whose turn always begins on an exhausted budget
+    // never progresses.
+    do {
       await yieldToLoop();
       const rows = pacedBatchRows(opts);
-      const deleted = charge(() => deleteNoiseBatch(userId, sinceIso, cutoffIso, rows));
+      const deleted = chargeSized(() => deleteNoiseBatch(userId, sinceIso, cutoffIso, rows));
       result.noiseRowsDeleted += deleted;
       if (deleted < rows) {
         // Window clear (survivors are bookmarked). Compare-and-advance, not a
@@ -307,7 +336,7 @@ export async function runRetentionTick(
         advanceNoiseCursor(userId, sinceIso, cutoffIso);
         return true;
       }
-    }
+    } while (!outOfBudget());
     return false; // budget died mid-user
   };
 
@@ -336,7 +365,7 @@ export async function runRetentionTick(
         do {
           await yieldToLoop();
           const rows = pacedBatchRows(opts);
-          const deleted = charge(() => drainBufferBatch(userId, bufferId, daysNow, rows));
+          const deleted = chargeSized(() => drainBufferBatch(userId, bufferId, daysNow, rows));
           result.gcRowsDeleted += deleted;
           if (deleted < rows) {
             drained = true; // empty — or reopened / re-closed / bookmarked, all refused below


### PR DESCRIPTION
Follow-up to the 2026-08-28 hosted incident, and a prerequisite for enabling `LURKER_MAX_RETENTION_LINES` anywhere populated.

## The problem

The tick budget counts **statements**, which quietly assumes each one is cheap. On a cold start it isn't. Shipping 2.2.0 to a cell had the noise clock's first pass walk every user's history from epoch — a 500-row delete cascading into the FTS triggers blocked the event loop for **~800ms about once a second** on a 2.1 GB database.

That cascaded: Litestream could never win the write lock to checkpoint (`checkpoint: mode=PASSIVE err=database is locked` on repeat), the WAL grew to 808 MB, and a large WAL makes every read slower — which keeps the connection busy, which keeps Litestream losing. It does not clear on its own, and restarting doesn't help: nothing checkpoints on shutdown and `seedAllBuffersDirty()` re-marks every buffer on boot.

`maxBatchesPerTick: 20` is no guard at all when one statement is 800ms.

## The fix

Measure the block instead of counting statements:

- **`targetStatementMs`** (50ms) — the budget for *one* statement. Overrun halves the batch; comfortably inside it grows back. Slow to trust, quick to back off, so a single expensive buffer can't re-saturate the loop for a whole tick. **`minBatchRows`** (25) is the floor.
- **`maxTickMs`** (1s) — bounds time spent *inside* statements, the backstop a statement count can't provide. Wall clock isn't charged: the `setImmediate` yields between statements are exactly what's being protected.

50ms is deliberately per-statement rather than per-tick — the yields are what keep sockets breathing, so many short blocks are fine where one long one is not.

This is the mechanism the file header already described (*"the exact event-loop-starvation class the connect snapshot already had an incident with"*). It was only ever calibrated in statements.

## Why this unblocks the line cap

Setting `LURKER_MAX_RETENTION_LINES` is the same cold start from the other direction: `clampToCeiling` makes every user's effective cap nonzero at once, and boot marks every buffer dirty, so every buffer pays an `OFFSET cap` probe plus mass deletes. Pacing covers it without needing to know which path is cold.

**Known remaining cost, not addressed here:** the boundary probe is `O(cap)` in one statement and can't be batched, so a very large cap still means one slowish probe per tick. It's now bounded to roughly one per tick instead of twenty, and the operator chooses `cap`.

## Verification

Four new tests, **each mutation-checked to fail when its behaviour is broken** — no shrink on overrun, no `minBatchRows` floor, no `batchRows` cap, no time budget. The mocked statement burns real synchronous time, since that's what the sweeper measures; a mock returning instantly would prove nothing.

Both bounds live in `pacedBatchRows` alone. Clamping in the adjust path as well left mutations to either one behaviour-neutral — the first mutation round caught exactly that and it was collapsed.

The existing 24 tests opt out via `Infinity`, so they keep asserting the statement-count budget rather than the speed of the CI box. Making the new knobs required fields forced that opt-out to be explicit rather than inherited.

`npm run check` clean; full suite **306 files / 4363 tests** (up 4).

---

## Measured on a synthetic 2 GB database

Built **7.2M rows / 1.9 GB** through the app's own `db/index.ts`, so the partial noise index and the FTS triggers are the real ones: 6 users × 10 buffers × 120k rows, 70% presence noise, spread over a year so a 168h cutoff leaves a real cold-start backlog. `seedAllBuffersDirty()` first, as boot does.

The pre-PR behaviour is reachable purely through options — `minBatchRows: batchRows` pins the batch at 500 and `targetStatementMs: Infinity` disables adaptation — so both arms are **the same code on the same data**, differing only in configuration. Each runs in its own process on its own copy. Stalls are `monitorEventLoopDelay`, the same native histogram the app's own stall detector uses.

**Noise-clock cold start, in a container at 1 CPU / 1 GB (droplet-like):**

| | legacy | paced | |
|---|---|---|---|
| stall max | 337ms | **65ms** | 5.2× |
| stall p99 | 335ms | **53ms** | 6.3× |
| stall p50 | 106ms | **27ms** | 3.9× |
| throughput | 3,677 rows/s | **4,680 rows/s** | +27% |

**Same thing unconstrained** (fast laptop, whole DB in page cache): legacy 469 / 214 / 90ms at 4,462 rows/s; paced 87 / 54 / 40ms at 2,877 rows/s.

Two results worth stating plainly:

- **The controller holds its target regardless of machine.** p99 is 53ms constrained and 54ms unconstrained, against a 50ms goal — the target is wall-clock, so a slower box gets smaller batches rather than longer stalls. Legacy instead *degrades* on the slower box, 214ms → 335ms p99.
- **The throughput concern does not survive measurement.** It costs 35% on a machine that caches the entire database, and *gains* 27% on a constrained one, where smaller batches finish sooner and contend less.

**Also measured, and it corrects a claim in this PR's own description:** the line-cap path is the *cheap* one. At a 10,000-line cap both arms sit at ~40ms and are indistinguishable — a line-cap delete is buffer-scoped and contiguous, ~11× cheaper per row than the noise delete, which scans a time index shared across all users. At a 100k cap paced showed a slightly worse max (78ms vs 51ms) but better p99 (36 vs 47); the unbatchable `OFFSET` probe is the floor there, as documented above.

**Limits, stated honestly:** this does not reproduce the incident's 800ms, which came from an 808 MB WAL amplifying every page lookup on top of the live database; a freshly generated file with a truncated WAL gives 469ms unconstrained and 337ms constrained. The *ratio* between arms is the trustworthy part, not the absolute figure. 1 CPU / 1 GB is an approximation of a cell, not a measurement of one.