### PR TITLE
Link previews: find cached bytes the index cannot name (#776)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -404,10 +404,18 @@ VAPID_SUBJECT=mailto:you@example.com
 # ⚠ PUBLIC_BASE_URL must be https. Browsers block an http:// image on an https
 # page as mixed content, so an http base URL is a cache that never renders.
 #
-# ⚠ Set a LIFECYCLE RULE on the prefix — 30 days is the recommendation. Lurker
-# stops serving an object after 7 days and drops its index row, so the bucket
-# rule only has to be comfortably longer than that; nothing here deletes objects
-# for you, and without a rule the bucket grows forever.
+# ⚠ Set a LIFECYCLE RULE on the prefix — 30 days is the recommendation, and the
+# figure Lurker's own bound is set against. Lurker stops serving an object 25
+# days after it was stored, so a 30-day rule leaves the margin that keeps the
+# index row provably shorter-lived than the object it names. Nothing here
+# deletes objects for you, and without a rule the bucket grows forever.
+#
+# ⚠ SHORTEN THE RULE IF YOU WANT IMAGES REFRESHED SOONER, but keep it clear of
+# 25 days. Lurker serves a stored object for up to that long — checked against
+# the object's own Last-Modified, so it holds whether or not the index still
+# remembers it — which is also how long a picture that changed at a stable URL
+# (an avatar, a `latest.png`) can stay stale. Set the rule below 25 days and the
+# cell may hand out a public URL for an object your bucket has already deleted.
 #
 # ⚠ Only three of the six hardening headers the proxy sends can be stored on an
 # object (Content-Type, Content-Disposition, Cache-Control). If you want

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -439,6 +439,11 @@ not re-fetching popular images:
   ships zero bytes for an image it has already fetched. This one has real
   operational requirements — the objects are publicly readable, the base URL
   must be https, and **you** own eviction via a lifecycle rule on the bucket.
+  Thirty days is the recommendation: Lurker serves a stored object for up to 25
+  days (judged on the object's own `Last-Modified`), so a rule comfortably above
+  that keeps it from ever pointing a browser at an object you have deleted. That
+  25 days is also the staleness ceiling for an image that changes at a fixed URL,
+  so shorten the rule — but not below 25 days — if you want them refreshed sooner.
 
 Posters work under `local` or `s3` — the gate is "a cache exists", not `local`
 specifically.

--- a/server/routes/linkPreview.droppercache.test.ts
+++ b/server/routes/linkPreview.droppercache.test.ts
@@ -336,8 +336,8 @@ describe('the dropper byte cache, end to end', () => {
   });
 
   it('does not mint a CDN URL for a row past its age bound', async () => {
-    // Seven days against the bucket rule's thirty is the margin that makes the
-    // row provably the shorter-lived of the two — same bound, same reasoning,
+    // Twenty-five days against the bucket rule's thirty is the margin that makes
+    // the row provably the shorter-lived of the two — same bound, same reasoning,
     // same test as s3, because the dropper's objects die by the same rule.
     servePng();
     const imageUrl = `${base}/ageing.png`;
@@ -348,7 +348,7 @@ describe('the dropper byte cache, end to end', () => {
     expect(warm.body.previews[0].src).toBe(`${CDN}/${byteCacheKey(imageUrl)}`);
 
     const { default: db } = await import('../db/index.js');
-    const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
     db.prepare('UPDATE preview_cache SET created_at = ?').run(old);
 
     const stale = await agent.post('/api/link-preview/resolve').send({ urls: [imageUrl] });

--- a/server/routes/linkPreview.s3cache.test.ts
+++ b/server/routes/linkPreview.s3cache.test.ts
@@ -41,7 +41,9 @@ interface Put {
 
 let puts: Put[] = [];
 /** Objects the stub bucket is holding, by request path. */
-let objects = new Map<string, { body: Buffer; contentType: string }>();
+let objects = new Map<string, { body: Buffer; contentType: string; storedAt?: number }>();
+/** Flip to make the bucket omit Last-Modified, so a cold read cannot date the object. */
+let bucketOmitsLastModified = false;
 /** Flip to make every write fail, without changing anything else. */
 let bucketRejects = false;
 /** Flip to serve reads without a Content-Length, as a proxy in front of a bucket
@@ -110,6 +112,7 @@ beforeAll(async () => {
         objects.set(req.url || '', {
           body,
           contentType: String(req.headers['content-type'] || ''),
+          storedAt: Date.now(),
         });
         res.writeHead(200).end();
         return;
@@ -137,9 +140,15 @@ beforeAll(async () => {
           res.end(held.body);
           return;
         }
+        // ⚠ `Last-Modified` on every GET, because S3 and R2 both send one and `lookup`'s
+        // cold read fails CLOSED without it — a stub that omits it would make the cold
+        // path untestable and, worse, would pass a build that never reads the header.
         res.writeHead(200, {
           'content-type': held.contentType,
           'content-length': String(held.body.length),
+          ...(bucketOmitsLastModified
+            ? {}
+            : { 'last-modified': new Date(held.storedAt ?? Date.now()).toUTCString() }),
         });
         res.end(held.body);
         return;
@@ -206,9 +215,15 @@ beforeEach(async () => {
   objects = new Map();
   bucketRejects = false;
   bucketOmitsLength = false;
+  bucketOmitsLastModified = false;
   bucketStallsAfterHeaders = false;
   const { default: db } = await import('../db/index.js');
   db.prepare('DELETE FROM preview_cache').run();
+  // ⚠ Module state, so it outlives the DB wipe — a key one case proved absent would stay
+  // memoised into the next, which is exactly the kind of cross-test leak that makes a
+  // cold-read assertion pass for the wrong reason.
+  const { resetAbsentMemoForTests } = await import('../services/previewCache/index.js');
+  resetAbsentMemoForTests();
 });
 
 /** The request path the stub bucket should have seen for one origin URL. */
@@ -386,8 +401,8 @@ describe('the s3 byte cache, end to end', () => {
     // request reaching us. Objects are deleted by a 30-day bucket lifecycle rule the
     // cell does not run and cannot observe, so a row that outlived its object would
     // have the descriptor handing every user a public URL that 404s — with nothing
-    // arriving at the cell to notice. Seven days against thirty is the margin that
-    // makes the row provably the shorter-lived of the two.
+    // arriving at the cell to notice. Twenty-five days against thirty is the margin
+    // that makes the row provably the shorter-lived of the two.
     servePng();
     const imageUrl = `${base}/ageing.png`;
     await agent.get(`/api/link-preview/media/${mintProxyToken(imageUrl)}`);
@@ -396,9 +411,9 @@ describe('the s3 byte cache, end to end', () => {
     const warm = await agent.post('/api/link-preview/resolve').send({ urls: [imageUrl] });
     expect(warm.body.previews[0].src).toBe(`${CDN}/${PREFIX}/${byteCacheKey(imageUrl)}`);
 
-    // Age the row past the bound. Eight days: the bound is seven.
+    // Age the row past the bound. Thirty days: the bound is twenty-five.
     const { default: db } = await import('../db/index.js');
-    const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
     db.prepare('UPDATE preview_cache SET created_at = ?').run(old);
 
     const stale = await agent.post('/api/link-preview/resolve').send({ urls: [imageUrl] });
@@ -647,6 +662,73 @@ describe('finding cached bytes the index cannot name', () => {
     // A genuine 404 is the ONLY thing that means gone, and it still costs exactly
     // one origin fetch — the probe must not turn a miss into two.
     expect(originHits).toBe(before + 1);
+  });
+
+  it('refuses a cold object past the age bound, judged on the object itself', async () => {
+    // ⚠⚠ The staleness ceiling has to survive the cold path, and the row cannot carry it
+    // there — there is no row. `Last-Modified` is the object's own account of its age, and
+    // it is what stops "serve what the index cannot name" from quietly meaning "serve it
+    // for as long as the bucket keeps it": 30 days under the recommended lifecycle rule,
+    // and forever on a self-hosted bucket that has none.
+    objects.set(keyPathFor('/ancient.png'), {
+      body: PNG,
+      contentType: 'image/png',
+      storedAt: Date.now() - 30 * 24 * 60 * 60 * 1000,
+    });
+    servePng();
+    const before = originHits;
+
+    const res = await agent.get(`/api/link-preview/media/${tokenFor('/ancient.png')}`);
+    expect(res.status).toBe(200);
+    // Refused as a hit, so the origin supplies a fresh copy — which is the whole point of
+    // having a bound at all.
+    expect(originHits).toBe(before + 1);
+  });
+
+  it('refuses a cold object the bucket will not date', async () => {
+    // ⚠ Fails CLOSED. A store that does not send Last-Modified leaves the age unknowable,
+    // and an unknowable age must not be read as "fresh" — that is the same mistake as
+    // treating an absent row as "gone", pointed the other way. S3 and R2 both send it, so
+    // the closed direction costs nothing real.
+    bucketOmitsLastModified = true;
+    objects.set(keyPathFor('/undated.png'), { body: PNG, contentType: 'image/png' });
+    servePng();
+    const before = originHits;
+
+    expect((await agent.get(`/api/link-preview/media/${tokenFor('/undated.png')}`)).status).toBe(
+      200,
+    );
+    expect(originHits).toBe(before + 1);
+  });
+
+  it('does not re-probe the bucket for a key it has already said it lacks', async () => {
+    // ⚠⚠ Without a memo the cold read is a PERMANENT extra round trip for every URL that
+    // will never be stored — an origin sending `no-store`, a body over the cap, a bucket
+    // refusing writes. Each request would pay a bucket 404 on top of the origin fetch it
+    // was always going to pay, on the one path that is already the slow one.
+    // ⚠ An origin that forbids storing, so no row is ever written and the memo is the
+    // ONLY thing that can stop the second request probing again. Using a storable image
+    // here tests nothing: the first request creates a row, and the second request's bucket
+    // GET is an ordinary cache hit rather than a re-probe. (It did, and it was.)
+    handler = (_req, res) => {
+      res.writeHead(200, {
+        'content-type': 'image/png',
+        'content-length': String(PNG.length),
+        'cache-control': 'no-store',
+      });
+      res.end(PNG);
+    };
+    const gets = (): number =>
+      puts.filter((p) => p.method === 'GET' && p.url === keyPathFor('/nostore.png')).length;
+
+    await agent.get(`/api/link-preview/media/${tokenFor('/nostore.png')}`);
+    await whenStoresSettle();
+    expect(countCached()).toBe(0);
+    expect(gets()).toBe(1);
+
+    await agent.get(`/api/link-preview/media/${tokenFor('/nostore.png')}`);
+    await whenStoresSettle();
+    expect(gets()).toBe(1);
   });
 
   it('refuses cold bytes that are not an image, however the object is labelled', async () => {

--- a/server/routes/linkPreview.s3cache.test.ts
+++ b/server/routes/linkPreview.s3cache.test.ts
@@ -752,11 +752,14 @@ describe('finding cached bytes the index cannot name', () => {
 });
 
 /**
- * ⚠⚠ A 200 carrying real image bytes is not permission to KEEP them. GitHub's og:image
- * service answers a card it could not render with a 200 and a valid PNG — the dark
- * Octocat placeholder — marked `cache-control: public, max-age=0`, while a card it DID
- * render comes back `max-age=21600, immutable`. The bytes are indistinguishable; the
- * header is the whole of the difference, and nothing on either side of the seam read it.
+ * ⚠⚠ A 200 carrying real image bytes is not permission to KEEP them. Every other guard in
+ * the cache tests what the bytes ARE — signature, length, framing — and an origin can pass
+ * all of them while saying plainly not to keep the result.
+ *
+ * ⚠ The GitHub placeholder that prompted this (a 200 + valid PNG under `max-age=0`) is not
+ * reachable through the pipeline as it stands — the repo behind it 404s from github.com, so
+ * the resolver never mints an image URL — so these pin a general rule rather than a
+ * reproduction. See `originPermitsStoring`.
  */
 describe('the origin’s own caching instruction', () => {
   /** An origin that serves `body` with an explicit Cache-Control. */

--- a/server/routes/linkPreview.s3cache.test.ts
+++ b/server/routes/linkPreview.s3cache.test.ts
@@ -215,6 +215,16 @@ beforeEach(async () => {
 const keyPathFor = (originPath: string): string =>
   `/${BUCKET_NAME}/${PREFIX}/${byteCacheKey(`${base}${originPath}`)}`;
 
+/**
+ * The bucket requests that actually WROTE.
+ *
+ * ⚠ `puts` records every method, and a store is no longer the first thing the stub
+ * sees: `lookup` now probes the bucket before falling back to the origin, so an
+ * uncached URL costs a GET (404) and then a PUT. Indexing `puts[0]` would silently
+ * start asserting against the probe.
+ */
+const writes = (): Put[] => puts.filter((p) => p.method === 'PUT');
+
 describe('the s3 byte cache, end to end', () => {
   it('PUTs the object to <bucket>/<prefix>/<key>, signed, and records it', async () => {
     servePng();
@@ -223,8 +233,8 @@ describe('the s3 byte cache, end to end', () => {
     expect(Buffer.from(first.body).equals(PNG)).toBe(true);
     await whenStoresSettle();
 
-    expect(puts).toHaveLength(1);
-    const put = puts[0]!;
+    expect(writes()).toHaveLength(1);
+    const put = writes()[0]!;
     // ⚠ The METHOD is asserted. The pre-split suite never did, so changing PUT to
     // POST passed all five of its tests — a stub that records everything cannot
     // tell you it was written to wrongly unless you ask.
@@ -246,7 +256,7 @@ describe('the s3 byte cache, end to end', () => {
     await agent.get(`/api/link-preview/media/${tokenFor('/headers.png')}`);
     await whenStoresSettle();
 
-    const put = puts[0]!;
+    const put = writes()[0]!;
     expect(put.headers['content-disposition']).toBe('inline');
     // ⚠ NOT the uploader's `public, max-age=31536000, immutable`. A URL-keyed cache
     // legitimately points at different bytes over time, and a year at the edge would
@@ -566,5 +576,160 @@ describe('resource bounds and diagnostics', () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+/**
+ * ⚠⚠ The state this whole group is about: an object in the bucket that the index
+ * cannot name. It is not an edge case — it is the ORDINARY state of every object
+ * between the row's age bound (7 d) and the bucket's lifecycle rule (30 d), and of
+ * every object on every cell that did not personally store it. lurker#776.
+ */
+describe('finding cached bytes the index cannot name', () => {
+  it('serves an object whose row has aged out, without going back to the origin', async () => {
+    servePng();
+    expect((await agent.get(`/api/link-preview/media/${tokenFor('/aged.png')}`)).status).toBe(200);
+    await whenStoresSettle();
+    expect(countCached()).toBe(1);
+    const settled = originHits;
+
+    // Age the ROW only. The object is deliberately left where it is — that
+    // asymmetry is the bug: `MAX_AGE_MS` is 7 days precisely so the row is
+    // provably shorter-lived than the object, and we then treated the row's
+    // expiry as proof the object was gone.
+    const { default: db } = await import('../db/index.js');
+    db.prepare(
+      `UPDATE preview_cache SET created_at = strftime('%Y-%m-%dT%H:%M:%fZ','now','-30 days')`,
+    ).run();
+
+    const again = await agent.get(`/api/link-preview/media/${tokenFor('/aged.png')}`);
+    expect(again.status).toBe(200);
+    expect(Buffer.from(again.body).equals(PNG)).toBe(true);
+    // ⚠⚠ THE POINT. Measured on app.lurker.chat as a byte-identical re-upload of a
+    // GitHub og:image 18 days after it was first stored — and a permanently broken
+    // card whenever the origin refused that pointless re-fetch.
+    expect(originHits).toBe(settled);
+  });
+
+  it('serves an object another cell stored, for which this cell has no row at all', async () => {
+    // The fleet shares one bucket but every cell keeps its own SQLite index, so
+    // "no row, object present" is the normal state for every cell that did not do
+    // the storing. Before this the shared bucket deduplicated writes and shared
+    // nothing on reads: each cell paid its own origin fetch for every image.
+    objects.set(keyPathFor('/foreign.png'), { body: PNG, contentType: 'image/png' });
+    expect(countCached()).toBe(0);
+    servePng();
+    const before = originHits;
+
+    const res = await agent.get(`/api/link-preview/media/${tokenFor('/foreign.png')}`);
+    expect(res.status).toBe(200);
+    expect(Buffer.from(res.body).equals(PNG)).toBe(true);
+    expect(originHits).toBe(before);
+  });
+
+  it('does NOT record a row for a cold hit', async () => {
+    objects.set(keyPathFor('/norow.png'), { body: PNG, contentType: 'image/png' });
+    expect((await agent.get(`/api/link-preview/media/${tokenFor('/norow.png')}`)).status).toBe(200);
+    await whenStoresSettle();
+    // ⚠⚠ `recordCached` stamps `created_at` with NOW, and a cold read does not know
+    // the object's real age. A day-25 object would get a row expiring at day 32 —
+    // past the lifecycle deletion — and `publicByteUrl` would then mint a public URL
+    // that 404s for every viewer with no request reaching us to notice. Serving the
+    // bytes needs no row; minting a URL for them does.
+    expect(countCached()).toBe(0);
+  });
+
+  it('falls through to the origin when the bucket really does not have it', async () => {
+    servePng();
+    const before = originHits;
+    const res = await agent.get(`/api/link-preview/media/${tokenFor('/absent.png')}`);
+    expect(res.status).toBe(200);
+    // A genuine 404 is the ONLY thing that means gone, and it still costs exactly
+    // one origin fetch — the probe must not turn a miss into two.
+    expect(originHits).toBe(before + 1);
+  });
+
+  it('refuses cold bytes that are not an image, however the object is labelled', async () => {
+    // ⚠⚠ With no row to vouch for them the stored Content-Type is a CLAIM by
+    // whatever wrote the key, and there is no recorded size to cross-check against
+    // either — so the signature is the whole of the evidence. The store path gates
+    // on it for the same reason; this is the same gate on the way back out.
+    objects.set(keyPathFor('/liar.png'), {
+      body: Buffer.from('<!doctype html><script>alert(1)</script>'),
+      contentType: 'image/png',
+    });
+    servePng();
+    const before = originHits;
+
+    const res = await agent.get(`/api/link-preview/media/${tokenFor('/liar.png')}`);
+    // Refused as a hit, so the origin answers — and what the client gets is the
+    // origin's PNG, never the bucket's HTML.
+    expect(originHits).toBe(before + 1);
+    expect(Buffer.from(res.body).equals(PNG)).toBe(true);
+  });
+});
+
+/**
+ * ⚠⚠ A 200 carrying real image bytes is not permission to KEEP them. GitHub's og:image
+ * service answers a card it could not render with a 200 and a valid PNG — the dark
+ * Octocat placeholder — marked `cache-control: public, max-age=0`, while a card it DID
+ * render comes back `max-age=21600, immutable`. The bytes are indistinguishable; the
+ * header is the whole of the difference, and nothing on either side of the seam read it.
+ */
+describe('the origin’s own caching instruction', () => {
+  /** An origin that serves `body` with an explicit Cache-Control. */
+  const serveWith = (cacheControl: string, body = PNG): void => {
+    handler = (_req, res) => {
+      res.writeHead(200, {
+        'content-type': 'image/png',
+        'content-length': String(body.length),
+        'cache-control': cacheControl,
+      });
+      res.end(body);
+    };
+  };
+
+  it('serves but does not store a placeholder the origin marked max-age=0', async () => {
+    serveWith('public, max-age=0');
+    const res = await agent.get(`/api/link-preview/media/${tokenFor('/placeholder.png')}`);
+    // ⚠ SERVED — refusing to keep it is not refusing to show it. The reader still gets
+    // whatever the origin sent; we simply do not hold it for a week afterwards.
+    expect(res.status).toBe(200);
+    expect(Buffer.from(res.body).equals(PNG)).toBe(true);
+
+    await whenStoresSettle();
+    expect(writes()).toHaveLength(0);
+    expect(countCached()).toBe(0);
+  });
+
+  it.each(['no-store', 'no-cache', 'private, max-age=600'])(
+    'does not store under %s',
+    async (cc) => {
+      serveWith(cc);
+      await agent.get(`/api/link-preview/media/${tokenFor(`/${cc.replace(/\W/g, '')}.png`)}`);
+      await whenStoresSettle();
+      expect(countCached()).toBe(0);
+    },
+  );
+
+  it('still stores what the origin says is cacheable', async () => {
+    // ⚠ The positive control, and it is the half that matters most: a guard that refuses
+    // everything passes every test above while quietly turning the cache off.
+    serveWith('public, max-age=21600, immutable');
+    expect((await agent.get(`/api/link-preview/media/${tokenFor('/real.png')}`)).status).toBe(200);
+    await whenStoresSettle();
+    expect(writes()).toHaveLength(1);
+    expect(countCached()).toBe(1);
+  });
+
+  it('still stores when the origin says nothing at all', async () => {
+    // ⚠ Silence is permission. Plenty of image hosts send no Cache-Control, and treating
+    // absence as prohibition would switch the cache off for most of the web.
+    servePng();
+    expect((await agent.get(`/api/link-preview/media/${tokenFor('/silent.png')}`)).status).toBe(
+      200,
+    );
+    await whenStoresSettle();
+    expect(countCached()).toBe(1);
   });
 });

--- a/server/routes/linkPreview.ts
+++ b/server/routes/linkPreview.ts
@@ -454,21 +454,39 @@ router.get('/poster/:token', async (req: Request, res: Response) => {
   // ⚠⚠ Cache or nothing, BY DESIGN. A poster is the one preview image with no origin URL —
   // these bytes were decoded by this instance and exist nowhere else — so there is no
   // proxy-path fallback, and a miss (evicted, cache turned off, a restored backup) is an
-  // honest 404: the card renders without its poster, which is a supported state. The
-  // deliberately-unpooled read is fine at this size: posters are ≤640px q4 JPEGs, and the
-  // shared throttle above bounds the rate.
+  // honest 404: the card renders without its poster, which is a supported state.
   if (!cacheEnabled()) {
     res.status(404).end();
     return;
   }
-  const hit = await lookup(key);
-  if (!hit) {
-    res.status(404).end();
+
+  // ⚠⚠ POOLED, and it did not used to be. The reasoning for leaving it out was that a
+  // poster miss is a pure SQLite read — no I/O worth bounding, and the per-user throttle
+  // above caps the rate. That stopped being true when `lookup` gained its cold read: a
+  // miss can now issue an outbound bucket GET, and `mediaThrottle` is PER ACCOUNT, so
+  // nothing bounded these in aggregate. A fleet of clients re-rendering cards on reconnect
+  // — after a sweep has dropped a cell's poster rows, which happens to every row at once —
+  // is precisely the burst that shape produces.
+  if (!(await mediaPool.acquire())) {
+    res.set('Retry-After', '5');
+    res.status(503).end();
     return;
   }
-  applyMediaHeaders(res, hit.contentType);
-  res.setHeader('Content-Length', String(hit.body.length));
-  res.status(200).end(hit.body);
+  try {
+    const hit = await lookup(key);
+    if (!hit) {
+      res.status(404).end();
+      return;
+    }
+    applyMediaHeaders(res, hit.contentType);
+    res.setHeader('Content-Length', String(hit.body.length));
+    res.status(200).end(hit.body);
+  } finally {
+    // ⚠ `finally`, not a `close` listener as the media route uses: this response is
+    // `end()`ed synchronously with a buffer already in hand, so the slot is done with when
+    // the block is. A listener would hold it until the socket drained, for nothing.
+    mediaPool.release();
+  }
 });
 
 export default router;

--- a/server/routes/linkPreview.ts
+++ b/server/routes/linkPreview.ts
@@ -331,7 +331,12 @@ router.get('/media/:token', async (req: Request, res: Response) => {
     // never a reason for the bytes to sit in RSS on the way there. `declared` when the
     // decoder gave one, the cap when it did not: the writer reserves room before the first
     // byte, and under-reserving is how the ceiling gets crossed.
-    const wantCache = cacheable(contentType, isRange) && upstream.status !== 206;
+    // ⚠ The origin's own Cache-Control is forwarded across the seam by the decoder and
+    // consulted HERE, at the store decision. See `originPermitsStoring` — GitHub marks its
+    // unrendered-card placeholder `max-age=0`, and we used to keep it for a week.
+    const wantCache =
+      cacheable(contentType, isRange, upstream.headers['cache-control'] as string | undefined) &&
+      upstream.status !== 206;
     const writer = wantCache
       ? await beginStore(cacheKey, Number.isFinite(declared) ? declared : cap)
       : null;

--- a/server/services/previewCache/cache.test.ts
+++ b/server/services/previewCache/cache.test.ts
@@ -221,18 +221,23 @@ describe('preview byte cache — local', () => {
     expect(Math.abs(Date.now() - Date.parse(row!.created_at))).toBeLessThan(60_000);
   });
 
-  it('stops serving an entry once it is older than the metadata TTL', async () => {
+  it('stops serving an entry once it is past the age bound', async () => {
     // ⚠ Eviction is by PRESSURE, so without an age bound an image at a stable
     // address that changed underneath us — an avatar, a `latest.png` — is served
-    // from disk indefinitely under `max-age=86400, immutable`, long after the
-    // metadata row for it has re-resolved. Before this cache existed the staleness
-    // window was a day; unbounded is a regression, not a feature.
+    // from disk indefinitely under `max-age=86400, immutable`. Before this cache
+    // existed the staleness window was a day; unbounded is a regression, not a
+    // feature.
+    //
+    // ⚠ The bound is no longer the METADATA TTL, and the decoupling is the point: a
+    // page's title changes, and image bytes at the content-addressed URLs most
+    // og:images use do not. It is set against the bucket lifecycle rule instead —
+    // see MAX_AGE_MS.
     const key = '7'.repeat(64);
     await mod.store(key, bytes(64), 'image/png');
     expect(await mod.lookup(key)).not.toBeNull();
 
     const { default: db } = await import('../../db/index.js');
-    db.prepare(`UPDATE preview_cache SET created_at = datetime('now', '-8 days')`).run();
+    db.prepare(`UPDATE preview_cache SET created_at = datetime('now', '-30 days')`).run();
 
     expect(await mod.lookup(key)).toBeNull();
     // ...and it is cleared out rather than re-checked on every future request.

--- a/server/services/previewCache/config.ts
+++ b/server/services/previewCache/config.ts
@@ -287,23 +287,39 @@ function defaultWarn(msg: string): void {
 }
 
 /**
+ * The bucket lifecycle rule this cache is designed against, in days.
+ *
+ * ⚠ Documented here because `MAX_AGE_MS` is only meaningful RELATIVE to it, and the
+ * cell can neither run the rule nor observe it. Hosted sets 30 days on the `previews/`
+ * prefix (LINK_PREVIEWS_CACHE_PLAN.md); a self-hoster's `s3` bucket is their own to
+ * configure, and .env.example says so.
+ */
+const LIFECYCLE_DAYS = 30;
+
+/**
  * How long a cached object may be served before it is re-fetched.
  *
- * ⚠ Deliberately the same seven days as `link_previews`' OK_TTL. The two caches
- * describe the same URL, and letting the bytes outlive the metadata means an image
- * that changed at a stable address — an avatar, a `latest.png` — is served from
- * disk long after the record for it was re-resolved. Eviction is by PRESSURE, so
- * without an age bound the staleness window is unbounded; before this cache
- * existed it was a day.
+ * ⚠⚠ A CORRECTNESS bound first and a freshness one second, and the correctness half
+ * is what fixes the number. Objects in a bucket are deleted by a lifecycle rule the
+ * cell does not run and cannot observe, and a row outliving its object would have
+ * `publicByteUrl` mint a public URL that 404s for every user — fetched by the browser
+ * directly, so the 404 never reaches us to notice. Staying strictly under
+ * `LIFECYCLE_DAYS` is what makes the row provably the shorter-lived of the two.
  *
- * ⚠⚠ For `s3` it is also a CORRECTNESS bound, not a freshness one. Objects there
- * are deleted by a bucket lifecycle rule the cell does not run and cannot observe
- * (30 days, per LINK_PREVIEWS_CACHE_PLAN.md), and a row that outlived its object
- * would have `publicByteUrl` mint a public URL that 404s for every user with no
- * request reaching us to notice. Seven against thirty is the margin that makes the
- * row provably the shorter-lived of the two.
+ * ⚠⚠ NO LONGER TIED TO `link_previews`' OK_TTL, and the coupling was the mistake. The
+ * two answer different questions: OK_TTL governs a page's TITLE, which genuinely
+ * changes, while this governs IMAGE BYTES, which at the content-addressed URLs most
+ * og:images use cannot change at all. Matching them meant every image was re-fetched
+ * from its origin every seven days for no reason — measured on app.lurker.chat as a
+ * byte-identical re-upload of a GitHub og:image, same ETag, 18 days on — and when the
+ * origin refused that re-fetch the card broke (lurker#776). Five days of margin under
+ * the lifecycle rule is plenty for a clock skew and a sweep interval.
+ *
+ * ⚠ The freshness half survives, and it is enforced on the OBJECT rather than only on
+ * the row: an image that changed at a stable address — an avatar, a `latest.png` — is
+ * bounded by this figure whether or not the index still remembers it. See `lookup`.
  */
-export const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+export const MAX_AGE_MS = (LIFECYCLE_DAYS - 5) * 24 * 60 * 60 * 1000;
 
 /** Past the age bound, and therefore not to be served or minted. */
 export function expired(createdAt: string): boolean {

--- a/server/services/previewCache/index.ts
+++ b/server/services/previewCache/index.ts
@@ -35,8 +35,15 @@ import {
 import { kindForContentType, MAX_IMAGE_PROXY_BYTES } from '../previewShared.js';
 import { imageSignatureOf, SIGNATURE_BYTES } from '../../utils/imageSignature.js';
 import { cacheConfig, cacheEnabled, expired, MAX_AGE_MS } from './config.js';
-import { evictLocal, objectPath, openLocalWrite, readLocal, removeLocal } from './local.js';
-import { openS3Write, readS3, removeS3, type S3Writer } from './s3.js';
+import {
+  evictLocal,
+  objectPath,
+  openLocalWrite,
+  readLocal,
+  removeLocal,
+  type LocalRead,
+} from './local.js';
+import { openS3Write, readS3, removeS3, type S3Read, type S3Writer } from './s3.js';
 import { openDropperWrite, readDropper } from './dropper.js';
 
 export type { CacheConfig, CacheMode } from './config.js';
@@ -203,10 +210,65 @@ function originPermitsStoring(cacheControl: string | undefined): boolean {
   ) {
     return false;
   }
-  // ⚠ Zero freshness is the placeholder's own tell. Read from BOTH forms, and only an
-  // explicit zero — a missing or unparseable max-age says nothing either way, and
-  // guessing from it would start refusing perfectly cacheable images.
-  return !directives.some((d) => /^(?:s-maxage|max-age)=0+$/.test(d));
+  // ⚠⚠ A positive `s-maxage` DECIDES, overriding `max-age` (RFC 9111 §5.2.2.10), because
+  // this is a shared cache — which the `private` refusal above already asserts.
+  // `public, max-age=0, s-maxage=86400` is the ordinary CDN spelling of "browsers
+  // revalidate, shared caches may keep this for a day": a Next.js `opengraph-image` route
+  // and a large slice of Cloudflare/Fastly-fronted image endpoints send exactly that.
+  // Reading `max-age` alone refused every one of them — no stored object, no minted CDN
+  // URL, every view relayed through the cell, for origins that had explicitly said yes.
+  const shared = directives.find((d) => /^s-maxage=\d+$/.test(d));
+  if (shared) return Number(shared.slice('s-maxage='.length)) > 0;
+  // ⚠ Zero freshness is the placeholder's own tell, and only an EXPLICIT zero — a missing
+  // or unparseable max-age says nothing either way, and guessing from it would start
+  // refusing perfectly cacheable images.
+  return !directives.some((d) => /^max-age=0+$/.test(d));
+}
+
+/**
+ * Keys a remote backend has told us it does not hold, and until when (epoch ms).
+ *
+ * ⚠⚠ Bounds the cost of the cold read, which without it re-probes forever for exactly
+ * the URLs that will never be stored. An origin sending `no-store`, a body over the cap,
+ * a bucket refusing writes — each leaves nothing behind, so every request would pay a
+ * bucket 404 on top of the decoder fetch it was always going to pay. A permanent extra
+ * round trip, added to the one path that is already the slow one.
+ *
+ * ⚠ Deliberately SHORT, and never consulted while a row exists: this remembers a fact
+ * about the BUCKET, not about the URL. A minute collapses the burst of viewers arriving
+ * at one message, and is far too short to hide a store that has just landed.
+ */
+const absentFromBackend = new Map<string, number>();
+const ABSENT_MEMO_MS = 60_000;
+
+function noteAbsent(key: string, now = Date.now()): void {
+  // ⚠ Swept here rather than on a timer — the same discipline as the decoder's origin
+  // cooldowns. Misses are the rare path, an O(n) pass costs microseconds, and there is no
+  // interval to own, unref, or remember to clear in a test.
+  for (const [seen, until] of absentFromBackend) {
+    if (until <= now) absentFromBackend.delete(seen);
+  }
+  absentFromBackend.set(key, now + ABSENT_MEMO_MS);
+}
+
+/** A store landed: whatever we remembered about this key being absent is now wrong. */
+function forgetAbsent(key: string): void {
+  absentFromBackend.delete(key);
+}
+
+function recentlyAbsent(key: string, now = Date.now()): boolean {
+  const until = absentFromBackend.get(key);
+  if (until === undefined) return false;
+  if (until <= now) {
+    absentFromBackend.delete(key);
+    return false;
+  }
+  return true;
+}
+
+/** Test seam. The memo is module state and would otherwise leak between cases. */
+export function resetAbsentMemoForTests(): void {
+  absentFromBackend.clear();
 }
 
 /**
@@ -272,10 +334,18 @@ export async function lookup(key: string): Promise<CacheHit | null> {
 
     // ⚠ An AGE bound as well as a size one. Eviction is by pressure, so without this
     // an entry at a stable URL that changes underneath it — an avatar, a
-    // `latest.png` — is served from disk indefinitely under `max-age=86400,
-    // immutable`, long after the metadata row has re-resolved. Before the cache
-    // existed the staleness window was a day; unbounded is a regression, not a
-    // feature. Matched to the metadata cache's own OK_TTL so the two agree.
+    // `latest.png` — is served indefinitely under `max-age=86400, immutable`, long
+    // after the metadata row has re-resolved. Before the cache existed the staleness
+    // window was a day; unbounded is a regression, not a feature.
+    //
+    // ⚠⚠ The ROW's age is a cheap PROXY for the object's, and when it says "too old"
+    // the object itself is asked rather than assumed. The two genuinely differ on a
+    // shared bucket — the row records this cell's own store, and another cell may
+    // have rewritten the object yesterday — so `MAX_AGE_MS` is enforced on the
+    // object's `Last-Modified` down in the cold branch. Dropping the bound entirely
+    // for the remote backends was the first version of this change, and it quietly
+    // turned a 7-day staleness ceiling into "however long the bucket keeps it",
+    // which on a self-hosted bucket with no lifecycle rule is forever.
     if (entry && expired(entry.createdAt)) {
       // ⚠ `local` is the cell's OWN volume: it runs the eviction, it owns the
       // lifetime, and an expired object is one it should reclaim. There is nothing
@@ -294,13 +364,26 @@ export async function lookup(key: string): Promise<CacheHit | null> {
     // purpose; resurrecting it would undo an eviction and desync the size ceiling
     // the rows are the accounting for.
     if (!entry && cfg.mode === 'local') return null;
+    // ⚠ Only with NO row. An expired row is evidence that something was once stored
+    // under this key, which is worth one probe; the memo is for keys nothing vouches for.
+    if (!entry && recentlyAbsent(key)) return null;
 
-    const read =
-      cfg.mode === 'local'
-        ? await readLocal(cfg, key)
-        : cfg.mode === 's3'
+    // ⚠ The remote result is held SEPARATELY as well as in `read`, because the cold
+    // branch below needs two things `readLocal` has no way to report — the object's age
+    // and its content type — and a ternary over all three backends collapses to a union
+    // the compiler will not re-correlate with `cfg.mode`. Branching says the same thing
+    // in a form it can follow, without a cast standing in for the argument.
+    let read: LocalRead | S3Read;
+    let remote: S3Read | null = null;
+    if (cfg.mode === 'local') {
+      read = await readLocal(cfg, key);
+    } else {
+      remote =
+        cfg.mode === 's3'
           ? await readS3(cfg, key, MAX_IMAGE_PROXY_BYTES)
           : await readDropper(cfg, key, MAX_IMAGE_PROXY_BYTES);
+      read = remote;
+    }
     // ⚠⚠ Only a GENUINELY MISSING object forgets its row. `readLocal` used to
     // collapse every errno to null, so a transient EMFILE — 24 concurrent reads is
     // within this pool's own budget — or an EACCES after a permissions change
@@ -311,6 +394,9 @@ export async function lookup(key: string): Promise<CacheHit | null> {
     // read as "the lifecycle rule took it".
     if (read.kind === 'missing') {
       forget(key);
+      // ⚠ Remembered only for the remote backends. `local` has no cold path to spare a
+      // round trip on, and its "read" is a stat on a volume this process owns.
+      if (cfg.mode !== 'local') noteAbsent(key);
       return null;
     }
     if (read.kind === 'error') return null;
@@ -329,15 +415,22 @@ export async function lookup(key: string): Promise<CacheHit | null> {
     }
 
     // A cold hit: no row vouches for these bytes, so they must vouch for
-    // themselves. The stored Content-Type is a CLAIM by whatever wrote the key —
-    // the same reasoning as the store path's own gate — and with no recorded size
-    // to cross-check, the signature is what stands in for it.
-    // ⚠ `in` rather than a cast. `readLocal` has no content type to report, and the
-    // guard above already makes this branch remote-only — but the compiler cannot
-    // see that correlation, and a cast would paper over it rather than state it.
-    const declared =
-      'contentType' in read && typeof read.contentType === 'string' ? read.contentType : '';
-    const contentType = declared.split(';')[0].trim().toLowerCase();
+    // themselves — age, type and signature, in that order.
+    //
+    // ⚠⚠ THE AGE IS CHECKED AGAINST THE OBJECT, and failing CLOSED when the store
+    // does not say. `MAX_AGE_MS` is the only staleness ceiling this cache has, and a
+    // cold read is precisely the path with no row to enforce it from; without this,
+    // serving an object the index cannot name means serving it for as long as the
+    // bucket keeps it — 30 days under the recommended lifecycle rule, and forever on
+    // a self-hosted bucket that has none. S3 and R2 both send `Last-Modified` on
+    // every GET, so the closed direction costs nothing real and is the safe one.
+    // ⚠ `remote.kind` re-checked, not assumed. The missing/error returns above narrowed
+    // `read`, and the compiler does not know `remote` is the same object — asserting that
+    // would be a cast, and the honest version costs one comparison.
+    if (!remote || remote.kind !== 'ok') return null;
+    if (remote.storedAt === null || Date.now() - remote.storedAt > MAX_AGE_MS) return null;
+
+    const contentType = remote.contentType.split(';')[0].trim().toLowerCase();
     if (kindForContentType(contentType) !== 'image') return null;
     if (!imageSignatureOf(read.body.subarray(0, SIGNATURE_BYTES))) return null;
     return { kind: 'buffer', body: read.body, contentType };
@@ -512,6 +605,10 @@ export async function beginStore(key: string, expected: number): Promise<StoreWr
             return false;
           }
           if (!(await writer.commit(contentType))) return false;
+          // The bucket now holds it, so anything remembered about it being absent is
+          // wrong. Cheap insurance: a row also exists, and `lookup` consults the memo
+          // only when one does not.
+          forgetAbsent(key);
           try {
             recordCached({ key, backend: cfg.mode, contentType, size });
           } catch {

--- a/server/services/previewCache/index.ts
+++ b/server/services/previewCache/index.ts
@@ -154,14 +154,59 @@ export async function sweepPreviewCache(): Promise<number> {
  * to run thirty-five lines earlier in the one caller. That is an ordering, not a
  * guarantee.
  */
-export function cacheable(contentType: string | undefined, isRangeRequest: boolean): boolean {
+export function cacheable(
+  contentType: string | undefined,
+  isRangeRequest: boolean,
+  cacheControl?: string,
+): boolean {
   if (!cacheEnabled()) return false;
   // ⚠ A range request is passed straight through, never served from cache and never
   // stored. Answering one correctly means honouring an arbitrary byte window, and
   // the only content that asks for ranges is the media this cache excludes anyway.
   // Serving a whole object to a request for bytes 100-200 is a correctness bug.
   if (isRangeRequest) return false;
+  if (!originPermitsStoring(cacheControl)) return false;
   return !!contentType && kindForContentType(contentType) === 'image';
+}
+
+/**
+ * Whether the ORIGIN permits us to keep a copy.
+ *
+ * ⚠⚠ A 200 carrying real image bytes is not the same as permission to KEEP them, and
+ * until this nothing here asked. `opengraph.githubassets.com` answers a card it cannot
+ * render with a 200 and a perfectly valid PNG — the dark Octocat placeholder — under
+ * `cache-control: public, max-age=0`; a card it DID render comes back `max-age=21600,
+ * immutable`. The placeholder passed every guard this module has (real PNG signature,
+ * honest Content-Length, cleanly framed) and was then stored and re-served under our own
+ * `private, max-age=86400, immutable` for the full seven days, long after GitHub had
+ * started rendering the real card. The one thing that distinguished the two was a header
+ * we never read.
+ *
+ * ⚠ Silence is PERMISSION, not prohibition: plenty of image hosts send no Cache-Control
+ * at all, and refusing those would turn the cache off for most of the web.
+ *
+ * ⚠ `no-cache` is refused even though HTTP allows storing it, because what it actually
+ * demands is revalidation on every use and this cache does not revalidate — so "store it
+ * and never check again" is the one thing it must not mean here. `private` is refused
+ * because this IS a shared cache: on hosted, one bucket serving the whole fleet.
+ */
+function originPermitsStoring(cacheControl: string | undefined): boolean {
+  if (!cacheControl) return true;
+  const directives = cacheControl
+    .toLowerCase()
+    .split(',')
+    .map((d) => d.trim());
+  if (
+    directives.includes('no-store') ||
+    directives.includes('no-cache') ||
+    directives.includes('private')
+  ) {
+    return false;
+  }
+  // ⚠ Zero freshness is the placeholder's own tell. Read from BOTH forms, and only an
+  // explicit zero — a missing or unparseable max-age says nothing either way, and
+  // guessing from it would start refusing perfectly cacheable images.
+  return !directives.some((d) => /^(?:s-maxage|max-age)=0+$/.test(d));
 }
 
 /**
@@ -178,20 +223,51 @@ export function cacheable(contentType: string | undefined, isRangeRequest: boole
  * throws, and the stump is served with `max-age=86400, immutable` — a permanently
  * broken image every viewer holds for a day. A zero-length Buffer is also truthy,
  * so a presence test does not catch that one either.
+ *
+ * ⚠⚠ AN ABSENT OR EXPIRED ROW IS NOT PROOF THE BYTES ARE GONE, and treating it as
+ * proof is what lurker#776 turned out to be. For the remote backends the object
+ * OUTLIVES its row by design: the row is bounded at `MAX_AGE_MS` (7 d) precisely so
+ * it is provably shorter-lived than the bucket's lifecycle rule (30 d). Between
+ * those two numbers sits an object nothing can name — even though the key that
+ * names it is a pure function of the URL we are already holding (`byteCacheKey`).
+ * We threw that away and went back to the ORIGIN for a file we already owned.
+ *
+ * Measured on app.lurker.chat: a GitHub og:image stored 10 Aug, re-fetched and
+ * re-uploaded byte-for-byte 18 days later (same ETag, same 48,559 bytes). And when
+ * the origin refused that pointless re-fetch — opengraph.githubassets.com
+ * rate-limits renders per IP — the card stayed permanently broken with the bytes
+ * sitting in the bucket the whole time. A genuine 404 from the backend is the ONLY
+ * thing that means gone.
+ *
+ * ⚠ This is the one place the module's "existence is answered from the index, never
+ * by asking the backend" rule is relaxed, and only where the index has already
+ * answered "no" — a hot hit still costs no round trip. On a real miss it is an edge
+ * 404 rather than an origin render, so it is strictly cheaper than the fetch it
+ * replaces. It also makes the fleet-shared bucket shared for READS: a cell that
+ * never stored an object can now serve one another cell did.
+ *
+ * ⚠⚠ A cold hit deliberately does NOT record a row. `recordCached` stamps
+ * `created_at` with NOW and the object's real age is unknown, so an object at day 25
+ * would get a row expiring at day 32 — past the lifecycle deletion — and
+ * `publicByteUrl` would then mint a public URL that 404s for every viewer, with no
+ * request reaching us to notice. That is the exact failure the age bound exists to
+ * prevent. Serving the bytes needs no row; minting a URL for them does. (The
+ * object's true age is in its `Last-Modified`, and carrying that into the row would
+ * let minting resume for days 7–30 — the obvious follow-up, once the upsert's
+ * `created_at` semantics are settled.)
  */
 export async function lookup(key: string): Promise<CacheHit | null> {
   try {
     const cfg = cacheConfig();
     if (cfg.mode === 'off') return null;
 
-    const entry = lookupCached(key);
-    if (!entry) return null;
     // ⚠ A row from another backend is FORGOTTEN, not merely skipped. Left in place
     // after a mode change it is unreachable and uncounted at once, so its bytes sit
     // on the volume forever with nothing able to name them.
-    if (entry.backend !== cfg.mode) {
+    let entry = lookupCached(key);
+    if (entry && entry.backend !== cfg.mode) {
       forget(key);
-      return null;
+      entry = null;
     }
 
     // ⚠ An AGE bound as well as a size one. Eviction is by pressure, so without this
@@ -200,17 +276,24 @@ export async function lookup(key: string): Promise<CacheHit | null> {
     // immutable`, long after the metadata row has re-resolved. Before the cache
     // existed the staleness window was a day; unbounded is a regression, not a
     // feature. Matched to the metadata cache's own OK_TTL so the two agree.
-    //
-    // ⚠⚠ It is also what keeps `s3` HONEST, and there it is load-bearing rather
-    // than merely tidy. A stored object is deleted by a bucket lifecycle rule the
-    // cell does not run and cannot observe; the row would otherwise outlive it and
-    // `publicByteUrl` would keep minting a CDN URL that 404s — for every user, with
-    // no request reaching us to notice. Seven days against a lifecycle rule of 30
-    // is the margin that makes the row provably the shorter-lived of the two.
-    if (expired(entry.createdAt)) {
-      if (cfg.mode !== 'local' || (await removeLocal(cfg, key))) forget(key);
-      return null;
+    if (entry && expired(entry.createdAt)) {
+      // ⚠ `local` is the cell's OWN volume: it runs the eviction, it owns the
+      // lifetime, and an expired object is one it should reclaim. There is nothing
+      // to verify against — deleting is the whole answer.
+      if (cfg.mode === 'local') {
+        if (await removeLocal(cfg, key)) forget(key);
+        return null;
+      }
+      // Remote: the row is stale, the OBJECT may not be. Fall through and ask.
+      // The row is kept for now — it still carries the size and content type this
+      // read is cross-checked against, and only a genuine 404 may drop it.
     }
+
+    // ⚠ No cold path for `local`, deliberately. There the row IS the index for a
+    // file this cell wrote and evicts, so an absent row means we dropped it on
+    // purpose; resurrecting it would undo an eviction and desync the size ceiling
+    // the rows are the accounting for.
+    if (!entry && cfg.mode === 'local') return null;
 
     const read =
       cfg.mode === 'local'
@@ -231,21 +314,37 @@ export async function lookup(key: string): Promise<CacheHit | null> {
       return null;
     }
     if (read.kind === 'error') return null;
-    if (read.body.length !== entry.size) {
-      // ⚠ For `local` the row is dropped only if the bad file actually went with it —
-      // otherwise we would forget an object that is still on the volume. For `s3` a
-      // length disagreement means the key holds bytes we did not put there, so the
-      // row is wrong either way; the object is left alone because it is not ours to
-      // assume, and the next store re-PUTs and re-records it.
-      if (cfg.mode !== 'local' || (await removeLocal(cfg, key))) forget(key);
-      return null;
+
+    if (entry) {
+      if (read.body.length !== entry.size) {
+        // ⚠ For `local` the row is dropped only if the bad file actually went with it —
+        // otherwise we would forget an object that is still on the volume. For `s3` a
+        // length disagreement means the key holds bytes we did not put there, so the
+        // row is wrong either way; the object is left alone because it is not ours to
+        // assume, and the next store re-PUTs and re-records it.
+        if (cfg.mode !== 'local' || (await removeLocal(cfg, key))) forget(key);
+        return null;
+      }
+      return { kind: 'buffer', body: read.body, contentType: entry.contentType };
     }
-    return { kind: 'buffer', body: read.body, contentType: entry.contentType };
+
+    // A cold hit: no row vouches for these bytes, so they must vouch for
+    // themselves. The stored Content-Type is a CLAIM by whatever wrote the key —
+    // the same reasoning as the store path's own gate — and with no recorded size
+    // to cross-check, the signature is what stands in for it.
+    // ⚠ `in` rather than a cast. `readLocal` has no content type to report, and the
+    // guard above already makes this branch remote-only — but the compiler cannot
+    // see that correlation, and a cast would paper over it rather than state it.
+    const declared =
+      'contentType' in read && typeof read.contentType === 'string' ? read.contentType : '';
+    const contentType = declared.split(';')[0].trim().toLowerCase();
+    if (kindForContentType(contentType) !== 'image') return null;
+    if (!imageSignatureOf(read.body.subarray(0, SIGNATURE_BYTES))) return null;
+    return { kind: 'buffer', body: read.body, contentType };
   } catch {
     return null;
   }
 }
-
 /**
  * Outstanding cache DECISIONS — not outstanding writes.
  *

--- a/server/services/previewCache/index.ts
+++ b/server/services/previewCache/index.ts
@@ -179,15 +179,20 @@ export function cacheable(
 /**
  * Whether the ORIGIN permits us to keep a copy.
  *
- * ⚠⚠ A 200 carrying real image bytes is not the same as permission to KEEP them, and
- * until this nothing here asked. `opengraph.githubassets.com` answers a card it cannot
- * render with a 200 and a perfectly valid PNG — the dark Octocat placeholder — under
- * `cache-control: public, max-age=0`; a card it DID render comes back `max-age=21600,
- * immutable`. The placeholder passed every guard this module has (real PNG signature,
- * honest Content-Length, cleanly framed) and was then stored and re-served under our own
- * `private, max-age=86400, immutable` for the full seven days, long after GitHub had
- * started rendering the real card. The one thing that distinguished the two was a header
- * we never read.
+ * ⚠⚠ A 200 carrying real image bytes is not the same as permission to KEEP them, and until
+ * this nothing here asked. Every other guard in this module tests what the bytes ARE — the
+ * signature, the length, the framing — and an origin can satisfy all of them while telling
+ * us plainly not to hold on to the result.
+ *
+ * ⚠ The case that prompted it is NOT one this pipeline can currently reach, and that is
+ * worth stating so nobody "fixes" it back out. `opengraph.githubassets.com` answers a card
+ * it cannot render with a 200 and a perfectly valid PNG — the dark Octocat placeholder —
+ * under `cache-control: public, max-age=0`, where a real card is `max-age=21600, immutable`;
+ * the bytes are indistinguishable and the header is the only tell. But a repo that would
+ * produce that placeholder is a 404 from github.com, so the resolver calls the URL dead and
+ * never mints an image URL for it at all, and an exhausted render budget answers 429 rather
+ * than a placeholder. So this guards a real origin behaviour by a route nothing takes today
+ * — kept because it is general and costs one header read, not because it was observed.
  *
  * ⚠ Silence is PERMISSION, not prohibition: plenty of image hosts send no Cache-Control
  * at all, and refusing those would turn the cache off for most of the web.

--- a/server/services/previewCache/s3.ts
+++ b/server/services/previewCache/s3.ts
@@ -146,7 +146,22 @@ export function objectKey(cfg: S3CacheConfig, key: string): string {
  * unnameable and unbilled-for by anything that could clean them up.
  */
 export type S3Read =
-  | { kind: 'ok'; body: Buffer; contentType: string }
+  | {
+      kind: 'ok';
+      body: Buffer;
+      contentType: string;
+      /**
+       * When the object was written, from `Last-Modified`, in epoch ms — or null
+       * when the store did not say.
+       *
+       * ⚠ Carried because it is the only HONEST age for these bytes. The index row's
+       * `created_at` is this cell's record of its own store, and the bucket is shared:
+       * a row can be absent (another cell wrote the object) or long expired while the
+       * object itself was rewritten yesterday. `lookup` needs the object's age, not
+       * ours, before it will serve one the index cannot vouch for.
+       */
+      storedAt: number | null;
+    }
   | { kind: 'missing' }
   | { kind: 'error' };
 
@@ -200,10 +215,15 @@ export async function readRemote(
     }
     const body = Buffer.from(await res.arrayBuffer());
     if (body.length > maxBytes) return { kind: 'error' };
+    // ⚠ `Date.parse` on an HTTP-date, and NaN is normalised to null rather than left
+    // to poison an arithmetic comparison — a bucket that omits the header or sends
+    // something unparseable must read as "age unknown", which the caller fails closed on.
+    const modified = Date.parse(res.headers.get('last-modified') ?? '');
     return {
       kind: 'ok',
       body,
       contentType: res.headers.get('content-type') || 'application/octet-stream',
+      storedAt: Number.isFinite(modified) ? modified : null,
     };
   } catch {
     return { kind: 'error' };

--- a/server/test-utils/stubDecoder.ts
+++ b/server/test-utils/stubDecoder.ts
@@ -205,6 +205,13 @@ function relayFetch(res: http.ServerResponse, url: string, range: string | undef
     if (chunkedOrigin || Number.isFinite(declared)) {
       head['x-lurker-origin-framed'] = '1';
     }
+    // Forwarded so the cell's STORE decision can consult it, exactly as the real decoder
+    // does. GitHub marks the placeholder it serves for a card it could not render
+    // `cache-control: public, max-age=0` — the only thing distinguishing it from a real
+    // card, since the bytes are a perfectly valid PNG either way.
+    if (origin.headers['cache-control']) {
+      head['cache-control'] = String(origin.headers['cache-control']);
+    }
     // The decoder's advertisement rule, faithfully: a 206, or a TOKEN match on the
     // origin's (possibly comma-joined) Accept-Ranges — never an echo of the raw value.
     const upstreamRanges =


### PR DESCRIPTION
Fixes #776. Pairs with amiantos/lurker-previews#2, which carries the origin-side half.

## What was happening

GitHub link previews went blank about a week after they were first seen, and stayed blank. The bytes were never missing — they were sitting in R2, complete and correct, the whole time.

`lookup` answered existence from the SQLite index alone (deliberately, to avoid a round trip) and treated an absent or expired row as proof the object was gone. But for the remote backends the object **outlives its row by design**: `MAX_AGE_MS` was 7 days precisely so the row stays provably shorter-lived than the bucket's 30-day lifecycle rule. Between those two numbers sits an object nothing can name — even though the key that names it is a pure function of the URL we are already holding.

Worse, the expired branch called `forget(key)` and left the object in the bucket, so the row was destroyed and the bytes orphaned. The cell then went back to the **origin** for a file it already owned, and when the origin refused that pointless re-fetch the card stayed permanently broken.

Measured on app.lurker.chat: an og:image stored 10 Aug, re-fetched and re-uploaded byte-for-byte 18 days later — same ETag, same 48,559 bytes. The 0-byte body users could save off a broken card was our own empty 503.

## The fix

A genuine 404 from the backend is now the only thing that means gone. The probe costs one edge GET on a path that was about to pay a full origin fetch, so it is strictly cheaper than what it replaces — and it makes the fleet-shared bucket shared for **reads** as well as writes: a cell can now serve an object another cell stored, which it never could before.

Follow-ups from review, all in the second commit:

- **The staleness ceiling rides on the object, not the row.** The first cut dropped it entirely for remote backends — after the sweep deletes an expired row, the object was served with no age check at all. `Last-Modified` is the object's own account of its age and is what the bound is enforced against now, so it holds whether or not the index still remembers it. A store that will not date an object fails closed.
- **`MAX_AGE_MS` is 25 days, decoupled from `link_previews`' `OK_TTL`.** They answer different questions: `OK_TTL` governs a page's *title*, which changes; this governs *image bytes*, which at the content-addressed URLs most og:images use cannot. Matching them re-fetched every image every 7 days for nothing. 25 against the 30-day lifecycle keeps the margin `publicByteUrl` needs, and hands days 7–25 back to the CDN where the cell ships no bytes at all.
- **The origin's `Cache-Control` is honoured at the store decision**, with a positive `s-maxage` overriding `max-age=0` per RFC 9111 — `public, max-age=0, s-maxage=86400` is the ordinary CDN spelling of "browsers revalidate, shared caches may keep this".
  ⚠ This is a **general rule, not a fix for something observed.** It was prompted by GitHub's unrenderable-card placeholder (a 200 + valid PNG under `max-age=0`), but that is not reachable through this pipeline: the repo behind such a placeholder 404s from github.com, so the resolver calls the URL dead and never mints an image URL, and an exhausted render budget answers 429 rather than a placeholder. Kept because every other guard tests what the bytes *are*, and an origin can pass all of them while saying plainly not to keep the result.
- **A negative memo on the cold probe**, so a URL that will never be stored does not pay a bucket 404 forever.
- **`/poster` joins `mediaPool`** — its miss used to be a pure SQLite read, and the cold read turned it into unpooled outbound I/O bounded only by a per-account throttle.
- `.env.example` and `docs/SELF_HOSTING.md` updated; the old text promised "stops serving an object after 7 days", which the change makes untrue.

## Testing

4389 tests, typecheck, lint and oxfmt clean. Every new behavioural test was verified to fail against the unfixed code; the two that pass at baseline are guards on the new path (the probe must not double-fetch on a real miss, and cold bytes must prove they are an image) and are noted as such.
