### PR TITLE
Engine: a close over a stale claim follows the attach rule (#849)

### DIFF
--- a/server/engine/engine.test.ts
+++ b/server/engine/engine.test.ts
@@ -47,8 +47,11 @@ afterEach(() => {
   for (const l of links.splice(0)) l.kill();
 });
 
-async function link(): Promise<TestLink> {
-  const l = await TestLink.connect(enginePort, SECRET);
+// `startedAt` is the app process's generation; the engine reads a missing one
+// as 0, which the ordinary tests are happy with — only the newest-wins cases
+// pass an explicit pair.
+async function link(startedAt?: number): Promise<TestLink> {
+  const l = await TestLink.connect(enginePort, SECRET, { startedAt });
   links.push(l);
   return l;
 }
@@ -626,7 +629,7 @@ describe('review findings', () => {
     expect(l.frames.some((f) => f.op === 'closed' && f.id === id)).toBe(false);
   });
 
-  it('lets any link close a socket nobody claims, and no link close one someone else does', async () => {
+  it('lets any link close a socket nobody claims, and no older process close one a newer one holds', async () => {
     const id = `orphan:${++counter}`;
     const a = await link();
     await register(a, id, 'orphan');
@@ -637,16 +640,55 @@ describe('review findings', () => {
     await gone(engine, id);
     expect(engine.held()).not.toContain(id);
 
+    // "Someone else" here is an OLDER process: the newer one owns the socket,
+    // and a process that was superseded must not end its successor's sessions.
+    // (A same-or-newer link closing over a stale claim is the #849 case below.)
     const id2 = `owned:${++counter}`;
-    const owner = await link();
+    const owner = await link(2000);
     await register(owner, id2, 'owned');
-    const stranger = await link();
+    const stranger = await link(1000);
     stranger.send({ op: 'close', id: id2 });
     expect(await stranger.waitFor((f) => f.op === 'error' && f.id === id2)).toMatchObject({
       message: 'not attached to this connection',
     });
     expect(engine.held()).toContain(id2);
+    expect(ircd.client('owned')).toBeDefined();
+    expect(owner.frames.some((f) => f.op === 'detached' || f.op === 'closed')).toBe(false);
   });
+});
+
+// #849: a close from a link the holder is not newer than ends the socket. The
+// rule and the race behind it: server.ts, contest(). Two shapes of "not newer"
+// — the dead predecessor link of the same process, and an older process; the
+// third, a newer holder refusing, is in 'review findings' above.
+describe('a close over a stale claim (#849)', () => {
+  it.each([
+    ['the same process', 5000, 5000],
+    ['an older process', 1000, 2000],
+  ])(
+    'a close from %s ends a socket the holder still claims',
+    async (_what, holderGen, closerGen) => {
+      const id = `stale:${++counter}`;
+      const nick = `stale${counter}`;
+      const holder = await link(holderGen);
+      await register(holder, id, nick);
+      // The holder is not killed: the point is that its claim is still on the
+      // books when the close arrives.
+      const closer = await link(closerGen);
+      closer.send({ op: 'close', id });
+      await gone(engine, id);
+      expect(engine.held()).not.toContain(id);
+      expect(closer.frames.some((f) => f.op === 'error' && f.id === id)).toBe(false);
+      // The stripped holder is told it was taken over — the path that disposes
+      // without reconnecting — not that its socket closed, which its transport
+      // would read as a network drop and re-dial through the engine.
+      expect(await holder.waitFor((f) => f.op === 'detached' && f.id === id)).toMatchObject({
+        reason: 'taken-over',
+      });
+      expect(holder.frames.some((f) => f.op === 'closed' && f.id === id)).toBe(false);
+      await until(() => ircd.client(nick) === undefined, 5000, 'ircd saw it go');
+    },
+  );
 });
 
 describe('second review round', () => {
@@ -780,27 +822,9 @@ describe('third review round', () => {
 
   it('an older process cannot steal a session from a newer one', async () => {
     const id = `gen:${++counter}`;
-    const older = await TestLink.open(enginePort);
-    older.send({
-      op: 'hello',
-      protocol: PROTOCOL_MAJOR,
-      secret: SECRET,
-      instance: TEST_INSTANCE,
-      app: { version: 'old', startedAt: 1000 },
-    });
-    await older.waitFor((f) => f.op === 'hello');
-    links.push(older);
+    const older = await link(1000);
     await register(older, id, 'gen');
-    const newer = await TestLink.open(enginePort);
-    newer.send({
-      op: 'hello',
-      protocol: PROTOCOL_MAJOR,
-      secret: SECRET,
-      instance: TEST_INSTANCE,
-      app: { version: 'new', startedAt: 2000 },
-    });
-    await newer.waitFor((f) => f.op === 'hello');
-    links.push(newer);
+    const newer = await link(2000);
     newer.send(connectFrame(id));
     await newer.waitFor((f) => f.op === 'live' && f.id === id);
     await older.waitFor((f) => f.op === 'detached' && f.id === id);

--- a/server/engine/engine.test.ts
+++ b/server/engine/engine.test.ts
@@ -662,9 +662,10 @@ describe('review findings', () => {
 // — the dead predecessor link of the same process, and an older process; the
 // third, a newer holder refusing, is in 'review findings' above.
 describe('a close over a stale claim (#849)', () => {
+  // Label = who sends the close, relative to the holder.
   it.each([
-    ['the same process', 5000, 5000],
-    ['an older process', 1000, 2000],
+    ['a replacement link of the same process', 5000, 5000],
+    ['a newer process over an older holder', 1000, 2000],
   ])(
     'a close from %s ends a socket the holder still claims',
     async (_what, holderGen, closerGen) => {

--- a/server/engine/protocol.ts
+++ b/server/engine/protocol.ts
@@ -55,8 +55,11 @@ export interface ConnectionInfo {
 }
 
 export type AppToEngine =
-  // `startedAt` is the app process's generation — its start time in ms, times
-  // 1000, plus a pid tiebreak, so no two processes share one: when two processes overlap
+  // `startedAt` is the app process's generation: its start time in ms, with a
+  // sub-millisecond pid tiebreak in the fraction so that two processes started
+  // in the same millisecond do not share one (equal means the same process —
+  // its predecessor link). Older apps send the plain integer ms, which compares
+  // in the same unit. When two processes overlap
   // (a rolling deploy), a connection goes to the NEWER one and an older one is
   // refused rather than allowed to steal it back.
   // `instance` identifies the Lurker DATABASE this app speaks for, and it is

--- a/server/engine/protocol.ts
+++ b/server/engine/protocol.ts
@@ -101,8 +101,12 @@ export type AppToEngine =
   // the implicit form.
   | { op: 'detach'; id: string }
   // End the IRC socket. This is what QUIT ends in. Allowed from the link that
-  // holds the claim — or from any link when NOBODY does (an orphan left behind
-  // by a previous process).
+  // holds the claim, from any link when NOBODY does (an orphan left behind by a
+  // previous process), and — the attach rule — from any link the holder is not
+  // NEWER than: the holder is then a superseded link (this process's dead
+  // predecessor, or an older process), its claim is dropped, it is sent
+  // `detached` (taken-over), and the socket ends. Only a newer holder refuses
+  // (`error`).
   | { op: 'close'; id: string }
   | { op: 'list' };
 
@@ -136,8 +140,9 @@ export type EngineToApp =
   | { op: 'live'; id: string }
   | { op: 'gap'; id: string; gap: Gap }
   // The engine stopped serving this id to THIS link because a newer app process
-  // claimed the connection. Not a socket event: the socket is alive elsewhere,
-  // so the receiver must not reconnect.
+  // claimed the connection — to serve it, or to end it (a `close` over this
+  // link's claim). Either way not a socket event for this link: it must not
+  // reconnect.
   | { op: 'detached'; id: string; reason: 'taken-over' }
   // The IRC socket is gone. The engine forgets the id.
   | { op: 'closed'; id: string; error?: string }

--- a/server/engine/protocol.ts
+++ b/server/engine/protocol.ts
@@ -55,7 +55,8 @@ export interface ConnectionInfo {
 }
 
 export type AppToEngine =
-  // `startedAt` is the app process's generation: when two processes overlap
+  // `startedAt` is the app process's generation — its start time in ms, times
+  // 1000, plus a pid tiebreak, so no two processes share one: when two processes overlap
   // (a rolling deploy), a connection goes to the NEWER one and an older one is
   // refused rather than allowed to steal it back.
   // `instance` identifies the Lurker DATABASE this app speaks for, and it is

--- a/server/engine/server.ts
+++ b/server/engine/server.ts
@@ -167,7 +167,8 @@ export class EngineServer {
   // well as for an attach, since its transport reads `closed` as a network
   // drop and would re-dial the same id through the engine, undoing the close,
   // while `detached` is the path that disposes without reconnecting. Returns
-  // the refusing holder, or null when the way is clear; logs either way.
+  // the refusing holder, or null when the way is clear; a refusal and a
+  // takeover are both logged, an uncontested socket is not.
   //
   // "Not newer" deliberately includes the SAME generation, which is a
   // predecessor link of the same process — the app never keeps two alive, and

--- a/server/engine/server.ts
+++ b/server/engine/server.ts
@@ -139,13 +139,60 @@ export class EngineServer {
   }
 
   // The sessions a given link may attach to: everything held that no OTHER
-  // link currently claims. A session another process owns is not offered.
+  // link currently claims. A session another process owns is not offered —
+  // and neither is one this process's own dead predecessor link still claims,
+  // deliberately: a `connect` for it takes the claim over (contest) a backoff
+  // later, whereas offering it would let reconcile re-adopt a session whose
+  // user-issued close is still sitting in the dead link's unread bytes, and
+  // turn that Disconnect into a reconnect.
   private heldFor(link: AppLink): string[] {
     return [...this.upstreams.values()]
       .filter((u) => u.opts.instance === link.instance)
       .filter((u) => u.state === 'open' && u.registered && !u.closing)
-      .filter((u) => ![...this.links].some((l) => l !== link && l.claimed.has(u)))
+      .filter((u) => !this.holderOf(u, link))
       .map((u) => u.id);
+  }
+
+  // The one other link holding `u`, if any. A claim is exclusive — every path
+  // that adds one strips the previous holder first — so there is at most one.
+  private holderOf(u: EngineUpstream, except: AppLink): AppLink | undefined {
+    for (const l of this.links) if (l !== except && l.claimed.has(u)) return l;
+    return undefined;
+  }
+
+  // Newest wins — the one rule for an attach and for a close. Another link
+  // holding `u` either refuses `link`, because it is a NEWER process and an
+  // older one must not take back or end what it lost, or is superseded: its
+  // claim is dropped and it is told `detached` (taken-over) — for a close as
+  // well as for an attach, since its transport reads `closed` as a network
+  // drop and would re-dial the same id through the engine, undoing the close,
+  // while `detached` is the path that disposes without reconnecting. Returns
+  // the refusing holder, or null when the way is clear; logs either way.
+  //
+  // "Not newer" deliberately includes the SAME generation, which is a
+  // predecessor link of the same process — the app never keeps two alive. That
+  // is the case that bites (#849): a Disconnect issued while the link was down
+  // is flushed on the replacement link, and under load the engine can read
+  // that link's hello and close before it has processed the dead socket's EOF
+  // — both are ready in the same poll batch, and the poll does not order them
+  // by time. Refusing the close then loses the user's Disconnect for good: the
+  // app has already forgotten it, and nobody holds the socket but a link that
+  // will be reaped a moment later.
+  private contest(link: AppLink, u: EngineUpstream, verb: 'attach' | 'close'): AppLink | null {
+    const other = this.holderOf(u, link);
+    if (!other) return null;
+    if (other.generation > link.generation) {
+      this.log(
+        `${u.id}: ${verb} from ${link.peer} (gen ${link.generation}) refused; held by newer ${other.peer} (gen ${other.generation})`,
+      );
+      return other;
+    }
+    other.claimed.delete(u);
+    other.send({ op: 'detached', id: u.id, reason: 'taken-over' });
+    this.log(
+      `${u.id}: ${verb === 'attach' ? 'taken over by' : 'closed by'} ${link.peer} over ${other.peer}'s claim`,
+    );
+    return null;
   }
 
   // The sessions an app can attach to: open, registered, and not on their way
@@ -319,13 +366,20 @@ export class EngineServer {
         // connection it no longer owns. Two exceptions. An `ack` from anyone is
         // welcome — it only says "persisted", and the process that was just taken
         // over is exactly the one whose in-flight acks decide whether its
-        // successor sees those lines a second time. And ending a socket NOBODY
-        // claims is what reconciling orphans after a restart is.
+        // successor sees those lines a second time. And a `close` follows the
+        // attach rule instead (contest): ending an orphan nobody claims is what
+        // reconciling after a restart is, and ending one a superseded link still
+        // claims is #849.
         if (!link.claimed.has(u) && frame.op !== 'ack') {
-          const claimedElsewhere = [...this.links].some((l) => l.claimed.has(u));
-          if (frame.op !== 'close' || claimedElsewhere) {
+          if (frame.op !== 'close') {
             return link.fail('not attached to this connection', frame.id);
           }
+          if (this.contest(link, u, 'close')) {
+            return link.fail('not attached to this connection', frame.id);
+          }
+          // Nothing from the closing socket reaches a link that was just told
+          // it no longer holds it.
+          u.silence();
         }
         if (frame.op === 'write') u.write(frame.line);
         else if (frame.op === 'ack') u.ack(frame.seq);
@@ -395,19 +449,9 @@ export class EngineServer {
     if (u) {
       // Someone else's? Take it over — unless that someone is a NEWER process,
       // in which case this is an older one trying to steal back what it lost.
-      for (const other of this.links) {
-        if (other !== link && other.claimed.has(u)) {
-          if (other.generation > link.generation) {
-            this.log(
-              `${id}: refused ${link.peer} (gen ${link.generation}); held by newer ${other.peer} (gen ${other.generation})`,
-            );
-            link.send({ op: 'detached', id, reason: 'taken-over' });
-            return;
-          }
-          other.claimed.delete(u);
-          other.send({ op: 'detached', id, reason: 'taken-over' });
-          this.log(`${id}: taken over by ${link.peer} from ${other.peer}`);
-        }
+      if (this.contest(link, u, 'attach')) {
+        link.send({ op: 'detached', id, reason: 'taken-over' });
+        return;
       }
       link.claimed.add(u);
       payload = u.attach(link);

--- a/server/engine/server.ts
+++ b/server/engine/server.ts
@@ -170,7 +170,9 @@ export class EngineServer {
   // the refusing holder, or null when the way is clear; logs either way.
   //
   // "Not newer" deliberately includes the SAME generation, which is a
-  // predecessor link of the same process — the app never keeps two alive. That
+  // predecessor link of the same process — the app never keeps two alive, and
+  // no two processes share a generation (the app's is its start time with a
+  // pid tiebreak, engineLink.ts). That
   // is the case that bites (#849): a Disconnect issued while the link was down
   // is flushed on the replacement link, and under load the engine can read
   // that link's hello and close before it has processed the dead socket's EOF

--- a/server/engine/server.ts
+++ b/server/engine/server.ts
@@ -172,8 +172,8 @@ export class EngineServer {
   // "Not newer" deliberately includes the SAME generation, which is a
   // predecessor link of the same process — the app never keeps two alive, and
   // no two processes share a generation (the app's is its start time with a
-  // pid tiebreak, engineLink.ts). That
-  // is the case that bites (#849): a Disconnect issued while the link was down
+  // pid tiebreak, engineLink.ts). That is the case that bites (#849): a
+  // Disconnect issued while the link was down
   // is flushed on the replacement link, and under load the engine can read
   // that link's hello and close before it has processed the dead socket's EOF
   // — both are ready in the same poll batch, and the poll does not order them

--- a/server/engine/server.ts
+++ b/server/engine/server.ts
@@ -173,13 +173,13 @@ export class EngineServer {
   // predecessor link of the same process — the app never keeps two alive, and
   // no two processes share a generation (the app's is its start time with a
   // pid tiebreak, engineLink.ts). That is the case that bites (#849): a
-  // Disconnect issued while the link was down
-  // is flushed on the replacement link, and under load the engine can read
-  // that link's hello and close before it has processed the dead socket's EOF
-  // — both are ready in the same poll batch, and the poll does not order them
-  // by time. Refusing the close then loses the user's Disconnect for good: the
-  // app has already forgotten it, and nobody holds the socket but a link that
-  // will be reaped a moment later.
+  // Disconnect issued while the link was down is flushed on the replacement
+  // link, and under load the engine can read that link's hello and close
+  // before it has processed the dead socket's EOF — both are ready in the same
+  // poll batch, and the poll does not order them by time. Refusing the close
+  // then loses the user's Disconnect for good: the app has already forgotten
+  // it, and nobody holds the socket but a link that will be reaped a moment
+  // later.
   private contest(link: AppLink, u: EngineUpstream, verb: 'attach' | 'close'): AppLink | null {
     const other = this.holderOf(u, link);
     if (!other) return null;

--- a/server/services/engineLink.ts
+++ b/server/services/engineLink.ts
@@ -26,11 +26,17 @@ import type { AppToEngine, EngineToApp } from '../engine/protocol.js';
 import { APP_VERSION } from '../utils/userAgent.js';
 
 // This process's generation, for the engine's newest-wins rule (protocol.ts):
-// the start time, with the pid as a sub-millisecond tiebreak. The engine reads
-// an EQUAL generation as "another link of the same process" (its predecessor,
-// which it may supersede), so two processes must never share one — and two
-// started in the same millisecond otherwise would.
-const PROCESS_GENERATION = Date.now() * 1000 + (process.pid % 1000);
+// the start time in milliseconds — the unit every app version has sent, so a
+// rollback still orders against what it replaces — with the pid as a
+// sub-millisecond tiebreak in the fraction. The engine reads an EQUAL
+// generation as "another link of the same process" (its predecessor, which it
+// may supersede), so two processes must never share one, and two started in
+// the same millisecond otherwise would. A thousandth is the finest step a
+// double resolves cleanly at this magnitude; what it cannot separate is two
+// processes of ONE database started in the same millisecond with pids equal
+// mod 1000 — two apps on one database is a misconfiguration before it is a
+// collision, and an exact per-pid encoding would need a wider field.
+const PROCESS_GENERATION = Date.now() + (process.pid % 1000) / 1000;
 
 // The id the engine knows a network's socket by. One definition, so the two
 // sides of every comparison agree.

--- a/server/services/engineLink.ts
+++ b/server/services/engineLink.ts
@@ -25,8 +25,12 @@ import { instanceId } from '../db/instanceId.js';
 import type { AppToEngine, EngineToApp } from '../engine/protocol.js';
 import { APP_VERSION } from '../utils/userAgent.js';
 
-// This process's generation, for the engine's newest-wins rule (protocol.ts).
-const PROCESS_STARTED_AT = Date.now();
+// This process's generation, for the engine's newest-wins rule (protocol.ts):
+// the start time, with the pid as a sub-millisecond tiebreak. The engine reads
+// an EQUAL generation as "another link of the same process" (its predecessor,
+// which it may supersede), so two processes must never share one — and two
+// started in the same millisecond otherwise would.
+const PROCESS_GENERATION = Date.now() * 1000 + (process.pid % 1000);
 
 // The id the engine knows a network's socket by. One definition, so the two
 // sides of every comparison agree.
@@ -324,7 +328,7 @@ export class EngineLink extends EventEmitter {
           protocol: PROTOCOL_MAJOR,
           secret: this.opts.secret,
           instance: instanceId(),
-          app: { version: APP_VERSION, startedAt: PROCESS_STARTED_AT },
+          app: { version: APP_VERSION, startedAt: PROCESS_GENERATION },
         }),
       );
     });

--- a/server/test-utils/engineLink.ts
+++ b/server/test-utils/engineLink.ts
@@ -49,7 +49,7 @@ export class TestLink {
   static async connect(
     port: number,
     secret: string,
-    opts: { protocol?: number; version?: string; instance?: string } = {},
+    opts: { protocol?: number; version?: string; instance?: string; startedAt?: number } = {},
   ): Promise<TestLink> {
     const link = await TestLink.open(port);
     link.send({
@@ -59,7 +59,8 @@ export class TestLink {
       // One default instance, so the ordinary tests all speak for the same
       // "database"; the cross-instance cases pass their own.
       instance: opts.instance ?? TEST_INSTANCE,
-      app: { version: opts.version ?? 'test' },
+      // startedAt is the process generation; omitted, the engine reads 0.
+      app: { version: opts.version ?? 'test', startedAt: opts.startedAt },
     });
     await link.waitFor((f) => f.op === 'hello' || f.op === 'error');
     return link;


### PR DESCRIPTION
Fixes #849.

## What was actually happening

A Disconnect issued while the app→engine link is down is remembered (`pendingCloses`) and flushed on the replacement link the moment it says hello. The engine refused that `close` whenever *any* other link still claimed the socket — and under load the other link is the **dead** one. An in-memory probe (dumped only on failure; a `console.log` probe hid the race in 0/116 runs) caught it three times in 80 runs with `npm test` as load:

```
+0    app: close <id> deferred (link down)
+264  app: flushing deferred close <id> on hello        ← replacement link
+264  engine: close <id> REFUSED  holders=<dead link> gen=<SAME> destroyed=false links=2
```

264 ms after the app destroyed its end, the engine had processed the replacement's hello and close but not the dead socket's EOF: both were ready in the same poll batch, and the poll doesn't order them by time. The refusal is routed by id to a transport that no longer exists, `pendingCloses` was already cleared, and nobody retries — the nick stays on IRC until the orphan reaper an hour later.

Two things the issue's hypothesis didn't have: the holder is the **same generation** (a link blip within one process, not an older process — "a newer generation may close" would not have covered it), and it is I/O ordering under starvation, not a slow reaper.

## The rule

A `close` now follows the attach rule — one function, `contest()`, shared by attach and close:

- a holder that is a **newer** process refuses (an older process must not take back or end what it lost — the old "stranger" test keeps that guard with an explicitly older stranger);
- any other holder is superseded: silenced off the socket, told `detached taken-over`, and the socket ends. A same-generation holder can only be a predecessor link of the same process — the app never keeps two alive.

Two deliberate choices, both from review:
- **`detached`, not `closed`, to the stripped holder.** A live older process reads `closed` as a network drop and re-dials the same id through the engine — undoing the close. `detached` is the path that disposes without reconnecting.
- **The hello's `held` list is unchanged.** It still withholds a session any other link claims, a dead predecessor's included. Offering those (tried, then reverted) would let reconcile re-adopt a session whose user-issued close is still sitting unread in the dead link, and turn that Disconnect into a reconnect. The connect a backoff later takes the claim over regardless.

## Tests

- `engine.test.ts`: same-process and older-process closes end the socket and the holder hears `detached` (an `it.each`), an older process is still refused and the socket stays; `link()` takes a `startedAt` (`TestLink.connect` too), replacing three hand-rolled hellos.
- `engineIntegration.test.ts` is untouched: it is the regression test. **0/80 under the load that produced 3/80 before the fix** (four loops of the file beside two full suite runs), both suite runs green.

## Release note

Engine behaviour changes, so `engine-1` moves on the next release (`docker-publish.yml` will pick it up from the path diff). Call it out as an engine upgrade — one IRC reconnect for self-hosters on the engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
