### PR TITLE
Engine: keep the negotiated cap set faithful across re-attach (#888)

### DIFF
--- a/server/engine/engine.test.ts
+++ b/server/engine/engine.test.ts
@@ -399,6 +399,10 @@ describe('attach after the app is gone', () => {
     await a.waitForLine(id, /CAP capped ACK :userhost-in-names/);
     ircd.sendRaw('capped', ':fake.test CAP capped DEL :away-notify');
     await a.waitForLine(id, /CAP capped DEL :away-notify/);
+    // No cap list at all: the last parameter is the subcommand, and reading it
+    // as one would enable a cap called "ACK".
+    ircd.sendRaw('capped', ':fake.test CAP capped ACK');
+    await a.waitForLine(id, /CAP capped ACK$/);
     ackAll(a, id);
     a.kill();
 

--- a/server/engine/engine.test.ts
+++ b/server/engine/engine.test.ts
@@ -79,6 +79,27 @@ function connectFrame(
   };
 }
 
+// The same, with a CAP handshake first, so the recorded burst carries the
+// server's ACK — the baseline a replay's cap delta is measured against.
+async function registerWithCaps(
+  l: TestLink,
+  id: string,
+  nick: string,
+  caps: string[],
+): Promise<void> {
+  l.send(connectFrame(id));
+  await l.waitFor((f) => f.op === 'open' && f.id === id);
+  l.send({ op: 'write', id, line: 'CAP LS 302' });
+  // The last LS line of a 302 handshake is the one without the `*`.
+  await l.waitForLine(id, / CAP \* LS :/);
+  l.send({ op: 'write', id, line: `CAP REQ :${caps.join(' ')}` });
+  await l.waitForLine(id, / CAP \* ACK /);
+  l.send({ op: 'write', id, line: 'CAP END' });
+  l.send({ op: 'write', id, line: `NICK ${nick}` });
+  l.send({ op: 'write', id, line: `USER ${nick} 0 * :${nick}` });
+  await l.waitForLine(id, / 376 /);
+}
+
 // Dial through the engine and register on the fake ircd with plain NICK/USER.
 async function register(l: TestLink, id: string, nick: string): Promise<void> {
   l.send(connectFrame(id));
@@ -361,6 +382,39 @@ describe('attach after the app is gone', () => {
     expect(att.replay.filter((x) => /JOIN/.test(x))).toEqual([
       ':renamer!~renamer@fake.host JOIN #New',
     ]);
+    b.send({ op: 'close', id });
+    await gone(engine, id);
+  });
+
+  it('replays the caps that changed after the burst, both ways (#888)', async () => {
+    const id = `caps:${++counter}`;
+    const a = await link();
+    await registerWithCaps(a, id, 'capped', ['away-notify', 'multi-prefix']);
+    a.send({ op: 'write', id, line: 'JOIN #c' });
+    await a.waitForLine(id, /JOIN #c/);
+    // cap-notify in the wild: this app asks for one more, and the server takes
+    // one away. Both are live lines — relayed once, then forgotten with the ack
+    // — so the burst on its own stops describing the socket here.
+    a.send({ op: 'write', id, line: 'CAP REQ :userhost-in-names' });
+    await a.waitForLine(id, /CAP capped ACK :userhost-in-names/);
+    ircd.sendRaw('capped', ':fake.test CAP capped DEL :away-notify');
+    await a.waitForLine(id, /CAP capped DEL :away-notify/);
+    ackAll(a, id);
+    a.kill();
+
+    const b = await link();
+    b.send(connectFrame(id));
+    const att = await b.waitFor<Attached>((f) => f.op === 'attached');
+    // The burst's own CAP lines, then the delta it cannot carry.
+    expect(att.replay.filter((x) => / CAP /.test(x)).slice(-2)).toEqual([
+      ':fake.test CAP capped DEL :away-notify',
+      ':fake.test CAP capped ACK :userhost-in-names',
+    ]);
+    // Registration first, then the caps, then the state: a cap that changes how
+    // a JOIN is read has to be in force before the synthesised JOINs land.
+    expect(att.replay.findIndex((x) => /CAP capped ACK/.test(x))).toBeLessThan(
+      att.replay.findIndex((x) => /JOIN #c/.test(x)),
+    );
     b.send({ op: 'close', id });
     await gone(engine, id);
   });

--- a/server/engine/upstream.ts
+++ b/server/engine/upstream.ts
@@ -429,6 +429,9 @@ export class EngineUpstream extends EventEmitter {
   // a live line — an app that can't see a cap simply doesn't ask for it, which
   // is the same answer it would have got from the server.
   private trackCaps(params: string[]): void {
+    // <target> <sub> :<caps>. Without the third the last parameter IS the
+    // subcommand, and reading it as a cap list enables a cap called "ACK".
+    if (params.length < 3) return;
     const sub = String(params[1] || '').toUpperCase();
     if (sub !== 'ACK' && sub !== 'DEL') return;
     for (const token of String(params[params.length - 1] || '').split(' ')) {

--- a/server/engine/upstream.ts
+++ b/server/engine/upstream.ts
@@ -4,7 +4,7 @@
 // One held IRC socket. The engine's whole reason to exist is that this object
 // outlives the app process that asked for it.
 //
-// It understands exactly seven IRC things, and nothing else:
+// It understands exactly eight IRC things, and nothing else:
 //   1. PING       — answered here, always, never forwarded. A detached (or
 //                   stalled) app can't ping out because the app isn't in the loop.
 //   2. 001        — our nick, as the server confirmed it.
@@ -12,7 +12,9 @@
 //   4. own NICK   — so a replay lands on the live nick.
 //   5. own JOIN / PART / KICK — the channel set a replay must re-enter.
 //   6. RENAME — the same set, under the name the channel has now.
-//   7. own CHGHOST — the hostmask the synthesised JOINs carry.
+//   7. CAP ACK / DEL — the caps that are on, which the burst alone stops
+//                   describing the moment one changes.
+//   8. own CHGHOST — the hostmask the synthesised JOINs carry.
 // Every other line is bytes: numbered, buffered until acked, relayed.
 //
 // Re-attach is a replay: the recorded burst (verbatim — irc-framework walks it
@@ -151,6 +153,18 @@ export class EngineUpstream extends EventEmitter {
   private registeredUnattended = false;
   private nickAtBurstEnd: string | null = null;
   private hostmask: string | null = null;
+  // The caps the server has said are on for this socket, from the first CAP
+  // ACK onwards. A cap-notify exchange after registration (a `CAP NEW` we
+  // asked for, a `CAP DEL` the server sent) is an ordinary live line: relayed
+  // once and dropped from the buffer as soon as the app acks it. The burst
+  // stops being the truth about this socket the moment one lands. (#888)
+  private caps = new Set<string>();
+  // What the burst on its own leaves a fresh Client with — the baseline the
+  // replay's delta is measured against. Null until the burst closes.
+  private capsAtBurstEnd: Set<string> | null = null;
+  // The server's own name, off the 001 prefix, so a synthesised CAP line looks
+  // like the ones around it.
+  private serverName: string | null = null;
   // folded name → name as the server spelled it on JOIN
   private channels = new Map<string, string>();
 
@@ -343,7 +357,11 @@ export class EngineUpstream extends EventEmitter {
       if (!this.sink) this.pingsAnsweredDetached++;
       return;
     }
-    if (command === '001') this.nick = msg.params[0] || null;
+    if (command === '001') {
+      this.nick = msg.params[0] || null;
+      this.serverName = msg.prefix || null;
+    }
+    if (command === 'CAP') this.trackCaps(msg.params);
     // Own state is tracked from the first line on — a NICK forced on us between
     // 001 and 376, or a server that JOINs us to a channel during registration,
     // must not be missed just because the burst is still open.
@@ -356,6 +374,7 @@ export class EngineUpstream extends EventEmitter {
       }
       if (command === '376' || command === '422') {
         this.burstDone = true;
+        this.capsAtBurstEnd = new Set(this.caps);
         this.nickAtBurstEnd = this.nick;
         this.registeredUnattended = this.sink === null;
       }
@@ -403,6 +422,26 @@ export class EngineUpstream extends EventEmitter {
       if (key && this.channels.has(key)) return key;
     }
     return undefined;
+  }
+
+  // The two CAP subcommands that change what is ON. LS and NEW only advertise,
+  // and what they advertise is either in the burst already or is re-learned from
+  // a live line — an app that can't see a cap simply doesn't ask for it, which
+  // is the same answer it would have got from the server.
+  private trackCaps(params: string[]): void {
+    const sub = String(params[1] || '').toUpperCase();
+    if (sub !== 'ACK' && sub !== 'DEL') return;
+    for (const token of String(params[params.length - 1] || '').split(' ')) {
+      if (!token) continue;
+      // `CAP ACK :-away-notify` is the server confirming a cap went OFF (the
+      // answer to a `CAP REQ :-away-notify`). Nothing in Lurker sends one, but
+      // reading it as an enable would be a lie the replay then repeats.
+      const off = sub === 'DEL' || token.startsWith('-');
+      const name = (token.startsWith('-') ? token.slice(1) : token).split('=')[0];
+      if (!name) continue;
+      if (off) this.caps.delete(name);
+      else this.caps.add(name);
+    }
   }
 
   private isSelf(nick: string): boolean {
@@ -602,12 +641,34 @@ export class EngineUpstream extends EventEmitter {
     // to a channel the server no longer has. (#889)
     const out = this.burst.filter((b) => !b.chan || this.channels.has(b.chan)).map((b) => b.line);
     if (!this.nick) return out;
+    out.push(...this.capDelta());
     const userhost = this.hostmask || FALLBACK_USERHOST;
     if (this.nickAtBurstEnd && this.nickAtBurstEnd !== this.nick) {
       out.push(`:${this.nickAtBurstEnd}!${userhost} NICK :${this.nick}`);
     }
     for (const chan of this.channels.values()) out.push(`:${this.nick}!${userhost} JOIN ${chan}`);
     return out;
+  }
+
+  // What the caps have done since the burst closed, as the two lines that would
+  // have got them there. irc-framework applies a post-registration ACK and DEL
+  // to the enabled set exactly as it applies the ones inside negotiation, so a
+  // fresh Client walking the replay ends up with the set this socket really
+  // has — including a cap a NEWER app asked for on an already-restored socket,
+  // which is what makes that request stick across the deploy after it. (#888)
+  private capDelta(): string[] {
+    const before = this.capsAtBurstEnd;
+    if (!before) return [];
+    const gone = [...before].filter((cap) => !this.caps.has(cap));
+    const added = [...this.caps].filter((cap) => !before.has(cap));
+    const from = this.serverName ? `:${this.serverName} ` : '';
+    // Addressed to the nick the replay is at by this point — the burst's — not
+    // the one the synthesised NICK below moves it to.
+    const target = this.nickAtBurstEnd || this.nick || '*';
+    const lines: string[] = [];
+    if (gone.length > 0) lines.push(`${from}CAP ${target} DEL :${gone.join(' ')}`);
+    if (added.length > 0) lines.push(`${from}CAP ${target} ACK :${added.join(' ')}`);
+    return lines;
   }
 
   // End the socket. The app asked (a QUIT went out first, or a user disconnected).

--- a/server/services/engineIntegration.test.ts
+++ b/server/services/engineIntegration.test.ts
@@ -70,10 +70,14 @@ const until = (pred: () => boolean, ms = 5000, what = 'condition') =>
 beforeAll(async () => {
   harness = await startEngineHarness({
     secret: SECRET,
-    // One cap nothing asks for at registration: irc-framework doesn't want it
-    // and neither does IrcConnection, so it is there for a LATER app version to
-    // discover on an already-registered socket (#888).
-    ircd: { caps: [...DEFAULT_CAPS, 'draft/channel-rename'] },
+    // Two caps nothing asks for at registration: irc-framework doesn't want
+    // them and neither does IrcConnection, so they are there for a LATER app
+    // version to discover on an already-registered socket. One the server
+    // grants, one it advertises and then refuses. (#888)
+    ircd: {
+      caps: [...DEFAULT_CAPS, 'draft/channel-rename', 'draft/refused'],
+      refuse: ['draft/refused'],
+    },
   });
   ircd = harness.ircd;
   engine = harness.engine;
@@ -514,6 +518,43 @@ describe('IrcConnection through the engine', () => {
     third.detach();
     await until(() => third.state === 'disconnected', 5000, 'detached again');
 
+    // Leave a live connection behind for the last test.
+    const fresh = ircManager.startNetwork(userId, network.id)!;
+    await until(() => fresh.state === 'connected', 8000, 'fresh connection for the next test');
+  }, 30000);
+
+  it('takes a NAK for an answer instead of re-asking on every re-attach (#888)', async () => {
+    ircManager.shutdown();
+    await until(() => engine.held().includes(engineId), 5000, 'engine holds it');
+    const conn = new IrcConnection({ network, onEvent: () => {} });
+    conn.client.requestCap('draft/refused');
+    conn.connect();
+    await until(() => conn.state === 'connected', 8000, 'reattached');
+    await until(
+      () => sentBy('lurk').includes('CAP REQ :draft/refused'),
+      5000,
+      'asked for the cap once',
+    );
+    // Advertised, so it stays in `available` and out of `enabled` for the life
+    // of the socket — the shape that would otherwise ask again forever.
+    expect(conn.client.network.cap.available.has('draft/refused')).toBe(true);
+    expect(conn.client.network.cap.enabled).not.toContain('draft/refused');
+    const asked = () => sentBy('lurk').filter((l) => l.startsWith('CAP REQ')).length;
+    const before = asked();
+
+    // A link blip is a re-attach of this same connection object — the case that
+    // repeats most often, and the one the refusal set has to survive.
+    EngineLink.shared().simulateLoss();
+    await until(() => conn.state !== 'connected', 5000, 'noticed the loss');
+    await until(() => conn.state === 'connected', 8000, 'reattached again');
+    // Bound the negative on the wire: anything the restore sent is ahead of
+    // this on the same ordered socket.
+    conn.raw('PING capbound');
+    await until(() => sentBy('lurk').includes('PING capbound'), 5000, 'the bound landed');
+    expect(asked()).toBe(before);
+
+    conn.detach();
+    await until(() => conn.state === 'disconnected', 5000, 'detached');
     // Leave a live connection behind for the last test.
     const fresh = ircManager.startNetwork(userId, network.id)!;
     await until(() => fresh.state === 'connected', 8000, 'fresh connection for the next test');

--- a/server/services/engineIntegration.test.ts
+++ b/server/services/engineIntegration.test.ts
@@ -28,6 +28,7 @@ import type { Network } from '../db/networks.js';
 import { IrcConnection } from './ircConnection.js';
 import ircManager from './ircManager.js';
 import type { EngineServer } from '../engine/server.js';
+import { DEFAULT_CAPS } from '../test-utils/fakeIrcd.js';
 import type { FakeIrcd } from '../test-utils/fakeIrcd.js';
 import { startEngineHarness } from '../test-utils/engineHarness.js';
 import type { EngineHarness } from '../test-utils/engineHarness.js';
@@ -67,7 +68,13 @@ const until = (pred: () => boolean, ms = 5000, what = 'condition') =>
   });
 
 beforeAll(async () => {
-  harness = await startEngineHarness({ secret: SECRET });
+  harness = await startEngineHarness({
+    secret: SECRET,
+    // One cap nothing asks for at registration: irc-framework doesn't want it
+    // and neither does IrcConnection, so it is there for a LATER app version to
+    // discover on an already-registered socket (#888).
+    ircd: { caps: [...DEFAULT_CAPS, 'draft/channel-rename'] },
+  });
   ircd = harness.ircd;
   engine = harness.engine;
 
@@ -467,6 +474,50 @@ describe('IrcConnection through the engine', () => {
       heldSet.delete(foreign);
     }
   });
+
+  // #888: the engine holds sockets across deploys, so a cap a new app version
+  // starts asking for would otherwise wait for the user's next real reconnect.
+  it('a newer app negotiates a cap on the held socket, and the engine keeps it', async () => {
+    const CAP = 'draft/channel-rename';
+    const conn = ircManager.getConnection(userId, network.id)!;
+    expect(conn.state).toBe('connected');
+    // Advertised all along, wanted by nobody: this socket registered without it.
+    expect(conn.client.network.cap.enabled).not.toContain(CAP);
+    const registrations = ircd.registrations.filter((r) => r.nick === 'lurk').length;
+
+    // "Deploy": the app goes away and the one that replaces it wants one more
+    // cap than the socket ever negotiated.
+    ircManager.shutdown();
+    await until(() => engine.held().includes(engineId), 5000, 'engine holds it');
+    const next = new IrcConnection({ network, onEvent: () => {} });
+    next.client.requestCap(CAP);
+    next.connect();
+    await until(() => next.state === 'connected', 8000, 'reattached');
+    await until(
+      () => next.client.network.cap.enabled.includes(CAP),
+      8000,
+      'the cap was REQd and ACKed on the held socket',
+    );
+    expect(ircd.client('lurk')!.caps.has(CAP)).toBe(true);
+    // Negotiated on the socket it already had — not by reconnecting.
+    expect(ircd.registrations.filter((r) => r.nick === 'lurk')).toHaveLength(registrations);
+
+    // And it sticks: a third app that never asks for it still finds it on,
+    // because the engine recorded the live ACK and the replay carries it.
+    next.detach();
+    await until(() => next.state === 'disconnected', 5000, 'detached');
+    const third = new IrcConnection({ network, onEvent: () => {} });
+    third.connect();
+    await until(() => third.state === 'connected', 8000, 'reattached again');
+    expect(third.client.request_extra_caps).not.toContain(CAP);
+    expect(third.client.network.cap.enabled).toContain(CAP);
+    third.detach();
+    await until(() => third.state === 'disconnected', 5000, 'detached again');
+
+    // Leave a live connection behind for the last test.
+    const fresh = ircManager.startNetwork(userId, network.id)!;
+    await until(() => fresh.state === 'connected', 8000, 'fresh connection for the next test');
+  }, 30000);
 
   it('ircManager.shutdown() detaches; dispose still QUITs', async () => {
     ircManager.shutdown();

--- a/server/services/engineIntegration.test.ts
+++ b/server/services/engineIntegration.test.ts
@@ -75,7 +75,7 @@ beforeAll(async () => {
     // version to discover on an already-registered socket. One the server
     // grants, one it advertises and then refuses. (#888)
     ircd: {
-      caps: [...DEFAULT_CAPS, 'draft/channel-rename', 'draft/refused'],
+      caps: [...DEFAULT_CAPS, 'draft/channel-rename', 'draft/refused', 'draft/granted'],
       refuse: ['draft/refused'],
     },
   });
@@ -528,12 +528,21 @@ describe('IrcConnection through the engine', () => {
     await until(() => engine.held().includes(engineId), 5000, 'engine holds it');
     const conn = new IrcConnection({ network, onEvent: () => {} });
     conn.client.requestCap('draft/refused');
+    // Asked for in the same restore. A REQ is all-or-nothing, so batching the
+    // two would have the server NAK both and put this one in the refusal set
+    // for good, though it would grant it on its own.
+    conn.client.requestCap('draft/granted');
     conn.connect();
     await until(() => conn.state === 'connected', 8000, 'reattached');
     await until(
       () => sentBy('lurk').includes('CAP REQ :draft/refused'),
       5000,
       'asked for the cap once',
+    );
+    await until(
+      () => conn.client.network.cap.enabled.includes('draft/granted'),
+      5000,
+      'the grantable one was granted',
     );
     // Advertised, so it stays in `available` and out of `enabled` for the life
     // of the socket — the shape that would otherwise ask again forever.

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -546,6 +546,13 @@ export class IrcConnection {
   private pendingJoinKeys = new Map<string, string>();
   userModes: Set<string>;
   awayState: AwayState;
+  // Caps this socket's server has answered a REQ for with a NAK. A refusal is
+  // an answer, and nothing in irc-framework records one: without this the
+  // post-restore REQ (requestUnnegotiatedCaps) would ask again every time the
+  // app re-attaches. Kept for the life of this connection object rather than
+  // cleared per socket — a fresh dial negotiates from CAP LS anyway, and that
+  // path never reads this. (#888)
+  private capsRefused: Set<string>;
   // One presence watch list keyed by lowercased nick. Each entry records WHY
   // we're watching it. The MONITOR watch and the shared peer_presence_state row
   // are reference-counted against those reasons — added when the first reason
@@ -806,6 +813,7 @@ export class IrcConnection {
     this.joinedFoldedCache = null;
     this.userModes = new Set();
     this.awayState = { active: false, message: null, since: null, autoSet: false, backAt: null };
+    this.capsRefused = new Set();
     // Lowercase nicks we watch for presence, each tagged with why. Gates the
     // per-peer presence writes so we don't churn the DB (and the WS broadcast
     // stream) on every JOIN/QUIT for an unrelated user on a busy network.
@@ -1278,6 +1286,11 @@ export class IrcConnection {
     // socket does die we must not reconnect-loop into the same rejection (which
     // on a server that requires auth is a fast failed-login hammer). We don't
     // publish here — the server's own error/ERROR line surfaces the cause.
+    c.on('cap nak', (event: Record<string, unknown>) => {
+      const caps = (event?.capabilities as Record<string, unknown> | undefined) || {};
+      for (const name of Object.keys(caps)) this.capsRefused.add(name);
+    });
+
     c.on('sasl failed', (event: Record<string, unknown>) => {
       const reason = (event?.reason as string | undefined) || undefined;
       if (isTerminalSaslFailure(reason)) {
@@ -4523,11 +4536,14 @@ export class IrcConnection {
     const cap = this.client.network?.cap;
     if (!cap) return;
     const enabled = new Set(cap.enabled || []);
-    // Only what the server advertised: a REQ for a cap it never listed is
-    // answered with a NAK at best, and asking again on every re-attach for the
-    // life of the socket is not free.
+    // Only what the server advertised and has not already refused. Both halves
+    // matter: a cap the server never listed is a NAK at best, and one it NAKed
+    // stays advertised-but-not-enabled for the life of the socket — so without
+    // the refusal set this would re-send the identical REQ on every re-attach,
+    // which on a socket whose whole point is that it never drops is every
+    // deploy and every link blip, forever.
     const missing = (this.client.request_extra_caps || []).filter(
-      (name) => cap.available?.has(name) && !enabled.has(name),
+      (name) => cap.available?.has(name) && !enabled.has(name) && !this.capsRefused.has(name),
     );
     if (missing.length === 0) return;
     try {

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -4287,6 +4287,7 @@ export class IrcConnection {
           topic: false,
         });
         this.rawQuiet('MODE', this.currentNick);
+        this.requestUnnegotiatedCaps();
         this.restoreQueue = [...this.channels.values()].map((ch) => ch.name);
         // Every queued channel is marked quiet now, not when its own step goes
         // out: the LAST process may have let go with a step in flight, and
@@ -4503,6 +4504,36 @@ export class IrcConnection {
     }
     if (step.owed.size === 0 && !this.disposed && this.state === 'connected') {
       this.drainRestoreQueue();
+    }
+  }
+
+  // Caps this app wants that the socket it just re-attached to never
+  // negotiated. The engine holds sockets across deploys, so a cap added in a
+  // release only reaches a held socket when the user next really reconnects —
+  // weeks, on a connection whose whole point is that it doesn't drop. A CAP REQ
+  // after registration is legal under CAP 302: the server answers ACK or NAK
+  // and no CAP END is owed. The ACK arrives as an ordinary line, and the engine
+  // records it so the NEXT re-attach replays it too (#888).
+  //
+  // Only the caps this app asked for through requestCap(): irc-framework's own
+  // want list is internal to its CAP handler, and it cannot drift under a held
+  // socket anyway — bumping irc-framework moves the engine image, and an engine
+  // recreate is a fresh dial with a fresh negotiation.
+  private requestUnnegotiatedCaps(): void {
+    const cap = this.client.network?.cap;
+    if (!cap) return;
+    const enabled = new Set(cap.enabled || []);
+    // Only what the server advertised: a REQ for a cap it never listed is
+    // answered with a NAK at best, and asking again on every re-attach for the
+    // life of the socket is not free.
+    const missing = (this.client.request_extra_caps || []).filter(
+      (name) => cap.available?.has(name) && !enabled.has(name),
+    );
+    if (missing.length === 0) return;
+    try {
+      this.client.raw(`CAP REQ :${missing.join(' ')}`);
+    } catch (_) {
+      /* ignore */
     }
   }
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -4546,10 +4546,16 @@ export class IrcConnection {
       (name) => cap.available?.has(name) && !enabled.has(name) && !this.capsRefused.has(name),
     );
     if (missing.length === 0) return;
-    try {
-      this.client.raw(`CAP REQ :${missing.join(' ')}`);
-    } catch (_) {
-      /* ignore */
+    // One REQ per cap, not one batch: a REQ is all-or-nothing, so a server that
+    // would grant `batch` and refuse `draft/multiline` NAKs both — and the NAK
+    // names both, which would put a perfectly grantable cap in the refusal set
+    // for good. There are only ever a handful.
+    for (const name of missing) {
+      try {
+        this.client.raw(`CAP REQ :${name}`);
+      } catch (_) {
+        /* ignore */
+      }
     }
   }
 

--- a/server/test-utils/fakeIrcd.ts
+++ b/server/test-utils/fakeIrcd.ts
@@ -78,7 +78,7 @@ export interface FakeClient {
   sent: string[];
 }
 
-const DEFAULT_CAPS = [
+export const DEFAULT_CAPS = [
   'server-time',
   'message-tags',
   'batch',

--- a/server/test-utils/fakeIrcd.ts
+++ b/server/test-utils/fakeIrcd.ts
@@ -55,6 +55,10 @@ export interface FakeIrcdOptions {
   // Offer SASL: advertises `sasl=<mechanisms>` in CAP LS and answers
   // AUTHENTICATE. Defaults to PLAIN + EXTERNAL when passed `true`.
   sasl?: boolean | { mechanisms: string[] };
+  // Caps that are advertised but NAKed when requested — a cap behind a
+  // privilege, or one the server lists and then declines. A REQ is
+  // all-or-nothing, so a batch containing one of these is NAKed whole.
+  refuse?: string[];
 }
 
 export interface FakeClient {
@@ -502,7 +506,11 @@ export class FakeIrcd extends EventEmitter {
       // Match on the cap NAME: an advertised cap may carry a value (`sasl=PLAIN`),
       // and a client REQs the bare name.
       const offered = new Set(this.caps.map(capName));
-      const ok = wanted.every((w) => offered.has(capName(w.replace(/^-/, ''))));
+      const refused = new Set(this.opts.refuse ?? []);
+      const ok = wanted.every((w) => {
+        const name = capName(w.replace(/^-/, ''));
+        return offered.has(name) && !refused.has(name);
+      });
       if (ok) {
         for (const w of wanted) {
           if (w.startsWith('-')) c.caps.delete(w.slice(1));

--- a/server/types/irc-framework.d.ts
+++ b/server/types/irc-framework.d.ts
@@ -142,6 +142,11 @@ declare module 'irc-framework' {
     /** Request an IRCv3 capability during CAP negotiation. */
     requestCap(cap: string): void;
 
+    /** What requestCap() has been called with. irc-framework's OWN want list
+     *  (server-time, away-notify, …) lives inside its CAP handler and is not
+     *  exposed — this is only the caps the host asked for on top of it. */
+    readonly request_extra_caps: string[];
+
     /** Open a connection to the IRC server. */
     connect(options: ConnectOptions): void;
 


### PR DESCRIPTION
Closes #888. **Stacked on #893** (`engine/rename-tracking`) because both change `upstream.ts`'s replay — GitHub retargets this to `main` when #893 merges. Review the top commit; the two below it are #893.

## What was wrong

A re-attach replays the recorded registration burst, so the fresh Client's enabled caps are whatever the burst's `CAP ACK` said. Everything after registration — a `CAP NEW` and the `ACK` irc-framework earns by requesting it, a `CAP DEL` — is an ordinary live line: relayed once and dropped from the buffer the moment the app acks it. The next re-attach replays the old burst, and the server has a cap enabled that the Client knows nothing about, or the reverse.

The second half is the one that compounds: every cap the app *starts* asking for (#858's `draft/channel-rename`, #607's `draft/metadata-2`, whatever is next) only takes effect on a real reconnect. With the engine holding sockets across deploys that means "until the user `/reconnect`s" — weeks, on the hosted fleet.

## Engine

Track `CAP ACK`/`DEL` from the first line on, snapshot the set when the burst closes, and put the difference into the replay as the two lines that would have got there: one `DEL`, one `ACK`, after the burst and before the synthesised NICK/JOINs. irc-framework applies a post-registration ACK/DEL to `network.cap.enabled` exactly as it applies the ones inside negotiation. A `-cap` inside an ACK is read as the disable it is.

`LS`/`NEW` are not tracked on purpose: what they advertise is either in the burst already or re-learned from a live line, and a cap the app cannot see is one it does not ask for — the same answer the server would have given.

## App

After `restored`, ask for the caps this version wants that the socket never negotiated: advertised, requested through `requestCap()`, not enabled, and not already refused. A `CAP REQ` after registration is legal under CAP 302 — ACK or NAK, no `CAP END` owed — and 001 is inside the replayed burst, which resets `cap.negotiating`, so the ACK cannot re-enter the SASL branch.

A NAK is an answer: irc-framework records refusals nowhere, so `cap nak` feeds a per-connection set. Without it a refused-but-advertised cap would be re-asked on every re-attach for the life of the socket.

irc-framework's own want list is not covered — it is internal to its CAP handler, and it cannot drift under a held socket anyway, because bumping irc-framework moves the engine image and an engine recreate is a fresh dial.

## Tests

- Engine: a cap enabled after the burst and one the server withdrew both land in the replay, in the right place — after registration, before the state. Four mutations checked (no delta, ACK only, DEL only, `-cap` read as an enable).
- Integration, end to end: a newer app REQs `draft/channel-rename` on the held socket, the server ACKs it with no re-registration, and a *third* app that never asks for it still finds it enabled — the engine recorded the live ACK and the replay carried it. Mutating out either half fails it.
- Integration: a cap the server advertises and then NAKs is asked for once, and a link blip does not ask again.
- The existing "no CAP after the restart" assertion pins the other direction: when nothing is missing, nothing goes on the wire.

No protocol change — the replay was already `string[]`. Full suite green (4525).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBmPG3L7g7S34otzrU3Kkm