### PR TITLE
Engine: offer a session released after hello; the link half-closes on stop (#894)

### DIFF
--- a/server/db/networks.ts
+++ b/server/db/networks.ts
@@ -142,7 +142,8 @@ export function createNetwork(userId: number, fields: NetworkFields): Network | 
       encryptSecret(server_password || null),
       // Default on when absent or null; otherwise by truthiness, like
       // trusted_certificates above — the option admits a number, and `0` must
-      // mean off (it read as on).
+      // mean off (it read as on). A null is "unset" on an update too: there it
+      // leaves the column alone (updateNetwork).
       autoconnect === undefined || autoconnect === null ? 1 : autoconnect ? 1 : 0,
       encryptSecret(sasl_account || null),
       encryptSecret(sasl_password || null),
@@ -180,13 +181,17 @@ export function updateNetwork(
   const params: unknown[] = [];
   for (const key of allowed) {
     if (key in fields) {
-      setClauses.push(`${key} = ?`);
       let value: unknown = fields[key];
-      if (key === 'tls' || key === 'autoconnect' || key === 'trusted_certificates')
+      if (key === 'tls' || key === 'autoconnect' || key === 'trusted_certificates') {
+        // A null is "unset", as on create — and on an update, unset means
+        // unchanged. Coercing it would switch the flag OFF, which for `tls` is
+        // a client meaning "leave it" silently dropping the encryption.
+        if (value === null || value === undefined) continue;
         value = value ? 1 : 0;
-      else if (ENCRYPTED_NETWORK_COLUMNS.includes(key)) {
+      } else if (ENCRYPTED_NETWORK_COLUMNS.includes(key)) {
         value = encryptSecret(value as string | null);
       }
+      setClauses.push(`${key} = ?`);
       params.push(value);
     }
   }

--- a/server/db/networks.ts
+++ b/server/db/networks.ts
@@ -140,7 +140,9 @@ export function createNetwork(userId: number, fields: NetworkFields): Network | 
       username || null,
       realname || null,
       encryptSecret(server_password || null),
-      autoconnect === false ? 0 : 1,
+      // Default on; otherwise by truthiness, like trusted_certificates above —
+      // the option admits a number, and `0` must mean off (it read as on).
+      autoconnect === undefined ? 1 : autoconnect ? 1 : 0,
       encryptSecret(sasl_account || null),
       encryptSecret(sasl_password || null),
       encryptSecret(connect_commands || null),

--- a/server/db/networks.ts
+++ b/server/db/networks.ts
@@ -140,9 +140,10 @@ export function createNetwork(userId: number, fields: NetworkFields): Network | 
       username || null,
       realname || null,
       encryptSecret(server_password || null),
-      // Default on; otherwise by truthiness, like trusted_certificates above —
-      // the option admits a number, and `0` must mean off (it read as on).
-      autoconnect === undefined ? 1 : autoconnect ? 1 : 0,
+      // Default on when absent or null; otherwise by truthiness, like
+      // trusted_certificates above — the option admits a number, and `0` must
+      // mean off (it read as on).
+      autoconnect === undefined || autoconnect === null ? 1 : autoconnect ? 1 : 0,
       encryptSecret(sasl_account || null),
       encryptSecret(sasl_password || null),
       encryptSecret(connect_commands || null),

--- a/server/engine/engine.test.ts
+++ b/server/engine/engine.test.ts
@@ -1197,9 +1197,9 @@ describe('third review round', () => {
 
 // The hello's `held` list withholds what another link still claims — a dead
 // link's included, since the engine may read a replacement's hello before the
-// corpse's EOF (#849) — and until #894 nothing ever re-listed those. TestLink
-// answers nothing on its own, so the pong that lets an offer through is the
-// test's to send, which is what makes the fence observable.
+// corpse's EOF (#849) — and until #894 nothing ever re-listed those. An offer
+// can cross a `close` the link already sent; that is the app's to drop
+// (engineLink.test.ts), so nothing here waits for anything.
 describe('a session released after hello is offered (#894)', () => {
   it('offers the session a dead link still claimed at hello, once that link is gone', async () => {
     const id = `late:${++counter}`;
@@ -1210,11 +1210,6 @@ describe('a session released after hello is offered (#894)', () => {
     // Strict at hello, as before: a is still on the books.
     expect(b.hello?.held).not.toContain(id);
     a.kill();
-    // The engine asks before it tells: nothing is offered ahead of the pong.
-    await b.waitFor((f) => f.op === 'ping');
-    await new Promise((r) => setTimeout(r, 30));
-    expect(b.frames.some((f) => f.op === 'held')).toBe(false);
-    b.send({ op: 'pong' });
     expect(await b.waitFor((f) => f.op === 'held')).toMatchObject({ op: 'held', id });
     // And it is adoptable: the connect attaches, it does not dial.
     b.send(connectFrame(id));
@@ -1230,40 +1225,12 @@ describe('a session released after hello is offered (#894)', () => {
     const b = await link();
     expect(b.hello?.held).not.toContain(id);
     a.send({ op: 'detach', id });
-    await b.waitFor((f) => f.op === 'ping');
-    b.send({ op: 'pong' });
     expect(await b.waitFor((f) => f.op === 'held')).toMatchObject({ id });
-    expect(a.frames.some((f) => f.op === 'ping' || f.op === 'held')).toBe(false);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(a.frames.some((f) => f.op === 'held')).toBe(false);
   });
 
-  it('a close the link had already sent wins: the offer is fenced behind a ping', async () => {
-    // #849's shape with the offer in it. A Disconnect issued during a link
-    // blip is flushed as a `close` the moment the replacement link is up, and
-    // that close and the dead link's EOF are read in either order. Here the
-    // EOF goes first, and the close is sent while the fence ping is in
-    // flight — after the engine released the session, before it can have
-    // read anything more from this link. An unfenced offer would say "held"
-    // to a link whose close then turns the session into a fresh dial.
-    const id = `fenced:${++counter}`;
-    const nick = `fenced${counter}`;
-    const a = await link();
-    await register(a, id, nick);
-    const b = await link();
-    a.kill();
-    await b.waitFor((f) => f.op === 'ping');
-    b.send({ op: 'close', id });
-    b.send({ op: 'pong' });
-    await gone(engine, id);
-    // Whatever the engine had to say about the offer was said before its
-    // answer to this ping.
-    b.send({ op: 'ping' });
-    await b.waitForNew((f) => f.op === 'pong');
-    expect(b.frames.some((f) => f.op === 'held')).toBe(false);
-    expect(b.frames.some((f) => f.op === 'error')).toBe(false);
-    await until(() => ircd.client(nick) === undefined, 5000, 'ircd saw it go');
-  });
-
-  it('offers a session that finished registering with nobody attached', async () => {
+  it('offers a session that finished registering after its link died', async () => {
     // A dial the dead link left behind: at b's hello it is not a session yet,
     // so the hello cannot list it, and the release at a's death has nothing
     // to offer either. Registration completing is the moment it becomes one.
@@ -1277,22 +1244,28 @@ describe('a session released after hello is offered (#894)', () => {
     a.send({ op: 'write', id, line: `NICK ${nick}` });
     a.send({ op: 'write', id, line: `USER ${nick} 0 * :u` });
     a.kill();
-    // Every ping is answered; the offer rides whichever one the session is a
-    // session by.
-    const held = b.waitFor((f) => f.op === 'held' && f.id === id);
-    const answer = (): void => {
-      void b
-        .waitForNew((f) => f.op === 'ping')
-        .then(
-          () => {
-            b.send({ op: 'pong' });
-            answer();
-          },
-          () => {},
-        );
-    };
-    answer();
-    await held;
+    await b.waitFor((f) => f.op === 'held' && f.id === id);
+    b.send(connectFrame(id));
+    const att = await b.waitFor<Attached>((f) => f.op === 'attached' && f.id === id);
+    expect(att.unattended).toBe(true);
+  });
+
+  it('does not offer a registration back to the link that let go of it mid-way', async () => {
+    // A detach is allowed from `open`, before 001 — and the link that sent it
+    // is still here. What registers afterwards is offered to the others only.
+    const id = `letgo-early:${++counter}`;
+    const nick = `letgoearly${counter}`;
+    const a = await link();
+    a.send(connectFrame(id));
+    await a.waitFor((f) => f.op === 'open' && f.id === id);
+    const b = await link();
+    expect(b.hello?.held).not.toContain(id);
+    a.send({ op: 'write', id, line: `NICK ${nick}` });
+    a.send({ op: 'write', id, line: `USER ${nick} 0 * :u` });
+    a.send({ op: 'detach', id });
+    await b.waitFor((f) => f.op === 'held' && f.id === id);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(a.frames.some((f) => f.op === 'held')).toBe(false);
     b.send(connectFrame(id));
     const att = await b.waitFor<Attached>((f) => f.op === 'attached' && f.id === id);
     expect(att.unattended).toBe(true);
@@ -1306,10 +1279,9 @@ describe('a session released after hello is offered (#894)', () => {
     links.push(stranger);
     const b = await link();
     a.kill();
-    await b.waitFor((f) => f.op === 'ping');
-    b.send({ op: 'pong' });
     await b.waitFor((f) => f.op === 'held' && f.id === id);
-    expect(stranger.frames.some((f) => f.op === 'ping' || f.op === 'held')).toBe(false);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(stranger.frames.some((f) => f.op === 'held')).toBe(false);
   });
 });
 

--- a/server/engine/engine.test.ts
+++ b/server/engine/engine.test.ts
@@ -1195,6 +1195,124 @@ describe('third review round', () => {
   });
 });
 
+// The hello's `held` list withholds what another link still claims — a dead
+// link's included, since the engine may read a replacement's hello before the
+// corpse's EOF (#849) — and until #894 nothing ever re-listed those. TestLink
+// answers nothing on its own, so the pong that lets an offer through is the
+// test's to send, which is what makes the fence observable.
+describe('a session released after hello is offered (#894)', () => {
+  it('offers the session a dead link still claimed at hello, once that link is gone', async () => {
+    const id = `late:${++counter}`;
+    const nick = `late${counter}`;
+    const a = await link();
+    await register(a, id, nick);
+    const b = await link();
+    // Strict at hello, as before: a is still on the books.
+    expect(b.hello?.held).not.toContain(id);
+    a.kill();
+    // The engine asks before it tells: nothing is offered ahead of the pong.
+    await b.waitFor((f) => f.op === 'ping');
+    await new Promise((r) => setTimeout(r, 30));
+    expect(b.frames.some((f) => f.op === 'held')).toBe(false);
+    b.send({ op: 'pong' });
+    expect(await b.waitFor((f) => f.op === 'held')).toMatchObject({ op: 'held', id });
+    // And it is adoptable: the connect attaches, it does not dial.
+    b.send(connectFrame(id));
+    const att = await b.waitFor<Attached>((f) => f.op === 'attached' && f.id === id);
+    expect(att.nick).toBe(nick);
+    expect(ircd.registrations.filter((r) => r.nick === nick)).toHaveLength(1);
+  });
+
+  it('offers what a link let go of to the others, not back to it', async () => {
+    const id = `letgo:${++counter}`;
+    const a = await link();
+    await register(a, id, `letgo${counter}`);
+    const b = await link();
+    expect(b.hello?.held).not.toContain(id);
+    a.send({ op: 'detach', id });
+    await b.waitFor((f) => f.op === 'ping');
+    b.send({ op: 'pong' });
+    expect(await b.waitFor((f) => f.op === 'held')).toMatchObject({ id });
+    expect(a.frames.some((f) => f.op === 'ping' || f.op === 'held')).toBe(false);
+  });
+
+  it('a close the link had already sent wins: the offer is fenced behind a ping', async () => {
+    // #849's shape with the offer in it. A Disconnect issued during a link
+    // blip is flushed as a `close` the moment the replacement link is up, and
+    // that close and the dead link's EOF are read in either order. Here the
+    // EOF goes first, and the close is sent while the fence ping is in
+    // flight — after the engine released the session, before it can have
+    // read anything more from this link. An unfenced offer would say "held"
+    // to a link whose close then turns the session into a fresh dial.
+    const id = `fenced:${++counter}`;
+    const nick = `fenced${counter}`;
+    const a = await link();
+    await register(a, id, nick);
+    const b = await link();
+    a.kill();
+    await b.waitFor((f) => f.op === 'ping');
+    b.send({ op: 'close', id });
+    b.send({ op: 'pong' });
+    await gone(engine, id);
+    // Whatever the engine had to say about the offer was said before its
+    // answer to this ping.
+    b.send({ op: 'ping' });
+    await b.waitForNew((f) => f.op === 'pong');
+    expect(b.frames.some((f) => f.op === 'held')).toBe(false);
+    expect(b.frames.some((f) => f.op === 'error')).toBe(false);
+    await until(() => ircd.client(nick) === undefined, 5000, 'ircd saw it go');
+  });
+
+  it('offers a session that finished registering with nobody attached', async () => {
+    // A dial the dead link left behind: at b's hello it is not a session yet,
+    // so the hello cannot list it, and the release at a's death has nothing
+    // to offer either. Registration completing is the moment it becomes one.
+    const id = `late-reg:${++counter}`;
+    const nick = `latereg${counter}`;
+    const a = await link();
+    a.send(connectFrame(id));
+    await a.waitFor((f) => f.op === 'open' && f.id === id);
+    const b = await link();
+    expect(b.hello?.held).not.toContain(id);
+    a.send({ op: 'write', id, line: `NICK ${nick}` });
+    a.send({ op: 'write', id, line: `USER ${nick} 0 * :u` });
+    a.kill();
+    // Every ping is answered; the offer rides whichever one the session is a
+    // session by.
+    const held = b.waitFor((f) => f.op === 'held' && f.id === id);
+    const answer = (): void => {
+      void b
+        .waitForNew((f) => f.op === 'ping')
+        .then(
+          () => {
+            b.send({ op: 'pong' });
+            answer();
+          },
+          () => {},
+        );
+    };
+    answer();
+    await held;
+    b.send(connectFrame(id));
+    const att = await b.waitFor<Attached>((f) => f.op === 'attached' && f.id === id);
+    expect(att.unattended).toBe(true);
+  });
+
+  it("offers only to links of the session's instance", async () => {
+    const id = `mine:${++counter}`;
+    const a = await link();
+    await register(a, id, `mine${counter}`);
+    const stranger = await TestLink.connect(enginePort, SECRET, { instance: 'some-other-db' });
+    links.push(stranger);
+    const b = await link();
+    a.kill();
+    await b.waitFor((f) => f.op === 'ping');
+    b.send({ op: 'pong' });
+    await b.waitFor((f) => f.op === 'held' && f.id === id);
+    expect(stranger.frames.some((f) => f.op === 'ping' || f.op === 'held')).toBe(false);
+  });
+});
+
 describe('orphan reaper', () => {
   it('ends a session no link has claimed for orphanMs', async () => {
     const own = new EngineServer({

--- a/server/engine/protocol.ts
+++ b/server/engine/protocol.ts
@@ -93,9 +93,7 @@ export type AppToEngine =
       app: { version: string; startedAt?: number };
     }
   // Link liveness, both directions: the engine answers `pong`; the app sends
-  // `ping` on a timer and drops a link that answers nothing for a while. The
-  // engine pings too, as the fence in front of a `held` offer (below): the app
-  // answers every ping with one pong, in order.
+  // `ping` on a timer and drops a link that answers nothing for a while.
   | { op: 'ping' }
   | { op: 'pong' }
   // Connect-or-attach. The app never has to know which one it is getting: the
@@ -175,12 +173,11 @@ export type EngineToApp =
   // The IRC socket is gone. The engine forgets the id.
   | { op: 'closed'; id: string; error?: string }
   // A session this instance may attach to that the hello could not list: the
-  // link holding it has since died, or detached it (or it finished registering
-  // with nobody attached). The engine sends this only after a ping/pong round
-  // trip with the receiving link, so a `close` that link had already sent for
-  // the id has been applied by the time the offer arrives — an offer never
-  // contradicts something the app already asked for. The app treats it as one
-  // more entry in hello.held: adopt if policy allows, close if not.
+  // link holding it has since died, or detached it, or it finished registering
+  // with nobody attached. One more entry in hello.held: adopt if policy
+  // allows, close if not. It can cross a `close` the app has already sent for
+  // the id; the app drops an offer for an id it has closed on this link
+  // (engineLink.ts), which frames-in-order makes exact.
   | { op: 'held'; id: string }
   | { op: 'listing'; connections: ConnectionInfo[] }
   | { op: 'error'; id?: string; message: string };

--- a/server/engine/protocol.ts
+++ b/server/engine/protocol.ts
@@ -26,7 +26,13 @@ export const PROTOCOL_MAJOR = 1;
 // the name it had at the rename — silently, and for the life of the socket —
 // which is why the app half of draft/channel-rename (#858) has a minor to gate
 // on rather than having to assume.
-export const PROTOCOL_MINOR = 3;
+// minor 4 (#894): `held` — a session offered AFTER hello. The hello's list
+// withholds what another link still claims, a dead link's included, and until
+// this minor nothing ever re-listed those: a session released after the hello
+// stayed unadopted (or, for a paused account, un-closed) until the orphan
+// reaper or the next restart. An engine below this still lists correctly at
+// hello; it just never says anything afterwards.
+export const PROTOCOL_MINOR = 4;
 
 // One frame is one JSON object on one line. Most wrap a single IRC line (≤ 8191
 // bytes with tags); the one large frame is `attached`, whose replay is bounded by
@@ -87,7 +93,9 @@ export type AppToEngine =
       app: { version: string; startedAt?: number };
     }
   // Link liveness, both directions: the engine answers `pong`; the app sends
-  // `ping` on a timer and drops a link that answers nothing for a while.
+  // `ping` on a timer and drops a link that answers nothing for a while. The
+  // engine pings too, as the fence in front of a `held` offer (below): the app
+  // answers every ping with one pong, in order.
   | { op: 'ping' }
   | { op: 'pong' }
   // Connect-or-attach. The app never has to know which one it is getting: the
@@ -166,6 +174,14 @@ export type EngineToApp =
   | { op: 'detached'; id: string; reason: 'taken-over' }
   // The IRC socket is gone. The engine forgets the id.
   | { op: 'closed'; id: string; error?: string }
+  // A session this instance may attach to that the hello could not list: the
+  // link holding it has since died, or detached it (or it finished registering
+  // with nobody attached). The engine sends this only after a ping/pong round
+  // trip with the receiving link, so a `close` that link had already sent for
+  // the id has been applied by the time the offer arrives — an offer never
+  // contradicts something the app already asked for. The app treats it as one
+  // more entry in hello.held: adopt if policy allows, close if not.
+  | { op: 'held'; id: string }
   | { op: 'listing'; connections: ConnectionInfo[] }
   | { op: 'error'; id?: string; message: string };
 

--- a/server/engine/server.ts
+++ b/server/engine/server.ts
@@ -26,7 +26,7 @@ import {
   PROTOCOL_MINOR,
   encodeFrame,
 } from './protocol.js';
-import type { AppToEngine, EngineToApp } from './protocol.js';
+import type { AppToEngine, ConnectionInfo, EngineToApp } from './protocol.js';
 import { isDialableCertPair } from '../utils/clientCert.js';
 
 export interface EngineServerOptions {
@@ -257,6 +257,11 @@ export class EngineServer {
   // Whether the engine still has a socket (in any state) under this id.
   hasConnection(id: string): boolean {
     return this.upstreams.has(id);
+  }
+
+  // One session's listing entry — what `list` would say about it.
+  info(id: string): ConnectionInfo | undefined {
+    return this.upstreams.get(id)?.info();
   }
 
   // Stop accepting, drop every link, and — because the engine going away IS

--- a/server/engine/server.ts
+++ b/server/engine/server.ts
@@ -9,6 +9,10 @@
 // connection to the new link and tells the old one `detached`. That is what
 // lets a deploy start the new app before the old one has finished dying — and
 // it is not a socket event, so the old app must not treat it as one.
+//
+// A link learns what it may attach to twice over: the hello's `held` list, and
+// a `held` frame for each session that becomes unclaimed after that (the link
+// holding it died, or let go). See heldFor() and offer().
 
 import net from 'node:net';
 import { createHash, timingSafeEqual } from 'node:crypto';
@@ -61,6 +65,9 @@ class AppLink implements FrameSink {
   // link touches must belong to it.
   instance = '';
   lastSeen = Date.now();
+  // Sessions to offer this link once it has answered the ping sent ahead of
+  // them, one batch per ping, in ping order. See offer().
+  readonly offers: EngineUpstream[][] = [];
 
   constructor(
     readonly socket: net.Socket,
@@ -145,20 +152,74 @@ export class EngineServer {
   // deliberately: a `connect` for it takes the claim over (contest) a backoff
   // later, whereas offering it would let reconcile re-adopt a session whose
   // user-issued close is still sitting in the dead link's unread bytes, and
-  // turn that Disconnect into a reconnect.
+  // turn that Disconnect into a reconnect. What the dead link claimed is
+  // offered when it is finally gone instead — offer(), which reads its unread
+  // bytes first by construction.
   private heldFor(link: AppLink): string[] {
     return [...this.upstreams.values()]
       .filter((u) => u.opts.instance === link.instance)
-      .filter((u) => u.state === 'open' && u.registered && !u.closing)
-      .filter((u) => !this.holderOf(u, link))
+      .filter((u) => this.isSession(u) && !this.holderOf(u, link))
       .map((u) => u.id);
   }
 
-  // The one other link holding `u`, if any. A claim is exclusive — every path
-  // that adds one strips the previous holder first — so there is at most one.
-  private holderOf(u: EngineUpstream, except: AppLink): AppLink | undefined {
+  // Something an app can attach to: open, registered, and not on its way out.
+  // Anything else in the map is not a session — a dial in progress, or a
+  // socket the previous app never finished registering — and advertising it
+  // would only make the app adopt something that ends in a fresh dial anyway.
+  private isSession(u: EngineUpstream): boolean {
+    return u.state === 'open' && u.registered && !u.closing;
+  }
+
+  // The link holding `u`, if any, other than `except`. A claim is exclusive —
+  // every path that adds one strips the previous holder first — so there is at
+  // most one.
+  private holderOf(u: EngineUpstream, except: AppLink | null): AppLink | undefined {
     for (const l of this.links) if (l !== except && l.claimed.has(u)) return l;
     return undefined;
+  }
+
+  // Sessions that have just become unclaimed — their link died, or detached
+  // them on purpose, or (a dial the dead link left behind) they finished
+  // registering with nobody attached — are offered to the instance's other
+  // links, whose hello may have come while the old link still held them; the
+  // hello's list is otherwise the last word, and a paused account's socket
+  // then stayed on IRC until the orphan reaper (#894).
+  //
+  // Not offered straight away, though. A link may have SENT a `close` for that
+  // very session that has not been read yet: a user's Disconnect during a link
+  // blip is flushed the moment the link is back, and the poll batch that has
+  // the replacement's hello ready can have the dead socket's EOF ready beside
+  // it, in no particular order (#849). An offer that overtook such a close
+  // would read as "still held", reconcile would attach, and the close applied
+  // a moment later would then hand the app a fresh dial — the Disconnect
+  // undone. So the offer queues behind a ping. Frames on a link are read in
+  // order, and the app answers a ping with a pong in its turn, so by the time
+  // the pong is read everything the link sent before it heard the ping has
+  // been read too — a session it closed meanwhile is `closing`, and the pong
+  // handler checks that before it says anything.
+  private offer(released: EngineUpstream[], except: AppLink | null): void {
+    if (released.length === 0) return;
+    for (const link of this.links) {
+      if (link === except || !link.authed || link.socket.destroyed) continue;
+      const theirs = released.filter((u) => u.opts.instance === link.instance);
+      if (theirs.length === 0) continue;
+      link.offers.push(theirs);
+      link.send({ op: 'ping' });
+    }
+  }
+
+  // The app answered a ping: the fence in front of the oldest batch of offers
+  // is down (pongs come back in ping order). What is still a session, and
+  // still unclaimed — the link's own `connect` may have taken it meanwhile —
+  // is offered now.
+  private onPong(link: AppLink): void {
+    const batch = link.offers.shift();
+    if (!batch) return;
+    for (const u of batch) {
+      if (!this.isSession(u) || this.holderOf(u, null)) continue;
+      link.send({ op: 'held', id: u.id });
+      this.log(`${u.id}: offered to ${link.peer}`);
+    }
   }
 
   // Newest wins — the one rule for an attach and for a close. Another link
@@ -199,14 +260,9 @@ export class EngineServer {
     return null;
   }
 
-  // The sessions an app can attach to: open, registered, and not on their way
-  // out. Anything else in the map is not a session — a dial in progress, or a
-  // socket the previous app never finished registering — and advertising it
-  // would only make the app adopt something that ends in a fresh dial anyway.
+  // Every session, whoever claims it.
   held(): string[] {
-    return [...this.upstreams.values()]
-      .filter((u) => u.state === 'open' && u.registered && !u.closing)
-      .map((u) => u.id);
+    return [...this.upstreams.values()].filter((u) => this.isSession(u)).map((u) => u.id);
   }
 
   connectionCount(): number {
@@ -345,7 +401,7 @@ export class EngineServer {
       case 'ping':
         return void link.send({ op: 'pong' });
       case 'pong':
-        return;
+        return this.onPong(link);
       case 'connect':
         return this.connect(link, frame);
       case 'list':
@@ -545,6 +601,12 @@ export class EngineServer {
       this.log(`${id}: open ${local.address}:${local.port} -> ${remote.address}:${remote.port}`);
     });
     const created = u;
+    // Registered with nobody attached: the link that dialed it is gone (or let
+    // go mid-registration), and the hello a successor sent meanwhile could not
+    // list a socket that was not a session yet.
+    u.on('registered', () => {
+      if (!created.attached) this.offer([created], null);
+    });
     u.on('closed', (error?: string) => {
       this.log(`${id}: closed${error ? ` (${error})` : ''}`);
       // Only if the id still means this socket — a fresh dial may have taken
@@ -571,14 +633,17 @@ export class EngineServer {
     if (!link.claimed.delete(u)) return;
     u.detach();
     this.log(`${u.id}: detached by ${link.peer} (pending ${u.buffer.length})`);
+    this.offer([u], link);
   }
 
   private onLinkClose(link: AppLink): void {
     if (!this.links.delete(link)) return;
-    for (const u of link.claimed) {
+    const released = [...link.claimed];
+    for (const u of released) {
       u.detach();
       this.log(`${u.id}: link ${link.peer} lost — holding (pending ${u.buffer.length})`);
     }
     link.claimed.clear();
+    this.offer(released, null);
   }
 }

--- a/server/engine/server.ts
+++ b/server/engine/server.ts
@@ -65,9 +65,6 @@ class AppLink implements FrameSink {
   // link touches must belong to it.
   instance = '';
   lastSeen = Date.now();
-  // Sessions to offer this link once it has answered the ping sent ahead of
-  // them, one batch per ping, in ping order. See offer().
-  readonly offers: EngineUpstream[][] = [];
 
   constructor(
     readonly socket: net.Socket,
@@ -93,6 +90,9 @@ export class EngineServer {
   private readonly log: (line: string) => void;
   private readonly secretDigest: Buffer;
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
+  // The link that last let go of a session on purpose (release), so that a
+  // registration completing after the detach is not offered back to it.
+  private readonly releasedBy = new WeakMap<EngineUpstream, AppLink>();
 
   constructor(private readonly opts: EngineServerOptions) {
     this.budget = new ByteBudget(opts.bufferTotalBytes);
@@ -185,40 +185,25 @@ export class EngineServer {
   // hello's list is otherwise the last word, and a paused account's socket
   // then stayed on IRC until the orphan reaper (#894).
   //
-  // Not offered straight away, though. A link may have SENT a `close` for that
-  // very session that has not been read yet: a user's Disconnect during a link
-  // blip is flushed the moment the link is back, and the poll batch that has
-  // the replacement's hello ready can have the dead socket's EOF ready beside
-  // it, in no particular order (#849). An offer that overtook such a close
-  // would read as "still held", reconcile would attach, and the close applied
-  // a moment later would then hand the app a fresh dial — the Disconnect
-  // undone. So the offer queues behind a ping. Frames on a link are read in
-  // order, and the app answers a ping with a pong in its turn, so by the time
-  // the pong is read everything the link sent before it heard the ping has
-  // been read too — a session it closed meanwhile is `closing`, and the pong
-  // handler checks that before it says anything.
+  // An offer can cross a `close` the receiving link has already sent for that
+  // very session: a user's Disconnect during a link blip is flushed the moment
+  // the link is back, and the poll batch that has the replacement's hello
+  // ready can have the dead socket's EOF ready beside it, in no particular
+  // order (#849). The app is the side that can tell. Frames on a link are read
+  // in the order they were written, so a `held` that arrives after the app's
+  // own `close` for the id went out is stale by construction, and
+  // engineLink.ts drops it. (A fence here — ping, offer on the pong — covers
+  // less: a close sent after the pong and before the offer lands is the same
+  // race one round trip later.)
   private offer(released: EngineUpstream[], except: AppLink | null): void {
-    if (released.length === 0) return;
-    for (const link of this.links) {
-      if (link === except || !link.authed || link.socket.destroyed) continue;
-      const theirs = released.filter((u) => u.opts.instance === link.instance);
-      if (theirs.length === 0) continue;
-      link.offers.push(theirs);
-      link.send({ op: 'ping' });
-    }
-  }
-
-  // The app answered a ping: the fence in front of the oldest batch of offers
-  // is down (pongs come back in ping order). What is still a session, and
-  // still unclaimed — the link's own `connect` may have taken it meanwhile —
-  // is offered now.
-  private onPong(link: AppLink): void {
-    const batch = link.offers.shift();
-    if (!batch) return;
-    for (const u of batch) {
+    for (const u of released) {
       if (!this.isSession(u) || this.holderOf(u, null)) continue;
-      link.send({ op: 'held', id: u.id });
-      this.log(`${u.id}: offered to ${link.peer}`);
+      for (const link of this.links) {
+        if (link === except || !link.authed || link.socket.destroyed) continue;
+        if (link.instance !== u.opts.instance) continue;
+        link.send({ op: 'held', id: u.id });
+        this.log(`${u.id}: offered to ${link.peer}`);
+      }
     }
   }
 
@@ -401,7 +386,7 @@ export class EngineServer {
       case 'ping':
         return void link.send({ op: 'pong' });
       case 'pong':
-        return this.onPong(link);
+        return;
       case 'connect':
         return this.connect(link, frame);
       case 'list':
@@ -601,11 +586,11 @@ export class EngineServer {
       this.log(`${id}: open ${local.address}:${local.port} -> ${remote.address}:${remote.port}`);
     });
     const created = u;
-    // Registered with nobody attached: the link that dialed it is gone (or let
-    // go mid-registration), and the hello a successor sent meanwhile could not
+    // Registered with nobody attached: the link that dialed it is gone, or let
+    // go mid-registration — and a successor's hello sent meanwhile could not
     // list a socket that was not a session yet.
-    u.on('registered', () => {
-      if (!created.attached) this.offer([created], null);
+    u.on('registered', (unattended: boolean) => {
+      if (unattended) this.offer([created], this.releasedBy.get(created) ?? null);
     });
     u.on('closed', (error?: string) => {
       this.log(`${id}: closed${error ? ` (${error})` : ''}`);
@@ -633,6 +618,7 @@ export class EngineServer {
     if (!link.claimed.delete(u)) return;
     u.detach();
     this.log(`${u.id}: detached by ${link.peer} (pending ${u.buffer.length})`);
+    this.releasedBy.set(u, link);
     this.offer([u], link);
   }
 

--- a/server/engine/server.ts
+++ b/server/engine/server.ts
@@ -255,6 +255,9 @@ export class EngineServer {
     // Detect a dead peer host (the app can be on another box) rather than hold
     // its connections "attached" to a link that will never ack again.
     socket.setKeepAlive(true, 10_000);
+    // Every frame is small and every one is a line on its way to a person;
+    // Nagle would hold each behind the previous one's ack.
+    socket.setNoDelay(true);
     socket.on('data', (chunk: string) => this.onData(link, chunk));
     socket.on('drain', () => {
       for (const u of link.claimed) u.resume();

--- a/server/engine/upstream.ts
+++ b/server/engine/upstream.ts
@@ -377,6 +377,7 @@ export class EngineUpstream extends EventEmitter {
         this.capsAtBurstEnd = new Set(this.caps);
         this.nickAtBurstEnd = this.nick;
         this.registeredUnattended = this.sink === null;
+        this.emit('registered');
       }
     }
     const seq = this.buffer.push(line);

--- a/server/engine/upstream.ts
+++ b/server/engine/upstream.ts
@@ -377,7 +377,7 @@ export class EngineUpstream extends EventEmitter {
         this.capsAtBurstEnd = new Set(this.caps);
         this.nickAtBurstEnd = this.nick;
         this.registeredUnattended = this.sink === null;
-        this.emit('registered');
+        this.emit('registered', this.registeredUnattended);
       }
     }
     const seq = this.buffer.push(line);

--- a/server/routes/networks.test.ts
+++ b/server/routes/networks.test.ts
@@ -143,6 +143,18 @@ describe('POST /api/networks', () => {
     expect(fakeManager.calls.some(([m]) => m === 'startNetwork')).toBe(true);
   });
 
+  // The body goes to createNetwork unvalidated, and a client that sends a
+  // number is taken at its word: 0 is off (it read as on until #894 found
+  // it), and a null is "unset", which is the default — on.
+  it('stores a numeric 0 as off and a null as the default', async () => {
+    const off = await makeNet(aliceAgent, { autoconnect: 0, name: 'num-off' });
+    expect(off.status).toBe(201);
+    expect(off.body.network.autoconnect).toBe(false);
+    const unset = await makeNet(aliceAgent, { autoconnect: null, name: 'null-unset' });
+    expect(unset.status).toBe(201);
+    expect(unset.body.network.autoconnect).toBe(true);
+  });
+
   it('500s and does not connect if createNetwork returns undefined', async () => {
     const networksDb = await import('../db/networks.js');
     const spy = vi.spyOn(networksDb, 'createNetwork').mockReturnValueOnce(undefined);

--- a/server/routes/networks.test.ts
+++ b/server/routes/networks.test.ts
@@ -155,6 +155,26 @@ describe('POST /api/networks', () => {
     expect(unset.body.network.autoconnect).toBe(true);
   });
 
+  // The same null on an update means "unchanged", for all three flags: the
+  // old coercion read it as false, which for `tls` turned "leave it" into
+  // "drop the encryption".
+  it('a null flag on PATCH leaves that flag alone', async () => {
+    const net = await makeNet(aliceAgent, { autoconnect: false, tls: true, name: 'null-patch' });
+    expect(net.status).toBe(201);
+    const id = net.body.network.id;
+    const nulls = await aliceAgent
+      .patch(`/api/networks/${id}`)
+      .send({ autoconnect: null, tls: null, trusted_certificates: null, nick: 'renamed' });
+    expect(nulls.status).toBe(200);
+    expect(nulls.body.network.autoconnect).toBe(false);
+    expect(nulls.body.network.tls).toBe(true);
+    expect(nulls.body.network.nick).toBe('renamed');
+    const on = await aliceAgent.patch(`/api/networks/${id}`).send({ autoconnect: true });
+    expect(on.body.network.autoconnect).toBe(true);
+    const off = await aliceAgent.patch(`/api/networks/${id}`).send({ autoconnect: 0 });
+    expect(off.body.network.autoconnect).toBe(false);
+  });
+
   it('500s and does not connect if createNetwork returns undefined', async () => {
     const networksDb = await import('../db/networks.js');
     const spy = vi.spyOn(networksDb, 'createNetwork').mockReturnValueOnce(undefined);

--- a/server/server.ts
+++ b/server/server.ts
@@ -284,8 +284,11 @@ function shutdown(signal: string): void {
   stopIgnoreSweeper();
   stopEventLoopMonitor();
   ircManager.shutdown();
-  stopEngineLink();
-  server.close(() => process.exit(0));
+  // The detaches just written must leave before this process's descriptors
+  // are closed out from under them: server.close with no client connected
+  // calls back on the next tick, and an exit before the loop turns closes the
+  // link with a reset, unsent bytes and all (engineLink.ts stop()).
+  void stopEngineLink().then(() => server.close(() => process.exit(0)));
   setTimeout(() => process.exit(1), 5000).unref();
 }
 process.on('SIGINT', () => shutdown('SIGINT'));

--- a/server/services/engineIntegration.test.ts
+++ b/server/services/engineIntegration.test.ts
@@ -389,6 +389,82 @@ describe('IrcConnection through the engine', () => {
     await until(() => fresh.state === 'connected', 5000, 'fresh connection for the next test');
   }, 30000);
 
+  // #894: the hello lists what no other link claims, and a link the engine has
+  // not yet seen die still claims what it held. Nothing re-listed those — a
+  // session left that way sat unadopted, or for a paused account un-closed,
+  // until the orphan reaper. The engine now offers it the moment the old link
+  // is gone. The corpse here is a bare link that attached and then died
+  // without a word, which is what a crashed process looks like to the engine.
+  it('a session released after hello is adopted, or closed, without a restart (#894)', async () => {
+    const conn = ircManager.getConnection(userId, network.id)!;
+    expect(conn.state).toBe('connected');
+    const corpse = async (): Promise<TestLink> => {
+      const c = await TestLink.connect(EngineLink.shared().opts.port, SECRET, {
+        instance: instanceId(),
+      });
+      c.send({
+        op: 'connect',
+        id: engineId,
+        host: '127.0.0.1',
+        port: ircd.port,
+        tls: false,
+        rejectUnauthorized: false,
+      });
+      await c.waitFor((f) => f.op === 'attached' && f.id === engineId);
+      return c;
+    };
+    ircManager.shutdown();
+    await until(() => engine.held().includes(engineId), 5000, 'engine holds the detached socket');
+    let c = await corpse();
+    EngineLink.resetForTests();
+    EngineLink.shared().start();
+    await until(() => EngineLink.shared().state === 'ready', 5000, 'new link ready');
+    // Strict at hello, as before.
+    expect(EngineLink.shared().held).not.toContain(engineId);
+    const rowsBefore = rows().length;
+    const registrations = ircd.registrations.filter((r) => r.nick === 'lurk').length;
+    ircManager.initAll();
+    expect(ircManager.getConnection(userId, network.id)).toBeNull();
+    c.kill();
+    await until(
+      () => ircManager.getConnection(userId, network.id)?.state === 'connected',
+      5000,
+      'adopted once the corpse was gone',
+    );
+    // An attach, not a dial: no "Connecting…", no second registration.
+    expect(
+      rows()
+        .slice(rowsBefore)
+        .some((r) => (r.text ?? '').startsWith('Connecting to ')),
+    ).toBe(false);
+    expect(ircd.registrations.filter((r) => r.nick === 'lurk')).toHaveLength(registrations);
+
+    // Same again, paused: the offer ends in a close.
+    ircManager.shutdown();
+    await until(() => engine.held().includes(engineId), 5000, 'engine holds it again');
+    c = await corpse();
+    setUserPaused(userId, true);
+    try {
+      EngineLink.resetForTests();
+      EngineLink.shared().start();
+      await until(() => EngineLink.shared().state === 'ready', 5000, 'link ready again');
+      ircManager.initAll();
+      expect(ircManager.getConnection(userId, network.id)).toBeNull();
+      c.kill();
+      await until(
+        () => !engine.held().includes(engineId),
+        5000,
+        "engine closed the paused account's socket",
+      );
+      await until(() => ircd.client('lurk') === undefined, 5000, 'ircd saw it go');
+    } finally {
+      setUserPaused(userId, false);
+    }
+    // Leave a live connection behind for the next test.
+    const fresh = ircManager.startNetwork(userId, network.id)!;
+    await until(() => fresh.state === 'connected', 5000, 'fresh connection for the next test');
+  }, 30000);
+
   it('a buffer closed while the link was down is PARTed on re-attach, not re-armed', async () => {
     const conn = ircManager.getConnection(userId, network.id)!;
     expect(conn.state).toBe('connected');

--- a/server/services/engineIntegration.test.ts
+++ b/server/services/engineIntegration.test.ts
@@ -33,6 +33,8 @@ import type { FakeIrcd } from '../test-utils/fakeIrcd.js';
 import { startEngineHarness } from '../test-utils/engineHarness.js';
 import type { EngineHarness } from '../test-utils/engineHarness.js';
 import { until as poll } from '../test-utils/until.js';
+import { TestLink } from '../test-utils/engineLink.js';
+import { instanceId } from '../db/instanceId.js';
 import { EngineLink, engineConnectionId, isOurConnectionId } from './engineLink.js';
 
 const SECRET = 'integration-secret';
@@ -351,6 +353,7 @@ describe('IrcConnection through the engine', () => {
     managerEvents.length = 0;
     const rowsBefore = rows().length;
     // autoconnect is 0 on this network, so initAll starts nothing itself…
+    expect(network.autoconnect).toBe(0);
     ircManager.initAll();
     // …and reconcile adopts what the engine kept.
     const adopted = ircManager.getConnection(userId, network.id);

--- a/server/services/engineIntegration.test.ts
+++ b/server/services/engineIntegration.test.ts
@@ -162,11 +162,17 @@ describe('IrcConnection through the engine', () => {
   }, 30000);
 
   it('a new IrcConnection re-attaches with no new history and no re-registration', async () => {
-    // Life while the app is away.
+    // Life while the app is away — and it has to have REACHED the engine
+    // before the app re-attaches, or it is live traffic rather than backlog.
+    // A server's socket is free to hold small writes back behind an unacked
+    // one (Nagle, ~40 ms on Linux), and a link with no such delay attaches
+    // well inside that window; a fixed sleep here was a coin toss.
+    const buffered = () => engine.info(engineId)?.bufferedLines ?? 0;
+    const bufferedBefore = buffered();
     ircd.kick('#gone', 'lurk');
     ircd.say('peer', '#stay', 'while away');
     ircd.say('peer', 'lurk', 'dm while away');
-    await new Promise((r) => setTimeout(r, 30));
+    await until(() => buffered() >= bufferedBefore + 3, 5000, 'the engine buffered the gap');
     managerEvents.length = 0;
 
     // Through ircManager this time, so the autojoin listener is on.

--- a/server/services/engineLink.test.ts
+++ b/server/services/engineLink.test.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // The app's side of the engine link on its own, against a bare listener
-// standing in for the engine: what the link does with the socket, not what
-// the engine does with the frames (server/engine/engine.test.ts has that).
+// standing in for the engine: what the link does with the socket and with the
+// frames it is offered, not what the engine does with the frames it is sent
+// (server/engine/engine.test.ts has that).
 
 // MUST be first: the link reads this instance's id from the database.
 import '../test-utils/isolateDb.js';
@@ -17,9 +18,11 @@ import { until } from '../test-utils/until.js';
 interface FakeEngine {
   port: number;
   seen: AppToEngine[];
-  // The engine's end of the one link, once it has arrived.
+  // The engine's end of the current link, once it has arrived.
   peer: net.Socket | null;
-  // How the link ended from the engine's side: a FIN, or a reset.
+  // How many links have arrived.
+  links: number;
+  // How the first link ended from the engine's side: a FIN, or a reset.
   ended: 'end' | 'error' | null;
   say(frame: EngineToApp): void;
   close(): Promise<void>;
@@ -30,6 +33,7 @@ async function fakeEngine(): Promise<FakeEngine> {
     port: 0,
     seen: [],
     peer: null,
+    links: 0,
     ended: null,
     say(frame) {
       fake.peer!.write(encodeFrame(frame));
@@ -38,19 +42,22 @@ async function fakeEngine(): Promise<FakeEngine> {
   };
   const server = net.createServer((s) => {
     fake.peer = s;
+    fake.links++;
     s.setEncoding('utf8');
     const reader = new FrameReader();
     s.on('data', (chunk: string) => {
       for (const f of reader.push(chunk) as AppToEngine[]) {
         fake.seen.push(f);
         if (f.op === 'hello') {
-          fake.say({
-            op: 'hello',
-            protocol: PROTOCOL_MAJOR,
-            minor: PROTOCOL_MINOR,
-            engine: { version: 'fake' },
-            held: [],
-          });
+          s.write(
+            encodeFrame({
+              op: 'hello',
+              protocol: PROTOCOL_MAJOR,
+              minor: PROTOCOL_MINOR,
+              engine: { version: 'fake' },
+              held: [],
+            }),
+          );
         }
       }
     });
@@ -89,6 +96,23 @@ async function readyLink(fake: FakeEngine): Promise<EngineLink> {
   return link;
 }
 
+// A frame the fake sends after another is answered only once the first was
+// read, so a pong to it bounds what the link has processed.
+async function roundTrip(fake: FakeEngine): Promise<void> {
+  const before = fake.seen.filter((f) => f.op === 'pong').length;
+  fake.say({ op: 'ping' });
+  await until(() => fake.seen.filter((f) => f.op === 'pong').length > before, 3000, 'pong');
+}
+
+const connectFrame = (id: string): AppToEngine => ({
+  op: 'connect',
+  id,
+  host: '127.0.0.1',
+  port: 1,
+  tls: false,
+  rejectUnauthorized: true,
+});
+
 describe('EngineLink', () => {
   // What shutdown() does: one `detach` per connection, then stopEngineLink(),
   // all in one tick. Those frames must still reach the engine. A destroy()
@@ -99,22 +123,30 @@ describe('EngineLink', () => {
   it('stop() half-closes the link, so what was just written arrives and the engine sees a FIN', async () => {
     const fake = await fakeEngine();
     const link = await readyLink(fake);
+    const offered: string[] = [];
+    link.on('held', (id: string) => offered.push(id));
     // Something the app has not read yet, deliberately: sent and stopped in
     // the same tick, so the app's socket closes with data pending.
     fake.peer!.write(encodeFrame({ op: 'pong' }).repeat(2000));
     link.send({ op: 'detach', id: 'a:1:1' });
     link.send({ op: 'detach', id: 'a:1:2' });
-    link.stop();
+    const stopped = link.stop();
+    // A stopped link is dark: not ready, and what the engine still writes
+    // before it reads the FIN goes nowhere.
+    expect(link.state).not.toBe('ready');
+    fake.say({ op: 'held', id: 'a:1:3' });
+    await stopped;
     await until(() => fake.ended !== null, 3000, 'the engine saw the link end');
     expect(fake.ended).toBe('end');
     expect(fake.seen.filter((f) => f.op === 'detach').map((f) => f.id)).toEqual(['a:1:1', 'a:1:2']);
+    expect(offered).toEqual([]);
+    expect(link.held).toEqual([]);
   });
 
   it("answers the engine's ping, and takes a held offer as one more held id", async () => {
     const fake = await fakeEngine();
     const link = await readyLink(fake);
-    fake.say({ op: 'ping' });
-    await until(() => fake.seen.some((f) => f.op === 'pong'), 3000, 'pong');
+    await roundTrip(fake);
     const offered: string[] = [];
     link.on('held', (id: string) => offered.push(id));
     expect(link.holds('x:1:1')).toBe(false);
@@ -123,5 +155,58 @@ describe('EngineLink', () => {
     expect(offered).toEqual(['x:1:1']);
     expect(link.held).toContain('x:1:1');
     expect(link.holds('x:1:1')).toBe(true);
+  });
+
+  // The engine writes an offer without knowing what is already on its way in:
+  // a `close` this link sent for the same id — a user's Disconnect during a
+  // link blip, flushed the moment the link is back — is read after the offer
+  // was written, and would then hand the app a fresh dial of what it just
+  // ended if the offer were taken. Frames on a link are read in order, so an
+  // offer that arrives after the close went out is stale, exactly.
+  it('drops a held offer for an id it has closed on this link, until it connects it again', async () => {
+    const fake = await fakeEngine();
+    const link = await readyLink(fake);
+    const offered: string[] = [];
+    link.on('held', (id: string) => offered.push(id));
+    link.requestClose('x:1:1');
+    await until(() => fake.seen.some((f) => f.op === 'close'), 3000, 'close sent');
+    fake.say({ op: 'held', id: 'x:1:1' });
+    await roundTrip(fake);
+    expect(offered).toEqual([]);
+    expect(link.holds('x:1:1')).toBe(false);
+    // Wanting a session under the id again lifts it.
+    link.send(connectFrame('x:1:1'));
+    fake.say({ op: 'held', id: 'x:1:1' });
+    await until(() => offered.length === 1, 3000, 'held after connect');
+  });
+
+  it('a new link starts with a clean slate: a close sent on the old one does not shadow an offer', async () => {
+    const fake = await fakeEngine();
+    const link = await readyLink(fake);
+    const offered: string[] = [];
+    link.on('held', (id: string) => offered.push(id));
+    link.requestClose('y:1:1');
+    await until(() => fake.seen.some((f) => f.op === 'close'), 3000, 'close sent');
+    link.simulateLoss();
+    await until(() => fake.links === 2 && link.state === 'ready', 3000, 'link back');
+    fake.say({ op: 'held', id: 'y:1:1' });
+    await until(() => offered.length === 1, 3000, 'held on the new link');
+    expect(offered).toEqual(['y:1:1']);
+    expect(link.holds('y:1:1')).toBe(true);
+  });
+
+  it('a close that had to wait for the link is sent at hello, and shadows an offer on that link', async () => {
+    const fake = await fakeEngine();
+    const link = await readyLink(fake);
+    const offered: string[] = [];
+    link.on('held', (id: string) => offered.push(id));
+    link.simulateLoss();
+    await until(() => link.state !== 'ready', 3000, 'link down');
+    link.requestClose('z:1:1');
+    await until(() => fake.links === 2 && link.state === 'ready', 3000, 'link back');
+    expect(fake.seen.filter((f) => f.op === 'close').map((f) => f.id)).toEqual(['z:1:1']);
+    fake.say({ op: 'held', id: 'z:1:1' });
+    await roundTrip(fake);
+    expect(offered).toEqual([]);
   });
 });

--- a/server/services/engineLink.test.ts
+++ b/server/services/engineLink.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The app's side of the engine link on its own, against a bare listener
+// standing in for the engine: what the link does with the socket, not what
+// the engine does with the frames (server/engine/engine.test.ts has that).
+
+// MUST be first: the link reads this instance's id from the database.
+import '../test-utils/isolateDb.js';
+import net from 'node:net';
+import { describe, it, expect, afterEach } from 'vitest';
+import { EngineLink } from './engineLink.js';
+import { FrameReader, PROTOCOL_MAJOR, PROTOCOL_MINOR, encodeFrame } from '../engine/protocol.js';
+import type { AppToEngine, EngineToApp } from '../engine/protocol.js';
+import { until } from '../test-utils/until.js';
+
+interface FakeEngine {
+  port: number;
+  seen: AppToEngine[];
+  // The engine's end of the one link, once it has arrived.
+  peer: net.Socket | null;
+  // How the link ended from the engine's side: a FIN, or a reset.
+  ended: 'end' | 'error' | null;
+  say(frame: EngineToApp): void;
+  close(): Promise<void>;
+}
+
+async function fakeEngine(): Promise<FakeEngine> {
+  const fake: FakeEngine = {
+    port: 0,
+    seen: [],
+    peer: null,
+    ended: null,
+    say(frame) {
+      fake.peer!.write(encodeFrame(frame));
+    },
+    close: () => new Promise((r) => server.close(() => r())),
+  };
+  const server = net.createServer((s) => {
+    fake.peer = s;
+    s.setEncoding('utf8');
+    const reader = new FrameReader();
+    s.on('data', (chunk: string) => {
+      for (const f of reader.push(chunk) as AppToEngine[]) {
+        fake.seen.push(f);
+        if (f.op === 'hello') {
+          fake.say({
+            op: 'hello',
+            protocol: PROTOCOL_MAJOR,
+            minor: PROTOCOL_MINOR,
+            engine: { version: 'fake' },
+            held: [],
+          });
+        }
+      }
+    });
+    s.on('end', () => {
+      fake.ended ??= 'end';
+    });
+    s.on('error', () => {
+      fake.ended ??= 'error';
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  fake.port = (server.address() as net.AddressInfo).port;
+  return fake;
+}
+
+const cleanup: Array<() => void | Promise<void>> = [];
+afterEach(async () => {
+  for (const fn of cleanup.splice(0)) await fn();
+});
+
+async function readyLink(fake: FakeEngine): Promise<EngineLink> {
+  const link = new EngineLink({
+    host: '127.0.0.1',
+    port: fake.port,
+    secret: 'link-test',
+    retryBaseMs: 100,
+    heartbeatMs: 600_000,
+    log: () => {},
+  });
+  cleanup.push(
+    () => link.stop(),
+    () => fake.close(),
+  );
+  link.start();
+  await until(() => link.state === 'ready', 3000, 'link ready');
+  return link;
+}
+
+describe('EngineLink', () => {
+  // What shutdown() does: one `detach` per connection, then stopEngineLink(),
+  // all in one tick. Those frames must still reach the engine. A destroy()
+  // closes the descriptor with them possibly still queued behind an unacked
+  // segment, and — when the engine has sent something we have not read yet —
+  // as a RESET, which throws the queue away (#894: the engine still had the
+  // dead link's claim when the next process said hello).
+  it('stop() half-closes the link, so what was just written arrives and the engine sees a FIN', async () => {
+    const fake = await fakeEngine();
+    const link = await readyLink(fake);
+    // Something the app has not read yet, deliberately: sent and stopped in
+    // the same tick, so the app's socket closes with data pending.
+    fake.peer!.write(encodeFrame({ op: 'pong' }).repeat(2000));
+    link.send({ op: 'detach', id: 'a:1:1' });
+    link.send({ op: 'detach', id: 'a:1:2' });
+    link.stop();
+    await until(() => fake.ended !== null, 3000, 'the engine saw the link end');
+    expect(fake.ended).toBe('end');
+    expect(fake.seen.filter((f) => f.op === 'detach').map((f) => f.id)).toEqual(['a:1:1', 'a:1:2']);
+  });
+
+  it("answers the engine's ping, and takes a held offer as one more held id", async () => {
+    const fake = await fakeEngine();
+    const link = await readyLink(fake);
+    fake.say({ op: 'ping' });
+    await until(() => fake.seen.some((f) => f.op === 'pong'), 3000, 'pong');
+    const offered: string[] = [];
+    link.on('held', (id: string) => offered.push(id));
+    expect(link.holds('x:1:1')).toBe(false);
+    fake.say({ op: 'held', id: 'x:1:1' });
+    await until(() => offered.length === 1, 3000, 'held event');
+    expect(offered).toEqual(['x:1:1']);
+    expect(link.held).toContain('x:1:1');
+    expect(link.holds('x:1:1')).toBe(true);
+  });
+});

--- a/server/services/engineLink.ts
+++ b/server/services/engineLink.ts
@@ -195,11 +195,14 @@ export class EngineLink extends EventEmitter {
     return EngineLink.instance;
   }
 
-  // Tests build engines on ephemeral ports and need a fresh singleton each time.
-  static resetForTests(): void {
-    EngineLink.instance?.stop();
+  // Tests build engines on ephemeral ports and need a fresh singleton each
+  // time. Resolves once the old link's socket is closed (see stop()), so a
+  // teardown can wait for it rather than leave the handle to finish on its own.
+  static resetForTests(): Promise<void> {
+    const stopping = EngineLink.instance?.stop() ?? Promise.resolve();
     EngineLink.instance = null;
     disabledReason = null;
+    return stopping;
   }
 
   get address(): string {

--- a/server/services/engineLink.ts
+++ b/server/services/engineLink.ts
@@ -290,6 +290,17 @@ export class EngineLink extends EventEmitter {
     this.socket?.destroy();
   }
 
+  // Stop for good. The link is half-closed, not destroyed: what was written
+  // just before this — at shutdown, every connection's `detach`, and any
+  // `close` a user's Disconnect became a moment earlier — must still get
+  // there. A destroy() closes the descriptor with those bytes possibly still
+  // queued (Nagle holds a small write until the previous one is acked, and
+  // that ack can be a delayed one), and when the engine has sent something we
+  // have not read yet the kernel answers the close with a RESET, which throws
+  // the queue away: the engine reads our earlier frames, then a reset, and the
+  // detach is gone — it still had the dead link's claim on the socket when the
+  // next process said hello (#894, Linux). A FIN pushes the queue first; the
+  // engine reads to EOF and ends its side, which closes ours.
   stop(): void {
     this.stopped = true;
     if (this.retryTimer) {
@@ -297,8 +308,15 @@ export class EngineLink extends EventEmitter {
       this.retryTimer = null;
     }
     this.stopHeartbeat();
-    this.socket?.destroy();
+    const socket = this.socket;
     this.socket = null;
+    if (!socket || socket.destroyed) return;
+    socket.end();
+    // A peer that never answers the FIN would keep the handle (and, at
+    // shutdown, the process) around — bound it.
+    const timer = setTimeout(() => socket.destroy(), 2000);
+    timer.unref();
+    socket.once('close', () => clearTimeout(timer));
   }
 
   private startHeartbeat(socket: net.Socket): void {
@@ -342,6 +360,10 @@ export class EngineLink extends EventEmitter {
     let sawHello = false;
     socket.setEncoding('utf8');
     socket.setKeepAlive(true, 10_000);
+    // Every frame is small and every one is a line on its way somewhere; Nagle
+    // would hold each behind the previous one's ack. (Also what made the last
+    // frame before a stop() droppable — see stop().)
+    socket.setNoDelay(true);
     socket.on('connect', () => {
       socket.write(
         encodeFrame({
@@ -449,6 +471,13 @@ export class EngineLink extends EventEmitter {
       case 'detached':
         this.heldSet.delete(frame.id);
         break;
+      case 'held':
+        // A session the hello could not list, offered now that it is
+        // unclaimed (protocol.ts). Not a transport's frame: nothing here has
+        // claimed it — that is the point — so it goes to whoever reconciles.
+        this.heldSet.add(frame.id);
+        this.emit('held', frame.id);
+        return;
       default:
         break;
     }

--- a/server/services/engineLink.ts
+++ b/server/services/engineLink.ts
@@ -144,6 +144,14 @@ export class EngineLink extends EventEmitter {
   // reason to keep the session: they are sent the moment the link is back,
   // before anyone gets to adopt those sockets.
   private readonly pendingCloses = new Set<string>();
+  // Ids this link has sent a `close` for. A `held` offer for one of them is
+  // stale by construction — the close is ahead of it on this link, and the
+  // engine reads a link in the order it was written — so it is not one more
+  // held session, whatever the engine believed when it wrote the offer.
+  // Cleared by a `connect` for the id (the app wants a session under it
+  // again) and at the next hello (a new link; its closes are its own, and a
+  // hello's list is read at face value).
+  private readonly closedHere = new Set<string>();
   private retryTimer: ReturnType<typeof setTimeout> | null = null;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private lastFrameAt = 0;
@@ -269,6 +277,8 @@ export class EngineLink extends EventEmitter {
 
   send(frame: AppToEngine): boolean {
     if (this.state !== 'ready' || !this.socket || this.socket.destroyed) return false;
+    if (frame.op === 'close') this.closedHere.add(frame.id);
+    else if (frame.op === 'connect') this.closedHere.delete(frame.id);
     this.socket.write(encodeFrame(frame));
     return true;
   }
@@ -300,8 +310,10 @@ export class EngineLink extends EventEmitter {
   // the queue away: the engine reads our earlier frames, then a reset, and the
   // detach is gone — it still had the dead link's claim on the socket when the
   // next process said hello (#894, Linux). A FIN pushes the queue first; the
-  // engine reads to EOF and ends its side, which closes ours.
-  stop(): void {
+  // engine reads to EOF and ends its side, which closes ours. Resolves once the
+  // socket is closed, so a shutdown can wait for those bytes to leave before
+  // the process exits and the kernel closes the descriptor its own way.
+  stop(): Promise<void> {
     this.stopped = true;
     if (this.retryTimer) {
       clearTimeout(this.retryTimer);
@@ -310,13 +322,22 @@ export class EngineLink extends EventEmitter {
     this.stopHeartbeat();
     const socket = this.socket;
     this.socket = null;
-    if (!socket || socket.destroyed) return;
+    // Nothing routes from here on, and nothing waits on a link that is not
+    // coming back: frames the engine writes before it reads our FIN would
+    // otherwise still reach reconcile in a process that has torn its
+    // connections down.
+    if (this.state !== 'refused') this.state = 'down';
+    if (!socket || socket.destroyed) return Promise.resolve();
     socket.end();
-    // A peer that never answers the FIN would keep the handle (and, at
-    // shutdown, the process) around — bound it.
-    const timer = setTimeout(() => socket.destroy(), 2000);
-    timer.unref();
-    socket.once('close', () => clearTimeout(timer));
+    return new Promise((resolve) => {
+      // A peer that never answers the FIN would keep the handle around — bound
+      // it.
+      const timer = setTimeout(() => socket.destroy(), 2000);
+      socket.once('close', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
   }
 
   private startHeartbeat(socket: net.Socket): void {
@@ -376,6 +397,8 @@ export class EngineLink extends EventEmitter {
       );
     });
     socket.on('data', (chunk: string) => {
+      // A stopped link still reads to EOF; what arrives is not for us.
+      if (this.socket !== socket) return;
       this.lastFrameAt = Date.now();
       let frames: EngineToApp[];
       try {
@@ -391,6 +414,7 @@ export class EngineLink extends EventEmitter {
             sawHello = true;
             this.state = 'ready';
             this.heldSet.clear();
+            this.closedHere.clear();
             for (const id of frame.held) this.heldSet.add(id);
             this.engineVersion = frame.engine.version;
             // Older engines predate the field; absent means minor 1.
@@ -475,6 +499,9 @@ export class EngineLink extends EventEmitter {
         // A session the hello could not list, offered now that it is
         // unclaimed (protocol.ts). Not a transport's frame: nothing here has
         // claimed it — that is the point — so it goes to whoever reconciles.
+        // Unless this link already asked for it to be closed: that close is
+        // ahead of the offer on the wire, and the offer is stale.
+        if (this.closedHere.has(frame.id)) return;
         this.heldSet.add(frame.id);
         this.emit('held', frame.id);
         return;
@@ -532,6 +559,7 @@ export function startEngineLink(timeoutMs = 5000): Promise<LinkState> {
   });
 }
 
-export function stopEngineLink(): void {
-  EngineLink.shared().stop();
+// Resolves once the link's socket is closed (bounded; see EngineLink.stop).
+export function stopEngineLink(): Promise<void> {
+  return EngineLink.shared().stop();
 }

--- a/server/services/engineTransport.test.ts
+++ b/server/services/engineTransport.test.ts
@@ -50,7 +50,7 @@ afterAll(async () => {
   await ircd.close();
 });
 
-afterEach(() => {
+afterEach(async () => {
   for (const c of clients.splice(0)) {
     try {
       c.connection.end();
@@ -58,7 +58,7 @@ afterEach(() => {
       /* already gone */
     }
   }
-  for (const l of links.splice(0)) l.stop();
+  await Promise.all(links.splice(0).map((l) => l.stop()));
 });
 
 function newLink(secret = SECRET, port = enginePort): EngineLink {
@@ -195,10 +195,22 @@ describe('EngineTransport', () => {
     expect(a.t.events.at(-1)).toBe(`socket close:${ENGINE_CLOSE.LINK_LOST}`);
     linkA.stop();
 
+    // What happens while nobody is attached — and it has to have REACHED the
+    // engine before B attaches, or it is live traffic rather than backlog: a
+    // server's socket is free to hold small writes back behind an unacked one
+    // (Nagle), and a link that does not (setNoDelay) attaches well inside
+    // that window on Linux.
+    const buffered = () => engine.info(id)?.bufferedLines ?? 0;
+    const bufferedBefore = buffered();
     ircd.say('peer', '#two', 'while away 1');
     ircd.say('peer', 'moved', 'dm while away');
     ircd.setTopic('peer', '#two', 'set while away');
     ircd.say('peer', '#two', 'while away 2');
+    await until(
+      () => buffered() >= bufferedBefore + 4,
+      'the engine buffered the four lines',
+      () => [`buffered ${buffered()} (was ${bufferedBefore})`],
+    );
 
     // Process B: a fresh Client, configured with the STALE nick.
     const linkB = newLink();

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -144,7 +144,10 @@ function engineHolds(userId: number, networkId: number): boolean {
 
 class IrcManager extends EventEmitter {
   byUser: Map<number, Map<number, IrcConnection>>;
-  private engineReconcileHooked = false;
+  // The link whose 'ready' and 'held' events reconcile listens on — held so a
+  // link replaced under us (tests rebuild the singleton) is hooked afresh
+  // rather than left to the listeners on its predecessor.
+  private reconcileHookedLink: EngineLink | null = null;
 
   constructor() {
     super();
@@ -205,11 +208,15 @@ class IrcManager extends EventEmitter {
     for (const id of userIds) this.initForUser(id);
     if (engineConfigured()) {
       this.reconcileEngine();
-      // Again whenever the link (re)connects: an engine that answered after the
-      // boot-time wait, or came back from an outage, reports a fresh held list.
-      if (!this.engineReconcileHooked) {
-        this.engineReconcileHooked = true;
-        EngineLink.shared().on('ready', () => this.reconcileEngine());
+      // Again whenever the link (re)connects — an engine that answered after
+      // the boot-time wait, or came back from an outage, reports a fresh held
+      // list — and whenever the engine offers a session after that: one whose
+      // previous link was still on the books at hello and has since let go.
+      const link = EngineLink.shared();
+      if (this.reconcileHookedLink !== link) {
+        this.reconcileHookedLink = link;
+        link.on('ready', () => this.reconcileEngine());
+        link.on('held', () => this.reconcileEngine());
       }
     }
   }

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -216,7 +216,7 @@ class IrcManager extends EventEmitter {
       if (this.reconcileHookedLink !== link) {
         this.reconcileHookedLink = link;
         link.on('ready', () => this.reconcileEngine());
-        link.on('held', () => this.reconcileEngine());
+        link.on('held', (id: string) => this.reconcileHeld(link, id));
       }
     }
   }
@@ -230,39 +230,42 @@ class IrcManager extends EventEmitter {
   reconcileEngine(): void {
     const link = EngineLink.shared();
     if (link.state !== 'ready') return;
-    for (const id of link.held) {
-      // The engine only offers us our own instance's sessions, but this is
-      // where a foreign id would do its damage — parsed into someone else's
-      // rowids and adopted as ours — so check the prefix here too rather than
-      // trusting the other side to have filtered.
-      if (!isOurConnectionId(id)) {
-        console.warn(`[lurker] engine offered ${id}, which is not this instance's — ignoring`);
-        continue;
-      }
-      const m = /^[0-9a-f]+:(\d+):(\d+)$/.exec(id);
-      if (!m) continue;
-      const userId = Number(m[1]);
-      const networkId = Number(m[2]);
-      if (this.getConnection(userId, networkId)) continue;
-      const gate = this.connectGate(userId, networkId);
-      if (gate.ok) {
-        systemLog.log({
-          userId,
-          scope: `net:${gate.network.name}`,
-          fields: { networkId },
-          text: 'Adopting the connection the engine kept open',
-        });
-        this.startNetwork(userId, networkId);
-      } else {
-        console.warn(`[lurker] engine holds ${id} but ${gate.reason} — closing it`);
-        // requestClose, not a bare send: the link can drop between the check at
-        // the top of this loop and here, and a policy close that silently
-        // evaporates leaves a paused account on IRC. The queue is also what
-        // makes this decision stick — EngineLink flushes pending closes before
-        // it emits 'ready', i.e. before anything can decide those sockets are
-        // worth adopting.
-        link.requestClose(id);
-      }
+    for (const id of link.held) this.reconcileHeld(link, id);
+  }
+
+  // One held session: adopt it, close it, or leave it to the connection that
+  // already speaks for it.
+  private reconcileHeld(link: EngineLink, id: string): void {
+    // The engine only offers us our own instance's sessions, but this is
+    // where a foreign id would do its damage — parsed into someone else's
+    // rowids and adopted as ours — so check the prefix here too rather than
+    // trusting the other side to have filtered.
+    if (!isOurConnectionId(id)) {
+      console.warn(`[lurker] engine offered ${id}, which is not this instance's — ignoring`);
+      return;
+    }
+    const m = /^[0-9a-f]+:(\d+):(\d+)$/.exec(id);
+    if (!m) return;
+    const userId = Number(m[1]);
+    const networkId = Number(m[2]);
+    if (this.getConnection(userId, networkId)) return;
+    const gate = this.connectGate(userId, networkId);
+    if (gate.ok) {
+      systemLog.log({
+        userId,
+        scope: `net:${gate.network.name}`,
+        fields: { networkId },
+        text: 'Adopting the connection the engine kept open',
+      });
+      this.startNetwork(userId, networkId);
+    } else {
+      console.warn(`[lurker] engine holds ${id} but ${gate.reason} — closing it`);
+      // requestClose, not a bare send: the link can drop between the check
+      // above and here, and a policy close that silently evaporates leaves a
+      // paused account on IRC. The queue is also what makes this decision
+      // stick — EngineLink flushes pending closes before it emits 'ready',
+      // i.e. before anything can decide those sockets are worth adopting.
+      link.requestClose(id);
     }
   }
 

--- a/server/test-utils/engineHarness.ts
+++ b/server/test-utils/engineHarness.ts
@@ -98,7 +98,7 @@ export async function startEngineHarness(opts: {
     until: (pred, ms, what) => until(pred, ms, what, wireTail),
     async stop() {
       ircManager.shutdown();
-      EngineLink.resetForTests();
+      await EngineLink.resetForTests();
       await engine.shutdown('tests done', 500);
       await ircd.close();
       restoreEnv();


### PR DESCRIPTION
Fixes #894. **Engine change — `engine-1` moves on the next release** (protocol minor 3 → 4), alongside #889 and #888.

### What the CI failure actually was

The signature — the engine still holding a paused account's socket with the link `ready` and no connection object — was blamed on poll-batch ordering under a starved runner. The failed runs were not starved (the whole file ran in 6.3 s), and the ordering argument does not hold on a single host: the old link's `detach` is in the kernel before the new link's connect exists.

Reproduced in Docker Linux (4/12 runs; never once on a Mac) with an in-memory probe: the engine read the dead link's last two `write` frames, then a **reset**. The `detach` written right before `EngineLink.stop()`'s `socket.destroy()` never arrived. Nagle held that small write behind the unacked one before it; the descriptor was closed with unread inbound bytes (the restore's `line` frames), which Linux answers with an RST that purges the send queue. The corpse's claim was released only at its close event, after the next hello.

`server.ts` shuts down the same way (`ircManager.shutdown()` then `stopEngineLink()`), so a deploy could drop its last detach — harmless on a cell, where the next process starts seconds later — or a `close` a user's Disconnect had just become, which the next process would then re-adopt.

Found alongside: `createNetwork({ autoconnect: 0 })` stored **1**, so the test's "nobody autoconnects" network autoconnected and only its paused half ever exercised reconcile — which is why CI failed only there.

### Four commits

1. **`createNetwork`: a numeric 0 autoconnect means off.** Truthiness, default on for absent or null, like `trusted_certificates` one line up. Production callers pass booleans; four engine test files pass `0` and meant it. Route test pins `0` → off and `null` → on.
2. **Engine link: half-close on stop, and no Nagle on either end.** `stop()` does `end()` (2 s destroy fallback); both ends set `noDelay` — every frame is a line on its way to a person. New `engineLink.test.ts`: with unread data pending the engine must see a FIN and the last frames; the `destroy()` mutant sees a reset.
3. **Engine: offer a session released after hello.** The hello's list stays strict (the #864 reasoning stands). A session that becomes unclaimed after hello — its link died, detached it, or it registered with nobody attached — is offered as `{op:'held', id}`. App side: `EngineLink` routes `held`; `ircManager.initAll` hooks `ready` and `held` per link instance (the old one-shot boolean left the hook on an instance tests had replaced).
4. **Review round** (`/code-review high`, nine findings, six taken). The first cut fenced the offer behind an engine→app ping; the review showed that only orders a close sent *before* the pong — a Disconnect landing between the pong and the offer's arrival is the same race one round trip later. The guard now lives where it is exact: **the app drops a `held` for an id it has sent a `close` for on this link** (`closedHere`, cleared by a `connect` for the id and at the next hello), because frames on a link are read in order. Also: shutdown waits for the link's socket to close before `server.close` (with no client connected, `server.close` calls back on the next tick and `process.exit` would close the descriptor before libuv issued the queued `shutdown(2)` — the same reset by another road); a stopped link goes `down` and stops routing; a mid-registration detach is not offered back to its own link; `held` reconciles one id rather than the whole list per frame. Not taken: a shared `gracefulEnd` helper across three files (its own change).

### Verification

- Five engine cases, five link cases, one integration case (a bare `TestLink` corpse that attaches, then dies without a word: adopted, and for a paused account closed, without a restart), one route case. Mutants killed: no `closedHere` check, no `down` state, no data guard after stop, `except: null` on the registration offer, `destroy()` in `stop()`.
- Docker Linux, the engine/link/route test files ×12: **12/12 green** against a 4/12 baseline on `main`.
- `npm run check` and the full `npm test` (313 files, 4537 tests) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBmPG3L7g7S34otzrU3Kkm
