### PR TITLE
bouncer: register a selector-less login instead of 464ing it

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -523,12 +523,14 @@ Point your IRC client at the host/port with a **server password** of:
 - `username:secret` — when you have one network configured
 - `username/networkname:secret` — to pick one of several (the network's name as shown in the web UI, or its numeric id)
 
+Logging in as just `username` when you have several networks (or none yet) is not an error — you land on an idle connection that isn't attached to anything, and Lurker sends a notice naming the networks you can pick from. Reconnect with `username/networkname` to attach one.
+
 The secret can be your Lurker account password, but a **read-write API token** (web UI → **Settings → API tokens**) is the better choice — IRC clients store the server password in plaintext config files, and a token can be revoked without changing your password.
 
 Modern IRCv3 clients (Halloy, gamja, Goguma, …) get more than the server-password floor above:
 
 - **SASL** — log in with the same credential via SASL PLAIN instead of a server password.
-- **Network discovery** (`soju.im/bouncer-networks`) — the client lists and binds your networks itself, so you don't hardcode `username/networkname`; connect as just `username` and pick from the list.
+- **Network discovery** (`soju.im/bouncer-networks`) — the client lists and binds your networks itself, so you don't hardcode `username/networkname`; connect as just `username` and pick from the list. This is what the idle connection above is for.
 - **On-demand scrollback** (`draft/chathistory`) — page back through history on demand instead of relying only on the fixed replay-on-attach.
 
 These are negotiated automatically; plain clients that don't support them keep working over the server-password path.

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -523,7 +523,7 @@ Point your IRC client at the host/port with a **server password** of:
 - `username:secret` — when you have one network configured
 - `username/networkname:secret` — to pick one of several (the network's name as shown in the web UI, or its numeric id)
 
-Logging in as just `username` when you have several networks (or none yet) is not an error — you land on an idle connection that isn't attached to anything, and Lurker sends a notice naming the networks you can pick from. Reconnect with `username/networkname` to attach one.
+Logging in as just `username` when you have several networks is not an error — you land on an idle connection that isn't attached to anything, and Lurker sends a notice naming the networks you can pick from. Reconnect with `username/networkname` to attach one. An account with no networks yet lands on that same idle connection with a notice telling you to add one in the web UI first; networks are created there, not from an IRC client.
 
 The secret can be your Lurker account password, but a **read-write API token** (web UI → **Settings → API tokens**) is the better choice — IRC clients store the server password in plaintext config files, and a token can be revoked without changing your password.
 

--- a/server/services/bouncer.networks.test.ts
+++ b/server/services/bouncer.networks.test.ts
@@ -288,6 +288,25 @@ describe('selector-less registration (soju parity)', () => {
     await c.waitFor((l) => l.includes('BOUNCER NETWORK') && l.includes('name=alpha'));
   });
 
+  it('keeps the advice under the wire cap when the account has many networks', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'sl7', networkName: 'a-long-network-name-00' });
+    for (let i = 1; i < 25; i++) {
+      harnessMod.seedNetwork(acct.user, {
+        networkName: `a-long-network-name-${String(i).padStart(2, '0')}`,
+        nick: `sl7n${i}`,
+      });
+    }
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl');
+    c.send('CAP END');
+    const notice = await c.waitForCommand('NOTICE');
+    // Names are unbounded TEXT, so a bare join would run past 512 bytes and the
+    // client would truncate or drop the very advice it needs.
+    expect(Buffer.byteLength(notice + '\r\n')).toBeLessThanOrEqual(512);
+    expect(notice).toContain('a-long-network-name-00');
+    expect(notice).toMatch(/\+\d+ more$/);
+  });
+
   it('still auto-binds the only network for a capless client (ZNC floor)', async () => {
     const acct = harnessMod.seedAccount({ nick: 'sl4', networkName: 'solo' });
     const c = await harness.connect();

--- a/server/services/bouncer.networks.test.ts
+++ b/server/services/bouncer.networks.test.ts
@@ -234,3 +234,82 @@ describe('bouncer-networks-notify', () => {
     c.close();
   });
 });
+
+// A login that names no network registers as a control connection instead of
+// failing, matching soju's register() (which never rejects a missing network
+// name). Goguma is why: its first-run registration negotiates no caps beyond
+// sasl and carries no selector, so a 464 here left it unable to onboard at all.
+describe('selector-less registration (soju parity)', () => {
+  it('registers a capless client with several networks as a control connection', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'sl1', networkName: 'alpha' });
+    harnessMod.seedNetwork(acct.user, { networkName: 'beta', nick: 'sl1b' });
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl'); // no soju.im/bouncer-networks
+    c.send('CAP END');
+    const welcome = await c.waitForCommand('005');
+    expect(welcome).not.toContain('BOUNCER_NETID');
+    expect(harnessMod.attachedFor(acct)).toBe(0);
+  });
+
+  it('names the available networks in a NOTICE when the client cannot discover them', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'sl2', networkName: 'alpha' });
+    harnessMod.seedNetwork(acct.user, { networkName: 'beta', nick: 'sl2b' });
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl');
+    c.send('CAP END');
+    const notice = await c.waitForCommand('NOTICE');
+    expect(notice).toContain(`${acct.user.username}/<network>`);
+    expect(notice).toContain('alpha');
+    expect(notice).toContain('beta');
+  });
+
+  it('stays quiet for a bouncer-networks client, which discovers them itself', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'sl3', networkName: 'alpha' });
+    harnessMod.seedNetwork(acct.user, { networkName: 'beta', nick: 'sl3b' });
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl soju.im/bouncer-networks');
+    c.send('CAP END');
+    await c.waitForCommand('422');
+    expect(c.lines.some((l) => harnessMod.commandOf(l) === 'NOTICE')).toBe(false);
+  });
+
+  it('still auto-binds the only network for a capless client (ZNC floor)', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'sl4', networkName: 'solo' });
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl');
+    c.send('CAP END');
+    await c.waitForCommand('422');
+    expect(harnessMod.attachedFor(acct)).toBe(1);
+  });
+
+  it('registers an account with no networks and says why it is empty', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'sl5' });
+    harnessMod.dropNetworks(acct.user);
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl'); // capless: this pairing used to 464
+    c.send('CAP END');
+    const notice = await c.waitForCommand('NOTICE');
+    expect(notice).toContain('No IRC networks configured yet');
+    await c.waitForCommand('422');
+  });
+
+  it("registers Goguma's pipelined first-run burst, which waits for nothing", async () => {
+    const acct = harnessMod.seedAccount({ nick: 'gog', networkName: 'alpha' });
+    harnessMod.seedNetwork(acct.user, { networkName: 'beta', nick: 'gogb' });
+    const c = await harness.connect();
+    // Goguma sends registration in one shot without reading CAP LS first, so it
+    // requests only sasl and its AUTHENTICATE precedes our `AUTHENTICATE +`.
+    c.send('CAP LS 302');
+    c.send('NICK client');
+    c.send('USER client 0 * :client');
+    c.send('CAP REQ :sasl');
+    c.send('AUTHENTICATE PLAIN');
+    c.send(`AUTHENTICATE ${saslPlain(acct.user.username, acct.password)}`);
+    c.send('CAP END');
+    await c.waitForCommand('903');
+    await c.waitForCommand('001');
+    await c.waitForCommand('422');
+    expect(c.lines.some((l) => harnessMod.commandOf(l) === '464')).toBe(false);
+    expect(harnessMod.attachedFor(acct)).toBe(0); // control mode, not a blind bind
+  });
+});

--- a/server/services/bouncer.networks.test.ts
+++ b/server/services/bouncer.networks.test.ts
@@ -269,8 +269,23 @@ describe('selector-less registration (soju parity)', () => {
     const c = await harness.connect();
     await negotiate(c, acct, 'sasl soju.im/bouncer-networks');
     c.send('CAP END');
+    // The notice precedes 422 in the burst, so seeing 422 is a sufficient
+    // barrier for asserting its absence — no arrival race here.
     await c.waitForCommand('422');
     expect(c.lines.some((l) => harnessMod.commandOf(l) === 'NOTICE')).toBe(false);
+  });
+
+  it('stays quiet for a -notify-only client, which still reads BOUNCER NETWORK', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'sl6', networkName: 'alpha' });
+    harnessMod.seedNetwork(acct.user, { networkName: 'beta', nick: 'sl6b' });
+    const c = await harness.connect();
+    // Requesting -notify without the base cap is a client error, but the advice
+    // would flatly contradict the network dump that follows it.
+    await negotiate(c, acct, 'sasl soju.im/bouncer-networks-notify');
+    c.send('CAP END');
+    await c.waitForCommand('422');
+    expect(c.lines.some((l) => harnessMod.commandOf(l) === 'NOTICE')).toBe(false);
+    await c.waitFor((l) => l.includes('BOUNCER NETWORK') && l.includes('name=alpha'));
   });
 
   it('still auto-binds the only network for a capless client (ZNC floor)', async () => {

--- a/server/services/bouncer.test.ts
+++ b/server/services/bouncer.test.ts
@@ -16,6 +16,7 @@ let rewriteNumericTarget: typeof import('./bouncer.js').rewriteNumericTarget;
 let filterRelayLine: typeof import('./bouncer.js').filterRelayLine;
 let memberPrefixSymbol: typeof import('./bouncer.js').memberPrefixSymbol;
 let buildNamesLines: typeof import('./bouncer.js').buildNamesLines;
+let withNetworkList: typeof import('./bouncer.js').withNetworkList;
 let isServicesNick: typeof import('./bouncer.js').isServicesNick;
 let escapeTagValue: typeof import('./bouncer.js').escapeTagValue;
 let buildNetworkAttrs: typeof import('./bouncer.js').buildNetworkAttrs;
@@ -35,6 +36,7 @@ beforeAll(async () => {
   filterRelayLine = mod.filterRelayLine;
   memberPrefixSymbol = mod.memberPrefixSymbol;
   buildNamesLines = mod.buildNamesLines;
+  withNetworkList = mod.withNetworkList;
   isServicesNick = mod.isServicesNick;
   escapeTagValue = mod.escapeTagValue;
   buildNetworkAttrs = mod.buildNetworkAttrs;
@@ -451,6 +453,55 @@ describe('buildNamesLines', () => {
       .split(' ');
     expect(all).toHaveLength(200);
     expect(new Set(all).size).toBe(200);
+  });
+});
+
+describe('withNetworkList', () => {
+  const head = 'Available: ';
+
+  it('joins a short list verbatim', () => {
+    expect(withNetworkList(head, ['alpha', 'beta'], 400)).toBe('Available: alpha, beta');
+  });
+
+  it('handles an empty list', () => {
+    expect(withNetworkList(head, [], 400)).toBe(head);
+  });
+
+  it('drops the tail as "+N more" and stays inside the budget', () => {
+    const names = Array.from({ length: 60 }, (_, i) => `network-number-${i}`);
+    const out = withNetworkList(head, names, 200);
+    expect(Buffer.byteLength(out)).toBeLessThanOrEqual(200);
+    expect(out).toContain('network-number-0');
+    expect(out).toMatch(/\+\d+ more$/);
+    // The count must name every network actually dropped, not a rounded guess.
+    const hidden = Number(out.match(/\+(\d+) more$/)![1]);
+    const shown = out.slice(head.length).split(', ').length - 1;
+    expect(shown + hidden).toBe(names.length);
+  });
+
+  it('budgets in bytes, not code units, for multi-byte names', () => {
+    const names = Array.from({ length: 20 }, () => '日本語ネットワーク'); // 3 bytes/char
+    const out = withNetworkList(head, names, 120);
+    expect(Buffer.byteLength(out)).toBeLessThanOrEqual(120);
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it('trims a single name that cannot fit at all', () => {
+    const out = withNetworkList(head, ['x'.repeat(500)], 200);
+    expect(Buffer.byteLength(out)).toBeLessThanOrEqual(200);
+    expect(out.startsWith(head)).toBe(true);
+  });
+
+  it('keeps a whole NOTICE under the 512-byte wire cap', () => {
+    const names = Array.from({ length: 40 }, (_, i) => `some-fairly-long-network-name-${i}`);
+    const budget = Math.max(64, 480 - Buffer.byteLength(':lurker.bouncer NOTICE someuser :'));
+    const text = withNetworkList(
+      'Not attached to a network — log in as someuser/<network> to attach. Available: ',
+      names,
+      budget,
+    );
+    const line = `:lurker.bouncer NOTICE someuser :${text}\r\n`;
+    expect(Buffer.byteLength(line)).toBeLessThanOrEqual(512);
   });
 });
 

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -974,7 +974,7 @@ class BouncerSession {
     // and soju parity means a client that named no network registers even when
     // it *can't* do that (soju's register() never fails on a missing network
     // name), rather than eating a 464 mid-onboarding. Goguma is the case that
-    // forced this: its first-run registration negotiates no caps at all and
+    // forced this: its first-run registration negotiates nothing but sasl and
     // carries no network selector, so it used to hit the "multiple networks"
     // 464 below and could never get far enough to discover them.
     //
@@ -1056,6 +1056,13 @@ class BouncerSession {
     });
   }
 
+  // True if the client speaks the bouncer-networks extension at all. BIND needs
+  // the base cap, but for *explaining* an unbound connection either cap means
+  // the client can read the BOUNCER NETWORK lines and doesn't need the prose.
+  private knowsBouncerNetworks(): boolean {
+    return this.caps.has(CAP_BOUNCER_NETWORKS) || this.caps.has(CAP_BOUNCER_NETWORKS_NOTIFY);
+  }
+
   // Register a control (unbound) connection: authenticated, bound to no network.
   // It lives only in the global `sessions` set (no per-network registry); state
   // notifications reach it via the user-scoped fan-out in dispatchIrcEvent.
@@ -1065,10 +1072,20 @@ class BouncerSession {
     this.registered = true;
     this.clearRegTimer();
     this.sendControlBurst(user, networks);
+    // failRegistration used to console.warn the reason for the commonest
+    // misconfiguration (bare username, several networks). It no longer fails,
+    // so record the reason where an operator debugging "it connects but shows
+    // nothing" will look.
+    const reason =
+      networks.length === 0
+        ? 'no networks configured'
+        : this.caps.has(CAP_BOUNCER_NETWORKS)
+          ? 'client picks a network itself'
+          : `no network named, ${networks.length} available`;
     systemLog.log({
       userId: this.userId,
       scope: 'bouncer',
-      text: `Bouncer control connection from ${this.remoteIp}`,
+      text: `Bouncer control connection from ${this.remoteIp} (${reason})`,
     });
   }
 
@@ -1181,21 +1198,22 @@ class BouncerSession {
     this.write(
       `:${SERVER_NAME} 005 ${nick} NETWORK=${APP_NAME} CASEMAPPING=ascii :are supported by this server`,
     );
-    this.write(`:${SERVER_NAME} 422 ${nick} :MOTD File is missing`);
-    // Say why nothing is here. A bouncer-networks client with networks to pick
-    // from needs no explanation (it's about to LISTNETWORKS/BIND), but an empty
-    // account gives it an empty list, and a client without the cap has landed
-    // somewhere it can't act on at all — that used to be a 464 carrying this
-    // same advice, so keep the advice now that registration succeeds.
+    // Say why nothing is here, ahead of the MOTD-missing line that closes the
+    // burst. A bouncer-networks client with networks to pick from needs no
+    // explanation (it's about to LISTNETWORKS/BIND), but an empty account gives
+    // it an empty list, and a client that knows nothing of the extension has
+    // landed somewhere it can't act on at all — that used to be a 464 carrying
+    // this same advice, so keep the advice now that registration succeeds.
     if (networks.length === 0) {
       this.notice('No IRC networks configured yet — add one in the web UI, then reconnect.');
-    } else if (!this.caps.has(CAP_BOUNCER_NETWORKS)) {
+    } else if (!this.knowsBouncerNetworks()) {
       this.notice(
         `Not attached to a network — log in as ${user.username}/<network> to attach. Available: ${networks
           .map((n) => n.name)
           .join(', ')}`,
       );
     }
+    this.write(`:${SERVER_NAME} 422 ${nick} :MOTD File is missing`);
     // A -notify client gets the full network list up-front as a batch.
     if (this.caps.has(CAP_BOUNCER_NETWORKS_NOTIFY)) this.sendNetworkList();
   }

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -24,6 +24,12 @@
 // (for now) ignored. Multi-upstream `*` is deliberately unsupported (soju
 // removed it too) — attach one network per connection.
 //
+// A login that names no network registers as a *control* connection rather
+// than failing (soju parity — its register() never rejects a missing network
+// name). A bouncer-networks client uses that to enumerate and BIND; a client
+// without the cap gets a NOTICE naming its networks. The exception is the ZNC
+// floor above: no cap, no selector, exactly one network → attach it.
+//
 // Design notes / v1 limitations, all deliberate:
 // - Upstream→client traffic is relayed as the RAW wire lines the network sent
 //   (minus registration/PING plumbing), so semantics stay exact. That means
@@ -939,8 +945,8 @@ class BouncerSession {
   }
 
   // Called at CAP END / registration completion. Resolves the target network
-  // (BIND id > username selector > single-network default), or drops into
-  // control mode for a bouncer-networks client that named no network.
+  // (BIND id > username selector > capless single-network default), or drops
+  // into control mode for any client that named no network.
   private completeAttach(user: User, networkSel: string | null): void {
     if (user.is_paused) {
       this.failRegistration('Account is paused');
@@ -963,15 +969,26 @@ class BouncerSession {
       return;
     }
 
-    // Control (unbound) mode: a bouncer-networks-aware client that named no
-    // network manages its networks via BOUNCER instead of attaching to one.
+    // Control (unbound) mode. A bouncer-networks-aware client that named no
+    // network manages its networks via BOUNCER instead of attaching to one —
+    // and soju parity means a client that named no network registers even when
+    // it *can't* do that (soju's register() never fails on a missing network
+    // name), rather than eating a 464 mid-onboarding. Goguma is the case that
+    // forced this: its first-run registration negotiates no caps at all and
+    // carries no network selector, so it used to hit the "multiple networks"
+    // 464 below and could never get far enough to discover them.
+    //
+    // The one exception is the documented ZNC floor (`PASS user:secret` with a
+    // single network): a client with no bouncer-networks cap can't do anything
+    // useful in our control mode, which carries no channel traffic, so keep
+    // auto-binding its only network.
     const hasSelector = this.boundNetId !== null || !!networkSel;
-    if (!hasSelector && this.caps.has(CAP_BOUNCER_NETWORKS)) {
-      this.registerControl(user);
+    const networks = listNetworksForUser(user.id);
+    if (!hasSelector && (this.caps.has(CAP_BOUNCER_NETWORKS) || networks.length !== 1)) {
+      this.registerControl(user, networks);
       return;
     }
 
-    const networks = listNetworksForUser(user.id);
     if (networks.length === 0) {
       this.failRegistration('No IRC networks configured — add one in the web UI first');
       return;
@@ -997,15 +1014,9 @@ class BouncerSession {
         );
         return;
       }
-    } else if (networks.length === 1) {
-      network = networks[0];
     } else {
-      this.failRegistration(
-        `Multiple networks — log in as ${user.username}/<network>. Available: ${networks
-          .map((n) => n.name)
-          .join(', ')}`,
-      );
-      return;
+      // Selector-less and capless: the guard above leaves exactly one network.
+      network = networks[0];
     }
     this.bindNetwork(user, network);
   }
@@ -1048,12 +1059,12 @@ class BouncerSession {
   // Register a control (unbound) connection: authenticated, bound to no network.
   // It lives only in the global `sessions` set (no per-network registry); state
   // notifications reach it via the user-scoped fan-out in dispatchIrcEvent.
-  private registerControl(user: User): void {
+  private registerControl(user: User, networks: Network[]): void {
     this.userId = user.id;
     this.isControl = true;
     this.registered = true;
     this.clearRegTimer();
-    this.sendControlBurst();
+    this.sendControlBurst(user, networks);
     systemLog.log({
       userId: this.userId,
       scope: 'bouncer',
@@ -1164,13 +1175,27 @@ class BouncerSession {
   // Minimal welcome for a control connection: it binds no network, so no
   // registrationLines / JOIN / playback / relay. The bouncer-scoped ISUPPORT
   // omits BOUNCER_NETID (its absence is how a client detects control mode).
-  private sendControlBurst(): void {
+  private sendControlBurst(user: User, networks: Network[]): void {
     const nick = this.clientNick || 'user';
     this.writeWelcomeNumerics(nick);
     this.write(
       `:${SERVER_NAME} 005 ${nick} NETWORK=${APP_NAME} CASEMAPPING=ascii :are supported by this server`,
     );
     this.write(`:${SERVER_NAME} 422 ${nick} :MOTD File is missing`);
+    // Say why nothing is here. A bouncer-networks client with networks to pick
+    // from needs no explanation (it's about to LISTNETWORKS/BIND), but an empty
+    // account gives it an empty list, and a client without the cap has landed
+    // somewhere it can't act on at all — that used to be a 464 carrying this
+    // same advice, so keep the advice now that registration succeeds.
+    if (networks.length === 0) {
+      this.notice('No IRC networks configured yet — add one in the web UI, then reconnect.');
+    } else if (!this.caps.has(CAP_BOUNCER_NETWORKS)) {
+      this.notice(
+        `Not attached to a network — log in as ${user.username}/<network> to attach. Available: ${networks
+          .map((n) => n.name)
+          .join(', ')}`,
+      );
+    }
     // A -notify client gets the full network list up-front as a batch.
     if (this.caps.has(CAP_BOUNCER_NETWORKS_NOTIFY)) this.sendNetworkList();
   }

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -449,6 +449,36 @@ export function buildNamesLines(nick: string, channel: string, names: string[]):
   return lines;
 }
 
+/**
+ * Join network names onto `head`, dropping the tail as `+N more` so the result
+ * fits `budget` bytes.
+ *
+ * Network names are unbounded TEXT (no length cap on create, unlike API token
+ * names) and an account may hold any number of them, so a bare join can push
+ * these lines past the 512-byte wire cap — where clients truncate or drop them,
+ * defeating the point of listing the networks at all. Same hazard buildNamesLines
+ * chunks NAMES to avoid; one line suffices here because this is advice, not data.
+ * Counted in bytes, not code units: names can be multi-byte and the wire cap is
+ * bytes. The trailing trim is the backstop for a single pathological name.
+ */
+export function withNetworkList(head: string, names: string[], budget: number): string {
+  let out = head;
+  let shown = 0;
+  for (const name of names) {
+    const piece = shown === 0 ? name : `, ${name}`;
+    const hidden = names.length - shown - 1;
+    const tail = hidden > 0 ? `, +${hidden} more` : '';
+    if (shown > 0 && Buffer.byteLength(out + piece + tail) > budget) break;
+    out += piece;
+    shown += 1;
+  }
+  if (names.length > shown) out += `, +${names.length - shown} more`;
+  while (Buffer.byteLength(out) > budget && out.length > head.length + 1) {
+    out = out.slice(0, -1);
+  }
+  return out;
+}
+
 function toIrcTime(iso: string): string {
   const d = new Date(iso);
   return Number.isNaN(d.getTime()) ? new Date().toISOString() : d.toISOString();
@@ -655,6 +685,15 @@ class BouncerSession {
   private numeric(code: string, params: string): void {
     const nick = this.currentNick() || this.clientNick || '*';
     this.write(`:${SERVER_NAME} ${code} ${nick} ${params}`);
+  }
+
+  // Bytes of message text that still fit on one 512-byte IRC line after this
+  // session's `:<server> <verb> <nick> :` prefix. Measured against the widest
+  // verb these list lines use (NOTICE), so it also covers the shorter 464.
+  // 480 leaves the same headroom for CRLF and prefix drift as buildNamesLines.
+  private wireTextBudget(): number {
+    const nick = this.currentNick() || this.clientNick || '*';
+    return Math.max(64, 480 - Buffer.byteLength(`:${SERVER_NAME} NOTICE ${nick} :`));
   }
 
   private notice(text: string): void {
@@ -1010,7 +1049,11 @@ class BouncerSession {
       network = networks.find((n) => n.name.toLowerCase() === sel || String(n.id) === sel);
       if (!network) {
         this.failRegistration(
-          `Unknown network '${networkSel}' — available: ${networks.map((n) => n.name).join(', ')}`,
+          withNetworkList(
+            `Unknown network '${networkSel}' — available: `,
+            networks.map((n) => n.name),
+            this.wireTextBudget(),
+          ),
         );
         return;
       }
@@ -1208,9 +1251,11 @@ class BouncerSession {
       this.notice('No IRC networks configured yet — add one in the web UI, then reconnect.');
     } else if (!this.knowsBouncerNetworks()) {
       this.notice(
-        `Not attached to a network — log in as ${user.username}/<network> to attach. Available: ${networks
-          .map((n) => n.name)
-          .join(', ')}`,
+        withNetworkList(
+          `Not attached to a network — log in as ${user.username}/<network> to attach. Available: `,
+          networks.map((n) => n.name),
+          this.wireTextBudget(),
+        ),
       );
     }
     this.write(`:${SERVER_NAME} 422 ${nick} :MOTD File is missing`);

--- a/server/test-utils/bouncerHarness.ts
+++ b/server/test-utils/bouncerHarness.ts
@@ -27,7 +27,7 @@ import {
 import { createUser, setPasswordHash } from '../db/users.js';
 import { hashPassword } from '../services/password.js';
 import { createToken } from '../db/apiTokens.js';
-import { createNetwork } from '../db/networks.js';
+import { createNetwork, deleteNetwork, listNetworksForUser } from '../db/networks.js';
 import type { Network } from '../db/networks.js';
 import type { User } from '../db/users.js';
 
@@ -155,6 +155,14 @@ export function seedAccount(
   ircManager.connectionsForUser(user.id).set(network.id, upstream as never);
 
   return { user, network, password, token, upstream };
+}
+
+/** Remove every network an account owns, leaving it with an empty bouncer. */
+export function dropNetworks(user: User): void {
+  for (const network of listNetworksForUser(user.id)) {
+    ircManager.connectionsForUser(user.id).delete(network.id);
+    deleteNetwork(network.id, user.id);
+  }
 }
 
 /** Registered bouncer sessions currently attached to an account's network. */


### PR DESCRIPTION
## The bug

Goguma can't complete onboarding against Lurker's bouncer. It reports **"Server password required but not supported"**, with the text `amiantos/<network>` embedded in it.

That message is Goguma's fixed rendering of *any* `ERR_PASSWDMISMATCH`, with the server's own text appended — so the real error was Lurker's `464 :Multiple networks — log in as <user>/<network>`. It says nothing about SASL.

Goguma's onboarding page builds its probe client with an **empty cap request set** (`connect.dart:110`, `requestCaps: {}`) and its `register()` pipelines the whole burst without waiting for the `CAP LS` reply (`client.dart:511-555`). So the first registration Lurker ever sees is:

```
CAP LS 302
NICK amiantos
USER amiantos 0 * amiantos
CAP REQ :sasl
AUTHENTICATE PLAIN
AUTHENTICATE <base64>
CAP END
```

No `soju.im/bouncer-networks`, and no `/network` selector. `completeAttach` gated control mode on that cap, so this fell through to the multi-network 464 — and Goguma could never get far enough to discover the networks it was being told to pick from. It only ever fails on the *first* connection; a stored server reconnects with `lastAvailableCaps` seeded and negotiates properly. It just never gets there.

Halloy and SeraphIRC were unaffected: they wait for `CAP LS`, negotiate `soju.im/bouncer-networks` (`halloy/data/src/capabilities.rs:73`), and land in control mode already.

## The divergence

soju's `register()` never rejects a missing network name, and `loadNetwork()` returns an unbound downstream for one (`soju/downstream.go:1646`):

```go
if dc.registration.networkName == "" {
    return nil   // unbound downstream, cap or no cap
}
```

Lurker additionally required the cap, and hard-failed on zero networks.

## The change

A login that names no network now registers as a control connection instead of failing.

**The ZNC floor is preserved deliberately.** Lurker's control mode is not soju's unbound mode — soju's is a working multi-network view with `#chan/network` names, ours refuses all channel traffic. A capless client can't act on it at all, so `PASS user:secret` with exactly one network still auto-binds, and `docs/SELF_HOSTING.md` stays true. Clients *with* the cap keep going to control mode regardless of network count, so Halloy/gamja behaviour is unchanged.

Zero networks and multiple networks now land on the control connection with a NOTICE explaining why it's empty — the advice the 464 used to carry, minus the disconnect. Suppressed for clients that speak the extension, since they're about to read the `BOUNCER NETWORK` dump.

## Tests

Six cases in `bouncer.networks.test.ts`, including Goguma's exact pipelined burst. I verified they discriminate by flipping the gate back to the old logic: four fail without the fix. The other two are regression guards (auto-bind still works; no notice leaks into the cap path).

`npm run check` exit 0; full suite 306 files / 4414 tests green.

## Not done

**Not QA'd against a real Goguma.** Registration is covered by a wire-level test, but the rest of the flow — control connection → `BOUNCER NETWORK` dump → one bound client per network via `BOUNCER BIND` — is traced from Goguma's source, not observed. Worth a real onboarding run before trusting it.

One review finding left unaddressed: control connections count toward `maxSessionsPerUser()` (32) and are only reaped after 240 s idle, where a capless multi-network login used to be closed instantly. A client in a reconnect loop closes its socket each time, and half-open sockets hit the reaper, so I don't think this accumulates — but a shorter idle reap for capless control connections is an option if it ever bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXutt4QohESJbqKfFC9X6m