### PR TITLE
Fix stale isChannelJoined cache during engine-restore late PART

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -41,6 +41,7 @@ import {
   ensureOpen as ensureBufferOpen,
   seedAutojoinChannel,
   listForNetwork as listBufferRowsForNetwork,
+  close as closeBuffer,
 } from '../db/buffers.js';
 import { getPeerPresence, writePeerState } from '../db/peerPresence.js';
 import { setUserSetting, deleteUserSetting } from '../db/settings.js';
@@ -4325,6 +4326,101 @@ describe('join echo, forwarded joins (470), and un-partable channels (442)', () 
     });
 
     expect(getBuffer(conn.network.user_id, conn.network.id, '#apple')?.autojoin).toBe(false);
+  });
+});
+
+// Regression pin for a bug in the engine-restore "late PART" correction: it
+// used to delete the channel without nulling joinedFoldedCache, so a warm
+// cache kept answering "still joined". engineIntegration.test.ts covers this
+// branch too but via until(), which only proves eventual consistency — the
+// corrective PART's echo re-nulls the cache moments later through a
+// different, already-correct path, hiding the regression. These tests read
+// isChannelJoined() synchronously, same tick as the delete, before that echo
+// could arrive.
+describe('engine-restore late PART keeps isChannelJoined in sync (#stale-cache)', () => {
+  function makeConn(name: string): IrcConnection {
+    const network = createNetwork(1, {
+      name,
+      host: 'irc.example.test',
+      port: 6697,
+      tls: 1,
+      trusted_certificates: 1,
+      nick: 'nick',
+      username: null,
+      realname: null,
+      server_password: null,
+      autoconnect: 0,
+      sasl_account: null,
+      sasl_password: null,
+      connect_commands: null,
+    })!;
+    return new IrcConnection({ network, onEvent: () => {} });
+  }
+
+  it('reports not-joined immediately for an un-autojoined channel, even with a warm cache', () => {
+    const conn = makeConn('restore-late-part-autojoin');
+    conn.client.user.nick = 'me';
+    // Survived the engine's attach-time live-channel diff (still really
+    // joined on the ircd), but the row says we left it while disconnected.
+    conn.upsertChannel('#leaving');
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#leaving', {
+      kind: 'channel',
+      autojoin: false,
+    });
+    conn.restoring = true;
+
+    // Warm the cache BEFORE the synthesised join, the way some other probe
+    // earlier in a real restore plausibly would — this is the state the
+    // stale-cache bug needed in order to bite.
+    expect(conn.isChannelJoined('#leaving')).toBe(true);
+
+    conn.client.emit('join', { channel: '#leaving', nick: 'me' });
+
+    // No await, no timer: this is the value in the exact tick the delete
+    // happens, before anything — including the raw PART this branch fires —
+    // gets a chance to correct it a different way.
+    expect(conn.channels.has('#leaving')).toBe(false);
+    expect(conn.isChannelJoined('#leaving')).toBe(false);
+  });
+
+  it('reports not-joined immediately for a closed-but-still-autojoined channel, even with a warm cache', () => {
+    const conn = makeConn('restore-late-part-closed');
+    conn.client.user.nick = 'me';
+    conn.upsertChannel('#leaving');
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#leaving', {
+      kind: 'channel',
+      autojoin: true,
+    });
+    closeBuffer(conn.network.user_id, conn.network.id, '#leaving');
+    conn.restoring = true;
+
+    expect(conn.isChannelJoined('#leaving')).toBe(true);
+
+    conn.client.emit('join', { channel: '#leaving', nick: 'me' });
+
+    expect(conn.channels.has('#leaving')).toBe(false);
+    expect(conn.isChannelJoined('#leaving')).toBe(false);
+  });
+
+  it('leaves an untouched channel joined and cached', () => {
+    const conn = makeConn('restore-late-part-sibling');
+    conn.client.user.nick = 'me';
+    conn.upsertChannel('#leaving');
+    conn.upsertChannel('#stay');
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#leaving', {
+      kind: 'channel',
+      autojoin: false,
+    });
+    ensureBufferOpen(conn.network.user_id, conn.network.id, '#stay', {
+      kind: 'channel',
+      autojoin: true,
+    });
+    conn.restoring = true;
+    expect(conn.isChannelJoined('#stay')).toBe(true);
+
+    conn.client.emit('join', { channel: '#leaving', nick: 'me' });
+
+    expect(conn.isChannelJoined('#stay')).toBe(true);
   });
 });
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -539,10 +539,14 @@ export class IrcConnection {
   onEvent: (event: EnrichedEvent) => void;
   client: IrcClient;
   state: string;
+  /** Mutate only through setChannel/deleteChannel — never `.set`/`.delete`
+   *  directly — so joinedFoldedCache can't drift from what's actually in
+   *  here. Reads (`.get`, `.values()`, `.has()`, iteration) are fine raw. */
   channels: Map<string, ChannelState>;
   /** Lazily-built per-network-folded index over `channels` for
-   *  isChannelJoined. null = rebuild on next probe. MUST be nulled by every
-   *  channels-map mutation and by a CASEMAPPING change (the folds move). */
+   *  isChannelJoined. null = rebuild on next probe. Nulled by setChannel/
+   *  deleteChannel on every mutation, and separately by a CASEMAPPING change
+   *  (the folds move even though membership doesn't). */
   joinedFoldedCache: Set<string> | null;
   // Join keys awaiting their echo, keyed by lowercased channel. Nothing is
   // persisted on a join REQUEST (the buffers row is echo-written), so the key
@@ -2280,7 +2284,7 @@ export class IrcConnection {
           row &&
           (!row.autojoin || isBufferClosed(this.network.user_id, this.network.id, eventChannel))
         ) {
-          this.channels.delete(eventChannel.toLowerCase());
+          this.deleteChannel(eventChannel.toLowerCase());
           try {
             c.raw('PART', eventChannel);
           } catch (_) {
@@ -2400,8 +2404,7 @@ export class IrcConnection {
       // branch now lowers autojoin, so a server that echoes our nick in the
       // PART prefix with different casing must not skip the correction.
       if (c.user.nick && eventNick.toLowerCase() === c.user.nick.toLowerCase()) {
-        this.channels.delete(eventChannel.toLowerCase());
-        this.joinedFoldedCache = null;
+        this.deleteChannel(eventChannel.toLowerCase());
         // The echo lowers autojoin, not just ircManager.partChannel. That path
         // is the app's own /part and buffer-close, so a PART Lurker did not
         // originate — a raw /quote PART, another client on the bouncer, a
@@ -2450,8 +2453,7 @@ export class IrcConnection {
       // Lowering autojoin also prevents the reconnect replay — rejoining a
       // channel that just kicked you reads as ban evasion to ops.
       if (eventKicked && c.user.nick && eventKicked.toLowerCase() === c.user.nick.toLowerCase()) {
-        this.channels.delete(eventChannel.toLowerCase());
-        this.joinedFoldedCache = null;
+        this.deleteChannel(eventChannel.toLowerCase());
         try {
           setBufferAutojoin(this.network.user_id, this.network.id, channel, false);
         } catch (_) {
@@ -3900,8 +3902,7 @@ export class IrcConnection {
   // nothing.
   private evictChannel(name: string, { forget = false }: { forget?: boolean } = {}): void {
     const canonical = canonicalChannelTarget(name, this.channels) ?? name;
-    this.channels.delete(name.toLowerCase());
-    this.joinedFoldedCache = null;
+    this.deleteChannel(name.toLowerCase());
     let favoritesChanged = false;
     try {
       if (forget && !hasMessageForTarget(this.network.id, canonical)) {
@@ -3976,13 +3977,25 @@ export class IrcConnection {
     return undefined;
   }
 
+  // setChannel and deleteChannel exist so that we don't forget to null
+  // joinedFoldedCache.
+  private setChannel(key: string, ch: ChannelState): void {
+    this.channels.set(key, ch);
+    this.joinedFoldedCache = null;
+  }
+
+  private deleteChannel(key: string): boolean {
+    const deleted = this.channels.delete(key);
+    if (deleted) this.joinedFoldedCache = null;
+    return deleted;
+  }
+
   upsertChannel(name: string): ChannelState {
     const key = name.toLowerCase();
     let ch = this.channels.get(key);
     if (!ch) {
       ch = { name, topic: null, members: new Map(), modes: new Set() };
-      this.channels.set(key, ch);
-      this.joinedFoldedCache = null;
+      this.setChannel(key, ch);
     }
     if (!ch.modes) ch.modes = new Set();
     return ch;
@@ -4388,8 +4401,7 @@ export class IrcConnection {
         const live = new Set((info.channels ?? []).map((c) => c.toLowerCase()));
         for (const [key, ch] of this.channels) {
           if (live.has(key)) continue;
-          this.channels.delete(key);
-          this.joinedFoldedCache = null;
+          this.deleteChannel(key);
           this.publish({ type: 'channel-parted', target: ch.name });
         }
         const away = info.detachedForMs


### PR DESCRIPTION
When the engine-restore replay discovers a synthesized JOIN is for a channel that was actually closed/parted while the app was disconnected, it deletes the channel from IrcConnection.channels and sends a corrective PART, but never nulled joinedFoldedCache — the lazily-built index isChannelJoined() reads from. Every other channel-removal site (self-part, self-kick, evictChannel) pairs the delete with a cache invalidation; this one didn't, violating the documented invariant on joinedFoldedCache ("MUST be nulled by every channels-map mutation").

Create two methods (setChannel, deleteChannel) that invalidate joinedFoldedCache.

This should be the root cause of the intermittent "reconnect doesn't rejoin a channel, but the UI still shows it as joined" symptom, and should also help #908.