### PR TITLE
Stop auto-joining a channel the server durably refuses

### DIFF
--- a/server/db/buffers.ts
+++ b/server/db/buffers.ts
@@ -249,6 +249,11 @@ const closedFoldedForNetworkStmt = db.prepare(`
   SELECT target_folded FROM buffers WHERE network_id = ? AND state = 'closed'
 `);
 
+const autojoinFlagStmt = db.prepare(`
+  SELECT autojoin FROM buffers
+  WHERE user_id = ? AND IFNULL(network_id, 0) = IFNULL(?, 0) AND target_folded = ?
+`);
+
 /** Folded state lookup without materializing the record: 'open', 'closed', or
  *  undefined when no row exists. */
 export function getState(
@@ -304,6 +309,17 @@ export function closedFoldedSetForNetwork(networkId: number): Set<string> {
  *  and could disagree with the folded snapshot filter about the same buffer. */
 export function isClosed(userId: number, networkId: number | null, target: string): boolean {
   return getState(userId, networkId, target) === 'closed';
+}
+
+/** Folded autojoin check (#868), decrypt-free for the same reason as getState: a
+ *  channel whose stored +k key was written under a since-rotated key-id would
+ *  make getBuffer's decryptSecret THROW, and this runs inside the IRC error
+ *  handler. False for a row that doesn't exist. */
+export function isAutojoin(userId: number, networkId: number | null, target: string): boolean {
+  const row = autojoinFlagStmt.get(userId, networkId, foldTargetFor(networkId, target)) as
+    | { autojoin: number }
+    | undefined;
+  return !!row?.autojoin;
 }
 
 export interface EnsureResult {

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -3567,6 +3567,133 @@ describe('join echo, forwarded joins (470), and un-partable channels (442)', () 
     ).toHaveLength(0);
   });
 
+  // A join the server durably refuses must stop replaying on every reconnect.
+  // The reported case: an invite-only channel seeded as a network default, so
+  // the join never echoed, no buffer was ever surfaced, and the rejection
+  // repeated on every connect with nothing on screen to cancel it.
+  it('473 stops auto-joining an invite-only channel and says so', () => {
+    const conn = makeConn('inviteonly-stop');
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#marco', {
+      kind: 'channel',
+      autojoin: true,
+    });
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('irc error', {
+      error: 'invite_only_channel',
+      channel: '#marco',
+      reason: 'Cannot join channel (+i)',
+    });
+
+    expect(getBuffer(conn.network.user_id, conn.network.id, '#marco')?.autojoin).toBe(false);
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: `:server:${conn.network.id}`,
+        text: 'Stopped auto-joining #marco because it is invite-only (+i). Use /join #marco to try again.',
+      }),
+    );
+  });
+
+  it('473 clears a config-seeded default channel without surfacing its buffer', () => {
+    // seedDefaultChannel's row is 'closed' with a NULL closed_at — the "never
+    // surfaced" shape. Cancelling the rejoin must not turn it into a visible
+    // empty buffer; the point is that it stops trying, silently, in the sidebar.
+    const conn = makeConn('inviteonly-seed');
+    seedAutojoinChannel(conn.network.user_id, conn.network.id, '#marco');
+    expect(getBuffer(conn.network.user_id, conn.network.id, '#marco')?.autojoin).toBe(true);
+
+    conn.client.emit('irc error', {
+      error: 'invite_only_channel',
+      channel: '#marco',
+      reason: 'Cannot join channel (+i)',
+    });
+
+    const row = getBuffer(conn.network.user_id, conn.network.id, '#marco')!;
+    expect(row.autojoin).toBe(false);
+    expect(row.state).toBe('closed');
+    expect(row.closedAt).toBeNull();
+  });
+
+  it('474 stops auto-joining a channel we are banned from', () => {
+    const conn = makeConn('banned-stop');
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#apple', {
+      kind: 'channel',
+      autojoin: true,
+    });
+
+    conn.client.emit('irc error', {
+      error: 'banned_from_channel',
+      channel: '#apple',
+      reason: 'Cannot join channel (+b)',
+    });
+
+    expect(getBuffer(conn.network.user_id, conn.network.id, '#apple')?.autojoin).toBe(false);
+  });
+
+  it('471 leaves autojoin alone — a full channel is a state of the moment', () => {
+    // The guard that keeps this from becoming a silent unsubscribe. Same for
+    // 405, and for 477 (which races SASL identification and would hit every
+    // channel on a slow-identify reconnect).
+    const conn = makeConn('full-keeps');
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#apple', {
+      kind: 'channel',
+      autojoin: true,
+    });
+
+    conn.client.emit('irc error', {
+      error: 'channel_is_full',
+      channel: '#apple',
+      reason: 'Cannot join channel (+l)',
+    });
+
+    expect(getBuffer(conn.network.user_id, conn.network.id, '#apple')?.autojoin).toBe(true);
+  });
+
+  it('473 on a channel we never auto-joined announces nothing', () => {
+    // A manual `/join #private` persists nothing (joinChannel writes on the
+    // echo, never the request), so there is no subscription to cancel — and
+    // claiming to have stopped one would be a lie.
+    const conn = makeConn('inviteonly-manual');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('irc error', {
+      error: 'invite_only_channel',
+      channel: '#private',
+      reason: 'Cannot join channel (+i)',
+    });
+
+    expect(getBuffer(conn.network.user_id, conn.network.id, '#private')).toBeUndefined();
+    expect(publish).not.toHaveBeenCalledWith(
+      expect.objectContaining({ target: `:server:${conn.network.id}` }),
+    );
+  });
+
+  it('473 still shows the join-error toast on the channel (#260)', () => {
+    const conn = makeConn('inviteonly-toast');
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#marco', {
+      kind: 'channel',
+      autojoin: true,
+    });
+    const ephemeral = vi.fn<(event: unknown) => void>();
+    conn.publishEphemeral = ephemeral;
+
+    conn.client.emit('irc error', {
+      error: 'invite_only_channel',
+      channel: '#marco',
+      reason: 'Cannot join channel (+i)',
+    });
+
+    expect(ephemeral).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'join-error',
+        target: '#marco',
+        text: 'This channel is invite-only.',
+      }),
+    );
+  });
+
   it('442 corrects a stale autojoin row even when the channel is not in the joined set', () => {
     // The in-memory set and the persisted row can disagree — after a restart
     // the row survives while this.channels is empty. The row is what

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -3801,12 +3801,21 @@ describe('join echo, forwarded joins (470), and un-partable channels (442)', () 
     expect(getBuffer(conn.network.user_id, conn.network.id, '#marco')?.autojoin).toBe(false);
   });
 
-  it('recognises non-NickServ services identification in connect_commands', () => {
-    // QuakeNet's Q, GameSurge's AuthServ — same race, different bot name.
-    const conn = makeScriptedConn(
-      'script-quakenet',
-      'PRIVMSG Q@CServe.quakenet.org :AUTH me hunter2',
-    );
+  // Every services flavour has to read as "wait", because a miss here is the
+  // dangerous direction: it unsubscribes someone mid-race. Matched as a family
+  // (any *Serv) plus the identification verbs, since the two networks whose
+  // services are not named *Serv — QuakeNet's Q, Undernet's X — are reachable
+  // only through the verb.
+  it.each([
+    ['NickServ', 'PRIVMSG NickServ :IDENTIFY me hunter2'],
+    ['SaslServ', 'PRIVMSG SaslServ :IDENTIFY me hunter2'],
+    ['SaslServ, no verb', 'PRIVMSG SaslServ :HELP'],
+    ['HostServ', 'MSG HostServ ON'],
+    ['GameSurge AuthServ', 'PRIVMSG AuthServ@services.gamesurge.net :AUTH me hunter2'],
+    ['QuakeNet Q', 'PRIVMSG Q@CServe.quakenet.org :AUTH me hunter2'],
+    ['Undernet X', 'PRIVMSG X@channels.undernet.org :LOGIN me hunter2'],
+  ])('treats %s in connect_commands as a services wait', (label, commands) => {
+    const conn = makeScriptedConn(`script-${label.replace(/\W+/g, '-')}`, commands);
     ensureBufferOpen(conn.network.user_id, conn.network.id, '#marco', {
       kind: 'channel',
       autojoin: true,

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -3388,6 +3388,27 @@ describe('join echo, forwarded joins (470), and un-partable channels (442)', () 
     return new IrcConnection({ network, onEvent: () => {} });
   }
 
+  /** A network that identifies to services via NickServ — the case where a
+   *  join rejection can arrive before identification has landed. */
+  function makeNickServConn(name: string): IrcConnection {
+    const network = createNetwork(1, {
+      name,
+      host: 'irc.example.test',
+      port: 6697,
+      tls: 1,
+      trusted_certificates: 1,
+      nick: 'nick',
+      username: null,
+      realname: null,
+      server_password: null,
+      autoconnect: 0,
+      sasl_account: null,
+      sasl_password: null,
+      connect_commands: 'PRIVMSG NickServ :IDENTIFY hunter2',
+    })!;
+    return new IrcConnection({ network, onEvent: () => {} });
+  }
+
   it('self-join echo mints the registry row with autojoin and the stashed key', () => {
     const conn = makeConn('echo-mints');
     conn.client.user.nick = 'me';
@@ -3690,6 +3711,76 @@ describe('join echo, forwarded joins (470), and un-partable channels (442)', () 
         type: 'join-error',
         target: '#marco',
         text: 'This channel is invite-only.',
+      }),
+    );
+  });
+
+  // The identification race. Account-based access (+I/$a:, +e/$a:) only starts
+  // matching once services consider us identified, and connect_commands and the
+  // autojoin batch both fire on 'registered' — so an early 473/474 can mean
+  // "NickServ hasn't caught up", not "you don't belong here".
+  it('473 before RPL_LOGGEDIN leaves autojoin alone on a NickServ network', () => {
+    const conn = makeNickServConn('inviteonly-race');
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#marco', {
+      kind: 'channel',
+      autojoin: true,
+    });
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('irc error', {
+      error: 'invite_only_channel',
+      channel: '#marco',
+      reason: 'Cannot join channel (+i)',
+    });
+
+    // Still in the rejoin list: the next reconnect gets to try again once
+    // NickServ has landed, instead of the channel silently disappearing.
+    expect(getBuffer(conn.network.user_id, conn.network.id, '#marco')?.autojoin).toBe(true);
+    expect(publish).not.toHaveBeenCalledWith(
+      expect.objectContaining({ target: `:server:${conn.network.id}` }),
+    );
+  });
+
+  it('473 after RPL_LOGGEDIN does stop auto-joining on a NickServ network', () => {
+    // Same network, same rejection — but now services have confirmed us, so
+    // the invex would already have matched. The refusal is durable.
+    const conn = makeNickServConn('inviteonly-identified');
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#marco', {
+      kind: 'channel',
+      autojoin: true,
+    });
+    conn.client.emit('loggedin', {});
+
+    conn.client.emit('irc error', {
+      error: 'invite_only_channel',
+      channel: '#marco',
+      reason: 'Cannot join channel (+i)',
+    });
+
+    expect(getBuffer(conn.network.user_id, conn.network.id, '#marco')?.autojoin).toBe(false);
+  });
+
+  it('475 tells the user to supply the key, since a bare /join will not resend it', () => {
+    // joinChannel coerces an absent key to undefined and passes it straight to
+    // client.join, so `/join #x` on a +k channel reproduces the failure.
+    const conn = makeConn('badkey-remedy');
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#marco', {
+      kind: 'channel',
+      autojoin: true,
+    });
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('irc error', {
+      error: 'bad_channel_key',
+      channel: '#marco',
+      reason: 'Cannot join channel (+k)',
+    });
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Stopped auto-joining #marco because the saved channel key is wrong (+k). Use /join #marco <key> to try again.',
       }),
     );
   });

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -3388,6 +3388,27 @@ describe('join echo, forwarded joins (470), and un-partable channels (442)', () 
     return new IrcConnection({ network, onEvent: () => {} });
   }
 
+  /** A network whose connect_commands do something ordinary — connect_commands
+   *  is a general-purpose script, not an identification marker. */
+  function makeScriptedConn(name: string, connect_commands: string): IrcConnection {
+    const network = createNetwork(1, {
+      name,
+      host: 'irc.example.test',
+      port: 6697,
+      tls: 1,
+      trusted_certificates: 1,
+      nick: 'nick',
+      username: null,
+      realname: null,
+      server_password: null,
+      autoconnect: 0,
+      sasl_account: null,
+      sasl_password: null,
+      connect_commands,
+    })!;
+    return new IrcConnection({ network, onEvent: () => {} });
+  }
+
   /** A network that identifies to services via NickServ — the case where a
    *  join rejection can arrive before identification has landed. */
   function makeNickServConn(name: string): IrcConnection {
@@ -3759,6 +3780,45 @@ describe('join echo, forwarded joins (470), and un-partable channels (442)', () 
     });
 
     expect(getBuffer(conn.network.user_id, conn.network.id, '#marco')?.autojoin).toBe(false);
+  });
+
+  it('connect_commands that do not identify are not treated as a services wait', () => {
+    // connect_commands is a general-purpose script. Gating on its presence
+    // alone would disable this fix entirely for anyone using it for ordinary
+    // things on a server that never sends 900.
+    const conn = makeScriptedConn('script-nonauth', 'JOIN #foo\nMODE me +x');
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#marco', {
+      kind: 'channel',
+      autojoin: true,
+    });
+
+    conn.client.emit('irc error', {
+      error: 'invite_only_channel',
+      channel: '#marco',
+      reason: 'Cannot join channel (+i)',
+    });
+
+    expect(getBuffer(conn.network.user_id, conn.network.id, '#marco')?.autojoin).toBe(false);
+  });
+
+  it('recognises non-NickServ services identification in connect_commands', () => {
+    // QuakeNet's Q, GameSurge's AuthServ — same race, different bot name.
+    const conn = makeScriptedConn(
+      'script-quakenet',
+      'PRIVMSG Q@CServe.quakenet.org :AUTH me hunter2',
+    );
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#marco', {
+      kind: 'channel',
+      autojoin: true,
+    });
+
+    conn.client.emit('irc error', {
+      error: 'invite_only_channel',
+      channel: '#marco',
+      reason: 'Cannot join channel (+i)',
+    });
+
+    expect(getBuffer(conn.network.user_id, conn.network.id, '#marco')?.autojoin).toBe(true);
   });
 
   it('475 tells the user to supply the key, since a bare /join will not resend it', () => {

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -3409,6 +3409,27 @@ describe('join echo, forwarded joins (470), and un-partable channels (442)', () 
     return new IrcConnection({ network, onEvent: () => {} });
   }
 
+  /** A SASL network. SASL completes before 001, so this is identified by the
+   *  time the rejoin goes out — but only if it succeeded. */
+  function makeSaslConn(name: string): IrcConnection {
+    const network = createNetwork(1, {
+      name,
+      host: 'irc.example.test',
+      port: 6697,
+      tls: 1,
+      trusted_certificates: 1,
+      nick: 'nick',
+      username: null,
+      realname: null,
+      server_password: null,
+      autoconnect: 0,
+      sasl_account: 'me',
+      sasl_password: 'hunter2',
+      connect_commands: null,
+    })!;
+    return new IrcConnection({ network, onEvent: () => {} });
+  }
+
   /** A network that identifies to services via NickServ — the case where a
    *  join rejection can arrive before identification has landed. */
   function makeNickServConn(name: string): IrcConnection {
@@ -3828,6 +3849,35 @@ describe('join echo, forwarded joins (470), and un-partable channels (442)', () 
     });
 
     expect(getBuffer(conn.network.user_id, conn.network.id, '#marco')?.autojoin).toBe(true);
+  });
+
+  it('a SASL network waits too, so a failed SASL cannot look like a durable refusal', () => {
+    // SASL lands before 001, so in the normal case RPL_LOGGEDIN has already
+    // arrived by the time the rejoin goes out and this gate costs nothing.
+    // It earns its keep when SASL FAILED: we are unidentified, the invex will
+    // not match, and every autojoined +i channel would otherwise be dropped
+    // in one pass.
+    const conn = makeSaslConn('sasl-unidentified');
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#marco', {
+      kind: 'channel',
+      autojoin: true,
+    });
+
+    conn.client.emit('irc error', {
+      error: 'invite_only_channel',
+      channel: '#marco',
+      reason: 'Cannot join channel (+i)',
+    });
+    expect(getBuffer(conn.network.user_id, conn.network.id, '#marco')?.autojoin).toBe(true);
+
+    // Once SASL has confirmed us, the same rejection is durable.
+    conn.client.emit('loggedin', {});
+    conn.client.emit('irc error', {
+      error: 'invite_only_channel',
+      channel: '#marco',
+      reason: 'Cannot join channel (+i)',
+    });
+    expect(getBuffer(conn.network.user_id, conn.network.id, '#marco')?.autojoin).toBe(false);
   });
 
   it('475 tells the user to supply the key, since a bare /join will not resend it', () => {

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -3780,9 +3780,21 @@ export class IrcConnection {
 
   /** Whether this connection is configured to identify to services but hasn't
    *  been confirmed yet. SASL lands before 001; NickServ via connect_commands
-   *  lands whenever it lands. */
+   *  lands whenever it lands.
+   *
+   *  connect_commands is a general-purpose script (people put `JOIN #foo` and
+   *  `MODE me +x` in it), so its mere presence says nothing — gating on that
+   *  would disable this feature outright for anyone using it for ordinary
+   *  things on a server that never sends 900. Look for identification
+   *  vocabulary instead.
+   *
+   *  A heuristic, and deliberately a generous one: a false positive costs a
+   *  channel that keeps retrying (the status quo), while a false negative
+   *  un-subscribes someone mid-race. When in doubt, wait. */
   private awaitingIdentification(): boolean {
-    return !!this.network.sasl_account || !!this.network.connect_commands;
+    if (this.network.sasl_account) return true;
+    const commands = this.network.connect_commands;
+    return !!commands && SERVICES_IDENTIFY_HINT.test(commands);
   }
 
   // Forget a channel the server has told us we are not on, outside the normal
@@ -6586,6 +6598,13 @@ const JOIN_REJECTION_MESSAGES: Record<string, string> = {
   '476': 'Bad channel mask.', // ERR_BADCHANMASK
   '477': 'This channel requires a registered nickname.', // ERR_NEEDREGGEDNICK
 };
+
+// Does a connect_commands script look like it identifies to services? Covers
+// the shapes people actually write: `PRIVMSG NickServ :IDENTIFY pw`, `NS
+// IDENTIFY pw`, QuakeNet's `PRIVMSG Q@CServe... :AUTH u pw`, GameSurge's
+// AuthServ. Ordinary uses — `JOIN #foo`, `PING connectcmd`, `MODE me +x` —
+// carry none of this vocabulary and correctly read as "nothing to wait for".
+const SERVICES_IDENTIFY_HINT = /\b(?:nickserv|authserv|identify|auth)\b/i;
 
 // The subset of join rejections that say something durable about US and this
 // channel, rather than about the moment. These are the ones worth cancelling

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -6599,12 +6599,19 @@ const JOIN_REJECTION_MESSAGES: Record<string, string> = {
   '477': 'This channel requires a registered nickname.', // ERR_NEEDREGGEDNICK
 };
 
-// Does a connect_commands script look like it identifies to services? Covers
-// the shapes people actually write: `PRIVMSG NickServ :IDENTIFY pw`, `NS
-// IDENTIFY pw`, QuakeNet's `PRIVMSG Q@CServe... :AUTH u pw`, GameSurge's
-// AuthServ. Ordinary uses — `JOIN #foo`, `PING connectcmd`, `MODE me +x` —
-// carry none of this vocabulary and correctly read as "nothing to wait for".
-const SERVICES_IDENTIFY_HINT = /\b(?:nickserv|authserv|identify|auth)\b/i;
+// Does a connect_commands script look like it talks to services? Matched as a
+// FAMILY, not a list of bot names — an enumeration keeps missing entries
+// (SaslServ, HostServ, and Undernet's `X ... LOGIN`, which uses none of the
+// usual verbs). Any `*Serv` pseudo-client counts, plus the identification
+// verbs, which is what catches the two networks whose services aren't named
+// that way: QuakeNet's `PRIVMSG Q@CServe... :AUTH` and Undernet's X.
+//
+// Deliberately over-inclusive: `PRIVMSG ChanServ :OP #foo` isn't
+// identification, but a script talking to services at all is a script that
+// probably identified first, and waiting costs nothing but a retry. Ordinary
+// uses — `JOIN #foo`, `PING connectcmd`, `MODE me +x` — carry none of this and
+// correctly read as "nothing to wait for".
+const SERVICES_IDENTIFY_HINT = /\b(?:\w*serv|identify|auth|login|sasl)\b/i;
 
 // The subset of join rejections that say something durable about US and this
 // channel, rather than about the moment. These are the ones worth cancelling

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -604,6 +604,11 @@ export class IrcConnection {
   // permission may have changed: on RPL_LOGGEDIN, on (re)registration, and when
   // we (re)join the channel — so a /part + /join or a reconnect resumes typing.
   unsendableTargets: Set<string>;
+  // RPL_LOGGEDIN (900) seen on this connection — the server considers us
+  // identified to services. Only used to decide whether a join rejection is
+  // durable (see stopAutojoining); the send-permission logic re-probes instead
+  // of consulting a flag.
+  identifiedToServices: boolean;
   // Last time the user sent a real PRIVMSG/NOTICE/ACTION to a target (lowercase
   // key → epoch ms). Lets the send-rejection handler tell an actual failed
   // message (surface it inline) from an automated TAGMSG/typing bounce (stay
@@ -833,6 +838,7 @@ export class IrcConnection {
     this.regainNick = null;
     this.pendingRegainSetup = false;
     this.identdId = null;
+    this.identifiedToServices = false;
     this.unsendableTargets = new Set();
     this.lastUserSendAt = new Map();
     this.autoWhoTargets = new Set();
@@ -1249,6 +1255,10 @@ export class IrcConnection {
     // or SASL). That's exactly what +R/+M channels were waiting on, so drop the
     // unsendable set and let the next message re-probe — typing resumes too (#283).
     c.on('loggedin', () => {
+      // Also the gate stopAutojoining waits on: account-based channel access
+      // (+I/+e $a:) only starts matching once the server considers us
+      // identified, so a join rejection before this point says nothing durable.
+      this.identifiedToServices = true;
       this.unsendableTargets.clear();
     });
 
@@ -3729,6 +3739,23 @@ export class IrcConnection {
    *  Deliberately does NOT touch the buffer's open/closed state or its history.
    *  The channel may well become joinable again; what stops is the retrying. */
   private stopAutojoining(name: string, tag: string): void {
+    // The identification race, which is the same one 477 is excluded for.
+    // Account-based channel access is the NORMAL way it is granted — +i with
+    // an invex `+I $a:account`, +b with an exempt `+e $a:account` — and both
+    // only start matching once the server considers us identified. Our
+    // connect_commands (the NickServ IDENTIFY) and the autojoin batch both
+    // fire on 'registered', in the same tick; the WAIT verb exists precisely
+    // because services lag that. So a 473/474 arriving before RPL_LOGGEDIN
+    // may just be "NickServ hasn't caught up", and acting on it would
+    // unsubscribe someone from a channel they belong to.
+    //
+    // SASL completes before 001, so a SASL network is already identified by
+    // the time the rejoin goes out and this costs it nothing. A network with
+    // no credentials configured has nothing to wait for, so a rejection there
+    // is as durable as it will ever be. The one deliberately conservative case
+    // is a NickServ network whose server never sends 900: we simply never act,
+    // which is the right way to be wrong.
+    if (!this.identifiedToServices && this.awaitingIdentification()) return;
     const canonical = canonicalChannelTarget(name, this.channels) ?? name;
     try {
       if (!isBufferAutojoin(this.network.user_id, this.network.id, canonical)) return;
@@ -3737,15 +3764,25 @@ export class IrcConnection {
       return;
     }
     const why = PERMANENT_JOIN_REJECTION_REASONS[tag] ?? 'the server refused the join';
+    // The retry has to name a key for +k: joinChannel coerces an absent key to
+    // undefined and passes that straight to client.join, so a bare `/join #x`
+    // does NOT resend the stored one. Telling a user to run the command that
+    // reproduces their failure is worse than saying nothing.
+    const retry = tag === 'bad_channel_key' ? `/join ${canonical} <key>` : `/join ${canonical}`;
     this.publish({
       type: 'notice',
       target: this.serverTarget(),
       nick: 'lurker',
       notable: false, // a status line, not unread-worthy — same as the nick-fallback notice
-      text:
-        `Stopped auto-joining ${canonical} because ${why}. ` +
-        `Use /join ${canonical} to try again.`,
+      text: `Stopped auto-joining ${canonical} because ${why}. Use ${retry} to try again.`,
     });
+  }
+
+  /** Whether this connection is configured to identify to services but hasn't
+   *  been confirmed yet. SASL lands before 001; NickServ via connect_commands
+   *  lands whenever it lands. */
+  private awaitingIdentification(): boolean {
+    return !!this.network.sasl_account || !!this.network.connect_commands;
   }
 
   // Forget a channel the server has told us we are not on, outside the normal

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -19,6 +19,7 @@ import {
   getBuffer,
   ensureExists as ensureBufferExists,
   setAutojoin as setBufferAutojoin,
+  isAutojoin as isBufferAutojoin,
   setChannelKey as setBufferChannelKey,
   deleteBuffer,
   listOpenDms,
@@ -3085,6 +3086,27 @@ export class IrcConnection {
         // Falls through to the generic server-buffer line below: 442 is rare
         // and worth showing, and the eviction above is silent on its own.
       }
+      // A rejection the server will keep giving us: stop replaying the join on
+      // every reconnect. Without this an auto-rejoin the ircd always refuses
+      // retries forever, and for a channel whose buffer is closed (or was
+      // never surfaced — a config-seeded default channel that has not had its
+      // first join echo) there is nothing on screen to cancel it: the user
+      // sees a rejection scroll past on every connect with no affordance
+      // attached to it.
+      //
+      // ONLY the durable three. 471 (+l full) and 405 (too many channels) are
+      // states of the moment, and 477 (needs a registered nick) is the classic
+      // race where the rejoin fires before SASL/NickServ identification lands
+      // — dropping autojoin on those would quietly unsubscribe people from
+      // channels they are perfectly able to join. (477 arrives on a different
+      // event entirely, so it is excluded structurally, not just by this map.)
+      //
+      // Lowering is not destructive: autojoin is raised again by the next join
+      // ECHO, so a channel that becomes joinable again is one /join away from
+      // being restored. That is what makes acting on a single rejection safe.
+      if (rejectChannel && PERMANENT_JOIN_REJECTION_TAGS.has(tag)) {
+        this.stopAutojoining(rejectChannel, tag);
+      }
       const rejectMsg = rejectChannel ? joinRejectionMessageByTag(tag) : null;
       if (rejectChannel && rejectMsg) {
         this.publishEphemeral({
@@ -3692,6 +3714,38 @@ export class IrcConnection {
       m.away = next;
       this.publishNames(ch);
     }
+  }
+
+  /** Cancel the reconnect rejoin for a channel the server durably refuses, and
+   *  say so where the user is already watching the refusal (#868).
+   *
+   *  Gated on the row ALREADY being an autojoin: a manual `/join #private` that
+   *  gets a 473 persisted nothing in the first place (joinChannel writes on the
+   *  echo, never the request), so there is no subscription to cancel and no
+   *  reason to announce one. Only a row that claims we belong here — a real
+   *  membership the ircd has now locked us out of, or a config-seeded default
+   *  channel that has never managed its first join — reaches the write.
+   *
+   *  Deliberately does NOT touch the buffer's open/closed state or its history.
+   *  The channel may well become joinable again; what stops is the retrying. */
+  private stopAutojoining(name: string, tag: string): void {
+    const canonical = canonicalChannelTarget(name, this.channels) ?? name;
+    try {
+      if (!isBufferAutojoin(this.network.user_id, this.network.id, canonical)) return;
+      setBufferAutojoin(this.network.user_id, this.network.id, canonical, false);
+    } catch (_) {
+      return;
+    }
+    const why = PERMANENT_JOIN_REJECTION_REASONS[tag] ?? 'the server refused the join';
+    this.publish({
+      type: 'notice',
+      target: this.serverTarget(),
+      nick: 'lurker',
+      notable: false, // a status line, not unread-worthy — same as the nick-fallback notice
+      text:
+        `Stopped auto-joining ${canonical} because ${why}. ` +
+        `Use /join ${canonical} to try again.`,
+    });
   }
 
   // Forget a channel the server has told us we are not on, outside the normal
@@ -6494,6 +6548,26 @@ const JOIN_REJECTION_MESSAGES: Record<string, string> = {
   '475': 'This channel requires a key (password).', // ERR_BADCHANNELKEY (+k)
   '476': 'Bad channel mask.', // ERR_BADCHANMASK
   '477': 'This channel requires a registered nickname.', // ERR_NEEDREGGEDNICK
+};
+
+// The subset of join rejections that say something durable about US and this
+// channel, rather than about the moment. These are the ones worth cancelling
+// an auto-rejoin over — see stopAutojoining for why the others are excluded
+// and why acting on one rejection is safe.
+const PERMANENT_JOIN_REJECTION_TAGS = new Set([
+  'invite_only_channel', // 473 (+i) — we are not on the invex
+  'banned_from_channel', // 474 (+b) — and retrying reads as ban evasion to ops
+  'bad_channel_key', // 475 (+k) — the key we hold is wrong; it will stay wrong
+]);
+
+// Why each is durable enough to act on, in one line: for 473 the invex is the
+// thing that would let us in and we are not on it; for 474 the ban is; for 475
+// the stored key is, and MODE -k is what clears it. None of the three resolves
+// by waiting, which is exactly what an auto-rejoin does.
+const PERMANENT_JOIN_REJECTION_REASONS: Record<string, string> = {
+  invite_only_channel: 'it is invite-only (+i)',
+  banned_from_channel: 'you are banned from it (+b)',
+  bad_channel_key: 'the saved channel key is wrong (+k)',
 };
 
 // irc-framework's 'irc error' event reports a short string tag instead of the


### PR DESCRIPTION
Closes #868.

## The bug

A user's Lurker re-JOINed an invite-only channel on every connect. The channel wasn't in their buffer list anywhere, and their server buffer showed `#marco Cannot join channel (+i)` over and over.

`buffers.autojoin` is written by the join **echo** and cleared by part / kick / 470 / 442. A channel that never successfully joins has nothing that can ever clear it:

- no echo, so `autojoin` is never confirmed *or* cleared
- no echo, so `ensureOpen` never runs and **no buffer is ever surfaced** — nothing in the sidebar to `/close`
- the reconnect pass reads `autojoin` and re-sends the JOIN
- the ircd refuses it again, forever

Rows reach that state via `seedAutojoinChannel` (a network's `default_channel` list writes `state='closed', closed_at=NULL` directly, and there's no UI to remove one) and via the schema-16 backfill. For a *joinable* channel this self-heals — the echo reopens the buffer, the user closes it again, `close-buffer` lowers the flag. It only becomes permanent when the join can never succeed.

## The fix

Treat a durable rejection as the answer it is: stop retrying, and say so where the user is already watching the refusal.

```
Stopped auto-joining #marco because it is invite-only (+i). Use /join #marco to try again.
```

Only **473 (+i)**, **474 (+b)** and **475 (+k)**. Not 471 (+l, full) or 405 (too many channels) — states of the moment. Not 477 (needs a registered nick), which arrives on a different event entirely, so it's excluded structurally rather than only by the tag list.

Acting on a single rejection is safe because lowering isn't destructive: the next join echo raises the flag again, so a channel that becomes joinable is one `/join` away from restored. The write is gated on the row *already* being an autojoin, so a manual `/join #private` — which persists nothing — announces nothing.

## Waiting for services (second commit)

473 and 474 are subject to the same identification race 477 is excluded for. Account-based access is the normal way it's granted — `+i` with `+I $a:account`, `+b` with `+e $a:account` — and neither matches until the server considers you identified. `runConnectCommands()` fires on `registered` (`ircConnection.ts:1410`) and the autojoin batch fires on the same `registered` (`ircManager.ts:424`), so the NickServ IDENTIFY and the JOINs go out in the same tick. The `WAIT` connect-command verb exists precisely because services lag that.

Without a gate, a slow NickServ permanently unsubscribes someone from a channel they belong to — and since the handler deliberately doesn't touch buffer state, a closed or never-surfaced buffer offers no affordance to notice it by.

So: gate on `RPL_LOGGEDIN` when the network is configured to identify. SASL completes before 001, so a SASL network is already identified when the rejoin goes out and pays nothing. A network with no credentials has nothing to wait for. The conservative case is a NickServ network whose server never sends 900 — there the feature never fires, which is the right way to be wrong.

The `+k` remedy also had to name the key: `joinChannel` coerces an absent key to `undefined` and passes it to `client.join`, so a bare `/join #x` doesn't resend the stored one.

## Notes

`buffers.isAutojoin` is new rather than reusing `getBuffer`, which AES-decrypts the `+k` envelope — a key written under a since-rotated key-id would make `decryptSecret` throw, and this runs inside the IRC error handler. Same decrypt-free reasoning as `getState`.

The notice is `notable: false`, matching the nick-fallback precedent, so it doesn't mark the server buffer unread. It fires once — after it, autojoin is down and the next reconnect doesn't try.

## Considered and rejected

A schema migration repairing the already-minted `closed + autojoin=1` rows. `retention.ts`'s `gcEligibleStmt` excludes buffers with `autojoin = 1`, so flipping that flag in bulk at boot would hand exactly those buffers — disproportionately the ones with the most history — to the closed-buffer GC, which is on by default on hosted via the ceiling. Silent history loss on upgrade with no user action. Recorded in #868 so nobody reaches for it later.

## Testing

9 new tests in `ircConnection.test.ts`, each mutation-verified to fail when its guard is removed:

| guard | test that dies without it |
|---|---|
| acts on 473/474/475 | `473 stops auto-joining…`, `473 clears a config-seeded…`, `474 stops…` |
| ignores 471/405 | `471 leaves autojoin alone` |
| requires an existing autojoin row | `473 on a channel we never auto-joined announces nothing` |
| waits for identification | `473 before RPL_LOGGEDIN leaves autojoin alone` |
| opens the gate on 900 | `473 after RPL_LOGGEDIN does stop auto-joining` |
| `+k` remedy names the key | `475 tells the user to supply the key` |

Plus one pinning that the #260 join-error toast still fires, since the hook sits directly above its early return.

`npm test` (4401) and `npm run check` both green. No schema change, no migration, no export-format change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S78yaGEueJtssGQ7fmZ1YP