### PR TITLE
Bump Lurker version to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Version increment only — `package.json` and lockfile in the root and in `vue_client`. No code.

Ships #866 (and its counterpart amiantos/lurker-previews#2).

## What's in the release

GitHub link preview cards went blank about a week after they were first seen and stayed that way. The bytes were never missing — they were in the bucket, complete and correct, the whole time.

The byte cache answered *"do we have this?"* from its SQLite index alone and read an absent or expired row as proof the object was gone. But the object outlives its row by design, so at the age bound the row was deleted and the object left behind — orphaning bytes with weeks of life left. The cell then went back to the **origin** for a file it already owned, and when the origin refused that pointless re-fetch, the card broke permanently.

- A genuine 404 from the bucket is now the only thing that means gone, with staleness enforced on the object's own `Last-Modified` rather than on the index row.
- The bound moves **7 → 25 days** and is decoupled from the metadata TTL. A page's title changes; image bytes at a content-addressed URL don't. Days 7–25 go back to the CDN, where the cell ships no bytes at all.
- The fleet-shared bucket is now shared for **reads** as well as writes.
- The origin's `Cache-Control` is honoured at the store decision; `/poster` joins the byte pool now that its miss can do outbound I/O; a short negative memo stops a never-storable URL re-probing forever.

## Deploying

⚠ **Operators running previews should pull the decoder too.** The other half of the fix is in `lurker-previews`: one retry before believing a pooled origin's 429 — which was blanking every GitHub image instance-wide for up to ten minutes at a time — plus HDR poster tone mapping. Its image is `:latest`, so `docker compose pull` picks it up.

The app degrades safely against an older decoder: an unforwarded `Cache-Control` reads as silence, which is permission, exactly as before.

⚠ **If you have shortened the bucket lifecycle rule**, it now needs to stay clear of 25 days — below that the cell can mint a public URL for an object the rule has already deleted. `.env.example` and `docs/SELF_HOSTING.md` say so.

**App-side only** — nothing in `server/engine` changed, so `engine-1` does not move and `docker compose pull && up -d` recreates the app while the engine keeps every held IRC connection.