### PR TITLE
CertFP 2/4: present the certificate and speak SASL EXTERNAL (#459)

### DIFF
--- a/server/db/networks.ts
+++ b/server/db/networks.ts
@@ -39,9 +39,12 @@ export interface Network {
   connect_commands: string | null;
   /** CertFP (#459): the PEM certificate + private key this network presents on
    *  the TLS handshake, so services identify the user by its fingerprint. Always
-   *  written as a pair — see setNetworkClientCert, which is the ONLY writer.
-   *  Deliberately absent from NetworkFields: a cert is a validated pair, not a
-   *  free-text field, so it can't ride a PATCH body onto the dialer. */
+   *  written as a pair — see setNetworkClientCert, the only writer that
+   *  validates. Deliberately absent from NetworkFields: a cert is a validated
+   *  pair, not a free-text field, so it can't ride a PATCH body onto the
+   *  dialer. Archive import DOES write both columns verbatim (exportSchema
+   *  drives its column list), which is why the dial path re-checks the pair
+   *  before presenting it rather than trusting what is stored. */
   client_cert: string | null;
   client_key: string | null;
   position: number;

--- a/server/routes/networks.test.ts
+++ b/server/routes/networks.test.ts
@@ -514,6 +514,17 @@ describe('client certificate', () => {
     ).toBe(null);
   });
 
+  // A certificate is presented during a TLS handshake; a plaintext network has
+  // none, so attaching one would hand the user a fingerprint to register that
+  // the network is never shown.
+  it('refuses to attach a certificate to a plaintext network', async () => {
+    const id = (await makeNet(aliceAgent, { name: 'plaintext', tls: false, port: 6667 })).body
+      .network.id;
+    const res = await aliceAgent.post(`/api/networks/${id}/certificate`).send({ mode: 'generate' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/TLS/);
+  });
+
   it('rejects an unknown mode rather than silently doing nothing', async () => {
     const id = (await makeNet(aliceAgent, { name: 'bad-mode' })).body.network.id;
     const res = await aliceAgent.post(`/api/networks/${id}/certificate`).send({ mode: 'rotate' });

--- a/server/routes/networks.ts
+++ b/server/routes/networks.ts
@@ -231,8 +231,10 @@ router.delete('/:id', (req: Request, res: Response) => {
 
 // CertFP (#459). The cert is a validated PEM pair, so it moves through these
 // dedicated routes rather than the PATCH allowlist — nothing that hasn't been
-// parsed and pair-checked can reach the dialer (or, in engine mode, the engine's
-// tls.connect, where a malformed key throws synchronously).
+// parsed and pair-checked can reach tls.connect, where a malformed key throws
+// synchronously. The routes are not the only writer, though (archive import
+// inserts the columns verbatim), so the dial path re-validates before it
+// presents anything.
 //
 // A change takes effect on the next connect: the certificate is presented during
 // the TLS handshake, so there is nothing to renegotiate on a live socket. The
@@ -259,6 +261,15 @@ async function attachCertificateInner(req: Request, res: Response): Promise<void
   const network = getNetwork(id, req.user!.id);
   if (!network) {
     res.status(404).json({ error: 'network not found' });
+    return;
+  }
+  // A certificate is presented during a TLS handshake. On a plaintext network
+  // there is no handshake to present it in, so attaching one would hand the
+  // user a fingerprint to register that the network is never shown.
+  if (!network.tls) {
+    res.status(400).json({
+      error: 'a client certificate can only be used on a TLS network — enable TLS first',
+    });
     return;
   }
   const mode = (req.body || {}).mode;

--- a/server/services/ircCertfp.test.ts
+++ b/server/services/ircCertfp.test.ts
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// CertFP end to end (#459): a real IrcConnection, over real TLS, against an ircd
+// that asks for a client certificate and only recognises fingerprints somebody
+// registered — which is the whole of CertFP as a client experiences it.
+//
+// Asserting on the connect() option dict would prove nothing here. The claim the
+// feature makes is that the network sees the fingerprint the UI told the user to
+// paste into NickServ, and the only thing that can confirm that is a server
+// looking at the certificate it was handed.
+
+// MUST be first: redirects DATABASE_PATH before anything opens the db.
+import '../test-utils/isolateDb.js';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createUser } from '../db/users.js';
+import { createNetwork, setNetworkClientCert } from '../db/networks.js';
+import type { Network } from '../db/networks.js';
+import { IrcConnection } from './ircConnection.js';
+import { FakeIrcd } from '../test-utils/fakeIrcd.js';
+import { generateClientCert, describeClientCert } from '../utils/clientCert.js';
+import { until } from '../test-utils/until.js';
+
+let ircd: FakeIrcd;
+let userId: number;
+let seq = 0;
+
+beforeAll(async () => {
+  ircd = await FakeIrcd.start({ tls: true, requestClientCert: true, sasl: true });
+  userId = createUser('certfp-int').id;
+});
+
+afterAll(async () => {
+  await ircd.close();
+});
+
+// A network pointed at the fake ircd. trusted_certificates is 0 because the
+// ircd's own cert is self-signed — that's the SERVER side of TLS and has
+// nothing to do with the client certificate under test.
+function makeNetwork(nick: string, fields: Record<string, unknown> = {}): Network {
+  return createNetwork(userId, {
+    name: `certfp-${seq++}`,
+    host: '127.0.0.1',
+    port: ircd.port,
+    tls: true,
+    trusted_certificates: false,
+    nick,
+    autoconnect: false,
+    ...fields,
+  })!;
+}
+
+function connect(network: Network): { conn: IrcConnection; events: Record<string, unknown>[] } {
+  const events: Record<string, unknown>[] = [];
+  const conn = new IrcConnection({
+    network,
+    onEvent: (e) => events.push(e as Record<string, unknown>),
+  });
+  conn.connect();
+  return { conn, events };
+}
+
+describe('CertFP over a real TLS socket', () => {
+  it('presents the attached certificate, and the network sees the registered fingerprint', async () => {
+    const pair = await generateClientCert('certuser');
+    const network = setNetworkClientCert(makeNetwork('certuser').id, userId, pair)!;
+
+    const { conn } = connect(network);
+    try {
+      await until(() => conn.state === 'connected', 5000, 'connected');
+      const client = ircd.client('certuser')!;
+      // The fingerprint the UI tells the user to paste is the one on the wire.
+      expect(client.certfp).toBe(describeClientCert(pair.cert).sha256);
+    } finally {
+      conn.dispose();
+    }
+  });
+
+  it('logs in with SASL EXTERNAL once the fingerprint is registered, sending no password', async () => {
+    const pair = await generateClientCert('extuser');
+    const network = setNetworkClientCert(makeNetwork('extuser').id, userId, pair)!;
+    // What `/msg NickServ CERT ADD` leaves behind.
+    ircd.certfpAccounts.set(describeClientCert(pair.cert).sha256, 'extaccount');
+
+    const { conn } = connect(network);
+    try {
+      await until(() => conn.state === 'connected', 5000, 'connected');
+      const client = ircd.client('extuser')!;
+      await until(() => client.account === 'extaccount', 5000, 'logged in');
+      expect(client.sent).toContain('AUTHENTICATE EXTERNAL');
+      // EXTERNAL carries no credential — the certificate already made the claim.
+      expect(client.sent.some((l) => l.startsWith('AUTHENTICATE PLAIN'))).toBe(false);
+      expect(client.sent).toContain('AUTHENTICATE +');
+    } finally {
+      conn.dispose();
+    }
+  });
+
+  it('is refused by a network that has never seen the fingerprint', async () => {
+    const pair = await generateClientCert('strangeruser');
+    const network = setNetworkClientCert(makeNetwork('strangeruser').id, userId, pair)!;
+    // Deliberately NOT registered at the fake NickServ.
+
+    const { conn } = connect(network);
+    try {
+      await until(() => conn.state === 'connected', 5000, 'connected');
+      const client = ircd.client('strangeruser')!;
+      expect(client.sent).toContain('AUTHENTICATE EXTERNAL');
+      // SASL is optional here, so the server keeps us — unauthenticated. That
+      // is the shape #617 is about, and it's why the advice this failure
+      // carries is asserted where the user actually reads it (the give-up
+      // message in ircConnection.test.ts) rather than here: registering clears
+      // the pending classification on the way past.
+      expect(client.account).toBe(null);
+    } finally {
+      conn.dispose();
+    }
+  });
+
+  it('keeps PLAIN when a SASL password is set, and still presents the certificate', async () => {
+    const pair = await generateClientCert('plainuser');
+    const network = setNetworkClientCert(
+      makeNetwork('plainuser', { sasl_account: 'plainaccount', sasl_password: 'hunter2' }).id,
+      userId,
+      pair,
+    )!;
+    ircd.saslAccounts.set('plainaccount', 'hunter2');
+
+    const { conn } = connect(network);
+    try {
+      await until(() => conn.state === 'connected', 5000, 'connected');
+      const client = ircd.client('plainuser')!;
+      await until(() => client.account === 'plainaccount', 5000, 'logged in');
+      expect(client.sent).toContain('AUTHENTICATE PLAIN');
+      expect(client.sent).not.toContain('AUTHENTICATE EXTERNAL');
+      // Passive CertFP works alongside a password, so the certificate goes on
+      // the wire either way — the password only decides the MECHANISM.
+      expect(client.certfp).toBe(describeClientCert(pair.cert).sha256);
+    } finally {
+      conn.dispose();
+    }
+  });
+
+  it('presents nothing, and asks for nothing, when no certificate is attached', async () => {
+    const { conn } = connect(makeNetwork('barecert'));
+    try {
+      await until(() => conn.state === 'connected', 5000, 'connected');
+      const client = ircd.client('barecert')!;
+      expect(client.certfp).toBe(null);
+      expect(client.sent.some((l) => l.startsWith('AUTHENTICATE'))).toBe(false);
+    } finally {
+      conn.dispose();
+    }
+  });
+});

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -2335,6 +2335,28 @@ describe('auto-reconnect controller', () => {
     ).toBe(true);
   });
 
+  // The give-up message is the one place a SASL rejection is actually spoken to
+  // the user, so it has to name the credential that was offered. Under EXTERNAL
+  // there is no password to go and check — the fingerprint has to be registered
+  // at NickServ, which is a different action in a different place. (#459)
+  it('tells a CertFP network what to fix, not to check a password it never sent', () => {
+    vi.useFakeTimers();
+    const { conn, events } = makeConn('rc-sasl-certfp');
+    conn.network.client_cert = 'cert-pem';
+    conn.network.client_key = 'key-pem';
+    for (let i = 0; i < 3; i += 1) {
+      conn.client.emit('sasl failed', { reason: 'fail' });
+      conn.client.emit('close', true);
+      vi.runAllTimers();
+    }
+    const text = String(
+      events.find((e) => e.type === 'error' && /SASL authentication failed/i.test(String(e.text)))
+        ?.text,
+    );
+    expect(text).toMatch(/NickServ CERT ADD/);
+    expect(text).not.toMatch(/account credentials/);
+  });
+
   // #617: a single rejection is not proof the credentials killed THIS socket. On
   // a network where SASL is optional the server keeps us, so a later drop (a
   // stalled registration timing out, a blip) is unrelated and must still retry —
@@ -3810,6 +3832,29 @@ describe('join echo, forwarded joins (470), and un-partable channels (442)', () 
     expect(publish).not.toHaveBeenCalledWith(
       expect.objectContaining({ target: `:server:${conn.network.id}` }),
     );
+  });
+
+  // A CertFP network identifies on the certificate: SASL EXTERNAL sends no
+  // account name, and passive NickServ CertFP sends nothing at all — so the
+  // sasl_account this gate used to read is empty on exactly the networks that
+  // ARE waiting for services. (#459)
+  it('473 before RPL_LOGGEDIN leaves autojoin alone on a CertFP network', () => {
+    const conn = makeNickServConn('inviteonly-certfp');
+    conn.network.connect_commands = null; // the cert is the only credential
+    conn.network.client_cert = 'cert-pem';
+    conn.network.client_key = 'key-pem';
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#marco', {
+      kind: 'channel',
+      autojoin: true,
+    });
+
+    conn.client.emit('irc error', {
+      error: 'invite_only_channel',
+      channel: '#marco',
+      reason: 'Cannot join channel (+i)',
+    });
+
+    expect(getBuffer(conn.network.user_id, conn.network.id, '#marco')?.autojoin).toBe(true);
   });
 
   it('473 after RPL_LOGGEDIN does stop auto-joining on a NickServ network', () => {

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -3954,6 +3954,30 @@ describe('join echo, forwarded joins (470), and un-partable channels (442)', () 
     );
   });
 
+  // connect() attempts SASL on a PASSWORD, using the nick as the authcid when no
+  // account is set — so a password-only network is mid-identification too. It
+  // bites where identifiedToServices never gets set: that flag comes from
+  // RPL_LOGGEDIN (900) alone, and a server may answer a successful SASL with 903
+  // and nothing else.
+  it('473 before RPL_LOGGEDIN leaves autojoin alone on a password-only SASL network', () => {
+    const conn = makeNickServConn('inviteonly-saslpw');
+    conn.network.connect_commands = null; // no NickServ script to hint off
+    conn.network.sasl_account = null; // authcid falls back to the nick
+    conn.network.sasl_password = 'hunter2';
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#marco', {
+      kind: 'channel',
+      autojoin: true,
+    });
+
+    conn.client.emit('irc error', {
+      error: 'invite_only_channel',
+      channel: '#marco',
+      reason: 'Cannot join channel (+i)',
+    });
+
+    expect(getBuffer(conn.network.user_id, conn.network.id, '#marco')?.autojoin).toBe(true);
+  });
+
   // A CertFP network identifies on the certificate: SASL EXTERNAL sends no
   // account name, and passive NickServ CertFP sends nothing at all — so the
   // sasl_account this gate used to read is empty on exactly the networks that

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -35,6 +35,7 @@ import connectScheduler from './connectScheduler.js';
 import { getRecent } from './systemLog.js';
 import { createUser } from '../db/users.js';
 import { createNetwork, getNetwork } from '../db/networks.js';
+import type { Network } from '../db/networks.js';
 import {
   getBuffer,
   ensureOpen as ensureBufferOpen,
@@ -375,6 +376,125 @@ describe('resolveChannelContext (#439)', () => {
     const channels = new Map([['#christian', { name: '#Christian' }]]);
     expect(resolveChannelContext({ '+draft/channel-context': '&nope' }, 'x', channels)).toBe(null);
     expect(resolveChannelContext(undefined, '[+nope] hi', channels)).toBe(null);
+  });
+});
+
+// CertFP (#459): every way an attached certificate can fail to reach the wire.
+// The rule is the same in all of them — a connection that presents no
+// certificate is not a degraded version of what the user configured, it is a
+// different identity, so the dial is refused and says why.
+describe('client certificate refusals', () => {
+  // One real pair for the whole block: the refusals under test are about
+  // everything AROUND the certificate, so an invalid one would just trip the
+  // validity check first and prove nothing.
+  let pair: { cert: string; key: string };
+  beforeAll(async () => {
+    pair = await (await import('../utils/clientCert.js')).generateClientCert('nick');
+  });
+
+  function makeCertConn(fields: Partial<Network> = {}): { conn: IrcConnection } {
+    const conn = new IrcConnection({
+      network: {
+        client_cert: pair.cert,
+        client_key: pair.key,
+        id: 1,
+        user_id: 1,
+        name: 'certfail',
+        host: 'irc.example.test',
+        port: 6697,
+        tls: 1,
+        trusted_certificates: 0,
+        nick: 'nick',
+        username: null,
+        realname: null,
+        server_password: null,
+        autoconnect: 1,
+        sasl_account: null,
+        sasl_password: null,
+        connect_commands: null,
+        position: 0,
+        casemapping: null,
+        created_at: new Date().toISOString(),
+        ...fields,
+      },
+      onEvent: () => {},
+    });
+    return { conn };
+  }
+
+  // publish() is stubbed rather than read through onEvent: these networks are
+  // synthetic rows that no buffer registry knows, and the real publish writes
+  // history.
+  function attempt(fields: Partial<Network> = {}): {
+    dialed: ReturnType<typeof vi.fn>;
+    published: Record<string, unknown>[];
+    conn: IrcConnection;
+  } {
+    const { conn } = makeCertConn(fields);
+    const published: Record<string, unknown>[] = [];
+    conn.publish = (event: unknown) => {
+      published.push(event as Record<string, unknown>);
+    };
+    const dialed = vi.fn<(options: ConnectOptions) => void>();
+    conn.client.connect = dialed;
+    conn.connect();
+    return { dialed, published, conn };
+  }
+
+  const refusal = (published: Record<string, unknown>[]) =>
+    String(
+      published.find((e) => e.type === 'error' && /Not connecting/.test(String(e.text)))?.text,
+    );
+
+  it('does not dial when the network is plaintext', () => {
+    const { dialed, published } = attempt({ tls: 0, port: 6667 });
+    expect(dialed).not.toHaveBeenCalled();
+    expect(refusal(published)).toMatch(/only be presented over TLS/);
+  });
+
+  // Archive import inserts client_cert/client_key verbatim (exportSchema drives
+  // its column list), so an edited or truncated archive is a real source of
+  // half a pair — and of a key that tls.connect throws on, SYNCHRONOUSLY,
+  // inside client.connect().
+  it('does not dial on half a pair', () => {
+    const { dialed, published } = attempt({ client_key: null });
+    expect(dialed).not.toHaveBeenCalled();
+    expect(refusal(published)).toMatch(/half a client certificate/);
+  });
+
+  it('does not hand an unparseable pair to tls.connect', () => {
+    const { dialed, published } = attempt({ client_cert: 'not a pem', client_key: 'not a key' });
+    expect(dialed).not.toHaveBeenCalled();
+    expect(refusal(published)).toMatch(/unusable/);
+  });
+
+  it('leaves the network disconnected rather than pinned on connecting', () => {
+    const { conn } = attempt({ tls: 0 });
+    expect(conn.state).toBe('disconnected');
+  });
+
+  // Engine mode dials in another process, which cannot be handed the
+  // certificate yet. Presenting nothing while the app still asks for SASL
+  // EXTERNAL fails registration and blames the wrong thing.
+  it('does not dial through an engine that cannot present it', () => {
+    process.env.LURKER_ENGINE_URL = 'tcp://127.0.0.1:9999';
+    try {
+      const { dialed, published } = attempt();
+      expect(dialed).not.toHaveBeenCalled();
+      expect(refusal(published)).toMatch(/engine/);
+    } finally {
+      delete process.env.LURKER_ENGINE_URL;
+    }
+  });
+
+  it('dials normally once the pair is valid and nothing is in the way', () => {
+    const { dialed } = attempt();
+    expect(dialed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sasl_mechanism: 'EXTERNAL',
+        client_certificate: { certificate: pair.cert, private_key: pair.key },
+      }),
+    );
   });
 });
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -3809,7 +3809,13 @@ export class IrcConnection {
    *  channel that keeps retrying (the status quo), while a false negative
    *  un-subscribes someone mid-race. When in doubt, wait. */
   private awaitingIdentification(): boolean {
-    if (this.network.sasl_account) return true;
+    // sasl_password, not just sasl_account: connect() attempts SASL whenever a
+    // PASSWORD is set, falling back to the nick as the authcid — so keying only
+    // on the account missed a password-only setup entirely. It matters because
+    // identifiedToServices is set by RPL_LOGGEDIN (900) alone, and a server may
+    // answer a successful SASL with 903 and no 900 at all; the gate is then the
+    // only thing standing between an early 473 and a durable unsubscribe.
+    if (this.network.sasl_account || this.network.sasl_password) return true;
     // A CertFP network identifies on the certificate, which means SASL EXTERNAL
     // leaves sasl_account empty — and a NickServ that recognises the fingerprint
     // passively needs no account field at all. Either way identification is

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1281,9 +1281,17 @@ export class IrcConnection {
         // Promoted to terminal at 'close' once the streak runs out; see
         // maybePromoteSaslFailure.
         this.saslFailureStreak += 1;
+        // Which credential to go and look at depends on which one was offered:
+        // under EXTERNAL there is no password to check, and the fix is at
+        // NickServ, where the fingerprint has to be registered before the
+        // network will recognise it. (#459)
+        const usingCert = !!this.network.client_cert && !this.network.sasl_password;
+        const advice = usingCert
+          ? " — the network didn't recognise your client certificate. Register its fingerprint with /msg NickServ CERT ADD while connected"
+          : " — check the network's account credentials";
         this.pendingSaslFailure = `SASL authentication failed${
           reason && reason !== 'fail' ? ` (${reason})` : ''
-        } — check the network's account credentials`;
+        }${advice}`;
       }
     });
 
@@ -3801,6 +3809,11 @@ export class IrcConnection {
    *  un-subscribes someone mid-race. When in doubt, wait. */
   private awaitingIdentification(): boolean {
     if (this.network.sasl_account) return true;
+    // A CertFP network identifies on the certificate, which means SASL EXTERNAL
+    // leaves sasl_account empty — and a NickServ that recognises the fingerprint
+    // passively needs no account field at all. Either way identification is
+    // pending, and a +R channel's rejoin must wait for it. (#459)
+    if (this.network.client_cert) return true;
     const commands = this.network.connect_commands;
     return !!commands && SERVICES_IDENTIFY_HINT.test(commands);
   }
@@ -4037,6 +4050,15 @@ export class IrcConnection {
     const account = sasl_password
       ? { account: sasl_account || nick, password: sasl_password }
       : undefined;
+    // CertFP (#459). The certificate is presented whenever one is attached: a
+    // network may recognise it passively (NickServ identifies you on the spot),
+    // which works alongside a SASL password rather than instead of it. The
+    // MECHANISM is what the password decides — PLAIN when there is one,
+    // EXTERNAL when the certificate is the only credential there is. EXTERNAL
+    // carries no account name: the fingerprint is the identity, and the network
+    // maps it to whichever account it was registered on.
+    const clientCert = this.clientCertificate();
+    const saslMechanism = clientCert && !sasl_password ? ('EXTERNAL' as const) : undefined;
     // In engine mode the notice waits for the engine to say it is dialing — a
     // CONNECT it answers with ATTACH connects nothing (see onEnginePhase).
     if (!engineConfigured()) this.announceConnecting();
@@ -4051,6 +4073,8 @@ export class IrcConnection {
       gecos: this.network.realname || nick,
       password: this.network.server_password || undefined,
       account,
+      client_certificate: clientCert,
+      sasl_mechanism: saslMechanism,
       // Lurker owns the reconnect policy (scheduleReconnectIfWarranted), so
       // irc-framework's built-in is disabled outright. Its heuristic only retries
       // a connection that was healthy for >5s and died cleanly, ~3 times — which
@@ -4084,6 +4108,15 @@ export class IrcConnection {
       outgoing_addr: outgoingAddr(),
       ...this.engineConnectOptions(),
     });
+  }
+
+  /** The attached CertFP pair in irc-framework's shape, or undefined. Both
+   *  halves or neither: a certificate without its key cannot complete a
+   *  handshake, and passing one alone makes tls.connect throw. */
+  private clientCertificate(): { certificate: string; private_key: string } | undefined {
+    const { client_cert, client_key } = this.network;
+    if (!client_cert || !client_key) return undefined;
+    return { certificate: client_cert, private_key: client_key };
   }
 
   private announceConnecting(): void {

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -50,6 +50,7 @@ import { APP_NAME, APP_VERSION } from '../utils/userAgent.js';
 import { findUserById } from '../db/users.js';
 import { isNodeMode } from '../utils/edition.js';
 import { deriveIdent } from '../../shared/ident.js';
+import { validateClientCertPair, isClientCertProblem } from '../utils/clientCert.js';
 import { classifyModeChange, modeLetter } from '../../shared/modes.js';
 import type { ModeChange } from '../../shared/modes.js';
 import { registerIdent, unregisterIdent, isIdentdEnabled, isOidentdFileEnabled } from './identd.js';
@@ -4057,6 +4058,22 @@ export class IrcConnection {
     // EXTERNAL when the certificate is the only credential there is. EXTERNAL
     // carries no account name: the fingerprint is the identity, and the network
     // maps it to whichever account it was registered on.
+    const certBlocked = this.clientCertBlockedReason();
+    if (certBlocked) {
+      // Never dial past this. Connecting without the certificate is not a
+      // degraded version of what the user asked for, it is a different
+      // identity: they arrive as an unrecognised stranger, +R channels refuse
+      // them, and under EXTERNAL the registration fails with a SASL error that
+      // points at the wrong thing entirely.
+      this.publish({
+        type: 'error',
+        target: this.serverTarget(),
+        text: `Not connecting: ${certBlocked}.`,
+      });
+      this.logNet(`Connect blocked: ${certBlocked}`, 'warn');
+      this.setState('disconnected');
+      return;
+    }
     const clientCert = this.clientCertificate();
     const saslMechanism = clientCert && !sasl_password ? ('EXTERNAL' as const) : undefined;
     // In engine mode the notice waits for the engine to say it is dialing — a
@@ -4110,9 +4127,43 @@ export class IrcConnection {
     });
   }
 
-  /** The attached CertFP pair in irc-framework's shape, or undefined. Both
-   *  halves or neither: a certificate without its key cannot complete a
-   *  handshake, and passing one alone makes tls.connect throw. */
+  /** Why an attached CertFP pair cannot be presented on this connect, or null
+   *  when there is nothing attached or nothing wrong. Checked before dialing:
+   *  every case here would otherwise become a connection that looks fine and
+   *  authenticates as nobody.
+   *
+   *  The PEMs are re-validated on each connect rather than trusted from the
+   *  write path, because the routes are not the only writer — archive import
+   *  inserts both columns verbatim (exportSchema drives its column list), so a
+   *  hand-edited or truncated archive can plant half a pair or an unparseable
+   *  key. An unparseable key reaching tls.connect throws SYNCHRONOUSLY out of
+   *  client.connect(), and on a backoff retry that is an uncaught exception in
+   *  a shared process. */
+  private clientCertBlockedReason(): string | null {
+    const { client_cert, client_key } = this.network;
+    if (!client_cert && !client_key) return null;
+    if (!client_cert || !client_key) {
+      return 'this network has half a client certificate — a certificate and its key are only usable together';
+    }
+    const pair = validateClientCertPair(client_cert, client_key);
+    if (isClientCertProblem(pair)) {
+      return `this network's client certificate is unusable (${pair.error})`;
+    }
+    if (!this.network.tls) {
+      return 'a client certificate can only be presented over TLS — enable TLS for this network, or remove the certificate';
+    }
+    if (engineConfigured()) {
+      // Engine mode dials in another process, which has no way to be handed
+      // the certificate yet (protocol minor 1). Presenting nothing while the
+      // app still asks for SASL EXTERNAL is the worst of both worlds.
+      return 'the IRC engine this deployment connects through cannot present a client certificate yet — update the engine, or remove the certificate';
+    }
+    return null;
+  }
+
+  /** The attached CertFP pair in irc-framework's shape, or undefined. Only ever
+   *  reached once clientCertBlockedReason() has passed, so both halves are
+   *  present and parse. */
   private clientCertificate(): { certificate: string; private_key: string } | undefined {
     const { client_cert, client_key } = this.network;
     if (!client_cert || !client_key) return undefined;

--- a/server/test-utils/fakeIrcd.ts
+++ b/server/test-utils/fakeIrcd.ts
@@ -40,6 +40,13 @@ export interface FakeIrcdOptions {
   burstNickTo?: string;
   serverName?: string;
   network?: string;
+  // Ask every TLS client for a certificate and record what it presents, the way
+  // an ircd doing CertFP does — it hashes what you show it rather than
+  // verifying a chain, so anything is accepted. Meaningless without `tls`.
+  requestClientCert?: boolean;
+  // Offer SASL: advertises `sasl=<mechanisms>` in CAP LS and answers
+  // AUTHENTICATE. Defaults to PLAIN + EXTERNAL when passed `true`.
+  sasl?: boolean | { mechanisms: string[] };
 }
 
 export interface FakeClient {
@@ -51,6 +58,14 @@ export interface FakeClient {
   caps: Set<string>;
   capNegotiating: boolean;
   channels: Set<string>;
+  // The SHA-256 of the certificate this client presented, bare lowercase hex —
+  // the form services want it registered in. null when it presented none (or
+  // the listener isn't asking).
+  certfp: string | null;
+  // The SASL mechanism in flight, between AUTHENTICATE <mech> and the outcome.
+  saslMech: string | null;
+  // The account this client authenticated as, once SASL has succeeded.
+  account: string | null;
   // Every line this client sent, in order.
   sent: string[];
 }
@@ -69,10 +84,30 @@ const DEFAULT_CAPS = [
   'echo-message',
 ];
 
+// `sasl=PLAIN,EXTERNAL` → `sasl`.
+function capName(cap: string): string {
+  return cap.split('=')[0];
+}
+
+// The SHA-256 of a peer's certificate as services want it registered: bare
+// lowercase hex. Null for a plain socket, or a TLS one that presented nothing.
+function peerCertFingerprint(socket: net.Socket): string | null {
+  if (!(socket instanceof tls.TLSSocket)) return null;
+  const peer = socket.getPeerCertificate();
+  if (!peer || !peer.fingerprint256) return null;
+  return peer.fingerprint256.replace(/:/g, '').toLowerCase();
+}
+
 export class FakeIrcd extends EventEmitter {
   readonly clients: FakeClient[] = [];
   readonly registrations: Array<{ nick: string; at: number }> = [];
   readonly topics = new Map<string, string>();
+  // Fingerprint → account, i.e. what `/msg NickServ CERT ADD` leaves behind.
+  // SASL EXTERNAL succeeds for a client whose presented certfp is in here and
+  // fails for one whose isn't, which is the whole of CertFP as a client sees it.
+  readonly certfpAccounts = new Map<string, string>();
+  // account → password, for SASL PLAIN.
+  readonly saslAccounts = new Map<string, string>();
   // Test hook: return true to swallow a client command — no reply of any kind —
   // for a test of what the client does when a reply never comes.
   hold: ((cmd: string, params: string[], c: FakeClient) => boolean) | null = null;
@@ -85,7 +120,14 @@ export class FakeIrcd extends EventEmitter {
 
   private constructor(private readonly opts: FakeIrcdOptions) {
     super();
-    this.caps = opts.caps ?? DEFAULT_CAPS;
+    this.caps = [...(opts.caps ?? DEFAULT_CAPS)];
+    if (opts.sasl) {
+      const mechanisms =
+        typeof opts.sasl === 'object' ? opts.sasl.mechanisms : ['PLAIN', 'EXTERNAL'];
+      // Advertised with its value, as SASL 3.2 does: irc-framework reads the
+      // mechanism list off the cap and refuses to try one that isn't there.
+      this.caps.push(`sasl=${mechanisms.join(',')}`);
+    }
     this.serverName = opts.serverName ?? 'fake.test';
     this.network = opts.network ?? 'FakeNet';
   }
@@ -106,7 +148,17 @@ export class FakeIrcd extends EventEmitter {
           },
         ],
       });
-      ircd.server = tls.createServer({ key: pems.private, cert: pems.cert }, (s) => ircd.accept(s));
+      ircd.server = tls.createServer(
+        {
+          key: pems.private,
+          cert: pems.cert,
+          requestCert: !!opts.requestClientCert,
+          // A CertFP client cert is self-signed by definition; verifying it
+          // would reject every one of them.
+          rejectUnauthorized: false,
+        },
+        (s) => ircd.accept(s),
+      );
     } else {
       ircd.server = net.createServer((s) => ircd.accept(s));
     }
@@ -230,6 +282,9 @@ export class FakeIrcd extends EventEmitter {
       caps: new Set(),
       capNegotiating: false,
       channels: new Set(),
+      certfp: peerCertFingerprint(socket),
+      saslMech: null,
+      account: null,
       sent: [],
     };
     this.clients.push(client);
@@ -310,6 +365,8 @@ export class FakeIrcd extends EventEmitter {
         return this.maybeRegister(c);
       case 'PASS':
         return;
+      case 'AUTHENTICATE':
+        return this.onAuthenticate(c, p[0] ?? '');
       case 'PING':
         return this.raw(c, `:${this.serverName} PONG ${this.serverName} :${p[p.length - 1] ?? ''}`);
       case 'PONG':
@@ -434,7 +491,10 @@ export class FakeIrcd extends EventEmitter {
       }
     } else if (sub === 'REQ') {
       const wanted = (p[1] ?? '').split(' ').filter(Boolean);
-      const ok = wanted.every((w) => this.caps.includes(w.replace(/^-/, '')));
+      // Match on the cap NAME: an advertised cap may carry a value (`sasl=PLAIN`),
+      // and a client REQs the bare name.
+      const offered = new Set(this.caps.map(capName));
+      const ok = wanted.every((w) => offered.has(capName(w.replace(/^-/, ''))));
       if (ok) {
         for (const w of wanted) {
           if (w.startsWith('-')) c.caps.delete(w.slice(1));
@@ -448,6 +508,62 @@ export class FakeIrcd extends EventEmitter {
       c.capNegotiating = false;
       this.maybeRegister(c);
     }
+  }
+
+  // SASL, as much of it as a client can tell apart: the mechanism is offered or
+  // it isn't, the credential is right or it isn't. EXTERNAL is the one that
+  // matters here — it carries no credential at all, so the answer turns entirely
+  // on the certificate presented back at the handshake.
+  private onAuthenticate(c: FakeClient, arg: string): void {
+    const mechanisms = this.saslMechanisms();
+    if (!mechanisms.length) return this.num(c, '904', 'SASL authentication failed');
+    if (!c.saslMech) {
+      const mech = arg.toUpperCase();
+      if (!mechanisms.includes(mech)) {
+        return this.num(c, '904', 'SASL authentication failed');
+      }
+      c.saslMech = mech;
+      // '+' means "go ahead": the client answers with its payload, or with a
+      // bare '+' for EXTERNAL, which has none.
+      return this.raw(c, 'AUTHENTICATE +');
+    }
+    const mech = c.saslMech;
+    c.saslMech = null;
+    if (mech === 'EXTERNAL') {
+      const account = c.certfp ? this.certfpAccounts.get(c.certfp) : undefined;
+      if (!account) {
+        // What an ircd says to a certificate nobody registered — and, just as
+        // importantly, to a client that presented none at all.
+        return this.num(c, '904', 'SASL authentication failed');
+      }
+      return this.saslSucceeded(c, account);
+    }
+    // PLAIN: authzid\0authcid\0password
+    const [, authcid, password] = Buffer.from(arg === '+' ? '' : arg, 'base64')
+      .toString('utf8')
+      .split('\u0000');
+    if (!authcid || this.saslAccounts.get(authcid) !== password) {
+      return this.num(c, '904', 'SASL authentication failed');
+    }
+    return this.saslSucceeded(c, authcid);
+  }
+
+  private saslSucceeded(c: FakeClient, account: string): void {
+    c.account = account;
+    this.num(
+      c,
+      '900',
+      `${c.nick ?? '*'}!${c.user ?? 'u'}@127.0.0.1`,
+      account,
+      `You are now logged in as ${account}`,
+    );
+    this.num(c, '903', 'SASL authentication successful');
+  }
+
+  private saslMechanisms(): string[] {
+    const advertised = this.caps.find((cap) => capName(cap) === 'sasl');
+    if (!advertised) return [];
+    return (advertised.split('=')[1] ?? '').split(',').filter(Boolean);
   }
 
   private maybeRegister(c: FakeClient): void {

--- a/server/types/irc-framework.d.ts
+++ b/server/types/irc-framework.d.ts
@@ -21,6 +21,15 @@ declare module 'irc-framework' {
     gecos?: string;
     password?: string;
     account?: { account: string; password: string };
+    /** SASL mechanism. irc-framework defaults to PLAIN when an `account` is set;
+     *  'EXTERNAL' authenticates with the TLS client certificate instead and
+     *  carries no credential. Compared case-SENSITIVELY in two of the three
+     *  places the library reads it, so it must be spelled exactly. */
+    sasl_mechanism?: 'PLAIN' | 'EXTERNAL';
+    /** TLS client certificate presented on the handshake (CertFP, #459).
+     *  Forwarded to tls.connect as {key, cert} by the net transport; in engine
+     *  mode EngineTransport relays it to the engine, which dials. */
+    client_certificate?: { certificate: string; private_key: string };
     auto_reconnect?: boolean;
     auto_reconnect_max_retries?: number;
     enable_chghost?: boolean;

--- a/server/types/irc-framework.d.ts
+++ b/server/types/irc-framework.d.ts
@@ -27,8 +27,10 @@ declare module 'irc-framework' {
      *  places the library reads it, so it must be spelled exactly. */
     sasl_mechanism?: 'PLAIN' | 'EXTERNAL';
     /** TLS client certificate presented on the handshake (CertFP, #459).
-     *  Forwarded to tls.connect as {key, cert} by the net transport; in engine
-     *  mode EngineTransport relays it to the engine, which dials. */
+     *  Forwarded to tls.connect as {key, cert} by the NET transport only — the
+     *  engine transport dials in another process and cannot carry it yet, which
+     *  is why ircConnection refuses to dial through an engine with a
+     *  certificate attached rather than presenting nothing. */
     client_certificate?: { certificate: string; private_key: string };
     auto_reconnect?: boolean;
     auto_reconnect_max_retries?: number;

--- a/server/utils/clientCert.test.ts
+++ b/server/utils/clientCert.test.ts
@@ -76,6 +76,17 @@ describe('generateClientCert', () => {
     expect(describeClientCert((await generateClientCert(',,==')).cert).subject).toContain('lurker');
   });
 
+  // The DN parser reads a leading '#' as "hex-encoded DER follows", so a
+  // channel-shaped nick threw out of the encoder rather than naming anything.
+  it('survives a nick that starts like a channel', async () => {
+    expect(describeClientCert((await generateClientCert('#chat')).cert).subject).toBe('CN=chat');
+    expect(describeClientCert((await generateClientCert('#')).cert).subject).toBe('CN=lurker');
+  });
+
+  it('keeps a # that is not leading', async () => {
+    expect(describeClientCert((await generateClientCert('a#b')).cert).subject).toBe('CN=a#b');
+  });
+
   it('mints a distinct key each time', async () => {
     const [a, b] = await Promise.all([generateClientCert('a'), generateClientCert('b')]);
     expect(describeClientCert(a.cert).sha256).not.toBe(describeClientCert(b.cert).sha256);

--- a/server/utils/clientCert.ts
+++ b/server/utils/clientCert.ts
@@ -59,6 +59,11 @@ function safeCommonName(raw: string): string {
     .join('')
     .replace(/\s+/g, ' ')
     .trim()
+    // A leading '#' means "what follows is hex-encoded DER" to the DN parser,
+    // so a nick like `#chat` throws ("not HEX encoded") instead of naming
+    // anything — the same unexplained 500, by a different route.
+    .replace(/^#+/, '')
+    .trim()
     .slice(0, 64);
   return cleaned || 'lurker';
 }


### PR DESCRIPTION
Second slice of CertFP (#459), stacked on #878. The app's own dial path now presents the certificate; the engine path is PR 3.

### The mechanism rule

The certificate rides **every** connect where one is attached, because a network may recognise it passively — NickServ identifies you the moment you connect — and that works *alongside* a SASL password rather than instead of it. The password decides only the mechanism:

- SASL password set → **PLAIN**, cert still presented.
- Cert only → **EXTERNAL**, which sends no account name. The fingerprint is the identity; the network maps it to whichever account it was registered on.

### Two things that would otherwise half-work

`awaitingIdentification()` gated on `sasl_account` — which EXTERNAL leaves empty. On exactly the networks that *are* waiting for services, an early `473` would have unsubscribed someone from a channel their account grants them.

The SASL give-up message said "check the network's account credentials". Under EXTERNAL there is no password to check; the fix is registering the fingerprint at NickServ, and the message now says so.

### Refusing rather than half-connecting

A connection that presents no certificate isn't a degraded version of what the user configured — it's a different identity. So the dial is refused, with a message naming the fix, when:

- **the engine is in the path** (it dials in another process and the connect frame carries no certificate yet — without this, a cell presents nothing while the app still asks for EXTERNAL: 904 on every connect, and the new advice tells the user to register a fingerprint they already registered). PR 3 narrows this to a protocol-version check.
- the network is **plaintext** (also a 400 at attach time),
- there is **half a pair**, or one that **doesn't parse**.

The last two are reachable because the routes aren't the only writer: archive import inserts both columns verbatim, and an unparseable key reaching `tls.connect` throws *synchronously* out of `client.connect()` — on a backoff retry, an uncaught exception in a shared process.

### Testing

`fakeIrcd` learns to ask for a client certificate and to speak SASL, with a `certfpAccounts` map standing in for what `/msg NickServ CERT ADD` leaves behind. So `ircCertfp.test.ts` is a real TLS handshake against a server that accepts one fingerprint and refuses another — not an inspection of the options dict: the presented fingerprint matches what the API showed, EXTERNAL logs in and sends no password, an unregistered fingerprint is refused, PLAIN stays PLAIN with the cert still on the wire, and a bare network presents nothing. Plus six refusal cases and the identification-race gate. Full suite green.

Reviewed with `/code-review high`; its findings are the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qCyi5Poh5nur5CoUUaoPR