### PR TITLE
CertFP 1/4: store a client certificate per network (#459)

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -1196,9 +1196,12 @@ add `key`/`code`/`status`). Exact multipart field names matter.
 CertFP: a network may carry a TLS client certificate, presented on the handshake
 so services identify the user by its fingerprint — passively (NickServ CertFP) or
 as SASL EXTERNAL. The network payload's `client_cert` is a **description, never a
-PEM**: `{sha256, sha1, subject, validFrom, validTo}`, or `null` when none is
-attached. Both digests are bare lowercase hex, the form
-`/msg NickServ CERT ADD <fingerprint>` takes. `client_key` never appears in any
+PEM**: `{sha256, sha1, sha512, subject, validFrom, validTo}`, or `null` when none
+is attached. All three digests are bare lowercase hex, the form
+`/msg NickServ CERT ADD <fingerprint>` takes — which one a network wants is the
+network's own business (Libera requires SHA-512 and rejects the others by
+length), so carry all three rather than picking one. `CERT ADD` with no argument
+takes it from the live connection instead, which sidesteps the question. `client_key` never appears in any
 payload. A change takes effect on the next connect — a certificate is presented
 during the TLS handshake, so there is nothing to renegotiate on a live socket.
 

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -1189,6 +1189,18 @@ add `key`/`code`/`status`). Exact multipart field names matter.
 | `POST /reorder`                                    | `{ids:[…]}` (409 on set mismatch, returns authoritative order)                                                                                                                                                                                               |
 | `POST /:id/connect` · `/disconnect` · `/reconnect` | `disconnect` takes `{reason?}`                                                                                                                                                                                                                               |
 | `POST /:id/join` · `/part`                         | `{channel*, key?}` / `{channel*, reason?}`; `409` if not connected                                                                                                                                                                                           |
+| `POST /:id/certificate`                            | CertFP. `{mode:'generate'}` mints a self-signed pair; `{mode:'import', cert*, key*}` takes PEM you already use elsewhere. → `{network, certificate}`; `400` names what was wrong with the pair                                                               |
+| `DELETE /:id/certificate`                          | Detach the pair → `{network}`                                                                                                                                                                                                                                |
+| `GET /:id/certificate/export`                      | The pair as one PEM file (key then cert — the `client.pem` shape HexChat/WeeChat want), `Cache-Control: no-store`. `404` when no cert is attached. **The only route that returns the private key**                                                           |
+
+CertFP: a network may carry a TLS client certificate, presented on the handshake
+so services identify the user by its fingerprint — passively (NickServ CertFP) or
+as SASL EXTERNAL. The network payload's `client_cert` is a **description, never a
+PEM**: `{sha256, sha1, subject, validFrom, validTo}`, or `null` when none is
+attached. Both digests are bare lowercase hex, the form
+`/msg NickServ CERT ADD <fingerprint>` takes. `client_key` never appears in any
+payload. A change takes effect on the next connect — a certificate is presented
+during the TLS handshake, so there is nothing to renegotiate on a live socket.
 
 `GET /api/network-presets` → `{presets, allowUserDefined}` for the add-network
 form.

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -99,7 +99,18 @@ export const EXPORT_TABLES = Object.freeze({
     // connect_commands is encrypted because it routinely carries
     // `/msg NickServ identify <password>` and oper passwords — IRCCloud
     // encrypts it for the same reason.
-    encryptedColumns: ['server_password', 'sasl_account', 'sasl_password', 'connect_commands'],
+    // client_key is the private half of the CertFP pair (#459) — encrypted for
+    // the same reason as the passwords. client_cert rides along encrypted too:
+    // the certificate itself is public, but splitting the pair across two
+    // storage regimes buys nothing and makes the write path conditional.
+    encryptedColumns: [
+      'server_password',
+      'sasl_account',
+      'sasl_password',
+      'connect_commands',
+      'client_cert',
+      'client_key',
+    ],
     columns: [
       'id',
       'user_id',
@@ -117,6 +128,8 @@ export const EXPORT_TABLES = Object.freeze({
       'sasl_account',
       'sasl_password',
       'connect_commands',
+      'client_cert',
+      'client_key',
       'position',
       // Server-declared CASEMAPPING (#707): exported so an imported network's
       // registry folds don't churn (and case-twins don't merge) on the first

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1084,6 +1084,13 @@ ensureColumn('messages', 'userhost', 'TEXT');
 ensureColumn('networks', 'sasl_account', 'TEXT');
 ensureColumn('networks', 'sasl_password', 'TEXT');
 ensureColumn('networks', 'trusted_certificates', 'INTEGER NOT NULL DEFAULT 1');
+// CertFP (#459): the TLS client certificate this network presents, so services
+// can recognise the user by its fingerprint — passively (NickServ CertFP) or
+// through SASL EXTERNAL. Stored as a pair because a cert without its key can't
+// complete a handshake; both are written together or not at all, and both are
+// encrypted at rest (see exportSchema encryptedColumns).
+ensureColumn('networks', 'client_cert', 'TEXT');
+ensureColumn('networks', 'client_key', 'TEXT');
 // Newline-delimited raw IRC commands fired after RPL_WELCOME, IRCCloud-style.
 // Supports `WAIT <seconds>` lines that pause before the next command.
 ensureColumn('networks', 'connect_commands', 'TEXT');

--- a/server/db/networks.ts
+++ b/server/db/networks.ts
@@ -37,6 +37,13 @@ export interface Network {
   sasl_account: string | null;
   sasl_password: string | null;
   connect_commands: string | null;
+  /** CertFP (#459): the PEM certificate + private key this network presents on
+   *  the TLS handshake, so services identify the user by its fingerprint. Always
+   *  written as a pair — see setNetworkClientCert, which is the ONLY writer.
+   *  Deliberately absent from NetworkFields: a cert is a validated pair, not a
+   *  free-text field, so it can't ride a PATCH body onto the dialer. */
+  client_cert: string | null;
+  client_key: string | null;
   position: number;
   /** ISUPPORT CASEMAPPING as last declared by the server (#707); null until
    *  the network first connects to one that declares it. Server-captured
@@ -182,6 +189,21 @@ export function updateNetwork(
   db.prepare(`UPDATE networks SET ${setClauses.join(', ')} WHERE id = ? AND user_id = ?`).run(
     ...params,
   );
+  return getNetwork(id, userId);
+}
+
+/** Attach a CertFP pair to a network, or clear it (both null). The caller
+ *  validates the PEMs first (utils/clientCert.validateClientCertPair) — this is
+ *  storage, not a parser. Written together so a cert can never outlive the key
+ *  that has to complete its handshake. */
+export function setNetworkClientCert(
+  id: number,
+  userId: number,
+  pair: { cert: string; key: string } | null,
+): Network | undefined {
+  db.prepare(
+    'UPDATE networks SET client_cert = ?, client_key = ? WHERE id = ? AND user_id = ?',
+  ).run(encryptSecret(pair ? pair.cert : null), encryptSecret(pair ? pair.key : null), id, userId);
   return getNetwork(id, userId);
 }
 

--- a/server/routes/networks.test.ts
+++ b/server/routes/networks.test.ts
@@ -458,3 +458,114 @@ describe('instance network lockdown', () => {
     });
   });
 });
+
+// CertFP (#459). The cert deliberately does NOT ride the PATCH allowlist, so
+// these routes are the whole write surface — and the private key must never
+// leave through any of the read ones.
+describe('client certificate', () => {
+  async function netWithCert(agent: LurkerTestAgent = aliceAgent) {
+    const id = (await makeNet(agent, { name: `cert-${Math.random()}`, nick: 'certnick' })).body
+      .network.id;
+    const res = await agent.post(`/api/networks/${id}/certificate`).send({ mode: 'generate' });
+    expect(res.status).toBe(200);
+    return { id, res };
+  }
+
+  it('generates a pair and reports its fingerprint', async () => {
+    const { res } = await netWithCert();
+    expect(res.body.certificate.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(res.body.network.client_cert.sha256).toBe(res.body.certificate.sha256);
+    // CN borrows the nick so the cert is recognisable in another client's list.
+    expect(res.body.certificate.subject).toContain('certnick');
+  });
+
+  it('never ships the private key with a network payload', async () => {
+    const { id } = await netWithCert();
+    const listing = await aliceAgent.get('/api/networks');
+    const mine = listing.body.networks.find((n: { id: number }) => n.id === id);
+    expect(mine.client_cert.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(mine.client_key).toBeUndefined();
+    expect(JSON.stringify(listing.body)).not.toContain('PRIVATE KEY');
+  });
+
+  it('imports an existing pair, keeping the fingerprint services already know', async () => {
+    const { generateClientCert, describeClientCert } = await import('../utils/clientCert.js');
+    const pair = await generateClientCert('elsewhere');
+    const id = (await makeNet(aliceAgent, { name: 'import-me' })).body.network.id;
+    const res = await aliceAgent
+      .post(`/api/networks/${id}/certificate`)
+      .send({ mode: 'import', cert: pair.cert, key: pair.key });
+    expect(res.status).toBe(200);
+    expect(res.body.certificate.sha256).toBe(describeClientCert(pair.cert).sha256);
+  });
+
+  it('rejects a mismatched pair with a message, not a stack trace', async () => {
+    const { generateClientCert } = await import('../utils/clientCert.js');
+    const [mine, theirs] = await Promise.all([generateClientCert('a'), generateClientCert('b')]);
+    const id = (await makeNet(aliceAgent, { name: 'bad-import' })).body.network.id;
+    const res = await aliceAgent
+      .post(`/api/networks/${id}/certificate`)
+      .send({ mode: 'import', cert: mine.cert, key: theirs.key });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/doesn't match/);
+    expect(
+      (await aliceAgent.get('/api/networks')).body.networks.find((n: { id: number }) => n.id === id)
+        .client_cert,
+    ).toBe(null);
+  });
+
+  it('rejects an unknown mode rather than silently doing nothing', async () => {
+    const id = (await makeNet(aliceAgent, { name: 'bad-mode' })).body.network.id;
+    const res = await aliceAgent.post(`/api/networks/${id}/certificate`).send({ mode: 'rotate' });
+    expect(res.status).toBe(400);
+  });
+
+  it('exports the pair as the single file other clients keep on disk', async () => {
+    const { id, res: gen } = await netWithCert();
+    const res = await aliceAgent.get(`/api/networks/${id}/certificate/export`);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-disposition']).toContain('.pem');
+    expect(res.text).toContain('BEGIN PRIVATE KEY');
+    expect(res.text).toContain('BEGIN CERTIFICATE');
+    const { describeClientCert } = await import('../utils/clientCert.js');
+    const cert = res.text.slice(res.text.indexOf('-----BEGIN CERTIFICATE-----'));
+    expect(describeClientCert(cert).sha256).toBe(gen.body.certificate.sha256);
+  });
+
+  it('has nothing to export before a cert is attached', async () => {
+    const id = (await makeNet(aliceAgent, { name: 'no-cert' })).body.network.id;
+    expect((await aliceAgent.get(`/api/networks/${id}/certificate/export`)).status).toBe(404);
+  });
+
+  it('clears the pair on delete', async () => {
+    const { id } = await netWithCert();
+    const res = await aliceAgent.delete(`/api/networks/${id}/certificate`);
+    expect(res.status).toBe(200);
+    expect(res.body.network.client_cert).toBe(null);
+    expect((await aliceAgent.get(`/api/networks/${id}/certificate/export`)).status).toBe(404);
+  });
+
+  // Ownership, on every verb: a fingerprint identifies its owner to services,
+  // and the key IS the credential.
+  it("refuses another user's network on every verb", async () => {
+    const { id } = await netWithCert();
+    expect(
+      (await bobAgent.post(`/api/networks/${id}/certificate`).send({ mode: 'generate' })).status,
+    ).toBe(404);
+    expect((await bobAgent.get(`/api/networks/${id}/certificate/export`)).status).toBe(404);
+    expect((await bobAgent.delete(`/api/networks/${id}/certificate`)).status).toBe(404);
+    // ...and alice still has hers.
+    expect((await aliceAgent.get(`/api/networks/${id}/certificate/export`)).status).toBe(200);
+  });
+
+  it('ignores a cert smuggled through a PATCH body', async () => {
+    const id = (await makeNet(aliceAgent, { name: 'patch-smuggle' })).body.network.id;
+    const res = await aliceAgent
+      .patch(`/api/networks/${id}`)
+      .send({ client_cert: 'not a pem', client_key: 'not a key', name: 'renamed' });
+    expect(res.status).toBe(200);
+    expect(res.body.network.name).toBe('renamed');
+    expect(res.body.network.client_cert).toBe(null);
+    expect((await aliceAgent.get(`/api/networks/${id}/certificate/export`)).status).toBe(404);
+  });
+});

--- a/server/routes/networks.ts
+++ b/server/routes/networks.ts
@@ -276,7 +276,15 @@ async function attachCertificateInner(req: Request, res: Response): Promise<void
     res.status(400).json({ error: "mode must be 'generate' or 'import'" });
     return;
   }
+  // The write can land on nothing: the network is looked up, then written, and
+  // another tab can delete it in between. Answering 200 with a certificate for
+  // a network that no longer exists is worse than the 404 the caller would have
+  // got a moment earlier.
   const updated = setNetworkClientCert(id, req.user!.id, pair);
+  if (!updated) {
+    res.status(404).json({ error: 'network not found' });
+    return;
+  }
   res.json({ network: networkPayload(updated), certificate: describeClientCert(pair.cert) });
 }
 
@@ -287,6 +295,10 @@ router.delete('/:id/certificate', (req: Request, res: Response) => {
     return;
   }
   const updated = setNetworkClientCert(id, req.user!.id, null);
+  if (!updated) {
+    res.status(404).json({ error: 'network not found' });
+    return;
+  }
   res.json({ network: networkPayload(updated) });
 });
 

--- a/server/routes/networks.ts
+++ b/server/routes/networks.ts
@@ -306,6 +306,9 @@ router.get('/:id/certificate/export', (req: Request, res: Response) => {
     return;
   }
   res.type('application/x-pem-file');
+  // A 200 carrying an unencrypted private key must not sit in a disk cache (or
+  // in any intermediary in front of a cell that terminates TLS upstream).
+  res.setHeader('Cache-Control', 'no-store');
   res.setHeader('Content-Disposition', `attachment; filename="lurker-${id}-client.pem"`);
   res.send(clientCertBundle({ cert: network.client_cert, key: network.client_key }));
 });

--- a/server/routes/networks.ts
+++ b/server/routes/networks.ts
@@ -12,7 +12,15 @@ import {
   updateNetwork,
   deleteNetwork,
   reorderNetworks,
+  setNetworkClientCert,
 } from '../db/networks.js';
+import {
+  generateClientCert,
+  describeClientCert,
+  validateClientCertPair,
+  isClientCertProblem,
+  clientCertBundle,
+} from '../utils/clientCert.js';
 import { listChannelsForNetwork, seedAutojoinChannel } from '../db/buffers.js';
 import ircManager from '../services/ircManager.js';
 import { isNetworkHostAllowed, hostAllowedChecker } from '../services/networkPolicy.js';
@@ -46,6 +54,14 @@ function parseChannelList(raw: unknown): string[] {
   return out;
 }
 
+function safeDescribe(certPem: string): ReturnType<typeof describeClientCert> | null {
+  try {
+    return describeClientCert(certPem);
+  } catch {
+    return null;
+  }
+}
+
 // `isAllowed` is injectable so a caller mapping over several networks can resolve
 // the (instance-global) policy once instead of re-reading it per row.
 function networkPayload(
@@ -53,7 +69,9 @@ function networkPayload(
   isAllowed: (host: string) => boolean = isNetworkHostAllowed,
 ): Record<string, unknown> | null {
   if (!network) return null;
-  const { server_password, sasl_password, ...safe } = network;
+  // client_key is destructured only to keep it OUT of `safe` — the private key
+  // leaves the server through exactly one route, and never in a listing.
+  const { server_password, sasl_password, client_cert, client_key: _key, ...safe } = network;
   return {
     ...safe,
     tls: !!network.tls,
@@ -61,6 +79,12 @@ function networkPayload(
     autoconnect: !!network.autoconnect,
     has_password: !!server_password,
     has_sasl_password: !!sasl_password,
+    // CertFP (#459). Neither PEM is in the payload: the key is a secret, and the
+    // certificate on its own is of no use to the UI, which needs the digests to
+    // paste at NickServ. `null` when no cert is attached — and also when a
+    // stored cert can't be parsed, which is unreachable through the routes below
+    // (they validate before writing) but must not take out the whole listing.
+    client_cert: client_cert ? safeDescribe(client_cert) : null,
     // Channel rows in the retired channels-table wire shape (`joined` is the
     // autojoin flag), sourced from the buffers registry.
     channels: listChannelsForNetwork(network.id).map((b) => ({
@@ -203,6 +227,87 @@ router.delete('/:id', (req: Request, res: Response) => {
   renumberFavorites(req.user!.id);
   fanOutToUser(req.user!.id, favoritesChangedFrame(req.user!.id));
   res.json({ ok: true });
+});
+
+// CertFP (#459). The cert is a validated PEM pair, so it moves through these
+// dedicated routes rather than the PATCH allowlist — nothing that hasn't been
+// parsed and pair-checked can reach the dialer (or, in engine mode, the engine's
+// tls.connect, where a malformed key throws synchronously).
+//
+// A change takes effect on the next connect: the certificate is presented during
+// the TLS handshake, so there is nothing to renegotiate on a live socket. The
+// client says so; reconnecting is the user's call, the same as for every other
+// network edit.
+// Not an async handler: Express 5 turns a rejection out of one into an
+// unhandled rejection rather than a response, so the async body answers its own
+// failures and the promise handed back here never rejects.
+router.post('/:id/certificate', (req: Request, res: Response) => {
+  void attachCertificate(req, res);
+});
+
+async function attachCertificate(req: Request, res: Response): Promise<void> {
+  try {
+    await attachCertificateInner(req, res);
+  } catch (err) {
+    console.error('[lurker] client certificate write failed:', err);
+    res.status(500).json({ error: 'failed to store the client certificate' });
+  }
+}
+
+async function attachCertificateInner(req: Request, res: Response): Promise<void> {
+  const id = Number(req.params.id);
+  const network = getNetwork(id, req.user!.id);
+  if (!network) {
+    res.status(404).json({ error: 'network not found' });
+    return;
+  }
+  const mode = (req.body || {}).mode;
+  let pair;
+  if (mode === 'generate') {
+    pair = await generateClientCert(network.nick || network.name);
+  } else if (mode === 'import') {
+    const result = validateClientCertPair((req.body || {}).cert, (req.body || {}).key);
+    if (isClientCertProblem(result)) {
+      res.status(400).json({ error: result.error });
+      return;
+    }
+    pair = result;
+  } else {
+    res.status(400).json({ error: "mode must be 'generate' or 'import'" });
+    return;
+  }
+  const updated = setNetworkClientCert(id, req.user!.id, pair);
+  res.json({ network: networkPayload(updated), certificate: describeClientCert(pair.cert) });
+}
+
+router.delete('/:id/certificate', (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  if (!getNetwork(id, req.user!.id)) {
+    res.status(404).json({ error: 'network not found' });
+    return;
+  }
+  const updated = setNetworkClientCert(id, req.user!.id, null);
+  res.json({ network: networkPayload(updated) });
+});
+
+// The pair in the single-file form other clients keep on disk (HexChat's
+// client.pem, WeeChat's ssl.crt). Its own route, never part of a listing: a
+// certificate you can't take with you is lock-in, but a private key must be
+// asked for explicitly rather than shipped with every sidebar refresh.
+router.get('/:id/certificate/export', (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  const network = getNetwork(id, req.user!.id);
+  if (!network) {
+    res.status(404).json({ error: 'network not found' });
+    return;
+  }
+  if (!network.client_cert || !network.client_key) {
+    res.status(404).json({ error: 'this network has no client certificate' });
+    return;
+  }
+  res.type('application/x-pem-file');
+  res.setHeader('Content-Disposition', `attachment; filename="lurker-${id}-client.pem"`);
+  res.send(clientCertBundle({ cert: network.client_cert, key: network.client_key }));
 });
 
 router.post('/:id/connect', (req: Request, res: Response) => {

--- a/server/services/chghostWiring.test.ts
+++ b/server/services/chghostWiring.test.ts
@@ -29,6 +29,8 @@ beforeAll(() => {
 function makeConn(): IrcConnection {
   return new IrcConnection({
     network: {
+      client_cert: null,
+      client_key: null,
       id: 1,
       user_id: 1,
       name: 'n',

--- a/server/services/ctcpWiring.test.ts
+++ b/server/services/ctcpWiring.test.ts
@@ -31,6 +31,8 @@ beforeAll(() => {
 function makeConn(): IrcConnection {
   return new IrcConnection({
     network: {
+      client_cert: null,
+      client_key: null,
       id: 1,
       user_id: 1,
       name: 'n',

--- a/server/services/dccWiring.test.ts
+++ b/server/services/dccWiring.test.ts
@@ -56,6 +56,8 @@ afterEach(() => {
 function makeConn(): IrcConnection {
   return new IrcConnection({
     network: {
+      client_cert: null,
+      client_key: null,
       id: 1,
       user_id: 1,
       name: 'n',

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -382,6 +382,8 @@ describe('tls certificate trust setting', () => {
   function makeConn(trusted_certificates: number): IrcConnection {
     return new IrcConnection({
       network: {
+        client_cert: null,
+        client_key: null,
         id: 1,
         user_id: 1,
         name: 'n',
@@ -442,6 +444,8 @@ describe('addPeerWatch live presence seed (#302)', () => {
   function makeConn(): IrcConnection {
     return new IrcConnection({
       network: {
+        client_cert: null,
+        client_key: null,
         id: 1,
         user_id: 1,
         name: 'n',
@@ -501,6 +505,8 @@ describe('nick-regain MONITOR teardown gating (#384)', () => {
   function makeConn(): IrcConnection {
     return new IrcConnection({
       network: {
+        client_cert: null,
+        client_key: null,
         id: 1,
         user_id: 1,
         name: 'n',
@@ -793,6 +799,8 @@ describe('refused-message handler routing (#283)', () => {
   function makeConn(): IrcConnection {
     return new IrcConnection({
       network: {
+        client_cert: null,
+        client_key: null,
         id: 1,
         user_id: 1,
         name: 'n',
@@ -1450,6 +1458,8 @@ describe('built-in identd registration', () => {
   function makeConn(): IrcConnection {
     return new IrcConnection({
       network: {
+        client_cert: null,
+        client_key: null,
         id: 1,
         user_id: 1,
         name: 'n',
@@ -1550,6 +1560,8 @@ describe('disconnect quit message (#324)', () => {
   function makeConn(): IrcConnection {
     return new IrcConnection({
       network: {
+        client_cert: null,
+        client_key: null,
         id: 1,
         user_id: 1,
         name: 'n',
@@ -1628,6 +1640,8 @@ describe('cancelled-reconnect notice (#785)', () => {
   function makeConn(events: unknown[]): IrcConnection {
     return new IrcConnection({
       network: {
+        client_cert: null,
+        client_key: null,
         id: 1,
         user_id: 1,
         name: 'n',
@@ -1696,6 +1710,8 @@ describe('self nick updates the input bar (#362)', () => {
   function makeConn(): IrcConnection {
     return new IrcConnection({
       network: {
+        client_cert: null,
+        client_key: null,
         id: 1,
         user_id: 1,
         name: 'n',
@@ -1796,6 +1812,8 @@ describe('capability negotiation (#310)', () => {
   function makeConn(): IrcConnection {
     return new IrcConnection({
       network: {
+        client_cert: null,
+        client_key: null,
         id: 1,
         user_id: 1,
         name: 'n',
@@ -2418,6 +2436,8 @@ describe('IRCv3 draft/multiline (#381)', () => {
   function makeConn(): IrcConnection {
     return new IrcConnection({
       network: {
+        client_cert: null,
+        client_key: null,
         id: 1,
         user_id: 1,
         name: 'n',
@@ -2681,6 +2701,8 @@ describe('inbound INVITE handler (#261)', () => {
   function makeConn(): IrcConnection {
     return new IrcConnection({
       network: {
+        client_cert: null,
+        client_key: null,
         id: 1,
         user_id: 1,
         name: 'n',
@@ -2779,6 +2801,8 @@ describe('invite channel lines + dedup (#261)', () => {
   function makeConn(): IrcConnection {
     return new IrcConnection({
       network: {
+        client_cert: null,
+        client_key: null,
         id: 1,
         user_id: 1,
         name: 'n',
@@ -2867,6 +2891,8 @@ describe('channel mode display (status bar)', () => {
   function makeConn(): IrcConnection {
     return new IrcConnection({
       network: {
+        client_cert: null,
+        client_key: null,
         id: 1,
         user_id: 1,
         name: 'n',
@@ -3310,6 +3336,8 @@ describe('join key forwarding', () => {
   function makeConn(): IrcConnection {
     return new IrcConnection({
       network: {
+        client_cert: null,
+        client_key: null,
         id: 1,
         user_id: 1,
         name: 'n',

--- a/server/services/ircE2eWiring.test.ts
+++ b/server/services/ircE2eWiring.test.ts
@@ -38,6 +38,8 @@ beforeAll(() => {
 function makeConn(): IrcConnection {
   return new IrcConnection({
     network: {
+      client_cert: null,
+      client_key: null,
       id: 1,
       user_id: 1,
       name: 'n',

--- a/server/services/ircEchoMessage.test.ts
+++ b/server/services/ircEchoMessage.test.ts
@@ -40,6 +40,8 @@ afterEach(() => {
 function makeConn(onEvent: (event: unknown) => void = () => {}): IrcConnection {
   const conn = new IrcConnection({
     network: {
+      client_cert: null,
+      client_key: null,
       id: networkId,
       user_id: userId,
       name: 'echonet',

--- a/server/services/networkSecretsRoundtrip.test.ts
+++ b/server/services/networkSecretsRoundtrip.test.ts
@@ -19,6 +19,7 @@ process.env.LURKER_SECRET_KEY = Buffer.alloc(32, 5).toString('base64');
 let db: typeof import('../db/index.js').default;
 let createUser: typeof import('../db/users.js').createUser;
 let createNetwork: typeof import('../db/networks.js').createNetwork;
+let setNetworkClientCert: typeof import('../db/networks.js').setNetworkClientCert;
 let getNetwork: typeof import('../db/networks.js').getNetwork;
 let buffers: typeof import('../db/buffers.js');
 let isEncrypted: typeof import('../utils/secretCrypto.js').isEncrypted;
@@ -31,12 +32,11 @@ const SECRETS = {
   sasl_password: 'sasl-secret',
   connect_commands: 'PRIVMSG NickServ :identify supersecret',
 };
-const SECRET_COLS = Object.keys(SECRETS) as (keyof typeof SECRETS)[];
 
 beforeAll(async () => {
   db = (await import('../db/index.js')).default;
   ({ createUser } = await import('../db/users.js'));
-  ({ createNetwork, getNetwork } = await import('../db/networks.js'));
+  ({ createNetwork, getNetwork, setNetworkClientCert } = await import('../db/networks.js'));
   buffers = await import('../db/buffers.js');
   ({ isEncrypted } = await import('../utils/secretCrypto.js'));
   ({ buildExportZip } = await import('./exportService.js'));
@@ -87,12 +87,26 @@ describe('network secret export/import round-trip (key configured)', () => {
       nick: 'alice',
       ...SECRETS,
     })!;
+    // The CertFP pair (#459) doesn't travel through createNetwork — it's written
+    // by its own validated path — but it's the same at-rest contract, and the
+    // private key is the one secret here that is a credential all by itself.
+    const { generateClientCert } = await import('../utils/clientCert.js');
+    const pair = await generateClientCert('alice');
+    setNetworkClientCert(net.id, alice.id, pair);
+    const expected: Record<string, string> = {
+      ...SECRETS,
+      client_cert: pair.cert,
+      client_key: pair.key,
+    };
+    const expectedCols = Object.keys(expected);
+
     // Stored encrypted at rest.
     const aliceRaw = db.prepare('SELECT * FROM networks WHERE id = ?').get(net.id) as Record<
       string,
       string | null
     >;
     expect(isEncrypted(aliceRaw.server_password)).toBe(true);
+    expect(isEncrypted(aliceRaw.client_key)).toBe(true);
 
     // ---- export carries plaintext ----
     const buf = await exportToBuffer(alice.id);
@@ -100,8 +114,8 @@ describe('network secret export/import round-trip (key configured)', () => {
       networks: Record<string, string>[];
     };
     const exported = data.networks[0];
-    for (const col of SECRET_COLS) {
-      expect(exported[col]).toBe(SECRETS[col]);
+    for (const col of expectedCols) {
+      expect(exported[col]).toBe(expected[col]);
     }
 
     // ---- import re-encrypts on a fresh, keyed account ----
@@ -111,12 +125,12 @@ describe('network secret export/import round-trip (key configured)', () => {
       string,
       string | null
     >;
-    for (const col of SECRET_COLS) {
+    for (const col of expectedCols) {
       expect(isEncrypted(bobNet[col])).toBe(true);
     }
     const bobFetched = getNetwork(bobNet.id as unknown as number, bob.id)!;
-    for (const col of SECRET_COLS) {
-      expect(bobFetched[col]).toBe(SECRETS[col]);
+    for (const col of expectedCols) {
+      expect(bobFetched[col as keyof typeof bobFetched]).toBe(expected[col]);
     }
   });
 

--- a/server/services/noticeRouting.test.ts
+++ b/server/services/noticeRouting.test.ts
@@ -47,6 +47,8 @@ afterEach(() => {
 function makeConn(): IrcConnection {
   return new IrcConnection({
     network: {
+      client_cert: null,
+      client_key: null,
       id: 1,
       user_id: 1,
       name: 'n',

--- a/server/utils/clientCert.test.ts
+++ b/server/utils/clientCert.test.ts
@@ -41,6 +41,9 @@ describe('generateClientCert', () => {
     const info = describeClientCert((await generateClientCert('alice')).cert);
     expect(info.sha256).toMatch(/^[0-9a-f]{64}$/);
     expect(info.sha1).toMatch(/^[0-9a-f]{40}$/);
+    // 128 characters, which is what Libera checks for by length before it will
+    // even look at the value.
+    expect(info.sha512).toMatch(/^[0-9a-f]{128}$/);
     expect(info.subject).toContain('alice');
   });
 

--- a/server/utils/clientCert.test.ts
+++ b/server/utils/clientCert.test.ts
@@ -54,6 +54,25 @@ describe('generateClientCert', () => {
     expect(describeClientCert((await generateClientCert('')).cert).subject).toContain('lurker');
   });
 
+  // A nick is free-form and reaches this as the CN. The DN grammar treats `,`
+  // and `=` as structure, so an unescaped one either rewrites the name into
+  // extra RDNs or throws out of the encoder — which surfaces as a 500 on a nick
+  // the network itself was happy with.
+  it('does not let a nick rewrite the distinguished name', async () => {
+    const info = describeClientCert((await generateClientCert('O=evil,CN=admin')).cert);
+    expect(info.subject).toBe('CN=O evil CN admin');
+  });
+
+  it('generates rather than throwing for a nick the DN encoder chokes on', async () => {
+    // `a,b=c` throws "Cannot get OID for name type" straight out of the encoder.
+    const info = describeClientCert((await generateClientCert('a,b=c')).cert);
+    expect(info.subject).toBe('CN=a b c');
+  });
+
+  it('falls back when a nick is nothing but separators', async () => {
+    expect(describeClientCert((await generateClientCert(',,==')).cert).subject).toContain('lurker');
+  });
+
   it('mints a distinct key each time', async () => {
     const [a, b] = await Promise.all([generateClientCert('a'), generateClientCert('b')]);
     expect(describeClientCert(a.cert).sha256).not.toBe(describeClientCert(b.cert).sha256);

--- a/server/utils/clientCert.test.ts
+++ b/server/utils/clientCert.test.ts
@@ -113,6 +113,29 @@ describe('validateClientCertPair', () => {
     expect(isClientCertProblem(result) && result.error).toMatch(/openssl rsa/);
   });
 
+  // The file HexChat and WeeChat keep on disk, and the file this module exports.
+  // Pasted whole into the certificate box, it is not really a mistake.
+  it('accepts a combined client.pem in the certificate field alone', async () => {
+    const pair = await generateClientCert('alice');
+    const result = validateClientCertPair(clientCertBundle(pair), '');
+    expect(isClientCertProblem(result)).toBe(false);
+    expect(describeClientCert((result as typeof pair).cert).sha256).toBe(
+      describeClientCert(pair.cert).sha256,
+    );
+    // And the key that came out of it really is the matching half.
+    expect(
+      isClientCertProblem(
+        validateClientCertPair((result as typeof pair).cert, (result as typeof pair).key),
+      ),
+    ).toBe(false);
+  });
+
+  it('still asks for the certificate when only a key was pasted', async () => {
+    const pair = await generateClientCert('alice');
+    const result = validateClientCertPair(pair.key, '');
+    expect(isClientCertProblem(result) && result.error).toMatch(/no certificate in it/);
+  });
+
   it('rejects an empty, absent, or non-string field', async () => {
     const pair = await generateClientCert('alice');
     for (const bad of ['', '   ', undefined, null, 42, { cert: 'x' }]) {

--- a/server/utils/clientCert.test.ts
+++ b/server/utils/clientCert.test.ts
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// CertFP cert handling (#459). The generated pair is checked against a REAL TLS
+// handshake rather than against its own PEM: the whole feature rests on a server
+// seeing the fingerprint we told the user to register, so the assertion that
+// matters is that an ircd's `getPeerCertificate()` agrees with
+// describeClientCert() — down to the format services want it pasted in.
+
+import { describe, it, expect } from 'vitest';
+import net from 'node:net';
+import tls from 'node:tls';
+import { once } from 'node:events';
+import { generate as generateSelfSigned } from 'selfsigned';
+import {
+  generateClientCert,
+  describeClientCert,
+  validateClientCertPair,
+  isClientCertProblem,
+  clientCertBundle,
+} from './clientCert.js';
+
+describe('generateClientCert', () => {
+  it('mints a usable pair whose fingerprint is what the peer sees', async () => {
+    const pair = await generateClientCert('alice');
+    const info = describeClientCert(pair.cert);
+
+    const server = await startCertRequestingServer();
+    try {
+      const seen = await presentCert(server.port, pair);
+      // Node hands both sides the same digest in different dress: colon-hex
+      // uppercase from the socket, bare lowercase from describeClientCert —
+      // which is the form `/msg NickServ CERT ADD` takes.
+      expect(seen.replace(/:/g, '').toLowerCase()).toBe(info.sha256);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('describes the cert in the form services want pasted', async () => {
+    const info = describeClientCert((await generateClientCert('alice')).cert);
+    expect(info.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(info.sha1).toMatch(/^[0-9a-f]{40}$/);
+    expect(info.subject).toContain('alice');
+  });
+
+  it('outlives any registration the user makes at NickServ', async () => {
+    const info = describeClientCert((await generateClientCert('alice')).cert);
+    const years = (Date.parse(info.validTo) - Date.parse(info.validFrom)) / (365.25 * 864e5);
+    expect(years).toBeGreaterThan(9);
+  });
+
+  it('falls back to a name when the network has no nick to borrow', async () => {
+    expect(describeClientCert((await generateClientCert('')).cert).subject).toContain('lurker');
+  });
+
+  it('mints a distinct key each time', async () => {
+    const [a, b] = await Promise.all([generateClientCert('a'), generateClientCert('b')]);
+    expect(describeClientCert(a.cert).sha256).not.toBe(describeClientCert(b.cert).sha256);
+  });
+});
+
+describe('validateClientCertPair', () => {
+  it('accepts a matching pair and trims the surrounding whitespace a paste carries', async () => {
+    const pair = await generateClientCert('alice');
+    const result = validateClientCertPair(`\n  ${pair.cert}\n\n`, `\n${pair.key}  \n`);
+    expect(isClientCertProblem(result)).toBe(false);
+    expect((result as typeof pair).cert).toBe(pair.cert.trim());
+  });
+
+  it('rejects a key that belongs to another certificate', async () => {
+    const [mine, theirs] = await Promise.all([
+      generateClientCert('alice'),
+      generateClientCert('mallory'),
+    ]);
+    const result = validateClientCertPair(mine.cert, theirs.key);
+    expect(isClientCertProblem(result) && result.error).toMatch(/doesn't match/);
+  });
+
+  it('names the mistake when the two fields are swapped', async () => {
+    const pair = await generateClientCert('alice');
+    const result = validateClientCertPair(pair.key, pair.key);
+    expect(isClientCertProblem(result) && result.error).toMatch(/looks like a private key/);
+  });
+
+  it('tells a passphrase-protected key apart from a broken one', () => {
+    const result = validateClientCertPair(
+      '-----BEGIN CERTIFICATE-----\nx\n-----END CERTIFICATE-----',
+      '-----BEGIN ENCRYPTED PRIVATE KEY-----\nx\n-----END ENCRYPTED PRIVATE KEY-----',
+    );
+    expect(isClientCertProblem(result) && result.error).toMatch(/openssl rsa/);
+  });
+
+  it('rejects an empty, absent, or non-string field', async () => {
+    const pair = await generateClientCert('alice');
+    for (const bad of ['', '   ', undefined, null, 42, { cert: 'x' }]) {
+      expect(isClientCertProblem(validateClientCertPair(bad, pair.key))).toBe(true);
+      expect(isClientCertProblem(validateClientCertPair(pair.cert, bad))).toBe(true);
+    }
+  });
+
+  it('rejects PEM-shaped garbage without throwing', async () => {
+    const pair = await generateClientCert('alice');
+    const result = validateClientCertPair(
+      '-----BEGIN CERTIFICATE-----\nnot base64 at all\n-----END CERTIFICATE-----',
+      pair.key,
+    );
+    expect(isClientCertProblem(result) && result.error).toMatch(/could not be parsed/);
+  });
+});
+
+describe('clientCertBundle', () => {
+  it('emits the key-then-cert single file other clients keep on disk', async () => {
+    const pair = await generateClientCert('alice');
+    const bundle = clientCertBundle(pair);
+    expect(bundle.indexOf('BEGIN PRIVATE KEY')).toBeLessThan(bundle.indexOf('BEGIN CERTIFICATE'));
+    expect(bundle.endsWith('\n')).toBe(true);
+    // Round-trips: a bundle split back apart is still a valid pair.
+    const [key, cert] = bundle.split(/(?=-----BEGIN CERTIFICATE-----)/);
+    expect(isClientCertProblem(validateClientCertPair(cert, key))).toBe(false);
+  });
+});
+
+// A TLS server that asks for a client cert but accepts anything, which is what
+// an ircd doing CertFP does: it hashes what you present rather than verifying a
+// chain.
+async function startCertRequestingServer(): Promise<{ port: number; close: () => void }> {
+  const pems = await generateSelfSigned([{ name: 'commonName', value: 'localhost' }], {
+    keySize: 2048,
+    algorithm: 'sha256',
+  });
+  const server = tls.createServer(
+    { key: pems.private, cert: pems.cert, requestCert: true, rejectUnauthorized: false },
+    (socket) => {
+      const peer = socket.getPeerCertificate();
+      socket.end(`${peer?.fingerprint256 ?? ''}\n`);
+    },
+  );
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  return {
+    port: (server.address() as net.AddressInfo).port,
+    close: () => server.close(),
+  };
+}
+
+async function presentCert(port: number, pair: { cert: string; key: string }): Promise<string> {
+  const socket = tls.connect({
+    port,
+    host: '127.0.0.1',
+    rejectUnauthorized: false,
+    cert: pair.cert,
+    key: pair.key,
+  });
+  let out = '';
+  socket.setEncoding('utf8');
+  socket.on('data', (chunk: string) => (out += chunk));
+  await once(socket, 'close');
+  return out.trim();
+}

--- a/server/utils/clientCert.ts
+++ b/server/utils/clientCert.ts
@@ -31,6 +31,11 @@ export interface ClientCertInfo {
   sha256: string;
   /** Same, SHA-1. Older ratbox-family networks (Rizon) still hash that way. */
   sha1: string;
+  /** Same, SHA-512 — 128 characters. Libera refuses anything else
+   *  ("Fingerprints on this network must be SHA2-512 digests"), and it is not
+   *  derivable from the others, so all three are carried rather than picking a
+   *  favourite: which one a network wants is the network's business. */
+  sha512: string;
   subject: string;
   validFrom: string;
   validTo: string;
@@ -88,6 +93,7 @@ export function describeClientCert(certPem: string): ClientCertInfo {
   return {
     sha256: bare(x509.fingerprint256),
     sha1: bare(x509.fingerprint),
+    sha512: bare(x509.fingerprint512),
     subject: x509.subject.replace(/\n/g, ', '),
     validFrom: new Date(x509.validFrom).toISOString(),
     validTo: new Date(x509.validTo).toISOString(),

--- a/server/utils/clientCert.ts
+++ b/server/utils/clientCert.ts
@@ -107,6 +107,17 @@ function bare(fingerprint: string): string {
   return fingerprint.replace(/:/g, '').toLowerCase();
 }
 
+// One PEM blob holding both halves → the two of them; null when it isn't that.
+// Takes the FIRST block of each kind deliberately: a bundle carrying a chain
+// presents the leaf, which is the certificate whose fingerprint services hold.
+function splitCombinedPem(pem: string): { cert: string; key: string } | null {
+  const cert = /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/.exec(pem)?.[0];
+  const key = /-----BEGIN ([A-Z ]*)PRIVATE KEY-----[\s\S]*?-----END \1PRIVATE KEY-----/.exec(
+    pem,
+  )?.[0];
+  return cert && key ? { cert, key } : null;
+}
+
 /** A rejected pair, with a message meant for the person who pasted it. */
 export interface ClientCertProblem {
   error: string;
@@ -120,14 +131,29 @@ export function validateClientCertPair(
   certPem: unknown,
   keyPem: unknown,
 ): ClientCertPair | ClientCertProblem {
-  const cert = typeof certPem === 'string' ? certPem.trim() : '';
-  const key = typeof keyPem === 'string' ? keyPem.trim() : '';
+  let cert = typeof certPem === 'string' ? certPem.trim() : '';
+  let key = typeof keyPem === 'string' ? keyPem.trim() : '';
+  // A combined client.pem — cert and key in one file — pasted into the
+  // certificate box with the key box left empty. It is the likeliest mistake
+  // (HexChat and WeeChat both keep the pair that way) and it is barely a
+  // mistake at all: that file is also exactly what clientCertBundle() below
+  // exports, so someone moving a certificate between two Lurker networks lands
+  // here. Split it rather than making them do it by hand.
+  if (!key && cert) {
+    const split = splitCombinedPem(cert);
+    if (split) ({ cert, key } = split);
+  }
   if (!cert || !key) {
+    // Only reached with genuinely nothing usable in hand, so name whichever
+    // half IS there rather than asking again for both.
+    if (cert && /PRIVATE KEY-----/.test(cert)) {
+      return {
+        error:
+          'that is a private key with no certificate in it — paste the certificate too, or both halves of your client.pem',
+      };
+    }
     return { error: 'a certificate and its private key are both required' };
   }
-  // A combined client.pem (cert and key in one file, the HexChat/WeeChat shape)
-  // pasted into the cert box alone is the single likeliest mistake, so name it
-  // instead of failing on "no key".
   if (!/-----BEGIN CERTIFICATE-----/.test(cert)) {
     return {
       error: /PRIVATE KEY-----/.test(cert)

--- a/server/utils/clientCert.ts
+++ b/server/utils/clientCert.ts
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// CertFP (#459): the TLS client certificate a network presents on its handshake,
+// which services then recognise by fingerprint — either passively (NickServ
+// CertFP identifies you the moment you connect) or through SASL EXTERNAL.
+//
+// Certs are self-signed by design. Nothing verifies a chain here: the ircd hashes
+// the certificate you present and compares that hash against the list on your
+// services account, so the only thing that matters is that the same key comes
+// back every time. That is also why generated certs last a decade — there is no
+// renewal story for a fingerprint someone has registered by hand, and an expiry
+// would silently log them out. Same reasoning as utils/bouncerCert.ts, which
+// this module deliberately mirrors rather than merges with: that one is a SERVER
+// cert for Lurker's own bouncer listener, with different extensions and its own
+// on-disk lifecycle.
+
+import crypto from 'crypto';
+import { generate as generateSelfSigned } from 'selfsigned';
+
+/** A cert and the private key that completes its handshake. Never separated. */
+export interface ClientCertPair {
+  cert: string;
+  key: string;
+}
+
+/** What the client is told about an attached cert. The private key is not part
+ *  of it, and never leaves the server outside the explicit export route. */
+export interface ClientCertInfo {
+  /** Lowercase hex, no colons — the form you paste into NickServ. */
+  sha256: string;
+  /** Same, SHA-1. Older ratbox-family networks (Rizon) still hash that way. */
+  sha1: string;
+  subject: string;
+  validFrom: string;
+  validTo: string;
+}
+
+const TEN_YEARS_MS = 3650 * 24 * 60 * 60 * 1000;
+
+/** Mint a self-signed client cert. `commonName` is cosmetic — services key on
+ *  the fingerprint — but it is what shows up in the cert list of whatever other
+ *  client the user exports this into, so it carries the nick. */
+export async function generateClientCert(commonName: string): Promise<ClientCertPair> {
+  const notBeforeDate = new Date();
+  const notAfterDate = new Date(notBeforeDate.getTime() + TEN_YEARS_MS);
+  const pems = await generateSelfSigned([{ name: 'commonName', value: commonName || 'lurker' }], {
+    notBeforeDate,
+    notAfterDate,
+    keySize: 2048,
+    algorithm: 'sha256',
+    extensions: [
+      { name: 'basicConstraints', cA: false },
+      { name: 'keyUsage', digitalSignature: true, keyEncipherment: true },
+      { name: 'extKeyUsage', clientAuth: true },
+    ],
+  });
+  return { cert: pems.cert, key: pems.private };
+}
+
+/** Digests and validity for an attached cert. Throws on an unparseable PEM —
+ *  callers hold pairs that went through validateClientCertPair. */
+export function describeClientCert(certPem: string): ClientCertInfo {
+  const x509 = new crypto.X509Certificate(certPem);
+  return {
+    sha256: bare(x509.fingerprint256),
+    sha1: bare(x509.fingerprint),
+    subject: x509.subject.replace(/\n/g, ', '),
+    validFrom: new Date(x509.validFrom).toISOString(),
+    validTo: new Date(x509.validTo).toISOString(),
+  };
+}
+
+// Node prints fingerprints as uppercase colon-hex ("AB:CD:…"); every services
+// package wants them bare and lowercase ("abcd…"), which is also what
+// `/msg NickServ CERT LIST` echoes back.
+function bare(fingerprint: string): string {
+  return fingerprint.replace(/:/g, '').toLowerCase();
+}
+
+/** A rejected pair, with a message meant for the person who pasted it. */
+export interface ClientCertProblem {
+  error: string;
+}
+
+/** Parse and pair-check a PEM cert + key. The failure messages matter more than
+ *  usual here: the raw OpenSSL errors underneath ("error:1E08010C:DECODER
+ *  routines::unsupported") tell a user nothing about which of the two fields
+ *  they pasted wrong. */
+export function validateClientCertPair(
+  certPem: unknown,
+  keyPem: unknown,
+): ClientCertPair | ClientCertProblem {
+  const cert = typeof certPem === 'string' ? certPem.trim() : '';
+  const key = typeof keyPem === 'string' ? keyPem.trim() : '';
+  if (!cert || !key) {
+    return { error: 'a certificate and its private key are both required' };
+  }
+  // A combined client.pem (cert and key in one file, the HexChat/WeeChat shape)
+  // pasted into the cert box alone is the single likeliest mistake, so name it
+  // instead of failing on "no key".
+  if (!/-----BEGIN CERTIFICATE-----/.test(cert)) {
+    return {
+      error: /PRIVATE KEY-----/.test(cert)
+        ? 'that looks like a private key, not a certificate — the certificate is the -----BEGIN CERTIFICATE----- block'
+        : 'the certificate must be PEM, starting with -----BEGIN CERTIFICATE-----',
+    };
+  }
+  if (/ENCRYPTED PRIVATE KEY-----/.test(key)) {
+    return {
+      error:
+        'passphrase-protected keys are not supported — decrypt it first with: openssl rsa -in key.pem -out key-decrypted.pem',
+    };
+  }
+  let x509: crypto.X509Certificate;
+  try {
+    x509 = new crypto.X509Certificate(cert);
+  } catch {
+    return { error: 'the certificate could not be parsed as PEM' };
+  }
+  let privateKey: crypto.KeyObject;
+  try {
+    privateKey = crypto.createPrivateKey(key);
+  } catch {
+    return { error: 'the private key could not be parsed as PEM' };
+  }
+  if (!x509.checkPrivateKey(privateKey)) {
+    return { error: "that private key doesn't match that certificate" };
+  }
+  return { cert, key };
+}
+
+export function isClientCertProblem(
+  result: ClientCertPair | ClientCertProblem,
+): result is ClientCertProblem {
+  return 'error' in result;
+}
+
+/** The single-file form other clients want on disk (HexChat's `client.pem`,
+ *  WeeChat's `ssl.crt`): key first, then cert. */
+export function clientCertBundle(pair: ClientCertPair): string {
+  return `${pair.key.trimEnd()}\n${pair.cert.trimEnd()}\n`;
+}

--- a/server/utils/clientCert.ts
+++ b/server/utils/clientCert.ts
@@ -38,23 +38,46 @@ export interface ClientCertInfo {
 
 const TEN_YEARS_MS = 3650 * 24 * 60 * 60 * 1000;
 
+// A distinguished name is a comma-separated list of `type=value` pairs, and the
+// generator hands ours to the X.509 encoder verbatim: an unescaped separator in
+// a nick doesn't produce a cert with a funny name, it produces a DIFFERENT DN
+// ("O=evil,CN=admin" becomes two RDNs) or an outright throw ("a,b=c" → "Cannot
+// get OID for name type"), which reaches the user as an unexplained 500 on a
+// nick the network itself accepted. Nothing downstream depends on the CN — the
+// fingerprint is the identity — so the separators are dropped rather than
+// escaped, and a name left with nothing to say falls back to the default.
+const DN_SEPARATORS = ',+="<>;\\/';
+
+function safeCommonName(raw: string): string {
+  const cleaned = [...(raw || '')]
+    .map((ch) => (DN_SEPARATORS.includes(ch) || ch.codePointAt(0)! < 0x20 ? ' ' : ch))
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 64);
+  return cleaned || 'lurker';
+}
+
 /** Mint a self-signed client cert. `commonName` is cosmetic — services key on
  *  the fingerprint — but it is what shows up in the cert list of whatever other
  *  client the user exports this into, so it carries the nick. */
 export async function generateClientCert(commonName: string): Promise<ClientCertPair> {
   const notBeforeDate = new Date();
   const notAfterDate = new Date(notBeforeDate.getTime() + TEN_YEARS_MS);
-  const pems = await generateSelfSigned([{ name: 'commonName', value: commonName || 'lurker' }], {
-    notBeforeDate,
-    notAfterDate,
-    keySize: 2048,
-    algorithm: 'sha256',
-    extensions: [
-      { name: 'basicConstraints', cA: false },
-      { name: 'keyUsage', digitalSignature: true, keyEncipherment: true },
-      { name: 'extKeyUsage', clientAuth: true },
-    ],
-  });
+  const pems = await generateSelfSigned(
+    [{ name: 'commonName', value: safeCommonName(commonName) }],
+    {
+      notBeforeDate,
+      notAfterDate,
+      keySize: 2048,
+      algorithm: 'sha256',
+      extensions: [
+        { name: 'basicConstraints', cA: false },
+        { name: 'keyUsage', digitalSignature: true, keyEncipherment: true },
+        { name: 'extKeyUsage', clientAuth: true },
+      ],
+    },
+  );
   return { cert: pems.cert, key: pems.private };
 }
 


### PR DESCRIPTION
First slice of CertFP (#459). Storage, crypto, and the write surface — **nothing dials with it yet**; the connection wiring is PR 2, the engine is PR 3, the UI is PR 4. Plan lives in `CERTFP_PLAN.md` (lurker-dev root).

A network can carry a TLS client certificate — generated here, or imported from whatever client the user is arriving from — which services then recognise by its fingerprint, either passively (NickServ CertFP) or via SASL EXTERNAL.

### Decisions

- **Per network, not per user.** Matches every desktop client, and keeps identities on different networks unlinkable — a shared cert hands anyone comparing fingerprints a join between your accounts.
- **Generate *and* import.** Someone arriving from HexChat/WeeChat keeps the fingerprint NickServ already knows, rather than re-registering everywhere.
- **Not on the PATCH allowlist.** A certificate is a validated pair, not a free-text field, so it moves only through the dedicated routes — nothing unparsed can reach a `tls.connect`, where a malformed key throws *synchronously* (which, in engine mode, would take down every held socket).
- **The private key leaves through exactly one route**, the export bundle other clients keep on disk as `client.pem`. Never in a listing; `no-store` on that response.

### Surface

| | |
|---|---|
| `client_cert` / `client_key` columns, `setNetworkClientCert` (the one writer) | `server/db/{index,networks}.ts` |
| Encrypted at rest + export/import contract | `server/db/exportSchema.ts` |
| generate / validate / describe / bundle | `server/utils/clientCert.ts` |
| `POST`/`DELETE /:id/certificate`, `GET /:id/certificate/export` | `server/routes/networks.ts` |
| Route + payload contract | `docs/CLIENT_PROTOCOL.md` |

### Testing

Full suite green (307 files / 4444 tests). The generated pair is asserted against a **real TLS handshake** rather than its own PEM: a `requestCert` server's `getPeerCertificate()` fingerprint must equal what `describeClientCert()` tells the user to paste into NickServ — bare lowercase hex, the form `/msg NickServ CERT ADD` takes. Plus: import rejects a mismatched pair, a swapped cert/key, a passphrase-protected key and PEM-shaped garbage, each with a message naming the actual mistake; ownership is checked on every verb; a cert smuggled through a PATCH body is ignored; and the pair round-trips through export/import re-encryption.

Reviewed with `/code-review high` before opening; its findings (DN injection through the nick, cacheable key response, undocumented routes) are the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qCyi5Poh5nur5CoUUaoPR