### PR TITLE
bouncer: trim the replayed welcome burst's tags to the client's caps

### DIFF
--- a/server/services/bouncer.integration.test.ts
+++ b/server/services/bouncer.integration.test.ts
@@ -65,6 +65,58 @@ describe('PASS login (ZNC-compat floor)', () => {
   });
 });
 
+// #892. The attach burst replays the network's own 001–005 as they came off the
+// wire, so a server-time upstream hands us each one behind a tag block. Those
+// tags answer to this client's caps like any relayed line, and the numeric
+// still has to be pointed at the nick the client asked for.
+describe('replayed registration burst', () => {
+  const TIME = '2026-09-06T05:04:37.800Z';
+
+  function seedTaggedBurst(acct: import('../test-utils/bouncerHarness.js').HarnessAccount): void {
+    const nick = acct.upstream.currentNick;
+    acct.upstream.registrationLines = [
+      `@time=${TIME} :irc.example.test 001 ${nick} :Welcome to the Example IRC Network`,
+      `@time=${TIME} :irc.example.test 005 ${nick} CHANTYPES=# PREFIX=(ov)@+ :are supported by this server`,
+    ];
+  }
+
+  it('strips the tags for a client that requested no caps', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'livenick' });
+    seedTaggedBurst(acct);
+    const c = await harness.connect();
+    // The reporter's exchange: list the caps, request none.
+    c.send('CAP LS 302');
+    c.send(`PASS ${acct.user.username}:${acct.password}`);
+    c.send('NICK client');
+    c.send('USER client 0 * :client');
+    c.send('CAP END');
+    await c.waitForCommand('422');
+    expect(c.lines.filter((l) => l.startsWith('@'))).toEqual([]);
+    expect(await c.waitForCommand('001')).toBe(
+      ':irc.example.test 001 client :Welcome to the Example IRC Network',
+    );
+    expect(await c.waitForCommand('005')).toBe(
+      ':irc.example.test 005 client CHANTYPES=# PREFIX=(ov)@+ :are supported by this server',
+    );
+  });
+
+  it('keeps the time tag for a server-time client, and rewrites the nick past it', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'livetime' });
+    seedTaggedBurst(acct);
+    const c = await harness.connect();
+    c.send('CAP LS 302');
+    c.send('CAP REQ :server-time');
+    c.send(`PASS ${acct.user.username}:${acct.password}`);
+    c.send('NICK client');
+    c.send('USER client 0 * :client');
+    c.send('CAP END');
+    await c.waitForCommand('422');
+    expect(await c.waitForCommand('001')).toBe(
+      `@time=${TIME} :irc.example.test 001 client :Welcome to the Example IRC Network`,
+    );
+  });
+});
+
 function saslPlain(authcid: string, passwd: string, authzid = ''): string {
   const NUL = String.fromCharCode(0);
   return Buffer.from([authzid, authcid, passwd].join(NUL), 'utf8').toString('base64');

--- a/server/services/bouncer.integration.test.ts
+++ b/server/services/bouncer.integration.test.ts
@@ -65,20 +65,37 @@ describe('PASS login (ZNC-compat floor)', () => {
   });
 });
 
-// #892. The attach burst replays the network's own 001–005 as they came off the
-// wire, so a server-time upstream hands us each one behind a tag block. Those
-// tags answer to this client's caps like any relayed line, and the numeric
-// still has to be pointed at the nick the client asked for.
+// #892. The attach burst replays the network's own 001–005, saved at
+// registration exactly as they came off the wire. Per-delivery tags on them are
+// stale by the time a client attaches, so, like ZNC, the replay keeps at most
+// `time`, and only for a server-time client. The numeric still has to be
+// pointed at the nick the client asked for.
 describe('replayed registration burst', () => {
   const TIME = '2026-09-06T05:04:37.800Z';
 
   function seedTaggedBurst(acct: import('../test-utils/bouncerHarness.js').HarnessAccount): void {
     const nick = acct.upstream.currentNick;
     acct.upstream.registrationLines = [
-      `@time=${TIME} :irc.example.test 001 ${nick} :Welcome to the Example IRC Network`,
-      `@time=${TIME} :irc.example.test 005 ${nick} CHANTYPES=# PREFIX=(ov)@+ :are supported by this server`,
+      `@time=${TIME};msgid=w1 :irc.example.test 001 ${nick} :Welcome to the Example IRC Network`,
+      `@time=${TIME};msgid=w5 :irc.example.test 005 ${nick} CHANTYPES=# PREFIX=(ov)@+ :are supported by this server`,
     ];
   }
+
+  it('keeps only the time tag for a message-tags client', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'livetags' });
+    seedTaggedBurst(acct);
+    const c = await harness.connect();
+    c.send('CAP LS 302');
+    c.send('CAP REQ :message-tags server-time');
+    c.send(`PASS ${acct.user.username}:${acct.password}`);
+    c.send('NICK client');
+    c.send('USER client 0 * :client');
+    c.send('CAP END');
+    await c.waitForCommand('422');
+    expect(await c.waitForCommand('001')).toBe(
+      `@time=${TIME} :irc.example.test 001 client :Welcome to the Example IRC Network`,
+    );
+  });
 
   it('strips the tags for a client that requested no caps', async () => {
     const acct = harnessMod.seedAccount({ nick: 'livenick' });

--- a/server/services/bouncer.test.ts
+++ b/server/services/bouncer.test.ts
@@ -264,6 +264,16 @@ describe('rewriteNumericTarget', () => {
       ':server 001 me :Welcome\r',
     );
   });
+
+  it('rewrites past a leading tag block, keeping the tags', () => {
+    expect(rewriteNumericTarget('@time=2026-09-06T05:04:37.800Z :server 001 old :Hi', 'me')).toBe(
+      '@time=2026-09-06T05:04:37.800Z :server 001 me :Hi',
+    );
+  });
+
+  it('leaves a tagged line with no prefix unchanged', () => {
+    expect(rewriteNumericTarget('@time=x PING :x', 'me')).toBe('@time=x PING :x');
+  });
 });
 
 describe('filterRelayLine', () => {

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -360,36 +360,51 @@ export function parseBouncerCredentials(
   return { username: parsed.username, secret, network };
 }
 
-// Rewrite the target-nick param of a server numeric (`:prefix NNN nick …`).
+// Rewrite the target-nick param of a server numeric (`[@tags ]:prefix NNN nick …`).
 // Used to point the replayed registration burst at whatever nick the attaching
-// client asked for, ZNC-style, before we NICK it over to the live one.
+// client asked for, ZNC-style, before we NICK it over to the live one. The burst
+// is stored as it came off the wire, so a leading tag block is stepped over
+// rather than read as an unprefixed line (#892).
 export function rewriteNumericTarget(line: string, nick: string): string {
   // [\s\S] instead of `.` so a stray trailing CR can't stop the tail group
   // short of `$` and silently skip the rewrite.
-  const m = /^(:\S+ \S+ )\S+([\s\S]*)$/.exec(line);
+  const m = /^((?:@\S+ )?:\S+ \S+ )\S+([\s\S]*)$/.exec(line);
   if (!m) return line;
   return `${m[1]}${nick}${m[2]}`;
 }
 
+// Trim a line's IRCv3 tag block to what the client negotiated: everything for
+// message-tags, just `time` for server-time, nothing otherwise. Returns null for
+// a tag block with no message after it.
+function trimTagsForClient(line: string, caps: ReadonlySet<string>): string | null {
+  if (!line.startsWith('@')) return line;
+  const sp = line.indexOf(' ');
+  if (sp === -1) return null;
+  if (caps.has('message-tags')) return line;
+  const tags = line.slice(1, sp);
+  const rest = line.slice(sp + 1);
+  if (caps.has('server-time')) {
+    const time = tags.split(';').find((t) => t === 'time' || t.startsWith('time='));
+    if (time) return `@${time} ${rest}`;
+  }
+  return rest;
+}
+
 /**
  * Filter one raw upstream line for an attached client: drop connection
- * plumbing, drop tag-only commands the client can't parse, and strip message
- * tags down to what the client negotiated (everything for message-tags, just
- * `time` for server-time, nothing otherwise). Returns null to drop the line.
+ * plumbing, drop tag-only commands the client can't parse, and trim message
+ * tags to what the client negotiated. Returns null to drop the line.
  */
 export function filterRelayLine(line: string, caps: ReadonlySet<string>): string | null {
   // irc-framework's raw event line keeps its trailing CR — strip it so the
   // relayed copy doesn't carry a stray control char into our own CRLF framing.
   line = line.replace(/[\r\n]+$/, '');
-  let tags = '';
-  let rest = line;
-  if (rest.startsWith('@')) {
-    const sp = rest.indexOf(' ');
+  let afterPrefix = line;
+  if (afterPrefix.startsWith('@')) {
+    const sp = afterPrefix.indexOf(' ');
     if (sp === -1) return null;
-    tags = rest.slice(1, sp);
-    rest = rest.slice(sp + 1);
+    afterPrefix = afterPrefix.slice(sp + 1);
   }
-  let afterPrefix = rest;
   if (afterPrefix.startsWith(':')) {
     const sp = afterPrefix.indexOf(' ');
     if (sp === -1) return null;
@@ -398,13 +413,7 @@ export function filterRelayLine(line: string, caps: ReadonlySet<string>): string
   const command = (afterPrefix.split(' ', 1)[0] || '').toUpperCase();
   if (RELAY_DROP.has(command)) return null;
   if ((command === 'TAGMSG' || command === 'BATCH') && !caps.has('message-tags')) return null;
-  if (!tags) return line;
-  if (caps.has('message-tags')) return line;
-  if (caps.has('server-time')) {
-    const time = tags.split(';').find((t) => t === 'time' || t.startsWith('time='));
-    if (time) return `@${time} ${rest}`;
-  }
-  return rest;
+  return trimTagsForClient(line, caps);
 }
 
 // Default IRC prefix ladder, used when the network's ISUPPORT PREFIX isn't
@@ -1164,8 +1173,11 @@ class BouncerSession {
     // the network's own 001–005 when we have them so the client sees the real
     // ISUPPORT tokens (CHANTYPES/PREFIX/NETWORK drive its parsing).
     if (conn.state === 'connected' && conn.registrationLines.length > 0) {
+      // Stored with the upstream's tags, which answer to this client's caps
+      // like any relayed line (#892).
       for (const line of conn.registrationLines) {
-        this.write(rewriteNumericTarget(line, requested));
+        const out = trimTagsForClient(line, this.caps);
+        if (out) this.write(rewriteNumericTarget(out, requested));
       }
     } else {
       this.writeWelcomeNumerics(requested);

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -1173,10 +1173,12 @@ class BouncerSession {
     // the network's own 001–005 when we have them so the client sees the real
     // ISUPPORT tokens (CHANTYPES/PREFIX/NETWORK drive its parsing).
     if (conn.state === 'connected' && conn.registrationLines.length > 0) {
-      // Stored with the upstream's tags, which answer to this client's caps
-      // like any relayed line (#892).
+      // Saved at registration with the upstream's tags, so any per-delivery tag
+      // on them (msgid, batch) is stale by now. Like ZNC, the replay keeps at
+      // most `time`, and only for a server-time client (#892).
+      const burstCaps = new Set(this.caps.has('server-time') ? ['server-time'] : []);
       for (const line of conn.registrationLines) {
-        const out = trimTagsForClient(line, this.caps);
+        const out = trimTagsForClient(line, burstCaps);
         if (out) this.write(rewriteNumericTarget(out, requested));
       }
     } else {


### PR DESCRIPTION
Fixes #892

A client that attached without negotiating any caps got the network's 001–005 lines with the upstream's `@time=` tag still on them.

The attach burst replays those lines exactly as `IrcConnection` saved them off the wire. When the network has server-time on, they're tagged, and unlike the live relay, the replay never trimmed the tags to the client's caps.

- Tag trimming moves out of `filterRelayLine` into `trimTagsForClient`. The live relay uses it with the client's caps.
- The burst replay keeps at most `time`, and only for a server-time client, whatever else the client negotiated. The lines are saved at registration, so per-delivery tags like `msgid` or `batch` are stale by the time anyone attaches. This matches ZNC, which drops every tag except `time` from its buffered 001–005 (`src/Buffer.cpp`, `CBufLine::GetLine`). soju builds its own welcome with no network tags at all.
- `rewriteNumericTarget` now skips over a leading tag block. Before, a tagged 001–005 line kept the network's nick instead of the one the client asked for.
- One change for malformed input: clients without `message-tags` no longer receive an empty tag block (`@ …`). `message-tags` clients still get the network's tags as-is, as before. ZNC and soju both parse `@ ` into a tag with an empty key and can write it back out to such a client too.

## Tests
- `bouncer.integration.test.ts`: the reporter's exchange (`CAP LS 302`, then `CAP END` with nothing requested) gets untagged 001/005 aimed at its nick. A server-time client keeps `@time` with the nick rewritten. A `message-tags` + `server-time` client gets only `@time` when the saved line also carries a `msgid`. Each test failed before its fix.
- `bouncer.test.ts`: `rewriteNumericTarget` on tagged lines.
- `npm run check` passes, and the full suite passes locally (318 files, 4,664 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013H7SZ5oDRRE5sPBGn4dZq2
