### PR TITLE
Engine re-attach: the snapshot says whose nicklists it does not know yet (#863)

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -367,7 +367,8 @@ One per network inside `kind:'snapshot'` (`ircConnection.snapshot()`,
   multilineLimits,
   away: { active, since, message, autoSet, backAt } | null,
   channels: [ { name, topic, modes,
-                members: [ { nick, modes: [], away, user, host, account } ] } ],
+                members: [ { nick, modes: [], away, user, host, account } ],
+                membersPending?: true } ],   // NAMES not heard yet — see §9.1
   peerPresence: { "<lowercased nick>": { nick, state, stateAt, awayMessage } },
   pinned: [], collapsedNicklists: {}, channelNotify: {},
   ignoredMasks: [], nickNotes: [], relayBots: [] }
@@ -943,6 +944,15 @@ these signals:
   arrives as a normal `irc` event and materializes the buffer via the DM rule.
 - **`channel-parted` → resolve, never materialize**: mark parted, clear members,
   keep the buffer and history. If you have no such buffer, ignore it.
+- **`membersPending` (on a snapshot channel, or on a `names` event) → keep the
+  members you already hold.** The server has not heard the channel's NAMES
+  since it last connected or attached — after an engine re-attach that is every
+  channel until the restore asks, one at a time — so the list it sends is only
+  the members learned so far, at least yourselves; rendering it looks like
+  everyone left. Take that list only if you hold none. Normally a definitive
+  `names` follows within seconds; a restore step whose NAMES the server never
+  answers sends nothing further, and the flag stays until a later `/names` or
+  rejoin.
 - **Never materialize from ambient signals:** `typing`, `member-update`, and
   `read-state` for unknown buffers must resolve-or-drop. (`mark-all-read` fans
   out `read-state` for _closed_ buffers too — resurrecting them in the sidebar

--- a/server/services/engineRestorePacing.test.ts
+++ b/server/services/engineRestorePacing.test.ts
@@ -165,6 +165,82 @@ describe('engine restore pacing', () => {
     }
     expect(peak).toBeLessThanOrEqual(4);
   }, 20000);
+  it('a snapshot and a `names` say which channels have not heard NAMES since the re-attach (#863)', async () => {
+    // Same six channels, the app "restarts" again — this time the previous
+    // session was ircManager's, so shutdown() is what lets go.
+    ircManager.shutdown();
+    // #p3's TOPIC is held: its step stays in flight, but its NAMES is answered.
+    // #p5's NAMES is held: the restore asks once, so nothing answers it — not
+    // even the deadline.
+    ircd.hold = (cmd, p) => {
+      const chan = (p[0] ?? '').toLowerCase();
+      return (cmd === 'TOPIC' && chan === '#p3') || (cmd === 'NAMES' && chan === '#p5');
+    };
+    // Every `names` the manager fans out, to see the flag ride republishes too.
+    const names: Array<Record<string, unknown>> = [];
+    const onEvent = (e: Record<string, unknown>) => {
+      if (e.type === 'names') names.push(e);
+    };
+    ircManager.on('event', onEvent);
+    wire.length = 0;
+    try {
+      const conn = ircManager.startNetwork(userId, network.id)!;
+      harness.tap(conn, 'pace');
+      await until(() => conn.state === 'connected', 5000, 'reattached');
+      const pending = (chan: string): boolean | undefined =>
+        conn.snapshot().channels.find((c) => c.name.toLowerCase() === chan)?.membersPending;
+      const lastNamesFor = (chan: string) =>
+        [...names].reverse().find((e) => String(e.target).toLowerCase() === chan);
+      const asked = (chan: string) => wire.some((w) => w.dir === '>' && w.line === `NAMES ${chan}`);
+
+      // #p3 in flight, TOPIC owed: the step is not over, but its NAMES was
+      // heard — pending is about NAMES, not the step. #p4 has not been asked.
+      await until(
+        () => pending('#p3') === undefined && pending('#p4') === true,
+        5000,
+        '#p3 step in flight',
+      );
+      expect(pending('#p1')).toBeUndefined();
+      expect(pending('#p2')).toBeUndefined();
+      expect(pending('#p6')).toBe(true);
+
+      // #p5 asked and unanswered: pending by construction, not by timing.
+      await until(() => asked('#p5'), DEADLINE_MS + 5000, 'NAMES #p5 on the wire');
+      expect(pending('#p5')).toBe(true);
+      // A republish in that window — here a mode on ourselves — carries the
+      // flag: the client keeping its real list must not take this one.
+      names.length = 0;
+      ircd.sendRaw('pace', ':oper!~oper@peer.fake MODE #p5 +o pace');
+      await until(() => lastNamesFor('#p5') !== undefined, 5000, 'names republished for #p5');
+      expect(lastNamesFor('#p5')).toMatchObject({ membersPending: true });
+
+      // The deadline moves the restore on and every other channel clears —
+      // #p5 does not: nothing answered, so nothing is known.
+      await until(
+        () => CHANNELS.filter((ch) => ch !== '#p5').every((ch) => pending(ch) === undefined),
+        DEADLINE_MS + 5000,
+        'restore moved on',
+      );
+      expect(pending('#p5')).toBe(true);
+
+      // A real NAMES — injected here, as a reply replayed from the engine's
+      // backlog or a later /names would be — clears it the moment it lands.
+      names.length = 0;
+      ircd.sendRaw('pace', ':irc.fake 353 pace = #p5 :@pace');
+      ircd.sendRaw('pace', ':irc.fake 366 pace #p5 :End of /NAMES list.');
+      await until(() => lastNamesFor('#p5') !== undefined, 5000, 'names from the injected reply');
+      expect(lastNamesFor('#p5')).not.toHaveProperty('membersPending');
+      expect(pending('#p5')).toBeUndefined();
+      // …and a republish after that is definitive too.
+      names.length = 0;
+      ircd.sendRaw('pace', ':oper!~oper@peer.fake MODE #p5 -o pace');
+      await until(() => lastNamesFor('#p5') !== undefined, 5000, 'names republished for #p5 again');
+      expect(lastNamesFor('#p5')).not.toHaveProperty('membersPending');
+    } finally {
+      ircManager.off('event', onEvent);
+      ircd.hold = null;
+    }
+  }, 20000);
 });
 
 function numericFor(line: string, numeric: string, chan: string): boolean {

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -743,6 +743,9 @@ export class IrcConnection {
   // requests (MODE → 324/329, TOPIC → 331/332/333; '*' → our umode 221), kept
   // out of the server buffer until they arrive or the deadline passes.
   private restoreQuiet: Map<string, { until: number; mode: boolean; topic: boolean }>;
+  // Folded channel keys whose NAMES this connection has heard since it last
+  // connected or attached — the one fact membersPending reads.
+  private namesHeard: Set<string>;
 
   constructor({
     network,
@@ -857,6 +860,7 @@ export class IrcConnection {
     this.engineTransport = null;
     this.engineSocketAlive = false;
     this.restoreQuiet = new Map();
+    this.namesHeard = new Set();
     this.bind();
   }
 
@@ -2680,11 +2684,7 @@ export class IrcConnection {
         time: event.time,
       });
       if (memberModesChanged && ch) {
-        this.publish({
-          type: 'names',
-          target: ch.name,
-          members: Array.from(ch.members.values()).map(memberSnapshot),
-        });
+        this.publishNames(ch);
       }
       if (chanModesChanged && ch) this.publishChannelModes(ch);
     });
@@ -2750,11 +2750,8 @@ export class IrcConnection {
           account: carry.account,
         });
       }
-      this.publish({
-        type: 'names',
-        target: eventChannel,
-        members: Array.from(ch.members.values()).map(memberSnapshot),
-      });
+      this.namesHeard.add(foldTargetFor(this.network.id, eventChannel));
+      this.publishNames(ch);
       // Issue a WHO so we learn the current away state for everyone in the
       // channel. away-notify keeps it live after this initial sync. Mark it so
       // the 'wholist' handler consumes the reply silently instead of echoing
@@ -2864,11 +2861,7 @@ export class IrcConnection {
         }
       }
       if (changed) {
-        this.publish({
-          type: 'names',
-          target: ch.name,
-          members: Array.from(ch.members.values()).map(memberSnapshot),
-        });
+        this.publishNames(ch);
       }
       const ms = Date.now() - tHandler;
       if (IRC_HANDLER_WARN_MS > 0 && ms >= IRC_HANDLER_WARN_MS) {
@@ -3697,11 +3690,7 @@ export class IrcConnection {
       if (!m) continue;
       if (m.away === next) continue;
       m.away = next;
-      this.publish({
-        type: 'names',
-        target: ch.name,
-        members: Array.from(ch.members.values()).map(memberSnapshot),
-      });
+      this.publishNames(ch);
     }
   }
 
@@ -4141,6 +4130,7 @@ export class IrcConnection {
     this.restoreQueue = [];
     this.endRestoreStep();
     this.restoreQuiet.clear();
+    this.namesHeard.clear();
   }
 
   // The step is over — answered, timed out, or abandoned (resetRestoreState
@@ -4155,6 +4145,34 @@ export class IrcConnection {
     const slot = this.restoreSlot;
     this.restoreSlot = null;
     slot?.release();
+  }
+
+  // True while this connection has not heard NAMES for the channel since it
+  // last connected or attached (#863). After an engine re-attach every channel
+  // starts that way: the replay's JOINs rebuild it with ourselves and whatever
+  // has landed since, and the members arrive with the restore's own NAMES, one
+  // channel at a time — or with a real 353/366 replayed from the engine's
+  // backlog, which counts the moment it lands. Read from that one fact rather
+  // than from the restore queue's position: a channel waiting its turn at the
+  // restoreGate cap is in neither the queue nor the in-flight step, and a
+  // step the deadline ended without a reply has still not heard anything.
+  private membersPending(name: string): boolean {
+    return !this.namesHeard.has(foldTargetFor(this.network.id, name));
+  }
+
+  // The one `names` publish — a full nicklist replace — flagged while the
+  // channel's NAMES is still unheard: a mode on ourselves, our own away flip
+  // or a WHO backfill can republish the incomplete list in that window, and a
+  // client keeping the real list must not take it for the truth. The userlist
+  // handler records the NAMES before it publishes, so that one is never
+  // flagged.
+  private publishNames(ch: ChannelState): void {
+    this.publish({
+      type: 'names',
+      target: ch.name,
+      members: Array.from(ch.members.values()).map(memberSnapshot),
+      ...(this.membersPending(ch.name) ? { membersPending: true } : {}),
+    });
   }
 
   // One channel in flight. The next channel's three requests go out when this
@@ -6303,6 +6321,8 @@ export class IrcConnection {
         topic: ch.topic,
         modes: [...(ch.modes || [])].join(''),
         members: Array.from(ch.members.values()).map(memberSnapshot),
+        // See membersPending (#863).
+        ...(this.membersPending(ch.name) ? { membersPending: true } : {}),
       })),
       // Object keyed by lowercase nick → { nick, state, stateAt }. Lands
       // directly on states[networkId].peerPresence on snapshot apply, same

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -274,7 +274,11 @@ function applyEvent(event: any): void {
       buffers.pushMessage(event);
       break;
     case 'names':
-      buffers.setMembers(event.networkId, event.target, event.members);
+      // Provisional while an engine re-attach has not heard the channel's
+      // NAMES yet (#863): keep the list already held, see setMembers.
+      buffers.setMembers(event.networkId, event.target, event.members, {
+        provisional: !!event.membersPending,
+      });
       break;
     // Incremental nicklist patch — not persisted, so no pushMessage/dedupe.
     case 'member-update':
@@ -602,7 +606,9 @@ function applySnapshot(snapshot: any[], globalIgnores: any[] = []): void {
           ? { nick: m, modes: [], away: false }
           : { nick: m.nick, modes: m.modes || [], away: !!m.away },
       );
-      buffers.setMembers(net.networkId, ch.name, normalized);
+      buffers.setMembers(net.networkId, ch.name, normalized, {
+        provisional: !!ch.membersPending,
+      });
       buffers.setTopic(net.networkId, ch.name, ch.topic);
       buffers.setChannelModes(net.networkId, ch.name, ch.modes || '');
     }

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -45,6 +45,33 @@ beforeEach(() => {
   vi.mocked(socketSend).mockClear();
 });
 
+describe('setMembers provisional (#863)', () => {
+  const alice = { nick: 'alice', modes: [], away: false };
+  const bob = { nick: 'bob', modes: ['o'], away: false };
+  const me = { nick: 'me', modes: [], away: false };
+
+  it('keeps a list it already holds when the server says its own is provisional', () => {
+    const store = useBuffersStore();
+    store.setMembers(1, '#chan', [alice, bob, me]);
+    // A re-attach snapshot: the channel rebuilt from the replay's JOIN — just us.
+    store.setMembers(1, '#chan', [me], { provisional: true });
+    expect(store.byKey('1::#chan')!.members.map((m) => m.nick)).toEqual(['alice', 'bob', 'me']);
+  });
+
+  it('takes a provisional list when it holds none — something beats nothing', () => {
+    const store = useBuffersStore();
+    store.setMembers(1, '#fresh', [me], { provisional: true });
+    expect(store.byKey('1::#fresh')!.members.map((m) => m.nick)).toEqual(['me']);
+  });
+
+  it('a definitive list still replaces, however short', () => {
+    const store = useBuffersStore();
+    store.setMembers(1, '#chan', [alice, bob, me]);
+    store.setMembers(1, '#chan', [me]);
+    expect(store.byKey('1::#chan')!.members.map((m) => m.nick)).toEqual(['me']);
+  });
+});
+
 describe('applyReadState', () => {
   // Regression for #319: mark-all-read fans out a read-state for every target
   // with history, including closed buffers (absent from the store). Applying

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -1082,8 +1082,17 @@ export const useBuffersStore = defineStore('buffers', {
       const buf = ensureBuffer(this, networkId, target);
       buf.loadingHistory = loading;
     },
-    setMembers(networkId: number | string, target: string, members: BufferMember[]) {
+    // `provisional`: the server says this list is incomplete (`membersPending`,
+    // CLIENT_PROTOCOL §9.1). A list already held is the better one; keep it. A
+    // buffer with none takes the provisional list — something beats nothing.
+    setMembers(
+      networkId: number | string,
+      target: string,
+      members: BufferMember[],
+      opts: { provisional?: boolean } = {},
+    ) {
       const buf = ensureBuffer(this, networkId, target);
+      if (opts.provisional && buf.members.length > 0) return;
       buf.members = members;
     },
 


### PR DESCRIPTION
Fixes #863.

## What was happening

After an app restart under the engine, the nicklist of the channel you're looking at vanished and came back a while later — one channel at a time — which reads as "I got disconnected" even though IRC never dropped. The new process rebuilds each channel from the replay's JOINs (yourself, plus whatever lands after) and only learns the members when that channel's restore step gets its NAMES reply, paced one channel at a time (#840). A client reconnecting in that window received a snapshot whose member lists were exactly that, and replaced its real lists with them.

## The approach

**The server says which nicklists it doesn't know yet; the client keeps what it has.** No overlay, no spinner: the list simply never disappears, and nothing else in the UI changes — which is what makes it stop looking like a disconnect.

- **Server:** a connection tracks the channels whose NAMES it has heard since it last connected or attached (cleared with the other restore state, added by the `userlist` handler). A snapshot channel — or a `names` event — for a channel not in that set carries `membersPending: true`. Every `names` publish goes through one helper, so a mode on ourselves, our own away flip or a WHO backfill can't republish the incomplete list unflagged.
- **Web client:** `setMembers` keeps a list it already holds when the incoming one is provisional, and takes the provisional list only if it holds none. The definitive `names` that follows replaces it, as before.
- **Protocol:** optional field, documented in `CLIENT_PROTOCOL.md` (snapshot shape + §9.1 rule). A native client that ignores it keeps today's behaviour; iOS can adopt the same rule when convenient.

Why "NAMES heard since attach" rather than the restore queue's position (the first cut, caught by review): a channel waiting its turn at the restoreGate cap is in neither the queue nor the in-flight step; a *real* 353/366 replayed from the engine's backlog must count the moment it lands; and a step the deadline ended without a reply has still not heard anything — so it stays pending until a later NAMES instead of serving the incomplete list as the truth.

## Tests

- `engineRestorePacing.test.ts`: holds one channel's TOPIC (step in flight, NAMES heard → not pending) and another's NAMES (asked and unanswered → pending by construction, still pending after the deadline while every other channel clears); a MODE on ourselves in that window republishes a flagged `names`; an injected real 353/366 clears the flag at once and the same MODE then republishes unflagged.
- `buffers.test.ts`: keeps, takes, and replaces as specified.
- Full suite green (306 files / 4375 tests).

## Not in this PR

- The deadline path: a restore step whose NAMES the server never answers sends nothing further, so the channel stays flagged until a later `/names` or rejoin. Honest, and pre-existing in effect (the incomplete list was shown before); a NAMES retry after a deadline would be a separate change to the pacing.
- iOS: field is ignored today; adopting the keep-if-pending rule there is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
