### PR TITLE
Test: wait for the wire, not a clock, in the engine re-attach test

### DIFF
--- a/server/services/engineIntegration.test.ts
+++ b/server/services/engineIntegration.test.ts
@@ -132,7 +132,7 @@ describe('IrcConnection through the engine', () => {
     // MODE #stay as a fourth #stay state line on re-attach). The socket is
     // ordered, so a landed WHO #gone implies everything before it landed.
     await until(
-      () => sentBy('lurk').filter((l) => /^WHO #(stay|gone)$/.test(l)).length >= 2,
+      () => ['WHO #stay', 'WHO #gone'].every((l) => sentBy('lurk').includes(l)),
       5000,
       'join MODEs and WHOs on the wire',
     );
@@ -209,7 +209,7 @@ describe('IrcConnection through the engine', () => {
     // No registration, no connect command, no JOIN of the autojoin list.
     expect(ircd.registrations.filter((r) => r.nick === 'lurk')).toHaveLength(1);
     expect(since().some((l) => /^(NICK|USER|CAP|JOIN) /.test(l))).toBe(false);
-    expect(stateRequests()).toHaveLength(3);
+    expect(stateRequests().sort()).toEqual(['MODE #stay', 'NAMES #stay', 'TOPIC #stay']);
     expect(since().filter((l) => l === 'PING connectcmd')).toHaveLength(0);
     expect(ircd.client('lurk')!.channels.has('#gone')).toBe(false);
   }, 30000);

--- a/server/services/engineIntegration.test.ts
+++ b/server/services/engineIntegration.test.ts
@@ -124,6 +124,19 @@ describe('IrcConnection through the engine', () => {
     expect(ircd.registrations.filter((r) => r.nick === 'lurk')).toHaveLength(1);
     expect(stateEvents(events)).toContain('connected');
 
+    // A join provokes MODE #chan (the join handler) and, after 366, WHO #chan
+    // (away sync) — and the WHOs go out one at a time, the second a round trip
+    // after the first. They are still crossing app → link → engine → ircd when
+    // the joins are seen here; let the LAST of them land before the wire is
+    // sampled, or it counts as sent by the dead process below (and a late
+    // MODE #stay as a fourth #stay state line on re-attach). The socket is
+    // ordered, so a landed WHO #gone implies everything before it landed.
+    await until(
+      () => sentBy('lurk').filter((l) => /^WHO #(stay|gone)$/.test(l)).length >= 2,
+      5000,
+      'join MODEs and WHOs on the wire',
+    );
+
     // The app "shuts down": detach, never QUIT.
     rowsBeforeDetach = rows().length;
     sentBeforeDetach = sentBy('lurk').length;
@@ -133,7 +146,7 @@ describe('IrcConnection through the engine', () => {
     expect(ircd.client('lurk')).toBeDefined();
     // Nothing more went to the wire from the dead process — in particular no QUIT.
     expect(sentBy('lurk').slice(sentBeforeDetach)).toEqual([]);
-  }, 20000);
+  }, 30000);
 
   it('a new IrcConnection re-attaches with no new history and no re-registration', async () => {
     // Life while the app is away.
@@ -148,14 +161,13 @@ describe('IrcConnection through the engine', () => {
     expect(conn).toBeTruthy();
     await until(() => conn.state === 'connected', 5000, 'reattached');
     await until(() => rows().length >= rowsBeforeDetach + 3, 5000, 'backlog persisted');
-    await new Promise((r) => setTimeout(r, 50));
 
     // The gap's messages — the deterministic part — persisted once each, in
     // order, with no re-registration and no duplication. (Two things here are
     // deliberately NOT pinned, because they race on a sub-second window and are
-    // covered elsewhere: whether the restore re-requests channel state and
-    // surfaces transient MODE/WHO `motd` rows, exactly as a normal reconnect
-    // does; and whether the self-KICK for #gone persists a row, which depends on
+    // covered elsewhere: whether the restore's MODE/WHO replies surface as
+    // transient `motd` rows, exactly as a normal reconnect's do; and whether
+    // the self-KICK for #gone persists a row, which depends on
     // whether the engine had already reconciled #gone out of the replay when the
     // app attached. What must never happen — the #829 property — is a duplicate.)
     const added = rows().slice(rowsBeforeDetach);
@@ -179,19 +191,28 @@ describe('IrcConnection through the engine', () => {
     expect(stateEvents(managerEvents)).toContain('connected');
     expect(stateEvents(managerEvents)).not.toContain('disconnected');
 
+    // The wire. The restore's channel-state requests go out the instant the
+    // replay ends, but "went out" here means what the ircd RECEIVED, three
+    // socket hops (app → link → engine → ircd) later — so wait for them, not a
+    // clock. Then, once `live` has run its callbacks (the manager's rejoin),
+    // say something: the PRIVMSG is written after anything a regression could
+    // have written — a JOIN at `live`, a re-run connect command — on the same
+    // ordered socket, so its arrival bounds the negative checks below.
+    const since = () => sentBy('lurk').slice(sentBeforeDetach);
+    const stateRequests = () => since().filter((l) => /^(MODE|NAMES|TOPIC) #stay$/.test(l));
+    await until(() => stateRequests().length >= 3, 5000, 'channel-state requests on the wire');
+    await until(() => !conn.catchingUp, 5000, 'live');
+    conn.say('#stay', 'back');
+    await ircd.waitForLine((l) => /^PRIVMSG #stay :?back$/.test(l));
+
     // The network saw: MODE/NAMES/TOPIC for the synthesised join, nothing else.
     // No registration, no connect command, no JOIN of the autojoin list.
     expect(ircd.registrations.filter((r) => r.nick === 'lurk')).toHaveLength(1);
-    const since = sentBy('lurk').slice(sentBeforeDetach);
-    expect(since.some((l) => /^(NICK|USER|CAP|JOIN) /.test(l))).toBe(false);
-    expect(since.filter((l) => /^(MODE|NAMES|TOPIC) #stay$/.test(l))).toHaveLength(3);
-    expect(since.filter((l) => l === 'PING connectcmd')).toHaveLength(0);
+    expect(since().some((l) => /^(NICK|USER|CAP|JOIN) /.test(l))).toBe(false);
+    expect(stateRequests()).toHaveLength(3);
+    expect(since().filter((l) => l === 'PING connectcmd')).toHaveLength(0);
     expect(ircd.client('lurk')!.channels.has('#gone')).toBe(false);
-
-    // And it is a working connection.
-    conn.say('#stay', 'back');
-    await ircd.waitForLine((l) => /^PRIVMSG #stay :?back$/.test(l));
-  }, 20000);
+  }, 30000);
 
   it('losing the link to the engine re-attaches without a disconnect', async () => {
     const conn = ircManager.getConnection(userId, network.id)!;


### PR DESCRIPTION
## Why

CI on #861 (run 33190587101) failed `engineIntegration.test.ts › a new IrcConnection re-attaches with no new history and no re-registration` with `expected [] to have a length of 3 but got +0` — the three `MODE/NAMES/TOPIC #stay` requests had not reached the fake ircd. Main was green all day; the PR touched no server code. Pre-existing timing flake.

## Mechanism

The test waited for the replayed backlog **rows** and then a fixed 50 ms before asserting what the ircd **received**. The requests are written the instant the replay ends (`engineTransport` emits `restored` right after the replay lines — `engineTransport.ts:331-346` — and `restoreGate.pump()` grants the first step synchronously), but "received" is three socket hops later — app → link → engine → ircd — on one shared event loop that CI load starves. No fixed sleep bounds that.

## What

`server/services/engineIntegration.test.ts` only:
- the assertion now waits `until` the three lines are on the wire (a step that never went out times out with the `until` dump instead of asserting on `[]`), and asserts exactly three
- **same race, one test earlier:** `sentBeforeDetach` was sampled while the joins' `MODE #chan` and `WHO #chan` were still crossing (the WHOs go out one at a time, the second a round trip after the first). It now waits for the *last* line a join provokes — ordered socket, so a landed `WHO #gone` implies the rest landed
- **negative assertions kept a bound:** the 50 ms sleep also loosely bounded "no JOIN / no re-run connect command". They're now bounded deterministically by the test's own `say` probe, moved above them and issued after `live` (`!conn.catchingUp`): the PRIVMSG is written after anything a regression could write on that socket, so its arrival proves their absence
- both tests' caps → 30 s, so a slow-but-progressing run reports the `until` dump rather than vitest's bare timeout

## Evidence

146 local runs under three load shapes did not reproduce the CI failure, so the proof is deterministic instead: with 60 ms of latency injected into the engine's `NAMES`/`TOPIC` writes only (`upstream.ts:rawWrite`, throwaway, reverted), the old assertion fails exactly as CI did — `[ 'MODE #stay' ]`, length 1 — and the new test passes.

Final tree, 36 runs of the file under the full suite as load: the two re-attach tests 36/36; full suite 306 files / 4369 tests green.

## Not this PR

The same loop reproduces the file's *other* known flake — `a reconcile close issued as the link dies is queued, not lost` timing out on `deferred close delivered` with `link=ready` and the engine still listing the id (1/36 baseline, 2/36 final; ~3–5% under suite load). That's the deferred-close race with the engine refusing a `close` from a new link while the dead link still holds the claim, untouched here — but it now has a local repro shape: three concurrent loops of this file while `npm test` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
