### PR TITLE
Add an option to prevent inline media URLs from hiding.

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1121,6 +1121,18 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'like any other link.',
   },
   {
+    key: 'chat.inline_media.hide_urls',
+    label: 'Hide inline media URLs',
+    category: 'chat',
+    group: 'viewing',
+    type: 'bool',
+    default: true,
+    description:
+      'When enabled, URLs that are rendered as inline media will be hidden from the message ' +
+      'and will instead appear as a button in the inline media modal. ' +
+      'When disabled, URLs will render normally as part of the message like link preview cards.',
+  },
+  {
     key: 'chat.link_previews.enabled',
     requiresFeature: 'linkPreviews',
     label: 'Link previews',

--- a/vue_client/src/components/MessageBody.vue
+++ b/vue_client/src/components/MessageBody.vue
@@ -98,6 +98,7 @@ const config = useConfigStore();
 const toggles = computed(() => ({
   inlineMedia: config.linkPreviews && settings.effective('chat.inline_media.enabled') === true,
   linkPreviews: config.linkPreviews && settings.effective('chat.link_previews.enabled') === true,
+  hideInlineUrls: settings.effective('chat.inline_media.hide_urls') === true,
 }));
 
 const urls = computed(() => previewableUrls(props.text, toggles.value));
@@ -257,5 +258,9 @@ const hiddenUrls = computed(() =>
   hideableUrls(props.text, new Set(visible.value.filter(rendersInline).map((p) => p.url))),
 );
 
-const shownSegments = computed(() => segmentsWithoutUrls(props.segments, hiddenUrls.value));
+const shownSegments = computed(() =>
+  toggles.value.hideInlineUrls
+    ? segmentsWithoutUrls(props.segments, hiddenUrls.value)
+    : props.segments,
+);
 </script>


### PR DESCRIPTION
Originally, when media is rendered inline the URLs are hidden.
This option adds the possibility to display URLs as well as the inline preview card.