### PR TITLE
CertFP 3/4: carry the certificate to the engine (#459)

### DIFF
--- a/docs/MIGRATION_ENGINE.md
+++ b/docs/MIGRATION_ENGINE.md
@@ -167,6 +167,17 @@ Only `lurker` is replaced. `pull` fetches nothing new for the engine, and `up -d
   An old engine that refuses the new app would otherwise hold every session open while the app dials its own and collides with its ghosts. (Sessions no app claims for an hour are ended — `LURKER_ENGINE_ORPHAN_MS` — but that is a backstop, not a procedure.)
 - Rebooting the host, obviously.
 
+**Features that need a newer engine.** The wire between app and engine is
+versioned separately from either one, and it only ever gains optional fields — so
+a newer app talks to an older engine happily, right up to a feature that needs a
+field the engine has never heard of. Today that is one thing: **CertFP** (a TLS
+client certificate on a network) needs an engine from Lurker 2.2.2 or later,
+because the engine is what dials and so the engine is what presents it. An app
+that finds itself pointed at an older engine refuses to connect that network and
+says so, rather than connecting without the certificate — which would log the
+user in as nobody. Pull the engine image (its tag doesn't move; its contents do)
+and restart it.
+
 **While the app is down**, the engine keeps what arrives: 4 MiB per connection, 256 MiB in total, tunable with `LURKER_ENGINE_BUFFER_BYTES` and `LURKER_ENGINE_BUFFER_TOTAL_BYTES`. Past the cap the oldest lines go and the app notes where the hole is. Deploys take seconds; the buffer covers hours of ordinary traffic.
 
 ---

--- a/server/engine/engine.test.ts
+++ b/server/engine/engine.test.ts
@@ -59,7 +59,13 @@ async function link(startedAt?: number): Promise<TestLink> {
 let counter = 0;
 function connectFrame(
   id: string,
-  extra: Partial<{ tls: boolean; rejectUnauthorized: boolean; ident: string; port: number }> = {},
+  extra: Partial<{
+    tls: boolean;
+    rejectUnauthorized: boolean;
+    ident: string;
+    port: number;
+    clientCert: { cert: string; key: string };
+  }> = {},
 ) {
   return {
     op: 'connect' as const,
@@ -69,6 +75,7 @@ function connectFrame(
     tls: extra.tls ?? false,
     rejectUnauthorized: extra.rejectUnauthorized ?? false,
     ...(extra.ident ? { ident: extra.ident } : {}),
+    ...(extra.clientCert ? { clientCert: extra.clientCert } : {}),
   };
 }
 
@@ -420,6 +427,61 @@ describe('TLS and identd', () => {
         (f) => f.op === 'closed' && f.id === strict,
       );
       expect(closed.error).toMatch(/self.signed|certificate/i);
+    } finally {
+      await secure.close();
+    }
+  });
+
+  // CertFP (#459). The engine is handed a private key over the wire and must
+  // treat it as untrusted input: tls.connect throws SYNCHRONOUSLY on a key it
+  // can't parse or one that doesn't match its certificate, and an uncaught
+  // throw here is every held socket in the process.
+  it('presents a client certificate, and refuses an unusable pair without dying', async () => {
+    const { generateClientCert, describeClientCert } = await import('../utils/clientCert.js');
+    const secure = await FakeIrcd.start({ tls: true, requestClientCert: true });
+    try {
+      const l = await link();
+      const healthy = `certfp-healthy:${++counter}`;
+      const pair = await generateClientCert('enginecert');
+      l.send(
+        connectFrame(healthy, {
+          port: secure.port,
+          tls: true,
+          rejectUnauthorized: false,
+          clientCert: { cert: pair.cert, key: pair.key },
+        }),
+      );
+      await l.waitFor((f) => f.op === 'open' && f.id === healthy);
+      l.send({ op: 'write', id: healthy, line: 'NICK certy' });
+      l.send({ op: 'write', id: healthy, line: 'USER certy 0 * :c' });
+      await l.waitForLine(healthy, / 001 /);
+      expect(secure.client('certy')!.certfp).toBe(describeClientCert(pair.cert).sha256);
+
+      // A key that doesn't parse, and a pair that doesn't match: both refused
+      // as frames, neither reaching tls.connect.
+      const other = await generateClientCert('someone-else');
+      for (const bad of [
+        { cert: pair.cert, key: 'not a key' },
+        { cert: pair.cert, key: other.key },
+        { cert: pair.cert, key: '' },
+      ]) {
+        l.send(
+          connectFrame(`certfp-bad:${++counter}`, {
+            port: secure.port,
+            tls: true,
+            rejectUnauthorized: false,
+            clientCert: bad,
+          }),
+        );
+        expect(await l.waitFor((f) => f.op === 'error')).toMatchObject({
+          message: expect.stringMatching(/clientCert/),
+        });
+      }
+
+      // Still here, still holding the good one, still relaying.
+      expect(engine.held()).toContain(healthy);
+      secure.say('peer', 'certy', 'alive');
+      await l.waitForLine(healthy, /alive/);
     } finally {
       await secure.close();
     }

--- a/server/engine/engine.test.ts
+++ b/server/engine/engine.test.ts
@@ -487,6 +487,51 @@ describe('TLS and identd', () => {
     }
   });
 
+  // The engine holds a socket for days, and a heap snapshot walks whatever is
+  // still reachable. The handshake is the only thing that needs the private
+  // key, so nothing keeps a reference past it — the certificate stays, because
+  // matchesDial compares it to tell this session from a new one.
+  it('stops holding the client key once the handshake has it', async () => {
+    const { generateClientCert } = await import('../utils/clientCert.js');
+    const { EngineUpstream } = await import('./upstream.js');
+    const { ByteBudget } = await import('./lineBuffer.js');
+    const secure = await FakeIrcd.start({ tls: true, requestClientCert: true });
+    try {
+      const pair = await generateClientCert('dropkey');
+      const upstream = new EngineUpstream(
+        {
+          id: `drop:${++counter}`,
+          instance: 'test',
+          host: '127.0.0.1',
+          port: secure.port,
+          tls: true,
+          rejectUnauthorized: false,
+          clientCert: { cert: pair.cert, key: pair.key },
+        },
+        64 * 1024,
+        new ByteBudget(1024 * 1024),
+      );
+      upstream.dial();
+
+      expect(upstream.opts.clientCert?.key).toBe('');
+      expect(upstream.opts.clientCert?.cert).toBe(pair.cert);
+      // Still able to answer the question the certificate is kept for.
+      expect(
+        upstream.matchesDial({
+          host: '127.0.0.1',
+          port: secure.port,
+          tls: true,
+          clientCert: { cert: pair.cert, key: pair.key },
+        }),
+      ).toBe(true);
+      // And a second dial is a loud error rather than a keyless handshake.
+      expect(() => upstream.dial()).toThrow(/once per instance/);
+      upstream.close();
+    } finally {
+      await secure.close();
+    }
+  });
+
   it('registers the ident on the raw TCP connect — before the TLS handshake — and releases it on close', async () => {
     process.env.LURKER_IDENTD_ENABLED = '1';
     const identd = createIdentdServer({ graceMs: 50, graceStepMs: 10 });

--- a/server/engine/protocol.ts
+++ b/server/engine/protocol.ts
@@ -17,7 +17,11 @@
 // new op is a minor change; renaming or re-meaning one is a major.
 
 export const PROTOCOL_MAJOR = 1;
-export const PROTOCOL_MINOR = 1;
+// minor 2 (#459): `connect` carries an optional client certificate. An app that
+// needs one refuses to dial through an engine below this rather than connecting
+// as an unrecognised stranger — an older engine would ignore the field, and
+// silence is indistinguishable from success on the app side.
+export const PROTOCOL_MINOR = 2;
 
 // One frame is one JSON object on one line. Most wrap a single IRC line (≤ 8191
 // bytes with tags); the one large frame is `attached`, whose replay is bounded by
@@ -96,6 +100,13 @@ export type AppToEngine =
       // the app because it is derived from the account, which the engine never
       // sees.
       ident?: string;
+      // CertFP (#459): the TLS client certificate to present on the handshake.
+      // The private key crosses this link, which is the same trust boundary the
+      // link already carries PASS and AUTHENTICATE lines across — but the engine
+      // must never log it, and must validate the pair before dialing, because
+      // tls.connect throws SYNCHRONOUSLY on a malformed key and an uncaught
+      // throw there is every held socket in the process.
+      clientCert?: { cert: string; key: string };
     }
   | { op: 'write'; id: string; line: string }
   // Everything up to and including `seq` has been persisted; the engine may

--- a/server/engine/server.ts
+++ b/server/engine/server.ts
@@ -23,6 +23,7 @@ import {
   encodeFrame,
 } from './protocol.js';
 import type { AppToEngine, EngineToApp } from './protocol.js';
+import { isDialableCertPair } from '../utils/clientCert.js';
 
 export interface EngineServerOptions {
   secret: string;
@@ -417,6 +418,23 @@ export class EngineServer {
         id,
       );
     }
+    // Validated HERE, before any upstream exists: tls.connect throws
+    // SYNCHRONOUSLY on a key it can't parse or one that doesn't match its
+    // certificate, and an uncaught throw in this process takes every held
+    // socket with it. The app validates too, but the app is not the only thing
+    // that can put a certificate in a database (archive import writes the
+    // columns verbatim), and an engine does not get to trust its callers.
+    if (frame.clientCert !== undefined) {
+      const { cert, key } = frame.clientCert ?? {};
+      if (typeof cert !== 'string' || typeof key !== 'string' || !cert || !key) {
+        return link.fail('connect: clientCert needs both a cert and a key', id);
+      }
+      if (!isDialableCertPair(cert, key)) {
+        // Deliberately says nothing about the key itself — not its length, not
+        // where parsing stopped. The engine logs this line.
+        return link.fail('connect: clientCert is not a usable certificate/key pair', id);
+      }
+    }
     let u = this.upstreams.get(id);
     // Belt and braces over the `<instance>:…` id prefix. If a session under this
     // id belongs to someone else's database, this app does not get to attach to
@@ -438,7 +456,13 @@ export class EngineServer {
     }
     if (
       u &&
-      !u.matchesDial({ host: frame.host, port, tls: !!frame.tls, outgoingAddr: frame.outgoingAddr })
+      !u.matchesDial({
+        host: frame.host,
+        port,
+        tls: !!frame.tls,
+        outgoingAddr: frame.outgoingAddr,
+        clientCert: frame.clientCert,
+      })
     ) {
       // Same id, different destination: the user edited the network. That is a
       // new session, not this one under new settings.
@@ -506,6 +530,7 @@ export class EngineServer {
         rejectUnauthorized: frame.rejectUnauthorized !== false,
         outgoingAddr: frame.outgoingAddr || undefined,
         ident: frame.ident || undefined,
+        clientCert: frame.clientCert,
         dialTimeoutMs: this.opts.dialTimeoutMs,
       },
       this.opts.bufferBytes,

--- a/server/engine/upstream.ts
+++ b/server/engine/upstream.ts
@@ -56,6 +56,11 @@ export interface UpstreamOptions {
   rejectUnauthorized: boolean;
   outgoingAddr?: string;
   ident?: string;
+  // CertFP (#459): the client certificate to present on the TLS handshake. The
+  // caller has already checked that the pair parses and matches — tls.connect
+  // throws synchronously on a malformed key, and this dial runs inside the
+  // process holding every other session.
+  clientCert?: { cert: string; key: string };
   // How long a dial (TCP + TLS handshake) may take before it is given up on.
   dialTimeoutMs?: number;
 }
@@ -184,19 +189,30 @@ export class EngineUpstream extends EventEmitter {
   // Is this the same session a CONNECT with these parameters would open? A
   // changed host/port/TLS/source address means the user edited the network and
   // wants a fresh dial, not the old socket under new settings.
-  matchesDial(frame: { host: string; port: number; tls: boolean; outgoingAddr?: string }): boolean {
+  matchesDial(frame: {
+    host: string;
+    port: number;
+    tls: boolean;
+    outgoingAddr?: string;
+    clientCert?: { cert: string; key: string };
+  }): boolean {
     return (
       this.opts.host === frame.host &&
       this.opts.port === frame.port &&
       this.opts.tls === !!frame.tls &&
-      (this.opts.outgoingAddr || '') === (frame.outgoingAddr || '')
+      (this.opts.outgoingAddr || '') === (frame.outgoingAddr || '') &&
+      // A changed client certificate is a changed IDENTITY: this socket is
+      // still presenting the old one, and services still know the user by the
+      // old fingerprint. Re-attaching would make the new certificate look
+      // applied while nothing about the connection had changed. (#459)
+      (this.opts.clientCert?.cert || '') === (frame.clientCert?.cert || '')
     );
   }
 
   // May throw synchronously (Node validates the port and the bind address
   // before it ever touches the network); the caller owns that.
   dial(): void {
-    const { host, port, outgoingAddr, rejectUnauthorized } = this.opts;
+    const { host, port, outgoingAddr, rejectUnauthorized, clientCert } = this.opts;
     const onConnect = () => this.onOpen();
     const base = {
       host,
@@ -214,6 +230,8 @@ export class EngineUpstream extends EventEmitter {
             // SNI only for a name — an IP literal is not a valid server name.
             servername: net.isIP(host) ? undefined : host,
             rejectUnauthorized,
+            key: clientCert?.key,
+            cert: clientCert?.cert,
           },
           onConnect,
         )

--- a/server/engine/upstream.ts
+++ b/server/engine/upstream.ts
@@ -118,6 +118,7 @@ function prefixNick(prefix: string | undefined): string {
 export class EngineUpstream extends EventEmitter {
   readonly id: string;
   state: 'dialing' | 'open' | 'closed' = 'dialing';
+  private dialed = false;
   // `close()`/`quit()` were called: the socket is on its way out. Not a state
   // of its own because `open`-specific bookkeeping still applies until 'close'
   // fires, but every entry point treats it as gone.
@@ -212,6 +213,13 @@ export class EngineUpstream extends EventEmitter {
   // May throw synchronously (Node validates the port and the bind address
   // before it ever touches the network); the caller owns that.
   dial(): void {
+    // Once per upstream, and the engine only ever calls it once (a socket that
+    // died is forgotten; a fresh CONNECT builds a new upstream). Stated as a
+    // throw because the client key is dropped below on the way out: a second
+    // dial would otherwise handshake without one and fail somewhere far less
+    // obvious than here.
+    if (this.dialed) throw new Error('EngineUpstream.dial() is once per instance');
+    this.dialed = true;
     const { host, port, outgoingAddr, rejectUnauthorized, clientCert } = this.opts;
     const onConnect = () => this.onOpen();
     const base = {
@@ -237,6 +245,15 @@ export class EngineUpstream extends EventEmitter {
         )
       : net.connect(base, onConnect);
     this.socket = socket;
+    // The handshake has the key now — TLS keeps its own copy in native memory
+    // for the life of the socket — so stop holding one here. This upstream can
+    // live for days, and a heap snapshot walks what is still reachable. It is
+    // not an erasure: JS strings are immutable, so this makes the key
+    // collectible rather than gone. The certificate stays, because matchesDial
+    // compares it to decide whether a CONNECT is this session or a new one.
+    if (this.opts.clientCert) {
+      this.opts.clientCert = { cert: this.opts.clientCert.cert, key: '' };
+    }
     // utf8 with a StringDecoder underneath, so a multibyte character split across
     // chunks reassembles correctly. Lurker never negotiates another encoding.
     socket.setEncoding('utf8');

--- a/server/routes/networks.test.ts
+++ b/server/routes/networks.test.ts
@@ -525,6 +525,38 @@ describe('client certificate', () => {
     expect(res.body.error).toMatch(/TLS/);
   });
 
+  // Turning TLS off would strand the network: every dial is then refused
+  // because the certificate can't be presented, and PATCH can't clear it.
+  it('refuses to turn TLS off while a certificate is attached', async () => {
+    const { id } = await netWithCert();
+    const res = await aliceAgent.patch(`/api/networks/${id}`).send({ tls: false });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/remove/i);
+    // Still TLS, still connectable.
+    const after = (await aliceAgent.get('/api/networks')).body.networks.find(
+      (n: { id: number }) => n.id === id,
+    );
+    expect(after.tls).toBe(true);
+    // And the order that does work.
+    expect((await aliceAgent.delete(`/api/networks/${id}/certificate`)).status).toBe(200);
+    expect((await aliceAgent.patch(`/api/networks/${id}`).send({ tls: false })).status).toBe(200);
+  });
+
+  // Archive import writes both columns verbatim, so a stored certificate that
+  // doesn't parse is reachable without anyone pasting one. Reading as "no
+  // certificate" would leave the user looking at a network that claims to have
+  // none and refuses to connect because of one.
+  it('says a stored certificate is unusable rather than pretending there is none', async () => {
+    const { id } = await netWithCert();
+    const db = (await import('../db/index.js')).default;
+    db.prepare('UPDATE networks SET client_cert = ? WHERE id = ?').run('not a pem', id);
+    const listed = (await aliceAgent.get('/api/networks')).body.networks.find(
+      (n: { id: number }) => n.id === id,
+    );
+    expect(listed.client_cert).toEqual({ unusable: true });
+    expect(listed.client_key).toBeUndefined();
+  });
+
   it('rejects an unknown mode rather than silently doing nothing', async () => {
     const id = (await makeNet(aliceAgent, { name: 'bad-mode' })).body.network.id;
     const res = await aliceAgent.post(`/api/networks/${id}/certificate`).send({ mode: 'rotate' });

--- a/server/routes/networks.ts
+++ b/server/routes/networks.ts
@@ -54,11 +54,16 @@ function parseChannelList(raw: unknown): string[] {
   return out;
 }
 
-function safeDescribe(certPem: string): ReturnType<typeof describeClientCert> | null {
+// A stored certificate that won't parse is NOT the same as no certificate: the
+// dial path refuses to connect while one is attached, so rendering it as null
+// would leave the user looking at a network that says it has no certificate and
+// refuses to connect because of one. Say it is unusable instead, and let the UI
+// offer the one thing that helps — removing it.
+function safeDescribe(certPem: string): ReturnType<typeof describeClientCert> | { unusable: true } {
   try {
     return describeClientCert(certPem);
   } catch {
-    return null;
+    return { unusable: true };
   }
 }
 
@@ -81,9 +86,9 @@ function networkPayload(
     has_sasl_password: !!sasl_password,
     // CertFP (#459). Neither PEM is in the payload: the key is a secret, and the
     // certificate on its own is of no use to the UI, which needs the digests to
-    // paste at NickServ. `null` when no cert is attached — and also when a
-    // stored cert can't be parsed, which is unreachable through the routes below
-    // (they validate before writing) but must not take out the whole listing.
+    // paste at NickServ. `null` means no certificate; `{unusable: true}` means
+    // there is one and it doesn't parse (archive import writes these columns
+    // verbatim, so that is reachable without anyone pasting anything).
     client_cert: client_cert ? safeDescribe(client_cert) : null,
     // Channel rows in the retired channels-table wire shape (`joined` is the
     // autojoin flag), sourced from the buffers registry.
@@ -207,7 +212,20 @@ router.patch('/:id', (req: Request, res: Response) => {
     res.status(403).json({ error: 'this server only allows the networks its admin has listed' });
     return;
   }
-  const updated = updateNetwork(id, req.user!.id, req.body || {});
+  // Turning TLS off on a network that carries a client certificate would leave
+  // it permanently unconnectable — there is no handshake to present the
+  // certificate in, so every dial is refused — and the certificate cannot be
+  // cleared through this route (it isn't on the allowlist). Refuse the edit and
+  // name the order to do it in.
+  const body = req.body || {};
+  if ('tls' in body && !body.tls && existing.client_cert) {
+    res.status(400).json({
+      error:
+        'remove this network’s client certificate before turning TLS off — a certificate can only be presented over TLS',
+    });
+    return;
+  }
+  const updated = updateNetwork(id, req.user!.id, body);
   res.json({ network: networkPayload(updated) });
 });
 

--- a/server/services/engineCertfp.test.ts
+++ b/server/services/engineCertfp.test.ts
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// CertFP through the engine (#459). The certificate is configured in the app's
+// database and presented by a different process entirely, so the only assertion
+// worth making is the one the ircd makes: the fingerprint on the handshake is
+// the one the app was told to register.
+//
+// Also pinned here, because both are silent when wrong: an engine that predates
+// the field must not be dialed through with a certificate attached, and changing
+// the certificate must force a fresh dial rather than re-attaching to a socket
+// still presenting the old one.
+
+// MUST be first: redirects DATABASE_PATH before anything opens the db.
+import '../test-utils/isolateDb.js';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createUser } from '../db/users.js';
+import { createNetwork, setNetworkClientCert } from '../db/networks.js';
+import type { Network } from '../db/networks.js';
+import { IrcConnection } from './ircConnection.js';
+import type { FakeIrcd } from '../test-utils/fakeIrcd.js';
+import { startEngineHarness } from '../test-utils/engineHarness.js';
+import type { EngineHarness } from '../test-utils/engineHarness.js';
+import { EngineLink } from './engineLink.js';
+import { generateClientCert, describeClientCert } from '../utils/clientCert.js';
+import { until } from '../test-utils/until.js';
+
+const SECRET = 'certfp-engine-secret';
+
+let harness: EngineHarness;
+let ircd: FakeIrcd;
+let userId: number;
+let seq = 0;
+
+beforeAll(async () => {
+  harness = await startEngineHarness({
+    secret: SECRET,
+    ircd: { tls: true, requestClientCert: true, sasl: true },
+  });
+  ircd = harness.ircd;
+  userId = createUser('certfp-engine').id;
+});
+
+afterAll(async () => {
+  await harness.stop();
+});
+
+function makeNetwork(nick: string): Network {
+  return createNetwork(userId, {
+    name: `engine-certfp-${seq++}`,
+    host: '127.0.0.1',
+    port: ircd.port,
+    tls: true,
+    // The ircd's own certificate is self-signed; that's the server side of TLS
+    // and unrelated to the client certificate under test.
+    trusted_certificates: false,
+    nick,
+    autoconnect: false,
+  })!;
+}
+
+function connect(network: Network): IrcConnection {
+  const conn = new IrcConnection({ network, onEvent: () => {} });
+  conn.connect();
+  return conn;
+}
+
+describe('CertFP through the engine', () => {
+  it('presents the certificate the app holds, from the process that dials', async () => {
+    const pair = await generateClientCert('engineuser');
+    const network = setNetworkClientCert(makeNetwork('engineuser').id, userId, pair)!;
+    ircd.certfpAccounts.set(describeClientCert(pair.cert).sha256, 'engineaccount');
+
+    const conn = connect(network);
+    try {
+      await until(() => conn.state === 'connected', 5000, 'connected');
+      const client = ircd.client('engineuser')!;
+      expect(client.certfp).toBe(describeClientCert(pair.cert).sha256);
+      // And it is good for more than the handshake: SASL EXTERNAL is spoken by
+      // the app, over a socket the engine opened.
+      await until(() => client.account === 'engineaccount', 5000, 'logged in');
+    } finally {
+      conn.dispose();
+    }
+  });
+
+  // The engine holds sockets across app restarts, and a CONNECT for an id it
+  // already holds is normally an attach. A changed certificate is a changed
+  // identity, though: the held socket is still presenting the old one, and
+  // services still know the user by the old fingerprint.
+  it('re-dials rather than re-attaching when the certificate changes', async () => {
+    const first = await generateClientCert('rotator');
+    const network = setNetworkClientCert(makeNetwork('rotator').id, userId, first)!;
+
+    const before = connect(network);
+    await until(() => before.state === 'connected', 5000, 'first connect');
+    expect(ircd.client('rotator')!.certfp).toBe(describeClientCert(first.cert).sha256);
+    // Detach without ending the socket — what a redeploy looks like to the
+    // engine, and the state in which an attach would be offered.
+    before.detach();
+    await until(() => before.state === 'disconnected', 5000, 'detached');
+
+    const second = await generateClientCert('rotator');
+    const rotated = setNetworkClientCert(network.id, userId, second)!;
+    const after = connect(rotated);
+    try {
+      await until(
+        () => ircd.registrations.filter((r) => r.nick === 'rotator').length === 2,
+        5000,
+        'second registration',
+      );
+      await until(() => after.state === 'connected', 5000, 'reconnected');
+      const live = ircd.clients.filter((c) => c.nick === 'rotator' && !c.socket.destroyed);
+      expect(live[live.length - 1].certfp).toBe(describeClientCert(second.cert).sha256);
+    } finally {
+      after.dispose();
+    }
+  });
+
+  // An engine below minor 2 has no field to carry the key in and would ignore
+  // it silently — leaving the app asking for SASL EXTERNAL over a socket that
+  // presented nothing, and the user re-registering a fingerprint that was never
+  // sent.
+  it('refuses to dial through an engine that predates the field', async () => {
+    const pair = await generateClientCert('skewed');
+    const network = setNetworkClientCert(makeNetwork('skewed').id, userId, pair)!;
+    const link = EngineLink.shared();
+    const real = link.engineMinor;
+    link.engineMinor = 1;
+    try {
+      const conn = connect(network);
+      try {
+        await until(() => conn.state === 'disconnected', 5000, 'refused');
+        expect(ircd.client('skewed')).toBeUndefined();
+      } finally {
+        conn.dispose();
+      }
+    } finally {
+      link.engineMinor = real;
+    }
+  });
+});

--- a/server/services/engineLink.ts
+++ b/server/services/engineLink.ts
@@ -82,6 +82,9 @@ export function parseEngineUrl(raw: string | undefined): { host: string; port: n
 
 let disabledReason: string | null = null;
 
+// Protocol minor at which `connect` learned to carry a client certificate (#459).
+export const CLIENT_CERT_MINOR = 2;
+
 export function engineConfigured(): boolean {
   return disabledReason === null && parseEngineUrl(process.env.LURKER_ENGINE_URL) !== null;
 }
@@ -124,6 +127,10 @@ const DEFAULT_HEARTBEAT_MS = 15_000;
 export class EngineLink extends EventEmitter {
   state: LinkState = 'idle';
   engineVersion: string | null = null;
+  // The engine's protocol MINOR, as of its last hello. null until one arrives.
+  // Minors are additive by contract, so this only ever answers "does the engine
+  // already know about X" — never "is it too new".
+  engineMinor: number | null = null;
   refusedReason: string | null = null;
 
   private socket: net.Socket | null = null;
@@ -197,6 +204,14 @@ export class EngineLink extends EventEmitter {
 
   holds(id: string): boolean {
     return this.heldSet.has(id);
+  }
+
+  /** Can this engine present a TLS client certificate on a connection it dials
+   *  (#459)? False until a hello has been seen: an engine we know nothing about
+   *  is one that cannot be trusted to carry the key, and answering optimistically
+   *  would authenticate the user with a certificate that never went out. */
+  supportsClientCert(): boolean {
+    return this.engineMinor !== null && this.engineMinor >= CLIENT_CERT_MINOR;
   }
 
   start(): void {
@@ -356,6 +371,8 @@ export class EngineLink extends EventEmitter {
             this.heldSet.clear();
             for (const id of frame.held) this.heldSet.add(id);
             this.engineVersion = frame.engine.version;
+            // Older engines predate the field; absent means minor 1.
+            this.engineMinor = typeof frame.minor === 'number' ? frame.minor : 1;
             if (this.everReady) {
               this.log(`link restored to ${this.address} after ${this.attempt} attempt(s)`);
             }

--- a/server/services/engineTransport.test.ts
+++ b/server/services/engineTransport.test.ts
@@ -407,4 +407,33 @@ describe('engine answers to a bad CONNECT', () => {
     );
     expect(String((t.closes[0] as Error)?.message)).toMatch(/invalid port/);
   });
+
+  // CertFP (#459). ircConnection refuses earlier when it can, but on a cold
+  // start the first dial can outrun the engine's hello — and an engine below
+  // minor 2 would ignore the certificate field silently, leaving the app to
+  // authenticate with something it never presented. This is the check that
+  // cannot race: it runs where the link is known to be ready.
+  it('does not send a certificate to an engine that predates the field', async () => {
+    const l = newLink();
+    const id = `t:${++counter}`;
+    const { t } = makeClient(l, id, 'skewy');
+    // Wait out the hello: it is what sets engineMinor, so pinning the minor
+    // before the link is ready would just be overwritten by the real one.
+    await until(
+      () => l.state === 'ready',
+      'the link to be ready',
+      () => t.events,
+    );
+    const opts = (t.transport as unknown as { options: Record<string, unknown> }).options;
+    opts.client_certificate = { certificate: 'cert-pem', private_key: 'key-pem' };
+    l.engineMinor = 1;
+    // Re-dial now that the options say a certificate is required.
+    (t.transport as unknown as { connect(): void }).connect();
+    await until(
+      () => t.events.some((e) => e.startsWith('socket close:')),
+      'a refused dial',
+      () => t.events,
+    );
+    expect(String((t.closes[0] as Error)?.message)).toMatch(/cannot present a client certificate/);
+  });
 });

--- a/server/services/engineTransport.ts
+++ b/server/services/engineTransport.ts
@@ -158,6 +158,20 @@ export class EngineTransport extends EventEmitter implements FrameHandler {
     this.link.register(this.id, this);
     const go = () => {
       const o = this.options;
+      // The authoritative skew check, made where the link is known to be ready
+      // and its protocol minor is therefore known. ircConnection refuses
+      // earlier and more quietly when it can, but on a cold start the first
+      // dial can outrun the engine's hello — and an engine that predates
+      // minor 2 would simply ignore the field, leaving the app to authenticate
+      // with a certificate that was never presented.
+      if (o.client_certificate && !this.link.supportsClientCert()) {
+        this.end(
+          new Error(
+            'the IRC engine this deployment connects through cannot present a client certificate — update the engine, or remove the certificate from this network',
+          ),
+        );
+        return;
+      }
       this.link.send({
         op: 'connect',
         id: this.id,
@@ -167,6 +181,14 @@ export class EngineTransport extends EventEmitter implements FrameHandler {
         rejectUnauthorized: o.rejectUnauthorized !== false,
         ...(o.outgoing_addr ? { outgoingAddr: o.outgoing_addr } : {}),
         ...(o.engineIdent ? { ident: o.engineIdent } : {}),
+        ...(o.client_certificate
+          ? {
+              clientCert: {
+                cert: o.client_certificate.certificate,
+                key: o.client_certificate.private_key,
+              },
+            }
+          : {}),
       });
       this.armReplyTimer();
     };

--- a/server/services/ircCertfp.test.ts
+++ b/server/services/ircCertfp.test.ts
@@ -141,6 +141,45 @@ describe('CertFP over a real TLS socket', () => {
     }
   });
 
+  // Not every network offers EXTERNAL. irc-framework refuses to try a mechanism
+  // the server didn't advertise, so this costs one 904 and nothing else — the
+  // connection registers, and the certificate is still on the handshake for a
+  // NickServ that recognises it passively.
+  it('survives a network whose SASL list has no EXTERNAL in it', async () => {
+    const plainOnly = await FakeIrcd.start({
+      tls: true,
+      requestClientCert: true,
+      sasl: { mechanisms: ['PLAIN'] },
+    });
+    try {
+      const pair = await generateClientCert('noextuser');
+      const network = setNetworkClientCert(
+        createNetwork(userId, {
+          name: `certfp-noext-${seq++}`,
+          host: '127.0.0.1',
+          port: plainOnly.port,
+          tls: true,
+          trusted_certificates: false,
+          nick: 'noextuser',
+          autoconnect: false,
+        })!.id,
+        userId,
+        pair,
+      )!;
+      const { conn } = connect(network);
+      try {
+        await until(() => conn.state === 'connected', 5000, 'connected');
+        const client = plainOnly.client('noextuser')!;
+        expect(client.sent).not.toContain('AUTHENTICATE EXTERNAL');
+        expect(client.certfp).toBe(describeClientCert(pair.cert).sha256);
+      } finally {
+        conn.dispose();
+      }
+    } finally {
+      await plainOnly.close();
+    }
+  });
+
   it('presents nothing, and asks for nothing, when no certificate is attached', async () => {
     const { conn } = connect(makeNetwork('barecert'));
     try {

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -476,14 +476,38 @@ describe('client certificate refusals', () => {
   // Engine mode dials in another process, which cannot be handed the
   // certificate yet. Presenting nothing while the app still asks for SASL
   // EXTERNAL fails registration and blames the wrong thing.
-  it('does not dial through an engine that cannot present it', () => {
+  it('does not dial through an engine too old to present it', async () => {
+    const { EngineLink } = await import('./engineLink.js');
+    const link = EngineLink.shared();
+    const realMinor = link.engineMinor;
     process.env.LURKER_ENGINE_URL = 'tcp://127.0.0.1:9999';
+    link.engineMinor = 1; // predates the certificate field
     try {
       const { dialed, published } = attempt();
       expect(dialed).not.toHaveBeenCalled();
       expect(refusal(published)).toMatch(/engine/);
     } finally {
       delete process.env.LURKER_ENGINE_URL;
+      link.engineMinor = realMinor;
+    }
+  });
+
+  // An engine that has not said hello yet has an unknown minor, and this check
+  // is deliberately quiet about those: the transport makes the same call again
+  // at frame-build time, after the link is ready, so a cold-start dial that
+  // outruns the hello is caught there rather than guessed at here.
+  it('leaves an engine of unknown vintage to the transport', async () => {
+    const { EngineLink } = await import('./engineLink.js');
+    const link = EngineLink.shared();
+    const realMinor = link.engineMinor;
+    process.env.LURKER_ENGINE_URL = 'tcp://127.0.0.1:9999';
+    link.engineMinor = null;
+    try {
+      const { dialed } = attempt();
+      expect(dialed).toHaveBeenCalled();
+    } finally {
+      delete process.env.LURKER_ENGINE_URL;
+      link.engineMinor = realMinor;
     }
   });
 

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -2497,8 +2497,11 @@ describe('auto-reconnect controller', () => {
       events.find((e) => e.type === 'error' && /SASL authentication failed/i.test(String(e.text)))
         ?.text,
     );
-    expect(text).toMatch(/NickServ CERT ADD/);
+    expect(text).toMatch(/CERT ADD/);
     expect(text).not.toMatch(/account credentials/);
+    // And a way out of the loop: on a network that requires SASL, this
+    // rejection is exactly what stops you connecting to run that command.
+    expect(text).toMatch(/remove the certificate/);
   });
 
   // #617: a single rejection is not proof the credentials killed THIS socket. On

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -713,6 +713,10 @@ export class IrcConnection {
   // us from its map so a later /connect builds a fresh IrcConnection instead of
   // finding this corpse and doing nothing.
   private readonly onTakenOver: (() => void) | undefined;
+  // Called when a dial is refused for a reason only a config change can fix, so
+  // the owner can drop this object rather than keep a corpse that will never
+  // retry (see clientCertBlockedReason).
+  private readonly onNeedsRebuild: (() => void) | undefined;
   // Engine mode (services/engineTransport.ts): the IRC socket lives in the
   // engine process and this Client is attached to it over a link.
   //
@@ -759,16 +763,19 @@ export class IrcConnection {
     onEvent,
     reconnectGate,
     onTakenOver,
+    onNeedsRebuild,
   }: {
     network: Network;
     onEvent: (event: EnrichedEvent) => void;
     reconnectGate?: ReconnectGate;
     onTakenOver?: () => void;
+    onNeedsRebuild?: () => void;
   }) {
     this.network = network;
     this.onEvent = onEvent;
     this.reconnectGate = reconnectGate;
     this.onTakenOver = onTakenOver;
+    this.onNeedsRebuild = onNeedsRebuild;
     // ALL CTCP handling lives in our 'ctcp request' handler (VERSION/PING/TIME/
     // SOURCE/CLIENTINFO, rate-limited + surfaced), so irc-framework's built-in
     // VERSION auto-reply is disabled with `version: false`. That MUST go in the
@@ -1287,8 +1294,11 @@ export class IrcConnection {
         // NickServ, where the fingerprint has to be registered before the
         // network will recognise it. (#459)
         const usingCert = !!this.network.client_cert && !this.network.sasl_password;
+        // Deliberately not "register it while connected": on a network that
+        // REQUIRES SASL this rejection is what stops you connecting, so that
+        // advice is a closed loop. Name the way out of it too.
         const advice = usingCert
-          ? " — the network didn't recognise your client certificate. Register its fingerprint with /msg NickServ CERT ADD while connected"
+          ? " — this network doesn't recognise your client certificate. Register its fingerprint with NickServ (CERT ADD); if that means getting in first, remove the certificate here"
           : " — check the network's account credentials";
         this.pendingSaslFailure = `SASL authentication failed${
           reason && reason !== 'fail' ? ` (${reason})` : ''
@@ -4078,6 +4088,14 @@ export class IrcConnection {
       });
       this.logNet(`Connect blocked: ${certBlocked}`, 'warn');
       this.setState('disconnected');
+      // Nothing here will retry — no socket opened, so no 'close' to schedule
+      // one from — and every one of these reasons is fixed by editing the
+      // network. Ask to be dropped, or the manager's map keeps a connection
+      // that no longer matches the row: startNetwork is a documented no-op when
+      // one already exists, so /connect would answer ok having done nothing,
+      // forever, even after the certificate is removed. Same reasoning as
+      // gateReconnect's delete (#616).
+      this.onNeedsRebuild?.();
       return;
     }
     const clientCert = this.clientCertificate();

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -4158,11 +4158,15 @@ export class IrcConnection {
     if (!this.network.tls) {
       return 'a client certificate can only be presented over TLS — enable TLS for this network, or remove the certificate';
     }
-    if (engineConfigured()) {
-      // Engine mode dials in another process, which has no way to be handed
-      // the certificate yet (protocol minor 1). Presenting nothing while the
-      // app still asks for SASL EXTERNAL is the worst of both worlds.
-      return 'the IRC engine this deployment connects through cannot present a client certificate yet — update the engine, or remove the certificate';
+    const link = EngineLink.shared();
+    if (engineConfigured() && link.engineMinor !== null && !link.supportsClientCert()) {
+      // Engine mode dials in ANOTHER process. An engine below protocol minor 2
+      // has no field to carry the certificate in and would ignore it silently,
+      // so the app would ask for SASL EXTERNAL over a socket that presented
+      // nothing. Only refuse once the engine has actually said hello — before
+      // that its minor is unknown, and the transport makes the same check again
+      // at frame-build time, where readiness is guaranteed.
+      return 'the IRC engine this deployment connects through cannot present a client certificate — update the engine, or remove the certificate';
     }
     return null;
   }

--- a/server/services/ircManager.test.ts
+++ b/server/services/ircManager.test.ts
@@ -73,6 +73,40 @@ describe('ircManager pause linchpin', () => {
 // #616: the gate the auto-reconnect controller now asks before each retry. Same
 // implementation startNetwork uses, so the two can't drift apart — which is the
 // whole point, since the reconnect path used to skip both checks entirely.
+// #459. A dial refused because the network's client certificate cannot be
+// presented opens no socket, so nothing ever schedules a retry — and
+// startNetwork is a documented no-op when a connection object already exists.
+// Leaving the refused one in the map would make /connect answer ok and do
+// nothing, forever, even after the user removes the certificate.
+describe('ircManager and a connection refused over its certificate', () => {
+  it('drops the refused connection so a later /connect builds a working one', async () => {
+    const { setNetworkClientCert } = await import('../db/networks.js');
+    const user = createUser('certfp-corpse');
+    const network = createNetwork(user.id, {
+      name: 'certfp-corpse-net',
+      host: 'irc.example.test',
+      port: 6697,
+      tls: true,
+      nick: 'nick',
+      autoconnect: false,
+    })!;
+    // Half a pair — what a hand-edited archive plants, and one of the reasons
+    // the dial is refused outright.
+    setNetworkClientCert(network.id, user.id, { cert: 'cert-only', key: '' });
+
+    expect(ircManager.startNetwork(user.id, network.id)).not.toBe(null);
+    // Refused, and gone: not a corpse the next call would hand back.
+    expect(ircManager.getConnection(user.id, network.id)).toBeFalsy();
+
+    // The user fixes it the only way the UI offers.
+    setNetworkClientCert(network.id, user.id, null);
+    const revived = ircManager.startNetwork(user.id, network.id);
+    expect(revived).not.toBe(null);
+    expect(ircManager.getConnection(user.id, network.id)).toBe(revived);
+    ircManager.disposeNetwork(user.id, network.id, 'test over');
+  });
+});
+
 describe('ircManager.connectGate', () => {
   let seq = 0;
   function gateUserNet(host = 'irc.example.invalid') {

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -350,6 +350,14 @@ class IrcManager extends EventEmitter {
       // (and tear its timers down — the transport is already dead, so the QUIT
       // dispose() sends goes nowhere) so the next /connect builds afresh
       // instead of finding it and doing nothing.
+      // A dial refused over configuration (a client certificate that cannot be
+      // presented) never retries, and the fix is an edit to the network row —
+      // so the object built from the OLD row must not outlive the refusal.
+      onNeedsRebuild: () => {
+        if (this.connectionsForUser(userId).get(networkId) === conn) {
+          this.connectionsForUser(userId).delete(networkId);
+        }
+      },
       onTakenOver: () => {
         if (this.connectionsForUser(userId).get(networkId) === conn) {
           this.connectionsForUser(userId).delete(networkId);

--- a/server/test-utils/engineHarness.ts
+++ b/server/test-utils/engineHarness.ts
@@ -11,6 +11,7 @@ import { EngineLink, engineConfigured } from '../services/engineLink.js';
 import ircManager from '../services/ircManager.js';
 import type { IrcConnection } from '../services/ircConnection.js';
 import { FakeIrcd } from './fakeIrcd.js';
+import type { FakeIrcdOptions } from './fakeIrcd.js';
 import { setEnvAll } from './env.js';
 import { until } from './until.js';
 
@@ -50,8 +51,11 @@ export async function startEngineHarness(opts: {
   secret: string;
   // Per-test knobs (LURKER_RESTORE_*, …), set alongside the engine ones.
   env?: Record<string, string>;
+  // What the engine dials. Defaults to a plaintext ircd; a CertFP test wants
+  // TLS and a listener that asks for a client certificate.
+  ircd?: FakeIrcdOptions;
 }): Promise<EngineHarness> {
-  const ircd = await FakeIrcd.start();
+  const ircd = await FakeIrcd.start(opts.ircd);
   const wire: WireLine[] = [];
   ircd.on('sent', (line: string, c: { nick: string | null }) =>
     wire.push({ t: Date.now(), dir: '<', nick: c.nick ?? '?', line }),

--- a/server/utils/clientCert.test.ts
+++ b/server/utils/clientCert.test.ts
@@ -147,6 +147,17 @@ describe('validateClientCertPair', () => {
     expect(isClientCertProblem(result) && result.error).toMatch(/no certificate in it/);
   });
 
+  // The traditional PKCS#1 form keeps the ordinary label and announces the
+  // encryption in a header — what `openssl genrsa -aes256` writes, and what a
+  // lot of existing HexChat/WeeChat setups have on disk.
+  it('recognises a passphrase-protected key in its other spelling', () => {
+    const result = validateClientCertPair(
+      '-----BEGIN CERTIFICATE-----\nx\n-----END CERTIFICATE-----',
+      '-----BEGIN RSA PRIVATE KEY-----\nProc-Type: 4,ENCRYPTED\nDEK-Info: AES-256-CBC,00\n\nx\n-----END RSA PRIVATE KEY-----',
+    );
+    expect(isClientCertProblem(result) && result.error).toMatch(/openssl rsa/);
+  });
+
   it('rejects an empty, absent, or non-string field', async () => {
     const pair = await generateClientCert('alice');
     for (const bad of ['', '   ', undefined, null, 42, { cert: 'x' }]) {

--- a/server/utils/clientCert.ts
+++ b/server/utils/clientCert.ts
@@ -16,7 +16,6 @@
 // on-disk lifecycle.
 
 import crypto from 'crypto';
-import { generate as generateSelfSigned } from 'selfsigned';
 
 /** A cert and the private key that completes its handshake. Never separated. */
 export interface ClientCertPair {
@@ -74,6 +73,11 @@ function safeCommonName(raw: string): string {
 export async function generateClientCert(commonName: string): Promise<ClientCertPair> {
   const notBeforeDate = new Date();
   const notAfterDate = new Date(notBeforeDate.getTime() + TEN_YEARS_MS);
+  // Imported here rather than at module scope so the IRC engine — which imports
+  // this module only to check that a pair it was handed is dialable — doesn't
+  // pull a certificate generator (and its crypto dependency tree) into a
+  // process whose whole job is holding sockets.
+  const { generate: generateSelfSigned } = await import('selfsigned');
   const pems = await generateSelfSigned(
     [{ name: 'commonName', value: safeCommonName(commonName) }],
     {
@@ -121,6 +125,19 @@ function splitCombinedPem(pem: string): { cert: string; key: string } | null {
     pem,
   )?.[0];
   return cert && key ? { cert, key } : null;
+}
+
+/** Will tls.connect accept this pair? Structural only — no opinion on whether
+ *  any network knows the fingerprint. Crypto-only (no certificate generator in
+ *  the import graph) so the IRC engine can ask the same question of a pair that
+ *  arrived over its wire before handing it to tls.connect, where a bad key
+ *  throws synchronously. */
+export function isDialableCertPair(certPem: string, keyPem: string): boolean {
+  try {
+    return new crypto.X509Certificate(certPem).checkPrivateKey(crypto.createPrivateKey(keyPem));
+  } catch {
+    return false;
+  }
 }
 
 /** A rejected pair, with a message meant for the person who pasted it. */

--- a/server/utils/clientCert.ts
+++ b/server/utils/clientCert.ts
@@ -183,7 +183,13 @@ export function validateClientCertPair(
         : 'the certificate must be PEM, starting with -----BEGIN CERTIFICATE-----',
     };
   }
-  if (/ENCRYPTED PRIVATE KEY-----/.test(key)) {
+  // Two spellings: PKCS#8 says so in the label, while the traditional PKCS#1
+  // form (what `openssl genrsa -aes256` writes, and what sits in a lot of
+  // existing HexChat/WeeChat setups) keeps its ordinary label and announces the
+  // encryption in a header. Without the second test that key falls through to
+  // "could not be parsed as PEM" — the exact misdiagnosis this branch exists to
+  // prevent.
+  if (/ENCRYPTED PRIVATE KEY-----/.test(key) || /Proc-Type:\s*4,\s*ENCRYPTED/.test(key)) {
     return {
       error:
         'passphrase-protected keys are not supported — decrypt it first with: openssl rsa -in key.pem -out key-decrypted.pem',


### PR DESCRIPTION
Third slice of CertFP (#459), stacked on #879. On a hosted cell the **engine** is what dials, so the engine is what presents the certificate — before this, PR 2 refused to connect such a network at all.

### Wire

`PROTOCOL_MINOR` 1 → 2: `connect` gains an optional `clientCert`. The private key crosses the app↔engine link, which is the same trust boundary that already carries `PASS` and `AUTHENTICATE` lines — but the engine never logs the frame, and **validates the pair before dialing**: `tls.connect` throws *synchronously* on a key it can't parse, and an uncaught throw there is every held socket in the process. The engine doesn't get to trust its callers; archive import writes those columns verbatim, so a bad pair can reach the wire without anyone typing one.

### `matchesDial` now compares the certificate

Without it, changing your certificate re-attaches to the socket still presenting the old one: the change looks applied and nothing about the connection has changed. The test asserts a *second registration* at the ircd, and I mutation-checked it — it fails when the clause is removed.

### Skew, checked twice on purpose

`ircConnection` refuses early and quietly once the engine's hello has said what it is (that's the message the user should see); `EngineTransport` checks again at frame-build time, where the link is known to be ready. A cold-start dial can outrun the hello, and an engine below minor 2 would ignore the field *silently*, leaving the app to authenticate with something it never presented.

### Second commit — review follow-ups

All the same shape: a refusal that was correct but left no way out.

- A refused dial opens no socket, so nothing schedules a retry — and `startNetwork` is a no-op when a connection already exists. The refused object stayed in the manager's map holding the pre-fix row, so **Connect answered ok and did nothing, forever**, even after the certificate was removed.
- A stored certificate that doesn't parse rendered as `null` — identical to "no certificate" — while the dial path refused every connect because of it. Now `{unusable: true}`.
- Turning TLS off left a cert-bearing network permanently unconnectable, and PATCH can't clear the pair. Refused, naming the order to do it in.
- The SASL advice said to register the fingerprint *"while connected"*, which on a SASL-required network is a closed loop.
- A PKCS#1 encrypted key (`Proc-Type: 4,ENCRYPTED`) was diagnosed as "could not be parsed" rather than as the passphrase it is.

An explicit per-network SASL mechanism setting was considered and **not** done — reasoning in `CERTFP_PLAN.md` §9a, short version: a server that doesn't advertise EXTERNAL is never offered it, and passive CertFP needs the same fingerprint registered that EXTERNAL does, so the knob buys nothing for the case it appears to be for.

### ⚠ Ops

**This needs an engine pull.** CertFP requires an engine from 2.2.2+; the tag doesn't move but its contents do, and the hosted fleet needs the new image before the feature works there. Documented in `docs/MIGRATION_ENGINE.md`. An app pointed at an older engine refuses to connect a cert-bearing network rather than logging the user in as nobody.

Full suite green (309 files / 4460 tests). Reviewed with `/code-review high`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qCyi5Poh5nur5CoUUaoPR