### PR TITLE
OAuth sign-in for third-party clients (#891)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -29,6 +29,7 @@ export default defineConfig({
         text: 'Developers',
         items: [
           { text: 'Client Protocol & API', link: '/CLIENT_PROTOCOL' },
+          { text: 'OAuth', link: '/OAUTH' },
           { text: 'MCP & HTTP API', link: '/MCP' },
           { text: 'IRCv3 Support', link: '/IRCV3' },
         ],
@@ -62,6 +63,7 @@ export default defineConfig({
           text: 'Developers',
           items: [
             { text: 'Client Protocol & API', link: '/CLIENT_PROTOCOL' },
+            { text: 'OAuth', link: '/OAUTH' },
             { text: 'Client Migration: 1.1.x → 2.0', link: '/MIGRATION_2_0' },
             { text: 'Client Migration: Search → REST', link: '/MIGRATION_SEARCH_REST' },
             { text: 'MCP & HTTP API', link: '/MCP' },

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -59,8 +59,10 @@ behind them, and the endpoints aren't mounted, so a toggle would do nothing.
 `linkPreviews` gates `chat.inline_media.enabled`, `chat.link_previews.enabled`,
 and the `/api/link-preview/*` endpoints.
 
-Node edition disables `/api/api-tokens`, `/mcp`, and `/uploads/*` static serving;
-standalone has no `/api/node/*`. The WS protocol itself is identical in both.
+Node edition disables `/api/api-tokens`, `/mcp`, the OAuth endpoints
+(`/api/oauth/*` and `/.well-known/oauth-authorization-server`), and `/uploads/*`
+static serving; standalone has no `/api/node/*`. The WS protocol itself is
+identical in both.
 Health check: `GET /api/health` → `{"status":"ok","time":"<ISO 8601>"}` (no
 auth, no version).
 
@@ -90,13 +92,15 @@ no feature flags on the socket.
 
 ## 3. Authentication
 
-Two credentials open every door (REST and WS); both resolve to the same
-`sessions` row:
+Three credentials open every door (REST and WS) with the same access. The cookie
+and the minted token resolve to the same `sessions` row; an OAuth access token
+belongs to an app the member approved:
 
-| Credential                      | Who uses it          | How                                                                                    |
-| ------------------------------- | -------------------- | -------------------------------------------------------------------------------------- |
-| Signed cookie `lurker_session`  | Browsers             | Set by the login endpoints; `httpOnly`, `SameSite=Lax`, 30-day                         |
-| `Authorization: Bearer <token>` | Native / TUI clients | Token from the mint endpoints below; sent on every REST call **and on the WS upgrade** |
+| Credential                             | Who uses it                      | How                                                                                    |
+| -------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------- |
+| Signed cookie `lurker_session`         | Browsers                         | Set by the login endpoints; `httpOnly`, `SameSite=Lax`, 30-day                         |
+| `Authorization: Bearer <token>`        | Native / TUI clients             | Token from the mint endpoints below; sent on every REST call **and on the WS upgrade** |
+| `Authorization: Bearer <access token>` | Third-party clients, self-hosted | Access token from the OAuth flow (§3.2); sent exactly like the minted token            |
 
 Browsers can't set headers on a WS upgrade, hence the cookie path. Native clients
 should use Bearer exclusively.
@@ -107,7 +111,7 @@ should use Bearer exclusively.
 POST /api/auth/login/token          (no auth; failure-throttled)
 { "username": "...", "password": "..." }
 → 200 { "token": "...", "expiresAt": "<ISO8601>", "user": { "id", "username", "role" } }
-→ 401 invalid credentials · 429 throttled (see §3.4)
+→ 401 invalid credentials · 429 throttled (see §3.5)
 ```
 
 The token is an opaque 32-byte base64url session token (`routes/auth.ts:558`,
@@ -125,7 +129,17 @@ The token is an opaque 32-byte base64url session token (`routes/auth.ts:558`,
   until it sets a password (`PUT /api/auth/password`). Surface that case: the
   mint endpoint just returns 401.
 
-### 3.2 Hosted (`app.lurker.chat`): mint at the control plane
+### 3.2 Self-hosted: OAuth for third-party clients
+
+A self-hosted server is also an OAuth 2 authorization server: the app registers
+itself, the member approves it in the browser, and the app exchanges a one-time
+code (PKCE `S256`) for an access token. The token has the same access as the
+minted token above and is sent the same way, but it never expires. The app never
+handles the password, so this is the recommended path for third-party clients,
+and it works for passkey-only accounts — see
+[OAuth for third-party clients](OAUTH.md).
+
+### 3.3 Hosted (`app.lurker.chat`): mint at the control plane
 
 ```
 POST https://app.lurker.chat/_cp/auth/app/login     (no auth)
@@ -141,7 +155,7 @@ reset invalidates every session, via the session epoch); there is no per-device
 revoke on hosted. After minting, use the token exactly as in §3.1 — same header,
 same endpoints — the control plane proxies you to the right cell transparently.
 
-### 3.3 Browser flows (for completeness)
+### 3.4 Browser flows (for completeness)
 
 WebAuthn/passkey and password login endpoints (`/api/auth/setup*`, `/invite/*`,
 `/login/options|verify|password`, `/passkeys*`) set the `lurker_session` cookie
@@ -150,12 +164,13 @@ them. `GET /api/auth/auth-methods` → `{passkey:boolean}` tells a login form wh
 to offer. `GET /api/auth/me` → `{user:{id,username,role,is_paused}}` validates a
 session.
 
-### 3.4 Cross-cutting auth behavior
+### 3.5 Cross-cutting auth behavior
 
 - **401 semantics:** any `401` from `/api/*` or a refused WS upgrade means _dead
   session_ — clear the stored token and return to login. The server deliberately
   never uses 401 for downstream failures (upload provider errors are 502/400),
-  so you can trust it.
+  so you can trust it. Exception: `401 invalid_client` from `/api/oauth/token`
+  or `/api/oauth/revoke` (§3.2) rejects the app's `client_id`, not the session.
 - **Rate limiting:** credential endpoints allow 10 failures / 15 min / IP →
   `429` + `Retry-After`; the whole `/api/auth` router is capped at 60 req/min/IP.
   Honor `Retry-After`.
@@ -1300,7 +1315,7 @@ account_not_empty`). A mobile/TUI client can skip all of this.
   networks). Admin-gated; build against it only if you're making an admin tool.
 - `/api/api-tokens` + `/mcp` (standalone only) — a _separate_ Bearer namespace
   for MCP/automation. **Those tokens cannot open the WS**; don't confuse them
-  with session tokens.
+  with session tokens or OAuth access tokens (§3.2).
 - `/api/node/*` (node edition) — control-plane internal, fleet-secret gated.
 
 ---

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -1313,9 +1313,10 @@ account_not_empty`). A mobile/TUI client can skip all of this.
 
 - `/api/admin/*` — admin panel (users, invites, presence, instance uploaders/
   networks). Admin-gated; build against it only if you're making an admin tool.
-- `/api/api-tokens` + `/mcp` (standalone only) — a _separate_ Bearer namespace
-  for MCP/automation. **Those tokens cannot open the WS**; don't confuse them
-  with session tokens or OAuth access tokens (§3.2).
+- `/api/api-tokens` + `/mcp` (standalone only) — API tokens are a _separate_
+  Bearer namespace for MCP/automation. **They cannot open the WS**; don't
+  confuse them with session tokens or with OAuth access tokens (§3.2), which
+  `/mcp` also accepts.
 - `/api/node/*` (node edition) — control-plane internal, fleet-secret gated.
 
 ---

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -213,7 +213,21 @@ malformed envelope, unknown method, missing tool name.
 ### Claude Code
 
 Claude Code's MCP client speaks streamable HTTP natively, so the setup is a
-single command — no stdio bridge needed:
+single command — no stdio bridge needed. To sign in through your browser,
+add the server without a token:
+
+```sh
+claude mcp add --transport http lurker https://<your-lurker>/mcp
+```
+
+In a new session, run `/mcp`, pick `lurker` and choose **Authenticate**. Your
+browser opens Lurker's approval page; approve it and the tools load. If sign-in
+fails, check that `https://<your-lurker>/.well-known/oauth-authorization-server`
+gives your public URL as its `issuer`. Behind a reverse proxy that doesn't pass
+it through, set `PUBLIC_BASE_URL` (see [OAuth for third-party clients](OAUTH.md)).
+
+To use an API token instead, pass it as a header. Claude Code doesn't offer
+OAuth sign-in for a server that has an `Authorization` header set:
 
 ```sh
 claude mcp add --transport http lurker https://<your-lurker>/mcp \
@@ -221,8 +235,8 @@ claude mcp add --transport http lurker https://<your-lurker>/mcp \
 ```
 
 `claude mcp list` confirms the entry. MCP servers load at session start, so
-restart Claude Code (start a new session) before the eight Lurker tools
-appear in tool calls. To remove it later, `claude mcp remove lurker`.
+restart Claude Code (start a new session) before the Lurker tools appear in
+tool calls. To remove it later, `claude mcp remove lurker`.
 
 ### Claude Desktop
 
@@ -247,8 +261,8 @@ bridge to expose it as a local MCP stdio server:
 }
 ```
 
-After restarting Claude Desktop, the eight Lurker tools appear in the
-tool picker and can be invoked directly.
+After restarting Claude Desktop, the Lurker tools appear in the tool picker
+and can be invoked directly.
 
 ### curl roundtrip
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -47,6 +47,8 @@ their own account.
   is read-write here and works everywhere a password sign-in does. Its redirect
   URI has to follow the rules in [OAuth for third-party clients](OAUTH.md).
 
+While an account is paused, either credential gets the read tools only.
+
 There is no way to drive the browser-style stateful protocol (presence, drafts,
 snapshot resume) from an MCP client — that surface is deliberately out of scope.
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -35,13 +35,20 @@ Scopes are coarse on purpose. Per-verb scopes are not implemented because
 the threat model assumes the operator is the only person holding tokens for
 their own account.
 
-## Tokens are HTTP-only
+## API tokens and OAuth sign-in
 
-API tokens authenticate the HTTP endpoint (`/mcp` and `/api/api-tokens`). The
-WebSocket endpoint used by the browser is cookie-only and does not accept
-bearer tokens. There is no way to drive the browser-style stateful protocol
-(presence, drafts, snapshot resume) from an MCP client — that surface is
-deliberately out of scope.
+`/mcp` accepts two bearer credentials:
+
+- **An API token** from your settings, with the scope you chose. API tokens
+  don't open the WebSocket the browser uses.
+- **An OAuth access token.** An MCP client that looks for an OAuth server at
+  your Lurker's root can skip the token and sign in through your browser: it
+  finds the discovery document, registers itself, and you approve it. The token
+  is read-write here and works everywhere a password sign-in does. Its redirect
+  URI has to follow the rules in [OAuth for third-party clients](OAUTH.md).
+
+There is no way to drive the browser-style stateful protocol (presence, drafts,
+snapshot resume) from an MCP client — that surface is deliberately out of scope.
 
 ## Tools (MCP verbs)
 
@@ -288,6 +295,10 @@ row stays in the listing with a `revoked` marker (so you can see whether a
 specific name was previously issued and torn down). The token immediately
 stops authenticating against `/mcp`. There is no token rotation flow —
 revoke the old one and mint a new one.
+
+An MCP client that signed in with OAuth is revoked under **Settings →
+Authorized apps**. Its token stops working at once, and the client has to be
+approved again.
 
 ## What's not here
 

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -185,8 +185,10 @@ JSON with the same parameters is also accepted.
 { "access_token": "…", "token_type": "Bearer", "created_at": 1757462400 }
 ```
 
-There is no `expires_in` and no `refresh_token`. A code that fails any check is
-spent and can't be retried; start a new authorization. See [Errors](#errors).
+There is no `expires_in` and no `refresh_token`. A code that fails a check is
+spent and can't be retried; start a new authorization. A request refused before
+the code is looked at (`invalid_request`, `unsupported_grant_type`,
+`invalid_client`) leaves it usable. See [Errors](#errors).
 
 ## Use the token
 

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -1,0 +1,322 @@
+# OAuth for third-party clients
+
+A self-hosted Lurker is an OAuth 2 authorization server for third-party apps. It
+follows Mastodon's model: an app registers itself, the member signs in and
+approves it in the browser, and the app exchanges a one-time code for an access
+token. Hosted lurker.chat doesn't offer it.
+
+## The flow at a glance
+
+1. **Register** once per server: `POST /api/oauth/register` returns a
+   `client_id`.
+2. **Authorize:** make a PKCE verifier and challenge, then open the member's
+   browser at `/oauth/authorize`. The member approves.
+3. **Get the code** from the redirect to your `redirect_uri`, or have the member
+   paste it (out-of-band).
+4. **Exchange** the code: `POST /api/oauth/token` returns an `access_token`.
+5. **Use** the token: `Authorization: Bearer <access_token>` on REST calls and
+   the WebSocket.
+6. **Revoke** it with `POST /api/oauth/revoke`, or the member does it in
+   Settings.
+
+The access token:
+
+- **Access:** the same as a password sign-in — every REST route and the
+  WebSocket. There are no scopes; a `scope` parameter is ignored.
+- **Lifetime:** never expires. There are no refresh tokens; a token lasts until
+  it's revoked.
+- **Clients:** public only. There are no client secrets, and PKCE with `S256` is
+  required on every authorization.
+- **Platforms:** native, desktop and CLI apps. An app running in a web page on
+  another origin can't call the API: the CORS allowlist and the WebSocket origin
+  check refuse it.
+
+The password endpoint `POST /api/auth/login/token`
+([Client Protocol](CLIENT_PROTOCOL.md) §3.1) still works. Third-party clients
+should use OAuth instead, so the app never handles the password.
+
+## Discovery
+
+`GET /.well-known/oauth-authorization-server` (RFC 8414), no auth:
+
+```json
+{
+  "issuer": "https://irc.example.com",
+  "authorization_endpoint": "https://irc.example.com/oauth/authorize",
+  "token_endpoint": "https://irc.example.com/api/oauth/token",
+  "revocation_endpoint": "https://irc.example.com/api/oauth/revoke",
+  "registration_endpoint": "https://irc.example.com/api/oauth/register",
+  "response_types_supported": ["code"],
+  "grant_types_supported": ["authorization_code"],
+  "token_endpoint_auth_methods_supported": ["none"],
+  "revocation_endpoint_auth_methods_supported": ["none"],
+  "code_challenge_methods_supported": ["S256"],
+  "service_documentation": "https://docs.lurker.chat/OAUTH"
+}
+```
+
+`issuer` comes from `PUBLIC_BASE_URL` if the operator set it, otherwise from the
+request's `Host` or `X-Forwarded-Host` header.
+
+## Register
+
+RFC 7591. JSON, no auth.
+
+```
+POST /api/oauth/register
+Content-Type: application/json
+
+{
+  "client_name": "My Client",
+  "client_uri": "https://myclient.example",
+  "redirect_uris": ["com.example.myclient:/oauth"]
+}
+```
+
+| Field           | Required | Rules                                                                                               |
+| --------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `client_name`   | yes      | At most 60 characters. No control or text-direction characters.                                     |
+| `redirect_uris` | yes      | Non-empty array, at most 2000 characters in total. See [Redirect URIs](#redirect-uris).             |
+| `client_uri`    | no       | An http or https URL, at most 2000 characters. The approval page shows its host. It isn't verified. |
+
+`scope`, `grant_types`, `response_types` and `token_endpoint_auth_method` are
+ignored. The response states what you got.
+
+`201`:
+
+```json
+{
+  "client_id": "…",
+  "client_id_issued_at": 1757462400,
+  "client_name": "My Client",
+  "client_uri": "https://myclient.example",
+  "redirect_uris": ["com.example.myclient:/oauth"],
+  "grant_types": ["authorization_code"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none"
+}
+```
+
+A rejected registration is `400` with `invalid_redirect_uri` or
+`invalid_client_metadata`.
+
+**Limits.** 5 registrations per IP per 10 minutes, then `429` with a
+`Retry-After` header. While 1,000 registrations are waiting for approval, every
+registration gets `429 temporarily_unavailable`.
+
+**Keep the `client_id`.** A registration nobody approves within one hour is
+deleted; an approved app's registration is kept. Store `client_id` per server and
+reuse it. If a request later fails with `invalid_client`, register again.
+
+## Authorize
+
+### PKCE
+
+Make a new `code_verifier` for each authorization and derive the
+`code_challenge` from it (RFC 7636):
+
+| Value                   | Rule                                                              |
+| ----------------------- | ----------------------------------------------------------------- |
+| `code_verifier`         | 43–128 characters of `[A-Za-z0-9._~-]`. Keep it for the exchange. |
+| `code_challenge`        | `BASE64URL(SHA-256(code_verifier))`, no padding: 43 characters.   |
+| `code_challenge_method` | `S256`. `plain` is refused.                                       |
+
+RFC 7636's test vector, to check your implementation:
+
+```
+code_verifier   dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+code_challenge  E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+```
+
+### Open the approval page
+
+Open the member's browser at:
+
+```
+GET /oauth/authorize?client_id=…&redirect_uri=…&response_type=code
+    &code_challenge=…&code_challenge_method=S256&state=…
+```
+
+| Parameter               | Value                                                                                  |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| `client_id`             | From registration.                                                                     |
+| `redirect_uri`          | One of the registered redirect URIs, exactly. A loopback URI may use a different port. |
+| `response_type`         | `code`                                                                                 |
+| `code_challenge`        | From your verifier.                                                                    |
+| `code_challenge_method` | `S256`                                                                                 |
+| `state`                 | Optional, at most 1024 characters. Returned unchanged.                                 |
+
+The member signs in if needed (password or passkey) and sees the approval page:
+the app's name, its website host, that it gets full access, and where the
+approval goes. The page appears every time, even for an app the member approved
+before. An invalid request is shown as an error on the page and is never
+redirected.
+
+| Member   | Redirect URI                               | Out-of-band                      |
+| -------- | ------------------------------------------ | -------------------------------- |
+| Approves | `redirect_uri?code=…&state=…`              | The page shows the code.         |
+| Denies   | `redirect_uri?error=access_denied&state=…` | The page says access was denied. |
+
+Codes are single-use and expire after 10 minutes.
+
+## Exchange the code
+
+```
+POST /api/oauth/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code&client_id=…&code=…&redirect_uri=…&code_verifier=…
+```
+
+JSON with the same parameters is also accepted.
+
+| Parameter       | Value                                       |
+| --------------- | ------------------------------------------- |
+| `grant_type`    | `authorization_code`                        |
+| `client_id`     | From registration.                          |
+| `code`          | From the redirect, or pasted by the member. |
+| `redirect_uri`  | Identical to the one used at authorization. |
+| `code_verifier` | The verifier the challenge was made from.   |
+
+`200`, with `Cache-Control: no-store`:
+
+```json
+{ "access_token": "…", "token_type": "Bearer", "created_at": 1757462400 }
+```
+
+There is no `expires_in` and no `refresh_token`. A code that fails any check is
+spent and can't be retried; start a new authorization. See [Errors](#errors).
+
+## Use the token
+
+```
+Authorization: Bearer <access_token>
+```
+
+Send it on every REST call and on the WebSocket upgrade, exactly like the session
+token in [Client Protocol](CLIENT_PROTOCOL.md) §3.1 and §4.1. A `401` means the
+token was revoked: discard it and authorize again.
+
+## Revoke
+
+RFC 7009. Form-encoded or JSON, no auth.
+
+```
+POST /api/oauth/revoke
+Content-Type: application/x-www-form-urlencoded
+
+client_id=…&token=…
+```
+
+The response is `200` whenever `client_id` is known, whether or not the token
+existed. Only a token issued to that `client_id` is revoked. An unknown
+`client_id` gets `401 invalid_client`, and a missing parameter gets
+`400 invalid_request`. Revoking closes any WebSocket the token opened (close
+code `4001`) and deletes the push subscriptions registered with it.
+
+`POST /api/auth/logout` with `Authorization: Bearer <access_token>` does the same.
+
+The member can revoke any app under **Settings → Authorized apps**. Account
+recovery revokes every app; a normal password change doesn't.
+
+## Redirect URIs
+
+Each registered redirect URI must take one of these forms:
+
+| Form                      | Example                                                | Notes                                                                                                 |
+| ------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| https                     | `https://myclient.example/oauth/callback`              |                                                                                                       |
+| Loopback http             | `http://127.0.0.1/callback` or `http://[::1]/callback` | At authorization the port may differ (RFC 8252 §7.3); host, path and query must match.                |
+| Reverse-DNS custom scheme | `com.example.myclient:/oauth`                          | The scheme must contain a dot.                                                                        |
+| Out-of-band               | `urn:ietf:wg:oauth:2.0:oob`                            | The approval page shows the code for the member to paste into the app. For TUIs over SSH and similar. |
+
+Refused: fragments, userinfo, anything but printable ASCII, `localhost` by name,
+and plain `http` anywhere but loopback.
+
+At authorization, `redirect_uri` must match a registered URI exactly, except for
+the loopback port.
+
+## Errors
+
+OAuth errors are JSON: `{ "error": "…", "error_description": "…" }`.
+
+| Status | `error`                   | Endpoint      | When                                                                                                                              |
+| ------ | ------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| 400    | `invalid_client_metadata` | register      | `client_name` is missing or invalid, or `client_uri` is invalid.                                                                  |
+| 400    | `invalid_redirect_uri`    | register      | `redirect_uris` is missing, empty or too long, or holds a URI that isn't an allowed form.                                         |
+| 429    | `temporarily_unavailable` | register      | 1,000 registrations are waiting for approval.                                                                                     |
+| 400    | `invalid_request`         | token, revoke | A parameter is missing.                                                                                                           |
+| 400    | `unsupported_grant_type`  | token         | `grant_type` isn't `authorization_code`.                                                                                          |
+| 400    | `invalid_grant`           | token         | The code is unknown, expired or already used, or `client_id`, `redirect_uri` or `code_verifier` doesn't match. The code is spent. |
+| 401    | `invalid_client`          | token, revoke | Unknown `client_id`. Register again.                                                                                              |
+| 400    | `invalid_request`         | all           | The request body is malformed (`413` if it's too large). No `error_description`.                                                  |
+
+Registration also answers `429` with `Retry-After` past 5 registrations per IP
+per 10 minutes.
+
+A `401 invalid_client` rejects the `client_id`, not the member's sign-in. Don't
+treat it as a revoked token.
+
+Errors during authorization never reach the app. They're shown on the approval
+page; the only error sent to `redirect_uri` is `access_denied`.
+
+## Example: a CLI with out-of-band sign-in
+
+The out-of-band redirect needs no local listener, so this works over SSH. It
+uses `curl`, `openssl` and `jq`.
+
+```sh
+SERVER=https://irc.example.com
+OOB=urn:ietf:wg:oauth:2.0:oob
+
+# 1. Register once. Store CLIENT_ID for this server and reuse it.
+CLIENT_ID=$(curl -s "$SERVER/api/oauth/register" \
+  -H 'Content-Type: application/json' \
+  -d '{"client_name":"lurk-cli","redirect_uris":["urn:ietf:wg:oauth:2.0:oob"]}' \
+  | jq -r .client_id)
+
+# 2. A new PKCE verifier and challenge for this authorization.
+VERIFIER=$(openssl rand -base64 48 | tr -d '=+/\n' | cut -c1-64)
+CHALLENGE=$(printf %s "$VERIFIER" | openssl dgst -sha256 -binary \
+  | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+
+# 3. The member opens this URL, approves, and pastes the code the page shows.
+AUTHORIZE="$SERVER/oauth/authorize?response_type=code&client_id=$CLIENT_ID"
+AUTHORIZE="$AUTHORIZE&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob"
+AUTHORIZE="$AUTHORIZE&code_challenge=$CHALLENGE&code_challenge_method=S256"
+echo "Open $AUTHORIZE"
+printf 'Code: '
+read -r CODE
+
+# 4. Exchange the code for an access token.
+TOKEN=$(curl -s "$SERVER/api/oauth/token" \
+  --data-urlencode grant_type=authorization_code \
+  --data-urlencode client_id="$CLIENT_ID" \
+  --data-urlencode code="$CODE" \
+  --data-urlencode redirect_uri="$OOB" \
+  --data-urlencode code_verifier="$VERIFIER" \
+  | jq -r .access_token)
+
+# 5. Use it.
+curl -s "$SERVER/api/auth/me" -H "Authorization: Bearer $TOKEN"
+
+# 6. Revoke it.
+curl -s "$SERVER/api/oauth/revoke" \
+  --data-urlencode client_id="$CLIENT_ID" \
+  --data-urlencode token="$TOKEN"
+```
+
+## For operators
+
+- OAuth is for self-hosted (standalone) Lurker only. Hosted lurker.chat doesn't
+  offer it.
+- **Set `PUBLIC_BASE_URL` behind a reverse proxy.** The discovery document's
+  `issuer` and endpoint URLs come from it, and otherwise from the request's
+  `Host` or `X-Forwarded-Host` header.
+- **Set `LURKER_TRUST_PROXY=true` behind a reverse proxy you control.**
+  Registration is rate-limited per client IP. Without it, Lurker sees only the
+  proxy's IP and every client shares one limit. See
+  [Auth rate limiting behind a proxy](SELF_HOSTING.md#auth-rate-limiting-behind-a-proxy).
+- **Never add a third-party app's origin to `CORS_ORIGIN`.** That grants the app
+  cookie access to the whole API without the member approving it. Apps that run
+  in a web page on another origin aren't supported.

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -224,15 +224,15 @@ recovery revokes every app; a normal password change doesn't.
 
 Each registered redirect URI must take one of these forms:
 
-| Form                      | Example                                                | Notes                                                                                                 |
-| ------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
-| https                     | `https://myclient.example/oauth/callback`              |                                                                                                       |
-| Loopback http             | `http://127.0.0.1/callback` or `http://[::1]/callback` | At authorization the port may differ (RFC 8252 §7.3); host, path and query must match.                |
-| Reverse-DNS custom scheme | `com.example.myclient:/oauth`                          | The scheme must contain a dot.                                                                        |
-| Out-of-band               | `urn:ietf:wg:oauth:2.0:oob`                            | The approval page shows the code for the member to paste into the app. For TUIs over SSH and similar. |
+| Form                      | Example                                                                             | Notes                                                                                                 |
+| ------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| https                     | `https://myclient.example/oauth/callback`                                           |                                                                                                       |
+| Loopback http             | `http://127.0.0.1/callback`, `http://[::1]/callback` or `http://localhost/callback` | At authorization the port may differ (RFC 8252 §7.3); host, path and query must match.                |
+| Reverse-DNS custom scheme | `com.example.myclient:/oauth`                                                       | The scheme must contain a dot.                                                                        |
+| Out-of-band               | `urn:ietf:wg:oauth:2.0:oob`                                                         | The approval page shows the code for the member to paste into the app. For TUIs over SSH and similar. |
 
-Refused: fragments, userinfo, anything but printable ASCII, `localhost` by name,
-and plain `http` anywhere but loopback.
+Refused: fragments, userinfo, anything but printable ASCII, and plain `http`
+anywhere but loopback.
 
 At authorization, `redirect_uri` must match a registered URI exactly, except for
 the loopback port.

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -21,8 +21,9 @@ token. Hosted lurker.chat doesn't offer it.
 
 The access token:
 
-- **Access:** the same as a password sign-in — every REST route and the
-  WebSocket. There are no scopes; a `scope` parameter is ignored.
+- **Access:** the same as a password sign-in — every REST route, the WebSocket
+  and the MCP endpoint (`/mcp`, read-write). There are no scopes; a `scope`
+  parameter is ignored.
 - **Lifetime:** never expires. There are no refresh tokens; a token lasts until
   it's revoked.
 - **Clients:** public only. There are no client secrets, and PKCE with `S256` is

--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect, afterAll, afterEach, vi } from 'vitest';
-import { existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import type { Express } from 'express';
 import { setupTestDb, testRequest, TEST_SESSION_SECRET } from './test-utils/testApp.js';
@@ -14,7 +15,17 @@ import { setupTestDb, testRequest, TEST_SESSION_SECRET } from './test-utils/test
 // standalone) rather than just that a route happens to be missing.
 const ctx = setupTestDb('app-gating');
 
-afterAll(() => ctx.cleanup());
+// CI runs the suite without building vue_client (.github/workflows/test.yml), so
+// the app serves a one-file stand-in for dist/. The SPA fallback, and the headers
+// it sets on the OAuth approval page, are then checked on every run rather than
+// skipped wherever no build happens to exist.
+const clientDist = mkdtempSync(path.join(os.tmpdir(), 'lurker-client-dist-'));
+writeFileSync(path.join(clientDist, 'index.html'), '<!doctype html><div id="app"></div>\n');
+
+afterAll(() => {
+  ctx.cleanup();
+  rmSync(clientDist, { recursive: true, force: true });
+});
 afterEach(() => {
   delete process.env.LURKER_EDITION;
 });
@@ -23,7 +34,7 @@ async function buildFor(edition: 'standalone' | 'node'): Promise<Express> {
   vi.resetModules();
   process.env.LURKER_EDITION = edition;
   const { buildApp } = await import('./app.js');
-  return buildApp(TEST_SESSION_SECRET);
+  return buildApp(TEST_SESSION_SECRET, { clientDist });
 }
 
 describe('buildApp route gating by edition', () => {
@@ -75,16 +86,7 @@ describe('buildApp route gating by edition', () => {
       expect(res.text ?? '').not.toContain('id="app"');
     });
 
-    // Asserting the client route still works needs a built client, and CI runs
-    // the suite without one (.github/workflows/test.yml never builds vue_client).
-    // Skipping when dist/ is absent is honest; the alternative — accepting a 404
-    // as a pass so the test runs everywhere — passed even when the fallback was
-    // broken outright, which is worse than no test because it reads as coverage.
-    const hasBuiltClient = existsSync(
-      path.join(import.meta.dirname, '../vue_client/dist/index.html'),
-    );
-
-    it.skipIf(!hasBuiltClient)('still serves index.html for a real client route', async () => {
+    it('still serves index.html for a real client route', async () => {
       const app = await buildFor('standalone');
       const res = await testRequest(app).get('/settings');
       // Strict: /settings must reach the catch-all and get the SPA shell, not
@@ -94,37 +96,32 @@ describe('buildApp route gating by edition', () => {
       expect(res.text).toContain('id="app"');
     });
 
-    it.skipIf(!hasBuiltClient)(
-      '404s a /.well-known URL nothing serves, rather than handing back the SPA',
-      async () => {
-        // A client probing for a discovery document (an MCP client asking for OAuth
-        // protected-resource metadata, #891) needs a 404 it can act on; the SPA's
-        // HTML with a 200 reads as a broken document instead.
-        const app = await buildFor('standalone');
-        const res = await testRequest(app).get('/.well-known/oauth-protected-resource/mcp');
-        expect(res.status).toBe(404);
-        expect(res.text ?? '').not.toContain('id="app"');
-      },
-    );
+    it('404s a /.well-known URL nothing serves, rather than handing back the SPA', async () => {
+      // A client probing for a discovery document (an MCP client asking for OAuth
+      // protected-resource metadata, #891) needs a 404 it can act on; the SPA's
+      // HTML with a 200 reads as a broken document instead.
+      const app = await buildFor('standalone');
+      const res = await testRequest(app).get('/.well-known/oauth-protected-resource/mcp');
+      expect(res.status).toBe(404);
+      expect(res.text ?? '').not.toContain('id="app"');
+    });
 
-    it.skipIf(!hasBuiltClient)(
-      'serves the OAuth approval page with headers that forbid framing it (#891)',
-      async () => {
-        const app = await buildFor('standalone');
-        // Every spelling the client router renders the page for, not just the canonical one.
-        for (const spelling of ['/oauth/authorize', '/oauth/authorize/', '/OAuth/Authorize']) {
-          const res = await testRequest(app).get(`${spelling}?client_id=x`);
-          expect(res.status).toBe(200);
-          expect(res.headers['content-security-policy']).toBe("frame-ancestors 'none'");
-          expect(res.headers['x-frame-options']).toBe('DENY');
-          expect(res.headers['cache-control']).toBe('no-store');
-          expect(res.headers['referrer-policy']).toBe('no-referrer');
-        }
-        // …and only there: the rest of the app stays embeddable.
-        const settings = await testRequest(app).get('/settings');
-        expect(settings.headers['x-frame-options']).toBeUndefined();
-      },
-    );
+    it('serves the OAuth approval page with headers that forbid framing it (#891)', async () => {
+      const app = await buildFor('standalone');
+      // Every spelling the client router renders the page for, not just the canonical one.
+      for (const spelling of ['/oauth/authorize', '/oauth/authorize/', '/OAuth/Authorize']) {
+        const res = await testRequest(app).get(`${spelling}?client_id=x`);
+        expect(res.status).toBe(200);
+        expect(res.text).toContain('id="app"');
+        expect(res.headers['content-security-policy']).toBe("frame-ancestors 'none'");
+        expect(res.headers['x-frame-options']).toBe('DENY');
+        expect(res.headers['cache-control']).toBe('no-store');
+        expect(res.headers['referrer-policy']).toBe('no-referrer');
+      }
+      // …and only there: the rest of the app stays embeddable.
+      const settings = await testRequest(app).get('/settings');
+      expect(settings.headers['x-frame-options']).toBeUndefined();
+    });
   });
 
   describe('standalone edition', () => {

--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -93,6 +93,25 @@ describe('buildApp route gating by edition', () => {
       expect(res.headers['content-type']).toMatch(/text\/html/);
       expect(res.text).toContain('id="app"');
     });
+
+    it.skipIf(!hasBuiltClient)(
+      'serves the OAuth approval page with headers that forbid framing it (#891)',
+      async () => {
+        const app = await buildFor('standalone');
+        // Every spelling the client router renders the page for, not just the canonical one.
+        for (const spelling of ['/oauth/authorize', '/oauth/authorize/', '/OAuth/Authorize']) {
+          const res = await testRequest(app).get(`${spelling}?client_id=x`);
+          expect(res.status).toBe(200);
+          expect(res.headers['content-security-policy']).toBe("frame-ancestors 'none'");
+          expect(res.headers['x-frame-options']).toBe('DENY');
+          expect(res.headers['cache-control']).toBe('no-store');
+          expect(res.headers['referrer-policy']).toBe('no-referrer');
+        }
+        // …and only there: the rest of the app stays embeddable.
+        const settings = await testRequest(app).get('/settings');
+        expect(settings.headers['x-frame-options']).toBeUndefined();
+      },
+    );
   });
 
   describe('standalone edition', () => {
@@ -115,5 +134,63 @@ describe('buildApp route gating by edition', () => {
       const res = await testRequest(app).get('/api/node/status');
       expect(res.status).toBe(404);
     });
+  });
+});
+
+describe('OAuth (#891) mounting', () => {
+  it('is mounted in standalone: registration answers rather than 404ing', async () => {
+    const app = await buildFor('standalone');
+    const res = await testRequest(app).post('/api/oauth/register').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_client_metadata');
+  });
+
+  it('is not mounted in node edition, where sign-in happens in front of the cell', async () => {
+    const app = await buildFor('node');
+    expect((await testRequest(app).post('/api/oauth/register').send({})).status).toBe(404);
+    expect((await testRequest(app).get('/api/oauth/apps')).status).toBe(404);
+    const discovery = await testRequest(app).get('/.well-known/oauth-authorization-server');
+    expect(discovery.headers['content-type'] ?? '').not.toMatch(/json/);
+  });
+
+  it('serves the discovery document as JSON, ahead of the SPA fallback', async () => {
+    const app = await buildFor('standalone');
+    const saved = process.env.PUBLIC_BASE_URL;
+    delete process.env.PUBLIC_BASE_URL;
+    try {
+      const res = await testRequest(app)
+        .get('/.well-known/oauth-authorization-server')
+        .set('Host', 'irc.example.com');
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        issuer: 'http://irc.example.com',
+        authorization_endpoint: 'http://irc.example.com/oauth/authorize',
+        registration_endpoint: 'http://irc.example.com/api/oauth/register',
+        token_endpoint_auth_methods_supported: ['none'],
+        code_challenge_methods_supported: ['S256'],
+      });
+    } finally {
+      if (saved !== undefined) process.env.PUBLIC_BASE_URL = saved;
+    }
+  });
+});
+
+describe('request body errors', () => {
+  it('answers a malformed body with 400 and never logs it', async () => {
+    // The parser attaches the raw body to its error, and that body can hold a
+    // password or an OAuth code verifier.
+    const app = await buildFor('standalone');
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const res = await testRequest(app)
+        .post('/api/oauth/token')
+        .set('Content-Type', 'application/json')
+        .send('{"code_verifier":"do-not-log-me"');
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ error: 'invalid_request' });
+      expect(logged).not.toHaveBeenCalled();
+    } finally {
+      logged.mockRestore();
+    }
   });
 });

--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -95,6 +95,19 @@ describe('buildApp route gating by edition', () => {
     });
 
     it.skipIf(!hasBuiltClient)(
+      '404s a /.well-known URL nothing serves, rather than handing back the SPA',
+      async () => {
+        // A client probing for a discovery document (an MCP client asking for OAuth
+        // protected-resource metadata, #891) needs a 404 it can act on; the SPA's
+        // HTML with a 200 reads as a broken document instead.
+        const app = await buildFor('standalone');
+        const res = await testRequest(app).get('/.well-known/oauth-protected-resource/mcp');
+        expect(res.status).toBe(404);
+        expect(res.text ?? '').not.toContain('id="app"');
+      },
+    );
+
+    it.skipIf(!hasBuiltClient)(
       'serves the OAuth approval page with headers that forbid framing it (#891)',
       async () => {
         const app = await buildFor('standalone');

--- a/server/app.ts
+++ b/server/app.ts
@@ -67,13 +67,19 @@ const errorHandler: ErrorRequestHandler = (err, _req, res, next) => {
   res.status(500).json({ error: 'internal error' });
 };
 
+export interface BuildAppOptions {
+  /** The built web client to serve. Defaults to vue_client/dist. */
+  clientDist?: string;
+}
+
 /**
  * Build the fully-wired Express app. `sessionSecret` keys cookie-parser for the
  * signed `lurker_session` cookie (the same secret server.ts hands to the WS
  * hub). Route gating reads the cached edition, so set LURKER_EDITION before the
- * first getEdition() call.
+ * first getEdition() call. Tests pass `clientDist` to serve a stand-in client,
+ * because CI runs the suite without building vue_client.
  */
-export function buildApp(sessionSecret: string): Express {
+export function buildApp(sessionSecret: string, options: BuildAppOptions = {}): Express {
   const app = express();
 
   // CORS_ORIGIN is a comma-separated allowlist, normalized to URL origins (see
@@ -180,7 +186,7 @@ export function buildApp(sessionSecret: string): Express {
   // this server doesn't publish (an MCP client asking for OAuth protected-resource
   // metadata before falling back to the authorization-server document, #891)
   // needs a 404 it can act on, not the SPA's HTML with a 200.
-  const clientDist = path.join(import.meta.dirname, '../vue_client/dist');
+  const clientDist = options.clientDist ?? path.join(import.meta.dirname, '../vue_client/dist');
   app.use(express.static(clientDist));
   app.get(/^\/(?!api|ws|mcp|assets|[.]well-known).*/, (req, res, next) => {
     // The OAuth approval page (#891) must never render inside someone else's

--- a/server/app.ts
+++ b/server/app.ts
@@ -175,9 +175,14 @@ export function buildApp(sessionSecret: string): Express {
   // index.html back with a 200 and Content-Type: text/html, so the browser
   // reports a confusing module-type refusal instead of a plain 404 — and the
   // client can't cleanly tell "chunk is gone" from "page is fine" (#571).
+  //
+  // `.well-known` is for machines, never a page. A client probing for a document
+  // this server doesn't publish (an MCP client asking for OAuth protected-resource
+  // metadata before falling back to the authorization-server document, #891)
+  // needs a 404 it can act on, not the SPA's HTML with a 200.
   const clientDist = path.join(import.meta.dirname, '../vue_client/dist');
   app.use(express.static(clientDist));
-  app.get(/^\/(?!api|ws|mcp|assets).*/, (req, res, next) => {
+  app.get(/^\/(?!api|ws|mcp|assets|[.]well-known).*/, (req, res, next) => {
     // The OAuth approval page (#891) must never render inside someone else's
     // frame, where an Approve click could be steered. Scoped to this one path so
     // self-hosters can keep embedding the rest of the app; the page's route forces

--- a/server/app.ts
+++ b/server/app.ts
@@ -35,13 +35,33 @@ import apiTokensRouter from './routes/apiTokens.js';
 import configRouter from './routes/config.js';
 import linkPreviewRouter from './routes/linkPreview.js';
 import nodeRouter from './routes/node.js';
+import { oauthRouter, wellKnownRouter } from './routes/oauth.js';
 import mcpRouter from './services/mcpServer.js';
 import { requireApiAuth } from './middleware/apiAuth.js';
 import { isNodeMode } from './utils/edition.js';
 import { previewsEnabled } from './utils/previews.js';
 import { allowedBrowserOrigins } from './utils/corsOrigins.js';
 
+// body-parser marks its own failures (malformed JSON or form data, a body over
+// the limit, an unsupported charset) with a `type` such as 'entity.parse.failed'
+// and a 4xx `status`.
+function isBodyParseError(err: unknown): err is { status: number } {
+  if (!err || typeof err !== 'object') return false;
+  const { type, status } = err as { type?: unknown; status?: unknown };
+  return typeof type === 'string' && typeof status === 'number' && status >= 400 && status < 500;
+}
+
 const errorHandler: ErrorRequestHandler = (err, _req, res, next) => {
+  // A body that didn't parse is the client's mistake, not a server fault. The
+  // parser attaches the raw body to the error, and that body can be a password or
+  // an OAuth code, so it is answered with its 4xx and never logged. This has to
+  // live here: the JSON parser runs app-wide, ahead of every router, so an error
+  // it raises never reaches a router's own handler.
+  if (isBodyParseError(err)) {
+    if (res.headersSent) return next(err);
+    res.status(err.status).json({ error: 'invalid_request' });
+    return;
+  }
   console.error('[lurker] error:', err);
   if (res.headersSent) return next(err);
   res.status(500).json({ error: 'internal error' });
@@ -125,6 +145,15 @@ export function buildApp(sessionSecret: string): Express {
     app.use('/mcp', requireApiAuth, mcpRouter);
   }
 
+  // OAuth sign-in for third-party clients (#891). Standalone only: hosted sign-in
+  // happens in front of the cells, so a cell must not mint credentials of its own.
+  // Discovery sits under /.well-known and has to be mounted before express.static
+  // below, or the SPA fallback answers it with index.html.
+  if (!isNodeMode()) {
+    app.use('/api/oauth', oauthRouter);
+    app.use('/.well-known', wellKnownRouter);
+  }
+
   // Orchestrator-only control surface. Mounted exclusively in node edition so a
   // standalone self-hosted instance never exposes it at all.
   if (isNodeMode()) {
@@ -148,7 +177,21 @@ export function buildApp(sessionSecret: string): Express {
   // client can't cleanly tell "chunk is gone" from "page is fine" (#571).
   const clientDist = path.join(import.meta.dirname, '../vue_client/dist');
   app.use(express.static(clientDist));
-  app.get(/^\/(?!api|ws|mcp|assets).*/, (_req, res, next) => {
+  app.get(/^\/(?!api|ws|mcp|assets).*/, (req, res, next) => {
+    // The OAuth approval page (#891) must never render inside someone else's
+    // frame, where an Approve click could be steered. Scoped to this one path so
+    // self-hosters can keep embedding the rest of the app; the page's route forces
+    // a full document load when reached client-side, so these always apply to it.
+    // Compared the way the client router matches routes (case-insensitive, trailing
+    // slash optional), or /OAuth/Authorize/ would render the page without them.
+    if (req.path.toLowerCase().replace(/\/+$/, '') === '/oauth/authorize') {
+      res.set({
+        'Content-Security-Policy': "frame-ancestors 'none'",
+        'X-Frame-Options': 'DENY',
+        'Cache-Control': 'no-store',
+        'Referrer-Policy': 'no-referrer',
+      });
+    }
     res.sendFile(path.join(clientDist, 'index.html'), (err) => {
       if (err) next();
     });

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -591,6 +591,23 @@ export const EXPORT_TABLES = Object.freeze({
       'bearer-token credentials bound to this instance; user re-issues tokens on the target instance',
   },
 
+  oauth_apps: {
+    mode: 'skip',
+    reason:
+      'third-party app registrations with this instance; an app registers itself with the target instance',
+  },
+
+  oauth_codes: {
+    mode: 'skip',
+    reason: 'one-time authorization codes that expire within minutes; nothing to carry over',
+  },
+
+  oauth_tokens: {
+    mode: 'skip',
+    reason:
+      'hashed access tokens for apps authorized on this instance; the user authorizes each app again on the target',
+  },
+
   peer_presence_state: {
     mode: 'skip',
     reason: 'transient cache; rebuilt by IRC events on next connect',

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -660,6 +660,57 @@ function migrate() {
     );
     CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(user_id);
 
+    -- OAuth 2 authorization server (#891). A third-party client registers itself
+    -- (open, RFC 7591), the member approves it in the browser, and the client
+    -- exchanges the one-time code for an access token with the same access as a
+    -- password sign-in. Public clients only: client_id is public and there is no
+    -- client secret, because with open registration a secret proves nothing.
+    -- PKCE binds each code to whoever started the flow instead.
+    --
+    -- first_authorized_at is set on the first approval. Registrations still NULL
+    -- an hour after creation are purged, which is what bounds a table anyone can
+    -- write to.
+    CREATE TABLE IF NOT EXISTS oauth_apps (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      client_id TEXT NOT NULL UNIQUE,
+      client_name TEXT NOT NULL,
+      client_uri TEXT,
+      redirect_uris TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+      first_authorized_at TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_oauth_apps_pending
+      ON oauth_apps(created_at) WHERE first_authorized_at IS NULL;
+
+    -- One row per approval until the client exchanges it. Only the SHA-256 of the
+    -- code is stored, and exchanging DELETEs the row, which is what makes a code
+    -- single-use. Bound to the redirect_uri and PKCE challenge it was issued for.
+    CREATE TABLE IF NOT EXISTS oauth_codes (
+      code_hash TEXT PRIMARY KEY,
+      app_id INTEGER NOT NULL,
+      user_id INTEGER NOT NULL,
+      redirect_uri TEXT NOT NULL,
+      code_challenge TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      FOREIGN KEY (app_id) REFERENCES oauth_apps(id) ON DELETE CASCADE,
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    );
+
+    -- Access tokens. SHA-256 only, never expire, and revoking DELETEs the row.
+    -- push_subscriptions.oauth_token_id cascades from it (added at the end of
+    -- this file), so an app's push registrations go with its token.
+    CREATE TABLE IF NOT EXISTS oauth_tokens (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      token_hash TEXT NOT NULL UNIQUE,
+      app_id INTEGER NOT NULL,
+      user_id INTEGER NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+      last_used_at TEXT,
+      FOREIGN KEY (app_id) REFERENCES oauth_apps(id) ON DELETE CASCADE,
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_oauth_tokens_user_app ON oauth_tokens(user_id, app_id);
+
     -- Per-user data-export jobs. A request to export account data spawns a
     -- background worker (separate readonly SQLite connection) that builds the
     -- .lurk archive to disk under data/exports/<token>.lurk; the row tracks
@@ -2571,5 +2622,20 @@ db.exec(`CREATE INDEX IF NOT EXISTS idx_ignored_masks_user_net
 // CREATE already ran before it — so recreate here for both fresh and rebuilt
 // paths. hasEnabledForUser hits it on the push hot path.
 db.exec(`CREATE INDEX IF NOT EXISTS idx_push_subs_user ON push_subscriptions(user_id)`);
+
+// #891: which OAuth token registered a push subscription, so revoking the app
+// deletes its registrations through the cascade. NULL for anything registered
+// through a session. Added HERE, after the unversioned push_subscriptions rebuild
+// above, and not in the ensureColumn block near the top: that rebuild copies an
+// explicit column list into a new table, so on a database still in the pre-#490
+// shape a column added earlier would be silently dropped.
+ensureColumn(
+  'push_subscriptions',
+  'oauth_token_id',
+  'INTEGER REFERENCES oauth_tokens(id) ON DELETE CASCADE',
+);
+db.exec(
+  `CREATE INDEX IF NOT EXISTS idx_push_subs_oauth_token ON push_subscriptions(oauth_token_id)`,
+);
 
 export default db;

--- a/server/db/oauth.test.ts
+++ b/server/db/oauth.test.ts
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Storage for the OAuth authorization server (#891): single-use codes, hashed
+// tokens, revocation that takes codes along with tokens, and the purge that
+// bounds what the open registration endpoint lets anyone write.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+const ctx = setupTestDb('db-oauth');
+
+let oauth: typeof import('./oauth.js');
+let users: typeof import('./users.js');
+let db: typeof import('./index.js').default;
+
+beforeAll(async () => {
+  oauth = await import('./oauth.js');
+  users = await import('./users.js');
+  db = (await import('./index.js')).default;
+});
+
+afterAll(() => ctx.cleanup());
+
+const OOB = 'urn:ietf:wg:oauth:2.0:oob';
+const CHALLENGE = 'c'.repeat(43);
+
+function newApp(name = 'Test app', now?: number) {
+  return oauth.createApp({ clientName: name, clientUri: null, redirectUris: [OOB] }, now);
+}
+
+function codeFor(appId: number, userId: number, now?: number): string {
+  return oauth.createCode({ appId, userId, redirectUri: OOB, codeChallenge: CHALLENGE }, now);
+}
+
+function codeRowExists(code: string): boolean {
+  const row = db
+    .prepare('SELECT COUNT(*) AS n FROM oauth_codes WHERE code_hash = ?')
+    .get(oauth.hashSecret(code)) as { n: number };
+  return row.n > 0;
+}
+
+describe('authorization codes', () => {
+  it('can be spent exactly once', () => {
+    const user = users.createUser('oauth-code-once');
+    const app = newApp();
+    const code = codeFor(app.id, user.id);
+    expect(oauth.consumeCode(code)).toEqual({
+      appId: app.id,
+      userId: user.id,
+      redirectUri: OOB,
+      codeChallenge: CHALLENGE,
+    });
+    expect(oauth.consumeCode(code)).toBeNull();
+  });
+
+  it('stop working once they expire', () => {
+    const now = Date.now();
+    const user = users.createUser('oauth-code-expired');
+    const code = codeFor(newApp().id, user.id, now);
+    expect(oauth.consumeCode(code, now + oauth.CODE_TTL_MS + 1)).toBeNull();
+  });
+
+  it('are stored only as a hash', () => {
+    const user = users.createUser('oauth-code-hashed');
+    const code = codeFor(newApp().id, user.id);
+    const raw = db.prepare('SELECT 1 FROM oauth_codes WHERE code_hash = ?').get(code);
+    expect(raw).toBeUndefined();
+    expect(codeRowExists(code)).toBe(true);
+  });
+
+  it('mark the app as approved, which exempts it from the pending purge', () => {
+    const user = users.createUser('oauth-code-approves');
+    const app = newApp();
+    expect(oauth.findAppByClientId(app.clientId)?.firstAuthorizedAt).toBeNull();
+    codeFor(app.id, user.id);
+    expect(oauth.findAppByClientId(app.clientId)?.firstAuthorizedAt).not.toBeNull();
+  });
+});
+
+describe('access tokens', () => {
+  it('are found by raw value and stored only as a hash', () => {
+    const user = users.createUser('oauth-token-find');
+    const app = newApp();
+    const token = oauth.createToken(app.id, user.id);
+    expect(oauth.findTokenByRaw(token)).toMatchObject({ appId: app.id, userId: user.id });
+    expect(
+      db.prepare('SELECT 1 FROM oauth_tokens WHERE token_hash = ?').get(token),
+    ).toBeUndefined();
+  });
+
+  it('can only be revoked by the client they were issued to', () => {
+    const user = users.createUser('oauth-token-client');
+    const mine = newApp('Mine');
+    const theirs = newApp('Theirs');
+    const token = oauth.createToken(mine.id, user.id);
+    expect(oauth.deleteTokenForClient(token, theirs.clientId)).toBeNull();
+    expect(oauth.findTokenByRaw(token)).not.toBeNull();
+    expect(oauth.deleteTokenForClient(token, mine.clientId)).toMatchObject({ userId: user.id });
+    expect(oauth.findTokenByRaw(token)).toBeNull();
+  });
+
+  it('revoking an app for one member takes its codes too, and nothing else', () => {
+    const alice = users.createUser('oauth-revoke-alice');
+    const bob = users.createUser('oauth-revoke-bob');
+    const app = newApp('Revoked');
+    const other = newApp('Untouched');
+    const aliceToken = oauth.createToken(app.id, alice.id);
+    const bobToken = oauth.createToken(app.id, bob.id);
+    const aliceOther = oauth.createToken(other.id, alice.id);
+    const pendingCode = codeFor(app.id, alice.id);
+
+    const ids = oauth.deleteOAuthForApp(alice.id, app.id);
+    expect(ids).toHaveLength(1);
+    expect(oauth.findTokenByRaw(aliceToken)).toBeNull();
+    // A code approved before the revoke must not mint a token after it.
+    expect(codeRowExists(pendingCode)).toBe(false);
+    expect(oauth.findTokenByRaw(bobToken)).not.toBeNull();
+    expect(oauth.findTokenByRaw(aliceOther)).not.toBeNull();
+  });
+
+  it('revoking everything for a member (account recovery) takes every token and code', () => {
+    const user = users.createUser('oauth-revoke-all');
+    const bystander = users.createUser('oauth-revoke-bystander');
+    const app = newApp();
+    const tokens = [oauth.createToken(app.id, user.id), oauth.createToken(newApp().id, user.id)];
+    const code = codeFor(app.id, user.id);
+    const kept = oauth.createToken(app.id, bystander.id);
+
+    expect(oauth.deleteOAuthForUser(user.id)).toHaveLength(2);
+    for (const token of tokens) expect(oauth.findTokenByRaw(token)).toBeNull();
+    expect(codeRowExists(code)).toBe(false);
+    expect(oauth.findTokenByRaw(kept)).not.toBeNull();
+  });
+
+  it('go with a deleted account', () => {
+    const user = users.createUser('oauth-deleted-user');
+    const app = newApp();
+    const token = oauth.createToken(app.id, user.id);
+    const code = codeFor(app.id, user.id);
+    users.deleteUser(user.id);
+    expect(oauth.findTokenByRaw(token)).toBeNull();
+    expect(codeRowExists(code)).toBe(false);
+  });
+});
+
+describe('listAuthorizedApps', () => {
+  it('lists each app once, with its first authorization and latest use', () => {
+    const user = users.createUser('oauth-list');
+    const app = oauth.createApp({
+      clientName: 'Listed',
+      clientUri: 'https://listed.example',
+      redirectUris: [OOB],
+    });
+    const first = oauth.createToken(app.id, user.id, Date.parse('2026-01-01T00:00:00.000Z'));
+    oauth.createToken(app.id, user.id, Date.parse('2026-02-01T00:00:00.000Z'));
+    oauth.touchTokenLastUsed(oauth.findTokenByRaw(first)!.id);
+
+    const apps = oauth.listAuthorizedApps(user.id);
+    expect(apps).toHaveLength(1);
+    expect(apps[0]).toMatchObject({
+      id: app.id,
+      name: 'Listed',
+      clientUri: 'https://listed.example',
+      authorizedAt: '2026-01-01T00:00:00.000Z',
+    });
+    expect(apps[0].lastUsedAt).not.toBeNull();
+  });
+
+  it('leaves out apps the member holds no token for', () => {
+    const user = users.createUser('oauth-list-empty');
+    codeFor(newApp('Approved but never exchanged').id, user.id);
+    expect(oauth.listAuthorizedApps(user.id)).toEqual([]);
+  });
+});
+
+describe('purgeOAuth', () => {
+  it('drops expired codes and stale unapproved registrations, and nothing else', () => {
+    const now = Date.parse('2026-06-01T12:00:00.000Z');
+    const user = users.createUser('oauth-purge');
+    const stale = newApp('Stale', now - oauth.PENDING_APP_TTL_MS - 1);
+    const fresh = newApp('Fresh', now - 1000);
+    const approved = newApp('Approved long ago', now - oauth.PENDING_APP_TTL_MS * 10);
+    const liveCode = codeFor(approved.id, user.id, now);
+    const expiredCode = codeFor(approved.id, user.id, now - oauth.CODE_TTL_MS - 1);
+
+    oauth.purgeOAuth(now);
+
+    expect(oauth.findAppByClientId(stale.clientId)).toBeNull();
+    expect(oauth.findAppByClientId(fresh.clientId)).not.toBeNull();
+    expect(oauth.findAppByClientId(approved.clientId)).not.toBeNull();
+    expect(codeRowExists(liveCode)).toBe(true);
+    expect(codeRowExists(expiredCode)).toBe(false);
+  });
+});

--- a/server/db/oauth.ts
+++ b/server/db/oauth.ts
@@ -1,0 +1,302 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import crypto from 'crypto';
+import db from './index.js';
+
+// Storage for the OAuth 2 authorization server (#891). A third-party client
+// registers itself (RFC 7591), the member approves it in the browser, and the
+// client trades the resulting code for an access token that works exactly like
+// a password sign-in.
+//
+// Client ids are public. Every other secret here is 32 random bytes stored only
+// as its SHA-256 -- the api_tokens reasoning: unguessable input makes an
+// unsalted hash enough, and reading these tables yields nothing usable. Codes
+// and tokens are hard-deleted when spent or revoked, so liveness is simply "the
+// row exists" and no revoked-but-present state can be misread later.
+//
+// Timestamps are ISO-8601 UTC strings compared lexicographically against a
+// caller-supplied `now`, which keeps expiry and purging unit-testable.
+
+/** How long an issued authorization code stays redeemable. */
+export const CODE_TTL_MS = 10 * 60 * 1000;
+/** How long a registration nobody has approved survives before the purge. */
+export const PENDING_APP_TTL_MS = 60 * 60 * 1000;
+/** Unapproved registrations allowed at once; registration answers 429 past it. */
+export const MAX_PENDING_APPS = 1000;
+
+export function generateSecret(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+export function hashSecret(raw: string): string {
+  return crypto.createHash('sha256').update(raw, 'utf8').digest('hex');
+}
+
+const iso = (ms: number): string => new Date(ms).toISOString();
+
+/** A registered client. */
+export interface OAuthApp {
+  id: number;
+  clientId: string;
+  clientName: string;
+  clientUri: string | null;
+  redirectUris: string[];
+  createdAt: string;
+  firstAuthorizedAt: string | null;
+}
+
+interface AppRow {
+  id: number;
+  client_id: string;
+  client_name: string;
+  client_uri: string | null;
+  redirect_uris: string;
+  created_at: string;
+  first_authorized_at: string | null;
+}
+
+function rowToApp(row: AppRow | undefined): OAuthApp | null {
+  if (!row) return null;
+  let redirectUris: string[] = [];
+  try {
+    const parsed: unknown = JSON.parse(row.redirect_uris);
+    if (Array.isArray(parsed)) {
+      redirectUris = parsed.filter((u): u is string => typeof u === 'string');
+    }
+  } catch {
+    // A corrupt row matches no redirect, which refuses every authorization.
+  }
+  return {
+    id: row.id,
+    clientId: row.client_id,
+    clientName: row.client_name,
+    clientUri: row.client_uri,
+    redirectUris,
+    createdAt: row.created_at,
+    firstAuthorizedAt: row.first_authorized_at,
+  };
+}
+
+export function createApp(
+  input: { clientName: string; clientUri: string | null; redirectUris: string[] },
+  now = Date.now(),
+): OAuthApp {
+  const clientId = generateSecret();
+  const createdAt = iso(now);
+  const info = db
+    .prepare(
+      `INSERT INTO oauth_apps (client_id, client_name, client_uri, redirect_uris, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+    .run(
+      clientId,
+      input.clientName,
+      input.clientUri,
+      JSON.stringify(input.redirectUris),
+      createdAt,
+    );
+  return {
+    id: Number(info.lastInsertRowid),
+    clientId,
+    clientName: input.clientName,
+    clientUri: input.clientUri,
+    redirectUris: input.redirectUris,
+    createdAt,
+    firstAuthorizedAt: null,
+  };
+}
+
+export function findAppByClientId(clientId: string): OAuthApp | null {
+  return rowToApp(
+    db.prepare('SELECT * FROM oauth_apps WHERE client_id = ?').get(clientId) as AppRow | undefined,
+  );
+}
+
+/** Registrations nobody has approved yet -- the only ones an anonymous caller can pile up. */
+export function countPendingApps(): number {
+  const row = db
+    .prepare('SELECT COUNT(*) AS n FROM oauth_apps WHERE first_authorized_at IS NULL')
+    .get() as { n: number };
+  return row.n;
+}
+
+/**
+ * Issue an authorization code for an approval, returning the RAW code. Also
+ * marks the app as approved at least once, which is what exempts it from the
+ * pending-registration purge.
+ */
+export function createCode(
+  input: { appId: number; userId: number; redirectUri: string; codeChallenge: string },
+  now = Date.now(),
+): string {
+  const code = generateSecret();
+  db.transaction(() => {
+    db.prepare(
+      `INSERT INTO oauth_codes (code_hash, app_id, user_id, redirect_uri, code_challenge, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      hashSecret(code),
+      input.appId,
+      input.userId,
+      input.redirectUri,
+      input.codeChallenge,
+      iso(now + CODE_TTL_MS),
+    );
+    db.prepare(
+      'UPDATE oauth_apps SET first_authorized_at = ? WHERE id = ? AND first_authorized_at IS NULL',
+    ).run(iso(now), input.appId);
+  })();
+  return code;
+}
+
+export interface ConsumedCode {
+  appId: number;
+  userId: number;
+  redirectUri: string;
+  codeChallenge: string;
+}
+
+/**
+ * Spend a live code, returning what it was bound to if THIS call spent it.
+ *
+ * One auto-committing statement, like consumeRecoveryToken: two simultaneous
+ * exchanges cannot both win, and the caller checks the client, redirect and
+ * PKCE verifier only AFTER the code is gone. A code that fails those checks has
+ * been seen by someone it wasn't issued to, so burning it is the point. Never
+ * wrap this in a transaction that throws on a failed check -- the rollback would
+ * hand the code back.
+ */
+export function consumeCode(code: string, now = Date.now()): ConsumedCode | null {
+  const row = db
+    .prepare(
+      `DELETE FROM oauth_codes WHERE code_hash = ? AND expires_at > ?
+       RETURNING app_id AS appId, user_id AS userId, redirect_uri AS redirectUri,
+                 code_challenge AS codeChallenge`,
+    )
+    .get(hashSecret(code), iso(now)) as ConsumedCode | undefined;
+  return row ?? null;
+}
+
+/** Mint an access token, returning the RAW value. It never expires; revoking deletes it. */
+export function createToken(appId: number, userId: number, now = Date.now()): string {
+  const token = generateSecret();
+  db.prepare(
+    'INSERT INTO oauth_tokens (token_hash, app_id, user_id, created_at) VALUES (?, ?, ?, ?)',
+  ).run(hashSecret(token), appId, userId, iso(now));
+  return token;
+}
+
+export interface OAuthToken {
+  id: number;
+  appId: number;
+  userId: number;
+}
+
+export function findTokenByRaw(raw: string): OAuthToken | null {
+  const row = db
+    .prepare('SELECT id, app_id AS appId, user_id AS userId FROM oauth_tokens WHERE token_hash = ?')
+    .get(hashSecret(raw)) as OAuthToken | undefined;
+  return row ?? null;
+}
+
+// Throttled in SQL, like api_tokens: a busy client doesn't rewrite the row on
+// every request. ISO on both sides of the comparison so it orders correctly.
+const touchStmt = db.prepare(`
+  UPDATE oauth_tokens
+     SET last_used_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+   WHERE id = ?
+     AND (last_used_at IS NULL
+          OR last_used_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-60 seconds'))
+`);
+
+export function touchTokenLastUsed(id: number): void {
+  touchStmt.run(id);
+}
+
+export interface DeletedToken {
+  id: number;
+  userId: number;
+}
+
+/** Revoke by raw value (sign-out with the token itself). */
+export function deleteTokenByRaw(raw: string): DeletedToken | null {
+  const row = db
+    .prepare('DELETE FROM oauth_tokens WHERE token_hash = ? RETURNING id, user_id AS userId')
+    .get(hashSecret(raw)) as DeletedToken | undefined;
+  return row ?? null;
+}
+
+/** Revoke by raw value, but only a token issued to `clientId` (RFC 7009). */
+export function deleteTokenForClient(raw: string, clientId: string): DeletedToken | null {
+  const row = db
+    .prepare(
+      `DELETE FROM oauth_tokens
+        WHERE token_hash = ? AND app_id = (SELECT id FROM oauth_apps WHERE client_id = ?)
+       RETURNING id, user_id AS userId`,
+    )
+    .get(hashSecret(raw), clientId) as DeletedToken | undefined;
+  return row ?? null;
+}
+
+/**
+ * Revoke one app for one member: its tokens AND any unexchanged codes, which
+ * would otherwise mint a fresh token minutes after the revoke. Returns the
+ * deleted token ids so the caller can close the sockets they opened.
+ */
+export function deleteOAuthForApp(userId: number, appId: number): number[] {
+  return db.transaction(() => {
+    db.prepare('DELETE FROM oauth_codes WHERE user_id = ? AND app_id = ?').run(userId, appId);
+    const rows = db
+      .prepare('DELETE FROM oauth_tokens WHERE user_id = ? AND app_id = ? RETURNING id')
+      .all(userId, appId) as Array<{ id: number }>;
+    return rows.map((r) => r.id);
+  })();
+}
+
+/** Revoke every app for a member (account recovery). Codes too, for the same reason. */
+export function deleteOAuthForUser(userId: number): number[] {
+  return db.transaction(() => {
+    db.prepare('DELETE FROM oauth_codes WHERE user_id = ?').run(userId);
+    const rows = db
+      .prepare('DELETE FROM oauth_tokens WHERE user_id = ? RETURNING id')
+      .all(userId) as Array<{ id: number }>;
+    return rows.map((r) => r.id);
+  })();
+}
+
+/** An app the member has approved and still holds a token for. */
+export interface AuthorizedApp {
+  id: number;
+  name: string;
+  clientUri: string | null;
+  authorizedAt: string;
+  lastUsedAt: string | null;
+}
+
+export function listAuthorizedApps(userId: number): AuthorizedApp[] {
+  return db
+    .prepare(
+      `SELECT a.id AS id, a.client_name AS name, a.client_uri AS clientUri,
+              MIN(t.created_at) AS authorizedAt, MAX(t.last_used_at) AS lastUsedAt
+         FROM oauth_tokens t
+         JOIN oauth_apps a ON a.id = t.app_id
+        WHERE t.user_id = ?
+        GROUP BY a.id
+        ORDER BY authorizedAt DESC`,
+    )
+    .all(userId) as AuthorizedApp[];
+}
+
+/**
+ * Drop expired codes and registrations nobody approved in time. Nothing reads a
+ * stale code (consumeCode filters on expiry); the app half is what bounds the
+ * table against anonymous registration.
+ */
+export function purgeOAuth(now = Date.now()): { codes: number; apps: number } {
+  const codes = db.prepare('DELETE FROM oauth_codes WHERE expires_at <= ?').run(iso(now)).changes;
+  const apps = db
+    .prepare('DELETE FROM oauth_apps WHERE first_authorized_at IS NULL AND created_at <= ?')
+    .run(iso(now - PENDING_APP_TTL_MS)).changes;
+  return { codes, apps };
+}

--- a/server/db/pushSubscriptions.ts
+++ b/server/db/pushSubscriptions.ts
@@ -179,9 +179,16 @@ export type SubscriptionInput =
 // mixed cases are refused rather than reasoned about.
 //
 // Returns { ok, sub } on success or { ok: false, error } on a refused collision.
+//
+// `oauthTokenId` is the OAuth token the registration came through (#891), or null
+// for a session. The column cascades from oauth_tokens, so revoking an app deletes
+// the push registrations it made -- otherwise a revoked app would go on receiving
+// the member's message content. A re-registration takes the latest registrant's
+// value, the same way user_id does.
 export function upsertSubscription(
   userId: number,
   input: SubscriptionInput,
+  oauthTokenId: number | null = null,
 ): { ok: true; sub: PushSubscription | null } | { ok: false; error: string } {
   const { transport, endpoint, userAgent } = input;
   const p256dh = transport === 'webpush' ? input.p256dh : null;
@@ -200,22 +207,24 @@ export function upsertSubscription(
       UPDATE push_subscriptions
       SET user_id = ?, transport = ?, p256dh = ?, auth = ?,
           user_agent = COALESCE(?, user_agent),
+          oauth_token_id = ?,
           enabled = 1, fail_count = 0,
           last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
       WHERE endpoint = ?
     `,
-    ).run(userId, transport, p256dh, auth, userAgent || null, endpoint);
+    ).run(userId, transport, p256dh, auth, userAgent || null, oauthTokenId, endpoint);
     return { ok: true, sub: getByEndpoint(endpoint) };
   }
   db.prepare(
     `
     INSERT INTO push_subscriptions
-      (user_id, endpoint, transport, p256dh, auth, user_agent, created_at, last_seen_at)
-    VALUES (?, ?, ?, ?, ?, ?,
+      (user_id, endpoint, transport, p256dh, auth, user_agent, oauth_token_id,
+       created_at, last_seen_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?,
       strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
       strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
   `,
-  ).run(userId, endpoint, transport, p256dh, auth, userAgent || null);
+  ).run(userId, endpoint, transport, p256dh, auth, userAgent || null, oauthTokenId);
   return { ok: true, sub: getByEndpoint(endpoint) };
 }
 

--- a/server/db/pushSubscriptionsMigration.test.ts
+++ b/server/db/pushSubscriptionsMigration.test.ts
@@ -156,6 +156,32 @@ describe('push_subscriptions rebuild (#490)', () => {
     ).toThrow(/UNIQUE/);
   });
 
+  it('ends with oauth_token_id, so an app’s subscriptions go with its token (#891)', () => {
+    // Added AFTER this rebuild on purpose: added before it, the rebuild's explicit
+    // column list would drop the column on exactly this kind of database.
+    expect(columns().some((c) => c.name === 'oauth_token_id')).toBe(true);
+    const appId = Number(
+      db
+        .prepare(`INSERT INTO oauth_apps (client_id, client_name, redirect_uris) VALUES (?, ?, ?)`)
+        .run('migration-app', 'Migration app', '[]').lastInsertRowid,
+    );
+    const tokenId = Number(
+      db
+        .prepare(`INSERT INTO oauth_tokens (token_hash, app_id, user_id) VALUES (?, ?, 2)`)
+        .run('migration-token-hash', appId).lastInsertRowid,
+    );
+    mod.upsertSubscription(
+      2,
+      { transport: 'webpush', endpoint: 'https://push.test/bob-app', p256dh: 'k', auth: 'a' },
+      tokenId,
+    );
+    expect(mod.getByEndpoint('https://push.test/bob-app')).not.toBeNull();
+    db.prepare(`DELETE FROM oauth_tokens WHERE id = ?`).run(tokenId);
+    expect(mod.getByEndpoint('https://push.test/bob-app')).toBeNull();
+    // Bob's own subscription from before the migration is untouched.
+    expect(mod.getByEndpoint('https://push.test/bob')).not.toBeNull();
+  });
+
   it('accepts a native subscription with no keys — the point of the rebuild', () => {
     const out = mod.upsertSubscription(1, {
       transport: 'apns',

--- a/server/middleware/apiAuth.test.ts
+++ b/server/middleware/apiAuth.test.ts
@@ -15,10 +15,14 @@ let createUser: typeof import('../db/users.js').createUser;
 let createToken: typeof import('../db/apiTokens.js').createToken;
 let revoke: typeof import('../db/apiTokens.js').revoke;
 let deleteUser: typeof import('../db/users.js').deleteUser;
+let createSession: typeof import('../db/sessions.js').createSession;
+let oauth: typeof import('../db/oauth.js');
 
 beforeAll(async () => {
   ({ createUser, deleteUser } = await import('../db/users.js'));
   ({ createToken, revoke } = await import('../db/apiTokens.js'));
+  ({ createSession } = await import('../db/sessions.js'));
+  oauth = await import('../db/oauth.js');
   const { requireApiAuth } = await import('./apiAuth.js');
   app = express();
   app.use(express.json());
@@ -28,11 +32,21 @@ beforeAll(async () => {
       username: req.user?.username,
       hasSession: 'session' in req,
       tokenScope: req.apiToken?.scope,
+      oauthTokenId: req.oauthToken?.id,
     });
   });
 });
 
 afterAll(() => ctx.cleanup());
+
+function oauthTokenFor(userId: number): string {
+  const oauthApp = oauth.createApp({
+    clientName: 'MCP client',
+    clientUri: null,
+    redirectUris: ['urn:ietf:wg:oauth:2.0:oob'],
+  });
+  return oauth.createToken(oauthApp.id, userId);
+}
 
 describe('requireApiAuth', () => {
   it('401 when Authorization header is missing', async () => {
@@ -89,5 +103,33 @@ describe('requireApiAuth', () => {
     const r2 = await testRequest(app).get('/protected').set('Authorization', `Bearer ${tRW.token}`);
     expect(r1.body.tokenScope).toBe('read');
     expect(r2.body.tokenScope).toBe('read-write');
+  });
+
+  // #891: an MCP client that signs in through OAuth comes back with an access
+  // token. Refusing it sends the client round the approval again.
+  it('authenticates an OAuth access token as the member, without an API token', async () => {
+    const u: User = createUser('mw-oauth');
+    const token = oauthTokenFor(u.id);
+    const res = await testRequest(app).get('/protected').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.userId).toBe(u.id);
+    expect(res.body.oauthTokenId).toBe(oauth.findTokenByRaw(token)?.id);
+    expect(res.body.tokenScope).toBeUndefined();
+    expect(res.body.hasSession).toBe(false);
+  });
+
+  it('rejects a revoked OAuth access token', async () => {
+    const u: User = createUser('mw-oauth-revoked');
+    const token = oauthTokenFor(u.id);
+    oauth.deleteTokenByRaw(token);
+    const res = await testRequest(app).get('/protected').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('still refuses a session token', async () => {
+    const u: User = createUser('mw-session');
+    const { token } = createSession(u.id);
+    const res = await testRequest(app).get('/protected').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(401);
   });
 });

--- a/server/middleware/apiAuth.ts
+++ b/server/middleware/apiAuth.ts
@@ -3,14 +3,21 @@
 
 import type { Request, Response, NextFunction } from 'express';
 import { findActiveByHash, hashToken, touchLastUsed } from '../db/apiTokens.js';
+import { findTokenByRaw, touchTokenLastUsed } from '../db/oauth.js';
 import { findUserById } from '../db/users.js';
 
-// Sibling of middleware/auth.ts#requireAuth, but for bearer-token clients
-// (HTTP API + MCP). Tokens are HTTP-only by design — the WebSocket endpoint
-// remains cookie-only so the in-process plugin runtime question stays
-// deferred without re-auth gymnastics. `req.user` is populated to the same
-// shape `requireAuth` sets so downstream handlers can't tell the transport
-// apart; `req.session` is intentionally absent.
+// Authentication for the MCP endpoint. Two bearer credentials work here:
+//
+//   - An API token, minted in Settings, carrying its own scope ('read' or
+//     'read-write') in req.apiToken.
+//   - An OAuth access token (#891) for an app the member approved in the
+//     browser. It has the access of a password sign-in, so the MCP server treats
+//     it as read-write. MCP clients find the OAuth server through its discovery
+//     document after this endpoint's 401; refusing the token they come back with
+//     would send them round the approval again and again.
+//
+// `req.user` is populated to the same shape requireAuth sets so handlers can't
+// tell the credential apart; `req.session` is intentionally absent.
 export function requireApiAuth(req: Request, res: Response, next: NextFunction): void {
   const header = req.headers.authorization || '';
   const match = /^Bearer\s+(\S+)$/.exec(header);
@@ -19,18 +26,29 @@ export function requireApiAuth(req: Request, res: Response, next: NextFunction):
     return;
   }
   const raw = match[1];
+
   const tokenRow = findActiveByHash(hashToken(raw));
-  if (!tokenRow) {
-    res.status(401).json({ error: 'unauthorized' });
+  if (tokenRow) {
+    const user = findUserById(tokenRow.userId);
+    if (!user) {
+      res.status(401).json({ error: 'unauthorized' });
+      return;
+    }
+    req.user = user;
+    req.apiToken = { id: tokenRow.id, scope: tokenRow.scope };
+    touchLastUsed(tokenRow.id);
+    next();
     return;
   }
-  const user = findUserById(tokenRow.userId);
-  if (!user) {
+
+  const oauth = findTokenByRaw(raw);
+  const user = oauth ? findUserById(oauth.userId) : undefined;
+  if (!oauth || !user) {
     res.status(401).json({ error: 'unauthorized' });
     return;
   }
   req.user = user;
-  req.apiToken = { id: tokenRow.id, scope: tokenRow.scope };
-  touchLastUsed(tokenRow.id);
+  req.oauthToken = { id: oauth.id, appId: oauth.appId };
+  touchTokenLastUsed(oauth.id);
   next();
 }

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -66,7 +66,8 @@ export function loadSession(req: Request): { session: Session; user: User } | nu
 // Both are 32 random bytes, and sessions are stored raw while OAuth tokens are
 // stored as SHA-256, so one can never be taken for the other; the order below
 // only decides which table is asked first. API tokens (middleware/apiAuth.ts)
-// are a third, separate namespace that only /mcp accepts.
+// are a third, separate namespace that only /mcp and the IRC bouncer accept;
+// /mcp takes OAuth tokens as well.
 export function bearerToken(authorization: string | undefined): string | null {
   const match = /^Bearer\s+(\S+)$/.exec(authorization ?? '');
   return match ? match[1] : null;

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -4,6 +4,7 @@
 import type { CookieOptions, NextFunction, Request, Response } from 'express';
 import { findSession } from '../db/sessions.js';
 import type { Session } from '../db/sessions.js';
+import { findTokenByRaw, touchTokenLastUsed } from '../db/oauth.js';
 import { findUserById, touchUserLastSeen } from '../db/users.js';
 import type { User } from '../db/users.js';
 
@@ -46,40 +47,62 @@ export function loadSession(req: Request): { session: Session; user: User } | nu
   return { session, user };
 }
 
-// Native clients (iOS/Android) authenticate with `Authorization: Bearer <token>`
-// instead of a cookie — they can set headers on a WebSocket upgrade, which
-// browsers cannot, and that is exactly why the web client stays cookie-bound.
+// Native and third-party clients authenticate with `Authorization: Bearer
+// <token>` instead of a cookie — they can set headers on a WebSocket upgrade,
+// which browsers cannot, and that is exactly why the web client stays
+// cookie-bound.
 //
-// The bearer here IS a session token: the same opaque `sessions.token` the
-// cookie carries, just handed to the app in a response body rather than wrapped
-// in a Set-Cookie (see POST /api/auth/login/token). So this resolves through the
-// unmodified findSession path and a native session is a real session row —
-// revoking one is deleting a row, and expiry works as it always has.
+// Two kinds of token arrive this way, and both mean "signed in as this member":
 //
-// This does NOT collide with the API-token bearer (middleware/apiAuth.ts): that
-// one is mounted only on /mcp, so the two bearer namespaces never meet on the
-// same route.
+//   - A session token: the same opaque `sessions.token` the cookie carries,
+//     handed to the app in a response body by POST /api/auth/login/token. It
+//     resolves through the unmodified findSession path, so a native session is a
+//     real session row — revoking one is deleting a row, and expiry works as it
+//     always has.
+//   - An OAuth access token (#891), minted for an app the member approved in the
+//     browser. Stored hashed, never expires, and carries exactly the access a
+//     session does. Revoking the app deletes it.
+//
+// Both are 32 random bytes, and sessions are stored raw while OAuth tokens are
+// stored as SHA-256, so one can never be taken for the other; the order below
+// only decides which table is asked first. API tokens (middleware/apiAuth.ts)
+// are a third, separate namespace that only /mcp accepts.
 export function bearerToken(authorization: string | undefined): string | null {
   const match = /^Bearer\s+(\S+)$/.exec(authorization ?? '');
   return match ? match[1] : null;
 }
 
-export function loadBearerSession(
-  authorization: string | undefined,
-): { session: Session; user: User } | null {
+/** Who a bearer token signs in as, and which credential it came through. */
+export interface BearerCredential {
+  user: User;
+  session: Session | null;
+  oauthToken: { id: number; appId: number } | null;
+}
+
+export function loadBearerCredential(authorization: string | undefined): BearerCredential | null {
   const token = bearerToken(authorization);
   if (!token) return null;
   const session = findSession(token);
-  if (!session) return null;
-  const user = findUserById(session.user_id);
+  if (session) {
+    const user = findUserById(session.user_id);
+    return user ? { user, session, oauthToken: null } : null;
+  }
+  const oauth = findTokenByRaw(token);
+  if (!oauth) return null;
+  const user = findUserById(oauth.userId);
   if (!user) return null;
-  return { session, user };
+  touchTokenLastUsed(oauth.id);
+  return { user, session: null, oauthToken: { id: oauth.id, appId: oauth.appId } };
 }
 
 export function requireAuth(req: Request, res: Response, next: NextFunction): void {
-  // Cookie first (every web request), bearer second (native only) — so the hot
-  // path is unchanged and a native request costs one extra header regex.
-  const ctx = loadSession(req) ?? loadBearerSession(req.headers.authorization);
+  // Cookie first (every web request), bearer second (native and third-party
+  // clients) — so the hot path is unchanged and a bearer request costs one extra
+  // header regex.
+  const cookieCtx = loadSession(req);
+  const ctx: BearerCredential | null = cookieCtx
+    ? { user: cookieCtx.user, session: cookieCtx.session, oauthToken: null }
+    : loadBearerCredential(req.headers.authorization);
   if (!ctx) {
     // If the request carried a lurker_session we can't honor — a stale cookie
     // whose signature no longer verifies (cell SESSION_SECRET rotated on a
@@ -105,7 +128,8 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
     return;
   }
   req.user = ctx.user;
-  req.session = ctx.session;
+  if (ctx.session) req.session = ctx.session;
+  if (ctx.oauthToken) req.oauthToken = ctx.oauthToken;
   // Paused accounts are read-only, enforced HERE (centrally) rather than per
   // router (#573): requireAuth guards every authed router, so folding the write
   // block in means no current or future router can forget it. GET/HEAD reads
@@ -115,6 +139,26 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
   // (fleet-secret authed — the orchestrator must still flip the flag). Live IRC
   // writes are separately gated in the WS layer + the ircManager startNetwork
   // gate, so this covers only the HTTP write surface.
+  if (isPausedWrite(req)) {
+    res.status(403).json({ error: 'account paused' });
+    return;
+  }
+  touchUserLastSeen(ctx.user.id);
+  next();
+}
+
+// The browser's session cookie and nothing else, for the OAuth approval
+// endpoints (#891). Approving an app is the one step that has to happen in front
+// of the member, so no bearer credential — not even a password-login session —
+// can stand in for it. Same paused-account rule as requireAuth.
+export function requireCookieSession(req: Request, res: Response, next: NextFunction): void {
+  const ctx = loadSession(req);
+  if (!ctx) {
+    res.status(401).json({ error: 'unauthorized' });
+    return;
+  }
+  req.user = ctx.user;
+  req.session = ctx.session;
   if (isPausedWrite(req)) {
     res.status(403).json({ error: 'account paused' });
     return;

--- a/server/routes/accountRecovery.test.ts
+++ b/server/routes/accountRecovery.test.ts
@@ -279,6 +279,31 @@ describe('POST /api/auth/recovery/:token/password', () => {
     expect(apiTokens.listForUser(u.id).filter((t) => !t.revokedAt)).toHaveLength(0);
   });
 
+  it('revokes OAuth apps, including an approval not yet exchanged (#891)', async () => {
+    const u = createUser('redeem-oauth');
+    const oauth = await import('../db/oauth.js');
+    const oauthApp = oauth.createApp({
+      clientName: 'Attacker app',
+      clientUri: null,
+      redirectUris: ['urn:ietf:wg:oauth:2.0:oob'],
+    });
+    const accessToken = oauth.createToken(oauthApp.id, u.id);
+    // Approved moments before the recovery and not exchanged yet. Deleting tokens
+    // alone would let this mint a fresh one after the member took the account back.
+    const code = oauth.createCode({
+      appId: oauthApp.id,
+      userId: u.id,
+      redirectUri: 'urn:ietf:wg:oauth:2.0:oob',
+      codeChallenge: 'c'.repeat(43),
+    });
+    const { token } = await issue(u.id);
+    await testRequest(app)
+      .post(`/api/auth/recovery/${token}/password`)
+      .send({ password: 'revoketheapps' });
+    expect(oauth.findTokenByRaw(accessToken)).toBeNull();
+    expect(oauth.consumeCode(code)).toBeNull();
+  });
+
   it('drops push registrations, which leak message content to an evicted device', async () => {
     const u = createUser('redeem-push');
     const push = await import('../db/pushSubscriptions.js');

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -830,12 +830,13 @@ router.get('/auth-methods', (_req: Request, res: Response) => {
 router.post('/logout', (req: Request, res: Response) => {
   // Cookie for web, bearer for native — a native client has no cookie to clear,
   // so without the bearer branch its "log out" would leave a live session row
-  // behind and the token on the device would keep working.
+  // behind and the token on the device would keep working. A request carrying
+  // both signs out both: a bearer must not keep working because a cookie came
+  // along with it.
   const cookieToken = req.signedCookies?.[SESSION_COOKIE];
   const bearer = bearerToken(req.headers.authorization);
-  if (cookieToken) {
-    deleteSession(cookieToken);
-  } else if (bearer) {
+  if (cookieToken) deleteSession(cookieToken);
+  if (bearer) {
     deleteSession(bearer);
     // A third-party app signing out with its OAuth token (#891) revokes that
     // token and closes the sockets it opened, rather than answering ok while the

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -43,10 +43,11 @@ import {
   deleteById as deleteCredentialById,
 } from '../db/webauthnCredentials.js';
 import { createSession, deleteSession, deleteSessionsForUser } from '../db/sessions.js';
-import { closeSocketsForUser } from '../services/wsHub.js';
+import { closeSocketsForUser, closeSocketsForOAuthTokens } from '../services/wsHub.js';
 import { isNodeMode } from '../utils/edition.js';
 import { dropSessionsForUser as dropBouncerSessionsForUser } from '../services/bouncer.js';
 import { revokeAllForUser as revokeApiTokensForUser } from '../db/apiTokens.js';
+import { deleteOAuthForUser, deleteTokenByRaw as deleteOAuthTokenByRaw } from '../db/oauth.js';
 import { deleteAllForUser as deletePushSubscriptionsForUser } from '../db/pushSubscriptions.js';
 import { SESSION_COOKIE, getCookieOptions, requireAuth, bearerToken } from '../middleware/auth.js';
 import { rpConfig, saveChallenge, consumeChallenge, userIdToHandle } from '../services/webauthn.js';
@@ -462,6 +463,10 @@ function finishRecovery(res: Response, user: { id: number; username: string; rol
   // Independent bearer credentials that outlive every session — an attacker who
   // minted one would otherwise keep read-write access straight through recovery.
   revokeApiTokensForUser(user.id);
+  // Apps authorized over OAuth (#891), and any approval not yet exchanged: a code
+  // approved before the recovery would otherwise mint a token minutes after it.
+  // Their sockets already went with closeSocketsForUser above.
+  deleteOAuthForUser(user.id);
   // Keyed on user_id with no session linkage, so an evicted device would keep
   // receiving the member's incoming messages as push content.
   deletePushSubscriptionsForUser(user.id);
@@ -826,8 +831,18 @@ router.post('/logout', (req: Request, res: Response) => {
   // Cookie for web, bearer for native — a native client has no cookie to clear,
   // so without the bearer branch its "log out" would leave a live session row
   // behind and the token on the device would keep working.
-  const token = req.signedCookies?.[SESSION_COOKIE] ?? bearerToken(req.headers.authorization);
-  if (token) deleteSession(token);
+  const cookieToken = req.signedCookies?.[SESSION_COOKIE];
+  const bearer = bearerToken(req.headers.authorization);
+  if (cookieToken) {
+    deleteSession(cookieToken);
+  } else if (bearer) {
+    deleteSession(bearer);
+    // A third-party app signing out with its OAuth token (#891) revokes that
+    // token and closes the sockets it opened, rather than answering ok while the
+    // token keeps working. At most one of the two deletes can match.
+    const revoked = deleteOAuthTokenByRaw(bearer);
+    if (revoked) closeSocketsForOAuthTokens(revoked.userId, [revoked.id], 'signed out');
+  }
   res.clearCookie(SESSION_COOKIE, { ...getCookieOptions(), maxAge: undefined });
   res.json({ ok: true });
 });

--- a/server/routes/oauth.test.ts
+++ b/server/routes/oauth.test.ts
@@ -197,6 +197,30 @@ describe('POST /api/oauth/register', () => {
       db.prepare(`DELETE FROM oauth_apps WHERE client_id LIKE 'pending-filler-%'`).run();
     }
   });
+
+  it('sweeps registrations over an hour old before turning anyone away', async () => {
+    // The hourly sweep can leave an expired registration for up to another hour.
+    // A full table of them must not keep refusing new apps in the meantime.
+    const room = oauthDb.MAX_PENDING_APPS - oauthDb.countPendingApps();
+    const stale = new Date(Date.now() - oauthDb.PENDING_APP_TTL_MS - 60_000).toISOString();
+    db.prepare(
+      `WITH RECURSIVE n(i) AS (SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < ?)
+       INSERT INTO oauth_apps (client_id, client_name, redirect_uris, created_at)
+       SELECT 'stale-filler-' || i, 'Filler', '[]', ? FROM n`,
+    ).run(room, stale);
+    try {
+      const res = await testRequest(app)
+        .post('/api/oauth/register')
+        .send({ client_name: 'After the hour', redirect_uris: [OOB] });
+      expect(res.status).toBe(201);
+      const left = db
+        .prepare(`SELECT COUNT(*) AS n FROM oauth_apps WHERE client_id LIKE 'stale-filler-%'`)
+        .get();
+      expect(left).toEqual({ n: 0 });
+    } finally {
+      db.prepare(`DELETE FROM oauth_apps WHERE client_id LIKE 'stale-filler-%'`).run();
+    }
+  });
 });
 
 describe('GET /api/oauth/authorize', () => {
@@ -515,6 +539,18 @@ describe('an OAuth access token', () => {
     const { token } = await tokenFor(user.id);
     expect((await asApp(token).post('/api/auth/logout')).status).toBe(200);
     expect((await asApp(token).get('/api/auth/me')).status).toBe(401);
+  });
+
+  it('stops working when it signs out alongside a session cookie', async () => {
+    // A client that keeps a cookie jar sends both. The cookie must not shadow the
+    // token: logout ends the session and revokes the token.
+    const user = createUser('oauth-token-logout-with-cookie');
+    const { token } = await tokenFor(user.id);
+    const browser = await createAuthedAgent(app, user.id);
+    const res = await browser.post('/api/auth/logout').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect((await asApp(token).get('/api/auth/me')).status).toBe(401);
+    expect((await browser.get('/api/auth/me')).status).toBe(401);
   });
 });
 

--- a/server/routes/oauth.test.ts
+++ b/server/routes/oauth.test.ts
@@ -243,6 +243,15 @@ describe('GET /api/oauth/authorize', () => {
     });
   });
 
+  it('accepts a localhost redirect registered the way Claude Code registers one', async () => {
+    const flow = await startFlow('http://localhost:54321/callback');
+    const res = await member
+      .get('/api/oauth/authorize')
+      .query(authorizeParams({ ...flow, redirectUri: 'http://localhost:61000/callback' }));
+    expect(res.status).toBe(200);
+    expect(res.body.destination).toEqual({ kind: 'loopback' });
+  });
+
   it('accepts a loopback redirect on a port other than the registered one', async () => {
     const flow = await startFlow(LOOPBACK);
     const res = await member

--- a/server/routes/oauth.test.ts
+++ b/server/routes/oauth.test.ts
@@ -206,7 +206,7 @@ describe('GET /api/oauth/authorize', () => {
     member = await createAuthedAgent(app, createUser('oauth-authorize-get').id);
   });
 
-  it('describes the app and where the approval goes', async () => {
+  it('describes the app, where the approval goes, and the request it checked', async () => {
     const { client_id } = await register([APP_REDIRECT], {
       client_uri: 'https://client.example/about',
     });
@@ -217,6 +217,29 @@ describe('GET /api/oauth/authorize', () => {
     expect(res.body).toEqual({
       app: { name: 'Test Client', website: 'client.example' },
       destination: { kind: 'app', scheme: 'com.example.testclient' },
+      request: authorizeParams(flow),
+    });
+  });
+
+  it('echoes its own reading of a query padded past the parser limit', async () => {
+    // The attack from review: the shown app's parameters first, filler past
+    // Express's 1000-key limit, then a second app's. The page approves whatever
+    // this echoes, so it has to be the app the page showed.
+    const shown = await startFlow(APP_REDIRECT);
+    const hidden = await startFlow('https://evil.example/cb');
+    const filler = Array.from({ length: 1000 }, (_, i) => `f${i}=1`);
+    const query = [
+      new URLSearchParams(authorizeParams(shown)).toString(),
+      ...filler,
+      `client_id=${hidden.clientId}`,
+      `redirect_uri=${encodeURIComponent(hidden.redirectUri)}`,
+    ].join('&');
+    const res = await member.get(`/api/oauth/authorize?${query}`);
+    expect(res.status).toBe(200);
+    expect(res.body.destination).toEqual({ kind: 'app', scheme: 'com.example.testclient' });
+    expect(res.body.request).toMatchObject({
+      client_id: shown.clientId,
+      redirect_uri: APP_REDIRECT,
     });
   });
 

--- a/server/routes/oauth.test.ts
+++ b/server/routes/oauth.test.ts
@@ -1,0 +1,570 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// End-to-end cover for OAuth sign-in (#891): a third-party app registers, the
+// member approves it with their browser session, the app exchanges the code, and
+// the token signs in exactly like a password session until it's revoked. The
+// routers are mounted together so the loop runs the way it does in production.
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import crypto from 'crypto';
+import type { Express } from 'express';
+import {
+  setupTestDb,
+  createTestApp,
+  createAuthedAgent,
+  testRequest,
+} from '../test-utils/testApp.js';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+
+const ctx = setupTestDb('routes-oauth');
+
+const OOB = 'urn:ietf:wg:oauth:2.0:oob';
+const APP_REDIRECT = 'com.example.testclient:/oauth';
+const LOOPBACK = 'http://127.0.0.1:8000/callback';
+
+let app: Express;
+let db: typeof import('../db/index.js').default;
+let createUser: typeof import('../db/users.js').createUser;
+let createSession: typeof import('../db/sessions.js').createSession;
+let oauthDb: typeof import('../db/oauth.js');
+let routes: typeof import('./oauth.js');
+let resetAuthRateLimits: typeof import('../middleware/rateLimit.js').resetAuthRateLimits;
+
+beforeAll(async () => {
+  db = (await import('../db/index.js')).default;
+  ({ createUser } = await import('../db/users.js'));
+  ({ createSession } = await import('../db/sessions.js'));
+  ({ resetAuthRateLimits } = await import('../middleware/rateLimit.js'));
+  oauthDb = await import('../db/oauth.js');
+  routes = await import('./oauth.js');
+  const authRouter = (await import('./auth.js')).default;
+  const apiTokensRouter = (await import('./apiTokens.js')).default;
+  const pushRouter = (await import('./push.js')).default;
+  app = createTestApp({
+    '/api/oauth': routes.oauthRouter,
+    '/api/auth': authRouter,
+    '/api/api-tokens': apiTokensRouter,
+    '/api/push': pushRouter,
+  });
+});
+
+afterAll(() => ctx.cleanup());
+
+beforeEach(() => {
+  routes.registrationThrottle.clear();
+  resetAuthRateLimits();
+});
+
+interface Flow {
+  clientId: string;
+  redirectUri: string;
+  verifier: string;
+  challenge: string;
+}
+
+function pkce(): { verifier: string; challenge: string } {
+  const verifier = crypto.randomBytes(32).toString('base64url');
+  const challenge = crypto.createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, challenge };
+}
+
+async function register(
+  redirectUris: string[] = [OOB],
+  extra: Record<string, unknown> = {},
+): Promise<{ client_id: string }> {
+  const res = await testRequest(app)
+    .post('/api/oauth/register')
+    .send({ client_name: 'Test Client', redirect_uris: redirectUris, ...extra });
+  expect(res.status).toBe(201);
+  return res.body;
+}
+
+async function startFlow(redirectUri = OOB): Promise<Flow> {
+  const { client_id } = await register([redirectUri]);
+  return { clientId: client_id, redirectUri, ...pkce() };
+}
+
+function authorizeParams(flow: Flow, extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    client_id: flow.clientId,
+    redirect_uri: flow.redirectUri,
+    response_type: 'code',
+    code_challenge: flow.challenge,
+    code_challenge_method: 'S256',
+    state: 'st4te',
+    ...extra,
+  };
+}
+
+// Approve as `member` and return the code, from the body for out-of-band or from
+// the redirect otherwise.
+async function approve(member: LurkerTestAgent, flow: Flow): Promise<string> {
+  const res = await member
+    .post('/api/oauth/authorize')
+    .send({ ...authorizeParams(flow), decision: 'approve' });
+  expect(res.status).toBe(200);
+  if (res.body.code) return res.body.code;
+  return new URL(res.body.redirect).searchParams.get('code') ?? '';
+}
+
+function exchange(flow: Flow, code: string, overrides: Record<string, string> = {}) {
+  return testRequest(app)
+    .post('/api/oauth/token')
+    .type('form')
+    .send({
+      grant_type: 'authorization_code',
+      client_id: flow.clientId,
+      code,
+      redirect_uri: flow.redirectUri,
+      code_verifier: flow.verifier,
+      ...overrides,
+    });
+}
+
+// The whole dance for a fresh app: the member approves it and the app gets a token.
+async function tokenFor(userId: number): Promise<{ token: string; flow: Flow }> {
+  const member = await createAuthedAgent(app, userId);
+  const flow = await startFlow();
+  const res = await exchange(flow, await approve(member, flow));
+  expect(res.status).toBe(200);
+  return { token: res.body.access_token, flow };
+}
+
+function asApp(token: string) {
+  return {
+    get: (path: string) => testRequest(app).get(path).set('Authorization', `Bearer ${token}`),
+    post: (path: string) => testRequest(app).post(path).set('Authorization', `Bearer ${token}`),
+  };
+}
+
+describe('POST /api/oauth/register', () => {
+  it('registers a public client and says so', async () => {
+    const res = await testRequest(app)
+      .post('/api/oauth/register')
+      .send({
+        client_name: 'Spooky',
+        redirect_uris: [APP_REDIRECT],
+        client_uri: 'https://spooky.example',
+        token_endpoint_auth_method: 'client_secret_basic',
+        scope: 'read',
+      });
+    expect(res.status).toBe(201);
+    expect(res.headers['cache-control']).toContain('no-store');
+    expect(res.body).toMatchObject({
+      client_name: 'Spooky',
+      client_uri: 'https://spooky.example',
+      redirect_uris: [APP_REDIRECT],
+      grant_types: ['authorization_code'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    });
+    expect(res.body.client_id).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(res.body).not.toHaveProperty('client_secret');
+  });
+
+  it('refuses an unsupported redirect URI', async () => {
+    const res = await testRequest(app)
+      .post('/api/oauth/register')
+      .send({ client_name: 'Bad', redirect_uris: ['javascript:alert(1)'] });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_redirect_uri');
+  });
+
+  it('allows five registrations per address every ten minutes', async () => {
+    for (let i = 0; i < 5; i++) await register();
+    const res = await testRequest(app)
+      .post('/api/oauth/register')
+      .send({ client_name: 'Sixth', redirect_uris: [OOB] });
+    expect(res.status).toBe(429);
+    expect(res.headers['retry-after']).toBeDefined();
+  });
+
+  it('stops accepting registrations while too many wait for approval', async () => {
+    const room = oauthDb.MAX_PENDING_APPS - oauthDb.countPendingApps();
+    db.prepare(
+      `WITH RECURSIVE n(i) AS (SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < ?)
+       INSERT INTO oauth_apps (client_id, client_name, redirect_uris)
+       SELECT 'pending-filler-' || i, 'Filler', '[]' FROM n`,
+    ).run(room);
+    try {
+      const res = await testRequest(app)
+        .post('/api/oauth/register')
+        .send({ client_name: 'One too many', redirect_uris: [OOB] });
+      expect(res.status).toBe(429);
+      expect(res.body.error).toBe('temporarily_unavailable');
+    } finally {
+      db.prepare(`DELETE FROM oauth_apps WHERE client_id LIKE 'pending-filler-%'`).run();
+    }
+  });
+});
+
+describe('GET /api/oauth/authorize', () => {
+  let member: LurkerTestAgent;
+
+  beforeAll(async () => {
+    member = await createAuthedAgent(app, createUser('oauth-authorize-get').id);
+  });
+
+  it('describes the app and where the approval goes', async () => {
+    const { client_id } = await register([APP_REDIRECT], {
+      client_uri: 'https://client.example/about',
+    });
+    const flow = { clientId: client_id, redirectUri: APP_REDIRECT, ...pkce() };
+    const res = await member.get('/api/oauth/authorize').query(authorizeParams(flow));
+    expect(res.status).toBe(200);
+    expect(res.headers['cache-control']).toContain('no-store');
+    expect(res.body).toEqual({
+      app: { name: 'Test Client', website: 'client.example' },
+      destination: { kind: 'app', scheme: 'com.example.testclient' },
+    });
+  });
+
+  it('accepts a loopback redirect on a port other than the registered one', async () => {
+    const flow = await startFlow(LOOPBACK);
+    const res = await member
+      .get('/api/oauth/authorize')
+      .query(authorizeParams({ ...flow, redirectUri: 'http://127.0.0.1:61234/callback' }));
+    expect(res.status).toBe(200);
+    expect(res.body.destination).toEqual({ kind: 'loopback' });
+  });
+
+  it('reports a bad redirect as an error, never as a redirect', async () => {
+    const flow = await startFlow(APP_REDIRECT);
+    const res = await member
+      .get('/api/oauth/authorize')
+      .query(authorizeParams({ ...flow, redirectUri: 'com.example.attacker:/steal' }));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_redirect_uri');
+    expect(res.body).not.toHaveProperty('redirect');
+  });
+
+  it.each([
+    ['an unknown client', { client_id: 'no-such-client' }, 'invalid_client'],
+    ['no PKCE method', { code_challenge_method: '' }, 'invalid_request'],
+    ['plain PKCE', { code_challenge_method: 'plain' }, 'invalid_request'],
+    ['response_type=token', { response_type: 'token' }, 'unsupported_response_type'],
+  ])('refuses %s', async (_label, override, error) => {
+    const flow = await startFlow();
+    const res = await member.get('/api/oauth/authorize').query(authorizeParams(flow, override));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe(error);
+  });
+
+  it('needs a signed-in member', async () => {
+    const flow = await startFlow();
+    const res = await testRequest(app).get('/api/oauth/authorize').query(authorizeParams(flow));
+    expect(res.status).toBe(401);
+  });
+
+  it('takes only the browser session cookie, not a bearer session', async () => {
+    // Otherwise a password-login client could approve apps for itself, with no page.
+    const { token } = createSession(createUser('oauth-authorize-bearer').id);
+    const flow = await startFlow();
+    const res = await testRequest(app)
+      .get('/api/oauth/authorize')
+      .query(authorizeParams(flow))
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /api/oauth/authorize', () => {
+  let member: LurkerTestAgent;
+
+  beforeAll(async () => {
+    member = await createAuthedAgent(app, createUser('oauth-authorize-post').id);
+  });
+
+  it('returns the code itself for an out-of-band redirect', async () => {
+    const flow = await startFlow(OOB);
+    const res = await member
+      .post('/api/oauth/authorize')
+      .send({ ...authorizeParams(flow), decision: 'approve' });
+    expect(res.status).toBe(200);
+    expect(res.body.code).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(res.body).not.toHaveProperty('redirect');
+  });
+
+  it('redirects to an app with the code and state', async () => {
+    const flow = await startFlow(APP_REDIRECT);
+    const res = await member
+      .post('/api/oauth/authorize')
+      .send({ ...authorizeParams(flow), decision: 'approve' });
+    const url = new URL(res.body.redirect);
+    expect(`${url.protocol}${url.pathname}`).toBe(APP_REDIRECT);
+    expect(url.searchParams.get('code')).toBeTruthy();
+    expect(url.searchParams.get('state')).toBe('st4te');
+  });
+
+  it('redirects to the loopback port the app asked for', async () => {
+    const flow = await startFlow(LOOPBACK);
+    const res = await member.post('/api/oauth/authorize').send({
+      ...authorizeParams({ ...flow, redirectUri: 'http://127.0.0.1:61234/callback' }),
+      decision: 'approve',
+    });
+    expect(new URL(res.body.redirect).port).toBe('61234');
+  });
+
+  it('sends a denial back as access_denied', async () => {
+    const flow = await startFlow(APP_REDIRECT);
+    const res = await member
+      .post('/api/oauth/authorize')
+      .send({ ...authorizeParams(flow), decision: 'deny' });
+    const url = new URL(res.body.redirect);
+    expect(url.searchParams.get('error')).toBe('access_denied');
+    expect(url.searchParams.get('state')).toBe('st4te');
+    expect(url.searchParams.has('code')).toBe(false);
+  });
+
+  it('answers an out-of-band denial without a redirect', async () => {
+    const flow = await startFlow(OOB);
+    const res = await member
+      .post('/api/oauth/authorize')
+      .send({ ...authorizeParams(flow), decision: 'deny' });
+    expect(res.body).toEqual({ denied: true });
+  });
+
+  it('refuses a form post, which a cross-site page could send', async () => {
+    const flow = await startFlow();
+    const res = await member
+      .post('/api/oauth/authorize')
+      .type('form')
+      .send({ ...authorizeParams(flow), decision: 'approve' });
+    expect(res.status).toBe(415);
+  });
+
+  it('refuses a missing decision', async () => {
+    const flow = await startFlow();
+    const res = await member.post('/api/oauth/authorize').send(authorizeParams(flow));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/oauth/token', () => {
+  let member: LurkerTestAgent;
+
+  beforeAll(async () => {
+    member = await createAuthedAgent(app, createUser('oauth-token').id);
+  });
+
+  it('exchanges a code for a token that never expires', async () => {
+    const flow = await startFlow();
+    const res = await exchange(flow, await approve(member, flow));
+    expect(res.status).toBe(200);
+    expect(res.headers['cache-control']).toContain('no-store');
+    expect(res.body.token_type).toBe('Bearer');
+    expect(res.body.access_token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(res.body).not.toHaveProperty('expires_in');
+    expect(res.body).not.toHaveProperty('refresh_token');
+  });
+
+  it('accepts a JSON body as well as a form', async () => {
+    const flow = await startFlow();
+    const code = await approve(member, flow);
+    const res = await testRequest(app).post('/api/oauth/token').send({
+      grant_type: 'authorization_code',
+      client_id: flow.clientId,
+      code,
+      redirect_uri: flow.redirectUri,
+      code_verifier: flow.verifier,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('spends a code once', async () => {
+    const flow = await startFlow();
+    const code = await approve(member, flow);
+    expect((await exchange(flow, code)).status).toBe(200);
+    const again = await exchange(flow, code);
+    expect(again.status).toBe(400);
+    expect(again.body.error).toBe('invalid_grant');
+  });
+
+  it.each([
+    ['the wrong verifier', () => ({ code_verifier: pkce().verifier })],
+    ['a different redirect_uri', () => ({ redirect_uri: 'com.example.other:/oauth' })],
+  ])('refuses %s, and the code is spent anyway', async (_label, override) => {
+    const flow = await startFlow();
+    const code = await approve(member, flow);
+    const bad = await exchange(flow, code, override());
+    expect(bad.status).toBe(400);
+    expect(bad.body.error).toBe('invalid_grant');
+    // Someone it wasn't issued to has seen it, so the right request can't use it now.
+    expect((await exchange(flow, code)).status).toBe(400);
+  });
+
+  it('refuses a code issued to another app, and burns it', async () => {
+    const mine = await startFlow();
+    const code = await approve(member, mine);
+    const other = await startFlow();
+    const res = await exchange({ ...other, verifier: mine.verifier }, code);
+    expect(res.body.error).toBe('invalid_grant');
+    expect((await exchange(mine, code)).status).toBe(400);
+  });
+
+  it('refuses an unknown client without burning the code', async () => {
+    const flow = await startFlow();
+    const code = await approve(member, flow);
+    const res = await exchange({ ...flow, clientId: 'no-such-client' }, code);
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('invalid_client');
+    expect((await exchange(flow, code)).status).toBe(200);
+  });
+
+  it('refuses an expired code', async () => {
+    const flow = await startFlow();
+    const code = await approve(member, flow);
+    db.prepare(
+      `UPDATE oauth_codes SET expires_at = '2000-01-01T00:00:00.000Z' WHERE code_hash = ?`,
+    ).run(oauthDb.hashSecret(code));
+    const res = await exchange(flow, code);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_grant');
+  });
+
+  it('refuses other grant types', async () => {
+    const res = await testRequest(app)
+      .post('/api/oauth/token')
+      .type('form')
+      .send({ grant_type: 'refresh_token', refresh_token: 'anything' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('unsupported_grant_type');
+  });
+
+  it('refuses a parameter sent twice', async () => {
+    const flow = await startFlow();
+    const code = await approve(member, flow);
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: flow.clientId,
+      code,
+      redirect_uri: flow.redirectUri,
+      code_verifier: flow.verifier,
+    });
+    body.append('code', code);
+    const res = await testRequest(app).post('/api/oauth/token').type('form').send(body.toString());
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_request');
+  });
+});
+
+describe('an OAuth access token', () => {
+  it('signs in like a session', async () => {
+    const user = createUser('oauth-token-signs-in');
+    const { token } = await tokenFor(user.id);
+    const me = await asApp(token).get('/api/auth/me');
+    expect(me.status).toBe(200);
+    expect(me.body.user.id).toBe(user.id);
+  });
+
+  it('reaches the same routes a password sign-in does', async () => {
+    const user = createUser('oauth-token-parity');
+    const { token } = await tokenFor(user.id);
+    const created = await asApp(token)
+      .post('/api/api-tokens')
+      .send({ name: 'made by an app', scope: 'read' });
+    expect(created.status).toBe(201);
+    const listed = await asApp(token).get('/api/api-tokens');
+    expect(listed.status).toBe(200);
+    expect(listed.body.items).toHaveLength(1);
+  });
+
+  it('is read-only while the account is paused, like a session', async () => {
+    const user = createUser('oauth-token-paused');
+    const { token } = await tokenFor(user.id);
+    db.prepare('UPDATE users SET is_paused = 1 WHERE id = ?').run(user.id);
+    const res = await asApp(token).post('/api/api-tokens').send({ name: 'x', scope: 'read' });
+    expect(res.status).toBe(403);
+  });
+
+  it('stops working once the app signs out with it', async () => {
+    const user = createUser('oauth-token-logout');
+    const { token } = await tokenFor(user.id);
+    expect((await asApp(token).post('/api/auth/logout')).status).toBe(200);
+    expect((await asApp(token).get('/api/auth/me')).status).toBe(401);
+  });
+});
+
+describe('POST /api/oauth/revoke', () => {
+  it('revokes a token for the client it was issued to', async () => {
+    const user = createUser('oauth-revoke');
+    const { token, flow } = await tokenFor(user.id);
+    const res = await testRequest(app)
+      .post('/api/oauth/revoke')
+      .type('form')
+      .send({ client_id: flow.clientId, token });
+    expect(res.status).toBe(200);
+    expect((await asApp(token).get('/api/auth/me')).status).toBe(401);
+  });
+
+  it('answers 200 for a token that never existed, so it cannot probe', async () => {
+    const flow = await startFlow();
+    const res = await testRequest(app)
+      .post('/api/oauth/revoke')
+      .type('form')
+      .send({ client_id: flow.clientId, token: 'no-such-token' });
+    expect(res.status).toBe(200);
+  });
+
+  it('leaves a token alone when a different client asks', async () => {
+    const user = createUser('oauth-revoke-other-client');
+    const { token } = await tokenFor(user.id);
+    const other = await startFlow();
+    await testRequest(app)
+      .post('/api/oauth/revoke')
+      .type('form')
+      .send({ client_id: other.clientId, token });
+    expect((await asApp(token).get('/api/auth/me')).status).toBe(200);
+  });
+
+  it('deletes the push subscriptions the app registered, and only those', async () => {
+    const user = createUser('oauth-revoke-push');
+    const { token, flow } = await tokenFor(user.id);
+    const browser = await createAuthedAgent(app, user.id);
+    const keys = { p256dh: 'key', auth: 'auth' };
+    const byApp = await asApp(token)
+      .post('/api/push/subscriptions')
+      .send({ endpoint: 'https://push.example/app', keys });
+    expect(byApp.status).toBe(201);
+    const byBrowser = await browser
+      .post('/api/push/subscriptions')
+      .send({ endpoint: 'https://push.example/browser', keys });
+    expect(byBrowser.status).toBe(201);
+
+    await testRequest(app)
+      .post('/api/oauth/revoke')
+      .type('form')
+      .send({ client_id: flow.clientId, token });
+
+    const push = await import('../db/pushSubscriptions.js');
+    expect(push.listAllForUser(user.id).map((s) => s.endpoint)).toEqual([
+      'https://push.example/browser',
+    ]);
+  });
+});
+
+describe('authorized apps', () => {
+  it('lists the apps a member authorized, and revokes one', async () => {
+    const user = createUser('oauth-apps');
+    const member = await createAuthedAgent(app, user.id);
+    const { token } = await tokenFor(user.id);
+
+    const list = await member.get('/api/oauth/apps');
+    expect(list.status).toBe(200);
+    expect(list.body.apps).toHaveLength(1);
+    expect(list.body.apps[0]).toMatchObject({ name: 'Test Client' });
+
+    const revoked = await member.delete(`/api/oauth/apps/${list.body.apps[0].id}`);
+    expect(revoked.status).toBe(200);
+    expect((await member.get('/api/oauth/apps')).body.apps).toEqual([]);
+    expect((await asApp(token).get('/api/auth/me')).status).toBe(401);
+  });
+
+  it('404s for an app the member never authorized', async () => {
+    const member = await createAuthedAgent(app, createUser('oauth-apps-404').id);
+    const { flow } = await tokenFor(createUser('oauth-apps-someone-else').id);
+    const appId = oauthDb.findAppByClientId(flow.clientId)?.id;
+    expect((await member.delete(`/api/oauth/apps/${appId}`)).status).toBe(404);
+  });
+});

--- a/server/routes/oauth.ts
+++ b/server/routes/oauth.ts
@@ -147,9 +147,22 @@ oauthRouter.get('/authorize', requireCookieSession, (req: Request, res: Response
     oauthError(res, 400, resolved.error, resolved.description);
     return;
   }
+  const { clientId, redirectUri, codeChallenge, state } = resolved.request;
   res.json({
     app: { name: resolved.app.clientName, website: hostOf(resolved.app.clientUri) },
-    destination: redirectDestination(resolved.request.redirectUri),
+    destination: redirectDestination(redirectUri),
+    // The request exactly as read and checked here. The page posts these values
+    // back on Approve or Deny instead of re-reading its own URL: a second parser
+    // can read a crafted query string differently (this one stops at 1000 keys,
+    // URLSearchParams doesn't), which would show one app and approve another.
+    request: {
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: 'code',
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+      ...(state !== undefined ? { state } : {}),
+    },
   });
 });
 

--- a/server/routes/oauth.ts
+++ b/server/routes/oauth.ts
@@ -18,6 +18,7 @@ import {
   deleteTokenForClient,
   findAppByClientId,
   listAuthorizedApps,
+  purgeOAuth,
 } from '../db/oauth.js';
 import type { OAuthApp } from '../db/oauth.js';
 import {
@@ -85,7 +86,10 @@ oauthRouter.post(
       return;
     }
     // The throttle bounds one address; this bounds the table, whatever the source.
-    // Approved apps don't count, and unapproved ones are purged after an hour.
+    // Approved apps don't count, and unapproved ones are purged after an hour. The
+    // hourly sweep can leave an expired registration in place for up to another
+    // hour, so a full table is swept before anyone is turned away.
+    if (countPendingApps() >= MAX_PENDING_APPS) purgeOAuth();
     if (countPendingApps() >= MAX_PENDING_APPS) {
       res.set('Retry-After', '3600');
       oauthError(

--- a/server/routes/oauth.ts
+++ b/server/routes/oauth.ts
@@ -1,0 +1,313 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import express, { Router } from 'express';
+import type { Request, Response } from 'express';
+import { requireAuth, requireCookieSession } from '../middleware/auth.js';
+import { RequestThrottle, limitRequests } from '../middleware/rateLimit.js';
+import { closeSocketsForOAuthTokens } from '../services/wsHub.js';
+import { publicBaseUrl } from '../utils/publicOrigin.js';
+import {
+  MAX_PENDING_APPS,
+  consumeCode,
+  countPendingApps,
+  createApp,
+  createCode,
+  createToken,
+  deleteOAuthForApp,
+  deleteTokenForClient,
+  findAppByClientId,
+  listAuthorizedApps,
+} from '../db/oauth.js';
+import type { OAuthApp } from '../db/oauth.js';
+import {
+  OOB_REDIRECT_URI,
+  hostOf,
+  matchRedirectUri,
+  parseAuthorizeRequest,
+  redirectDestination,
+  validateRegistration,
+  verifyPkceS256,
+  withQuery,
+} from '../services/oauth.js';
+import type { AuthorizeRequest } from '../services/oauth.js';
+
+// OAuth 2 authorization server for third-party clients (#891), on Mastodon's
+// model: any client registers itself, the member approves it in the browser, and
+// the token the client gets has the same access as a password sign-in.
+//
+// Public clients only. With open registration a client secret proves nothing --
+// anyone can register their own -- so every app authenticates with its client_id
+// alone and PKCE S256 binds each code to whoever started the flow. Tokens never
+// expire and there are no refresh tokens; revoking deletes the token and closes
+// every socket it opened.
+//
+// Standalone edition only (app.ts). Hosted sign-in happens in front of the cells.
+
+export const oauthRouter = Router();
+
+// Mastodon's figure for its own open registration endpoint. Behind a reverse
+// proxy without LURKER_TRUST_PROXY every client shares one key, which the docs say.
+export const registrationThrottle = new RequestThrottle({ windowMs: 10 * 60_000, maxRequests: 5 });
+
+// RFC 6749 token and revocation requests are form-encoded. Parsed on these two
+// routes only: a global urlencoded parser would let a cross-site form post to
+// every cookie-authenticated route, which JSON-only parsing currently prevents.
+const formBody = express.urlencoded({ extended: false, limit: '16kb' });
+
+function noStore(res: Response): void {
+  res.set('Cache-Control', 'no-store');
+  res.set('Pragma', 'no-cache');
+}
+
+function oauthError(res: Response, status: number, error: string, description: string): void {
+  res.status(status).json({ error, error_description: description });
+}
+
+// A parameter is only ever a single string. Express turns a repeated parameter
+// into an array, and anything that isn't a string reads as absent.
+function param(body: unknown, key: string): string | undefined {
+  if (!body || typeof body !== 'object') return undefined;
+  const value = (body as Record<string, unknown>)[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+// ---------- registration (RFC 7591) ----------
+
+oauthRouter.post(
+  '/register',
+  limitRequests(registrationThrottle),
+  (req: Request, res: Response) => {
+    noStore(res);
+    const result = validateRegistration(req.body);
+    if (!result.ok) {
+      oauthError(res, 400, result.error, result.description);
+      return;
+    }
+    // The throttle bounds one address; this bounds the table, whatever the source.
+    // Approved apps don't count, and unapproved ones are purged after an hour.
+    if (countPendingApps() >= MAX_PENDING_APPS) {
+      res.set('Retry-After', '3600');
+      oauthError(
+        res,
+        429,
+        'temporarily_unavailable',
+        'too many unapproved registrations; try later',
+      );
+      return;
+    }
+    const app = createApp(result.metadata);
+    res.status(201).json({
+      client_id: app.clientId,
+      client_id_issued_at: Math.floor(Date.parse(app.createdAt) / 1000),
+      client_name: app.clientName,
+      ...(app.clientUri ? { client_uri: app.clientUri } : {}),
+      redirect_uris: app.redirectUris,
+      grant_types: ['authorization_code'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    });
+  },
+);
+
+// ---------- authorization (the approval page's API) ----------
+
+type ResolvedAuthorize =
+  | { ok: true; app: OAuthApp; request: AuthorizeRequest }
+  | { ok: false; error: string; description: string };
+
+function resolveAuthorize(source: Record<string, unknown>): ResolvedAuthorize {
+  const parsed = parseAuthorizeRequest(source);
+  if (!parsed.ok) return parsed;
+  const app = findAppByClientId(parsed.request.clientId);
+  if (!app) return { ok: false, error: 'invalid_client', description: 'unknown client_id' };
+  if (!matchRedirectUri(app.redirectUris, parsed.request.redirectUri)) {
+    return {
+      ok: false,
+      error: 'invalid_redirect_uri',
+      description: 'redirect_uri is not registered for this app',
+    };
+  }
+  return { ok: true, app, request: parsed.request };
+}
+
+// Both authorize routes take the browser's session cookie and nothing else. The
+// approval page is the only way a token gets minted, so a client holding a
+// password-login bearer session can't approve an app for itself without it.
+//
+// Neither ever redirects on an error. Registration is open, so an attacker can
+// register any redirect they like; bouncing a signed-in member there from a bad
+// request would make Lurker an open redirector (RFC 9700 §4.11.2). Errors are
+// shown on the page, and only the member's own Approve or Deny click navigates.
+
+oauthRouter.get('/authorize', requireCookieSession, (req: Request, res: Response) => {
+  noStore(res);
+  const resolved = resolveAuthorize(req.query as Record<string, unknown>);
+  if (!resolved.ok) {
+    oauthError(res, 400, resolved.error, resolved.description);
+    return;
+  }
+  res.json({
+    app: { name: resolved.app.clientName, website: hostOf(resolved.app.clientUri) },
+    destination: redirectDestination(resolved.request.redirectUri),
+  });
+});
+
+oauthRouter.post('/authorize', requireCookieSession, (req: Request, res: Response) => {
+  noStore(res);
+  // JSON only: a cross-site HTML form can't send it, and the cookie is the
+  // credential here.
+  if (!req.is('application/json')) {
+    oauthError(res, 415, 'invalid_request', 'send the decision as application/json');
+    return;
+  }
+  const resolved = resolveAuthorize((req.body ?? {}) as Record<string, unknown>);
+  if (!resolved.ok) {
+    oauthError(res, 400, resolved.error, resolved.description);
+    return;
+  }
+  const { redirectUri, state, codeChallenge } = resolved.request;
+  const outOfBand = redirectUri === OOB_REDIRECT_URI;
+  const decision = param(req.body, 'decision');
+  if (decision === 'deny') {
+    res.json(
+      outOfBand
+        ? { denied: true }
+        : { redirect: withQuery(redirectUri, { error: 'access_denied', state }) },
+    );
+    return;
+  }
+  if (decision !== 'approve') {
+    oauthError(res, 400, 'invalid_request', 'decision must be approve or deny');
+    return;
+  }
+  const code = createCode({
+    appId: resolved.app.id,
+    userId: req.user!.id,
+    redirectUri,
+    codeChallenge,
+  });
+  res.json(outOfBand ? { code } : { redirect: withQuery(redirectUri, { code, state }) });
+});
+
+// ---------- token + revocation ----------
+
+oauthRouter.post('/token', formBody, (req: Request, res: Response) => {
+  noStore(res);
+  const grantType = param(req.body, 'grant_type');
+  if (grantType === undefined) {
+    oauthError(res, 400, 'invalid_request', 'grant_type is required');
+    return;
+  }
+  if (grantType !== 'authorization_code') {
+    oauthError(res, 400, 'unsupported_grant_type', 'only authorization_code is supported');
+    return;
+  }
+  const clientId = param(req.body, 'client_id');
+  const code = param(req.body, 'code');
+  const redirectUri = param(req.body, 'redirect_uri');
+  const codeVerifier = param(req.body, 'code_verifier');
+  if (!clientId || !code || !redirectUri || !codeVerifier) {
+    oauthError(
+      res,
+      400,
+      'invalid_request',
+      'client_id, code, redirect_uri and code_verifier are required',
+    );
+    return;
+  }
+  // Identify the client BEFORE touching the code, so a request that can't even
+  // name a real app can't burn someone else's code.
+  const app = findAppByClientId(clientId);
+  if (!app) {
+    oauthError(res, 401, 'invalid_client', 'unknown client_id');
+    return;
+  }
+  // Spent first, checked second: a code presented with the wrong client,
+  // redirect or verifier has been seen by someone it wasn't issued to.
+  const grant = consumeCode(code);
+  if (
+    !grant ||
+    grant.appId !== app.id ||
+    grant.redirectUri !== redirectUri ||
+    !verifyPkceS256(codeVerifier, grant.codeChallenge)
+  ) {
+    oauthError(
+      res,
+      400,
+      'invalid_grant',
+      'the code is invalid, expired, already used, or was issued to another request',
+    );
+    return;
+  }
+  res.json({
+    access_token: createToken(app.id, grant.userId),
+    token_type: 'Bearer',
+    created_at: Math.floor(Date.now() / 1000),
+  });
+});
+
+oauthRouter.post('/revoke', formBody, (req: Request, res: Response) => {
+  noStore(res);
+  const clientId = param(req.body, 'client_id');
+  const token = param(req.body, 'token');
+  if (!clientId || !token) {
+    oauthError(res, 400, 'invalid_request', 'client_id and token are required');
+    return;
+  }
+  if (!findAppByClientId(clientId)) {
+    oauthError(res, 401, 'invalid_client', 'unknown client_id');
+    return;
+  }
+  const revoked = deleteTokenForClient(token, clientId);
+  if (revoked) closeSocketsForOAuthTokens(revoked.userId, [revoked.id], 'app access revoked');
+  // RFC 7009: 200 whether or not the token existed, so this can't probe for tokens.
+  res.status(200).json({});
+});
+
+// ---------- the member's authorized apps (Settings) ----------
+
+oauthRouter.get('/apps', requireAuth, (req: Request, res: Response) => {
+  res.json({ apps: listAuthorizedApps(req.user!.id) });
+});
+
+oauthRouter.delete('/apps/:id', requireAuth, (req: Request, res: Response) => {
+  const appId = Number(req.params.id);
+  if (!Number.isInteger(appId) || appId <= 0) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  const tokenIds = deleteOAuthForApp(req.user!.id, appId);
+  if (tokenIds.length === 0) {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+  closeSocketsForOAuthTokens(req.user!.id, tokenIds, 'app access revoked');
+  res.json({ ok: true });
+});
+
+// ---------- discovery (RFC 8414) ----------
+
+export const wellKnownRouter = Router();
+
+wellKnownRouter.get('/oauth-authorization-server', (req: Request, res: Response) => {
+  const issuer = publicBaseUrl(req);
+  if (!issuer) {
+    res.status(500).json({ error: 'cannot work out this server’s URL; set PUBLIC_BASE_URL' });
+    return;
+  }
+  noStore(res);
+  res.json({
+    issuer,
+    authorization_endpoint: `${issuer}/oauth/authorize`,
+    token_endpoint: `${issuer}/api/oauth/token`,
+    revocation_endpoint: `${issuer}/api/oauth/revoke`,
+    registration_endpoint: `${issuer}/api/oauth/register`,
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code'],
+    token_endpoint_auth_methods_supported: ['none'],
+    revocation_endpoint_auth_methods_supported: ['none'],
+    code_challenge_methods_supported: ['S256'],
+    service_documentation: 'https://docs.lurker.chat/OAUTH',
+  });
+});

--- a/server/routes/push.ts
+++ b/server/routes/push.ts
@@ -77,11 +77,15 @@ router.post('/devices', (req: Request, res: Response) => {
     });
     return;
   }
-  const result = upsertSubscription(req.user!.id, {
-    transport,
-    endpoint: token,
-    userAgent: req.headers['user-agent'] || null,
-  });
+  const result = upsertSubscription(
+    req.user!.id,
+    {
+      transport,
+      endpoint: token,
+      userAgent: req.headers['user-agent'] || null,
+    },
+    req.oauthToken?.id ?? null,
+  );
   if (!result.ok || !result.sub) {
     // upsertSubscription rebinds rather than refusing for native, so !ok here is
     // not the cross-user case — it's a genuine storage failure.
@@ -130,13 +134,17 @@ router.post('/subscriptions', (req: Request, res: Response) => {
     res.status(400).json({ error: 'endpoint and keys.p256dh + keys.auth are required' });
     return;
   }
-  const result = upsertSubscription(req.user!.id, {
-    transport: 'webpush',
-    endpoint,
-    p256dh: keys.p256dh,
-    auth: keys.auth,
-    userAgent: userAgent || req.headers['user-agent'] || null,
-  });
+  const result = upsertSubscription(
+    req.user!.id,
+    {
+      transport: 'webpush',
+      endpoint,
+      p256dh: keys.p256dh,
+      auth: keys.auth,
+      userAgent: userAgent || req.headers['user-agent'] || null,
+    },
+    req.oauthToken?.id ?? null,
+  );
   if (!result.ok) {
     res.status(409).json({
       error:

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -46,36 +46,10 @@ import {
   setUploadFavorite,
 } from '../db/uploadHistory.js';
 import { reportUploadSoon } from '../services/moderationReport.js';
+import { publicBaseUrl } from '../utils/publicOrigin.js';
 
 const router = Router();
 router.use(requireAuth);
-
-// The absolute origin (scheme + host) a `local` upload's relative URL is prefixed
-// with so the pasted link works from IRC. PUBLIC_BASE_URL wins (explicit,
-// proxy-safe); otherwise derive from the request, honoring the reverse-proxy
-// forwarding headers a self-hoster's Caddy/nginx sets. Read here rather than via
-// a global `trust proxy` so the rest of the app's request handling is unchanged.
-// A forwarding header may be a list ("proto1, proto2"); take the first hop.
-function firstHeaderValue(v: unknown): string {
-  return String(v ?? '')
-    .split(',')[0]
-    .trim();
-}
-
-// A host is hostname[:port] or [ipv6][:port] — reject anything with characters
-// that could break out of the authority (slash, space, userinfo '@', etc.), so a
-// spoofed header can never inject path/scheme into the URL we construct + persist.
-const HOST_RE = /^[A-Za-z0-9.\-:[\]]+$/;
-
-function requestOrigin(req: Request): string {
-  // Only http/https are valid schemes; anything else (a spoofed "javascript" or
-  // garbage X-Forwarded-Proto) is ignored so it can never reach the built URL.
-  const rawProto = firstHeaderValue(req.headers['x-forwarded-proto']) || req.protocol;
-  const proto = rawProto === 'http' || rawProto === 'https' ? rawProto : 'https';
-  const rawHost = firstHeaderValue(req.headers['x-forwarded-host']) || req.get('host') || '';
-  const host = HOST_RE.test(rawHost) ? rawHost : '';
-  return host ? `${proto}://${host}` : '';
-}
 
 // Warn once (per process) the first time a local-upload link is built from
 // request headers because PUBLIC_BASE_URL isn't set. That fallback is the only
@@ -85,11 +59,11 @@ let warnedRequestOriginFallback = false;
 
 /** Absolutize a driver result URL. Drivers that store remotely already return an
  *  absolute URL; the local driver returns a root-relative path we prefix with the
- *  instance's public base (PUBLIC_BASE_URL, else the request origin). */
+ *  instance's public base (PUBLIC_BASE_URL, else the request origin — see
+ *  utils/publicOrigin). */
 function absolutizeUrl(url: string, storesRemotely: boolean, req: Request): string {
   if (storesRemotely || !url.startsWith('/')) return url;
-  const configured = process.env.PUBLIC_BASE_URL;
-  if (!configured && !warnedRequestOriginFallback) {
+  if (!process.env.PUBLIC_BASE_URL && !warnedRequestOriginFallback) {
     warnedRequestOriginFallback = true;
     console.warn(
       '[lurker] PUBLIC_BASE_URL is not set; local-upload links are derived from ' +
@@ -97,7 +71,7 @@ function absolutizeUrl(url: string, storesRemotely: boolean, req: Request): stri
         'PUBLIC_BASE_URL to this instance’s public origin for stable links.',
     );
   }
-  const base = (configured || requestOrigin(req)).replace(/\/+$/, '');
+  const base = publicBaseUrl(req);
   return base ? base + url : url;
 }
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -26,6 +26,7 @@ import { nodeUploadConfigured } from './services/uploadProviders/nodeUpload.js';
 import * as systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
 import { purgeExpiredRecoveryTokens } from './db/accountRecovery.js';
+import { purgeOAuth } from './db/oauth.js';
 import { sweepExpiredPreviews } from './db/linkPreviews.js';
 import { sweepPreviewCache } from './services/previewCache/index.js';
 import { startRetentionSweeper } from './services/retentionSweeper.js';
@@ -149,6 +150,11 @@ setInterval(purgeExpiredSessions, 60 * 60 * 1000).unref();
 // single slot and looking live in a table dump.
 purgeExpiredRecoveryTokens();
 setInterval(() => purgeExpiredRecoveryTokens(), 60 * 60 * 1000).unref();
+// OAuth (#891): expired authorization codes, and app registrations nobody
+// approved within the hour. The second half is what bounds a table the open
+// registration endpoint lets anyone write to.
+purgeOAuth();
+setInterval(() => purgeOAuth(), 60 * 60 * 1000).unref();
 
 // link_previews is a cache with a TTL, so lapsed rows have to actually go — without this it
 // only ever grows. Deliberately NOT gated on previewsEnabled(): an operator who turns the

--- a/server/services/mcpServer.test.ts
+++ b/server/services/mcpServer.test.ts
@@ -161,6 +161,62 @@ describe('MCP server', () => {
     expect(revoked.status).toBe(401);
   });
 
+  // A paused account can read but not change anything. REST enforces that in
+  // requireAuth; /mcp doesn't go through requireAuth, so the MCP server applies it
+  // to API tokens and OAuth tokens alike. set_nick_note is a database write, so
+  // it would succeed without IRC and shows the gate rather than a dead connection.
+  it('a paused account gets the read surface, whichever credential it uses', async () => {
+    const { createUser, setUserPaused } = await import('../db/users.js');
+    const { createNetwork } = await import('../db/networks.js');
+    const { createToken } = await import('../db/apiTokens.js');
+    const oauth = await import('../db/oauth.js');
+    const member = createUser('mcp-paused');
+    const memberNet = createNetwork(member.id, {
+      name: 'libera',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'paused',
+    }) as Network;
+    const oauthApp = oauth.createApp({
+      clientName: 'MCP client',
+      clientUri: null,
+      redirectUris: ['urn:ietf:wg:oauth:2.0:oob'],
+    });
+    const credentials = [
+      createToken({ userId: member.id, name: 'rw', scope: 'read-write' }).token,
+      oauth.createToken(oauthApp.id, member.id),
+    ];
+    const readSurface = (
+      await rpc(readToken.token, { jsonrpc: '2.0', id: 40, method: 'tools/list' })
+    ).body.result.tools;
+    const fullSurface = (await rpc(rwToken.token, { jsonrpc: '2.0', id: 41, method: 'tools/list' }))
+      .body.result.tools;
+
+    setUserPaused(member.id, true);
+    for (const token of credentials) {
+      const list = await rpc(token, { jsonrpc: '2.0', id: 42, method: 'tools/list' });
+      expect(list.body.result.tools).toEqual(readSurface);
+      const write = await rpc(token, {
+        jsonrpc: '2.0',
+        id: 43,
+        method: 'tools/call',
+        params: {
+          name: 'set_nick_note',
+          arguments: { networkId: memberNet.id, nick: 'bob', note: 'denied' },
+        },
+      });
+      expect(write.body.result.isError).toBe(true);
+      expect(JSON.parse(write.body.result.content[0].text)).toMatchObject({ error: 'forbidden' });
+    }
+
+    setUserPaused(member.id, false);
+    for (const token of credentials) {
+      const list = await rpc(token, { jsonrpc: '2.0', id: 44, method: 'tools/list' });
+      expect(list.body.result.tools).toEqual(fullSurface);
+    }
+  });
+
   it("tools/call list_networks returns the user's networks as a JSON text block", async () => {
     const res = await rpc(readToken.token, {
       jsonrpc: '2.0',

--- a/server/services/mcpServer.test.ts
+++ b/server/services/mcpServer.test.ts
@@ -140,6 +140,27 @@ describe('MCP server', () => {
     }
   });
 
+  // #891: an MCP client that signed in through OAuth holds an access token with
+  // the access of a password sign-in, which here means the read-write surface.
+  it('tools/list with an OAuth access token matches a read-write API token', async () => {
+    const oauth = await import('../db/oauth.js');
+    const oauthApp = oauth.createApp({
+      clientName: 'MCP client',
+      clientUri: null,
+      redirectUris: ['urn:ietf:wg:oauth:2.0:oob'],
+    });
+    const token = oauth.createToken(oauthApp.id, owner.id);
+
+    const viaOAuth = await rpc(token, { jsonrpc: '2.0', id: 30, method: 'tools/list' });
+    const viaApiToken = await rpc(rwToken.token, { jsonrpc: '2.0', id: 31, method: 'tools/list' });
+    expect(viaOAuth.status).toBe(200);
+    expect(viaOAuth.body.result.tools).toEqual(viaApiToken.body.result.tools);
+
+    oauth.deleteTokenByRaw(token);
+    const revoked = await rpc(token, { jsonrpc: '2.0', id: 32, method: 'tools/list' });
+    expect(revoked.status).toBe(401);
+  });
+
   it("tools/call list_networks returns the user's networks as a JSON text block", async () => {
     const res = await rpc(readToken.token, {
       jsonrpc: '2.0',

--- a/server/services/mcpServer.ts
+++ b/server/services/mcpServer.ts
@@ -45,15 +45,16 @@ function jsonRpcError(
   return { jsonrpc: '2.0', id, error };
 }
 
-// req.apiToken is attached by apiAuth middleware (still .js); cast through unknown
-// until that module is migrated.
-interface ApiToken {
-  scope: string;
-}
-
 router.post('/', (req: Request, res: Response) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- apiAuth.js not yet migrated
-  const apiToken = (req as any).apiToken as ApiToken;
+  // requireApiAuth attaches one of two credentials. An API token carries its own
+  // scope; an OAuth access token (#891) has the access of a password sign-in,
+  // which on this surface is read-write.
+  const scope = req.apiToken?.scope ?? (req.oauthToken ? 'read-write' : null);
+  if (!scope) {
+    res.status(401).json({ error: 'unauthorized' });
+    return;
+  }
+  const apiToken = { scope };
   const body = req.body as Record<string, unknown>;
   if (!body || typeof body !== 'object' || Array.isArray(body)) {
     res.json(jsonRpcError(null, -32600, 'Invalid Request'));

--- a/server/services/mcpServer.ts
+++ b/server/services/mcpServer.ts
@@ -49,12 +49,14 @@ router.post('/', (req: Request, res: Response) => {
   // requireApiAuth attaches one of two credentials. An API token carries its own
   // scope; an OAuth access token (#891) has the access of a password sign-in,
   // which on this surface is read-write.
-  const scope = req.apiToken?.scope ?? (req.oauthToken ? 'read-write' : null);
-  if (!scope) {
+  const granted = req.apiToken?.scope ?? (req.oauthToken ? 'read-write' : null);
+  if (!granted) {
     res.status(401).json({ error: 'unauthorized' });
     return;
   }
-  const apiToken = { scope };
+  // A paused account can read but not change anything, whatever it signed in
+  // with. REST enforces that in requireAuth, which /mcp doesn't go through.
+  const apiToken = { scope: req.user?.is_paused ? 'read' : granted };
   const body = req.body as Record<string, unknown>;
   if (!body || typeof body !== 'object' || Array.isArray(body)) {
     res.json(jsonRpcError(null, -32600, 'Invalid Request'));

--- a/server/services/oauth.test.ts
+++ b/server/services/oauth.test.ts
@@ -32,6 +32,8 @@ describe('isValidRedirectUri', () => {
     'http://127.0.0.1:8123/callback',
     'http://127.0.0.1/cb',
     'http://[::1]:9000/cb',
+    // How Claude Code registers its MCP sign-in callback.
+    'http://localhost:54321/callback',
     'com.example.spooky:/oauth',
     'com.example.spooky://oauth/callback',
     OOB_REDIRECT_URI,
@@ -41,7 +43,7 @@ describe('isValidRedirectUri', () => {
 
   it.each([
     ['plain http off loopback', 'http://example.com/cb'],
-    ['localhost by name', 'http://localhost:8123/cb'],
+    ['a host that only starts like localhost', 'http://localhost.evil.com/cb'],
     // The URL parser strips the tab, so a check on the raw string would see
     // "java<tab>script" while a browser navigating to it runs javascript:.
     ['a tab hidden inside javascript:', `java${TAB}script:alert(1)`],
@@ -70,10 +72,17 @@ describe('matchRedirectUri', () => {
     expect(matchRedirectUri(registered, 'http://127.0.0.1:53124/callback')).toBe(true);
   });
 
+  it('matches a localhost redirect on any port against a localhost registration', () => {
+    expect(
+      matchRedirectUri(['http://localhost:54321/callback'], 'http://localhost:61000/callback'),
+    ).toBe(true);
+  });
+
   it.each([
     ['a different loopback path', 'http://127.0.0.1:53124/other'],
     ['a different loopback query', 'http://127.0.0.1:53124/callback?x=1'],
     ['the other loopback address', 'http://[::1]:8000/callback'],
+    ['localhost against a 127.0.0.1 registration', 'http://localhost:8000/callback'],
     ['a host that starts with 127.0.0.1', 'http://127.0.0.1.evil.com:8000/callback'],
     ['userinfo in front of another host', 'http://127.0.0.1@evil.com:8000/callback'],
     ['an unregistered path on the app scheme', 'com.example.spooky:/other'],

--- a/server/services/oauth.test.ts
+++ b/server/services/oauth.test.ts
@@ -1,0 +1,291 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The request rules behind the OAuth authorization server (#891). Registration is
+// open, so these are what keep an attacker-registered app from turning Lurker into
+// a phishing or open-redirect tool — every refusal below is a shape someone could
+// otherwise register.
+
+import { describe, it, expect } from 'vitest';
+import crypto from 'crypto';
+import {
+  OOB_REDIRECT_URI,
+  hostOf,
+  isValidRedirectUri,
+  matchRedirectUri,
+  parseAuthorizeRequest,
+  redirectDestination,
+  validateRegistration,
+  verifyPkceS256,
+  withQuery,
+} from './oauth.js';
+
+// Built from code points so the test source itself never carries an invisible
+// character a reviewer can't see.
+const BELL = String.fromCharCode(0x07);
+const RIGHT_TO_LEFT_OVERRIDE = String.fromCharCode(0x202e);
+const TAB = String.fromCharCode(0x09);
+
+describe('isValidRedirectUri', () => {
+  it.each([
+    'https://app.example.com/callback',
+    'http://127.0.0.1:8123/callback',
+    'http://127.0.0.1/cb',
+    'http://[::1]:9000/cb',
+    'com.example.spooky:/oauth',
+    'com.example.spooky://oauth/callback',
+    OOB_REDIRECT_URI,
+  ])('accepts %s', (uri) => {
+    expect(isValidRedirectUri(uri)).toBe(true);
+  });
+
+  it.each([
+    ['plain http off loopback', 'http://example.com/cb'],
+    ['localhost by name', 'http://localhost:8123/cb'],
+    // The URL parser strips the tab, so a check on the raw string would see
+    // "java<tab>script" while a browser navigating to it runs javascript:.
+    ['a tab hidden inside javascript:', `java${TAB}script:alert(1)`],
+    ['javascript:', 'javascript:alert(1)'],
+    ['data:', 'data:text/html,hello'],
+    ['mailto:', 'mailto:someone@example.com'],
+    ['a custom scheme that is not reverse-DNS', 'myapp://callback'],
+    ['a fragment', 'https://app.example.com/cb#frag'],
+    ['userinfo on a loopback redirect', 'http://user@127.0.0.1:8123/cb'],
+    ['a host that only starts like loopback', 'http://127.0.0.1.evil.com/cb'],
+    ['a relative path', '/callback'],
+    ['a space', 'https://app.example.com/call back'],
+  ])('refuses %s', (_label, uri) => {
+    expect(isValidRedirectUri(uri)).toBe(false);
+  });
+});
+
+describe('matchRedirectUri', () => {
+  const registered = ['http://127.0.0.1:8000/callback', 'com.example.spooky:/oauth'];
+
+  it('matches a registered URI exactly', () => {
+    expect(matchRedirectUri(registered, 'com.example.spooky:/oauth')).toBe(true);
+  });
+
+  it('matches a loopback redirect on any port (RFC 8252 §7.3)', () => {
+    expect(matchRedirectUri(registered, 'http://127.0.0.1:53124/callback')).toBe(true);
+  });
+
+  it.each([
+    ['a different loopback path', 'http://127.0.0.1:53124/other'],
+    ['a different loopback query', 'http://127.0.0.1:53124/callback?x=1'],
+    ['the other loopback address', 'http://[::1]:8000/callback'],
+    ['a host that starts with 127.0.0.1', 'http://127.0.0.1.evil.com:8000/callback'],
+    ['userinfo in front of another host', 'http://127.0.0.1@evil.com:8000/callback'],
+    ['an unregistered path on the app scheme', 'com.example.spooky:/other'],
+  ])('refuses %s', (_label, requested) => {
+    expect(matchRedirectUri(registered, requested)).toBe(false);
+  });
+
+  it('keeps port flexibility to loopback only', () => {
+    expect(
+      matchRedirectUri(['https://app.example.com:8443/cb'], 'https://app.example.com:9443/cb'),
+    ).toBe(false);
+  });
+});
+
+describe('redirectDestination', () => {
+  it('describes where each kind of redirect lands', () => {
+    expect(redirectDestination(OOB_REDIRECT_URI)).toEqual({ kind: 'code' });
+    expect(redirectDestination('http://127.0.0.1:8000/cb')).toEqual({ kind: 'loopback' });
+    expect(redirectDestination('com.example.spooky:/oauth')).toEqual({
+      kind: 'app',
+      scheme: 'com.example.spooky',
+    });
+    expect(redirectDestination('https://app.example.com/cb')).toEqual({
+      kind: 'web',
+      host: 'app.example.com',
+    });
+  });
+});
+
+describe('withQuery', () => {
+  it('adds parameters and keeps the ones already there', () => {
+    const url = new URL(
+      withQuery('https://app.example.com/cb?keep=1', { code: 'abc', state: 'x' }),
+    );
+    expect(url.searchParams.get('keep')).toBe('1');
+    expect(url.searchParams.get('code')).toBe('abc');
+    expect(url.searchParams.get('state')).toBe('x');
+  });
+
+  it('leaves out undefined values', () => {
+    expect(withQuery('com.example.spooky:/oauth', { code: 'abc', state: undefined })).toBe(
+      'com.example.spooky:/oauth?code=abc',
+    );
+  });
+});
+
+describe('hostOf', () => {
+  it('returns the host of a client_uri, or null', () => {
+    expect(hostOf('https://spooky.example:8443/about')).toBe('spooky.example:8443');
+    expect(hostOf(null)).toBeNull();
+    expect(hostOf('not a url')).toBeNull();
+  });
+});
+
+describe('verifyPkceS256', () => {
+  const verifier = crypto.randomBytes(32).toString('base64url');
+  const challenge = crypto.createHash('sha256').update(verifier).digest('base64url');
+
+  it('accepts the verifier behind the challenge', () => {
+    expect(verifyPkceS256(verifier, challenge)).toBe(true);
+  });
+
+  it('refuses a different verifier', () => {
+    expect(verifyPkceS256(crypto.randomBytes(32).toString('base64url'), challenge)).toBe(false);
+  });
+
+  it('refuses a "plain" challenge that is just the verifier', () => {
+    expect(verifyPkceS256(verifier, verifier)).toBe(false);
+  });
+
+  it('refuses a verifier shorter than RFC 7636 allows', () => {
+    expect(verifyPkceS256('short', challenge)).toBe(false);
+  });
+});
+
+describe('validateRegistration', () => {
+  const base = { client_name: 'Spooky', redirect_uris: ['com.example.spooky:/oauth'] };
+
+  it('accepts a minimal registration', () => {
+    expect(validateRegistration(base)).toEqual({
+      ok: true,
+      metadata: {
+        clientName: 'Spooky',
+        clientUri: null,
+        redirectUris: ['com.example.spooky:/oauth'],
+      },
+    });
+  });
+
+  it('ignores the fields Lurker has only one answer to', () => {
+    const result = validateRegistration({
+      ...base,
+      scope: 'read write',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'client_secret_basic',
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('trims the name, dedupes redirect URIs and keeps an http(s) client_uri', () => {
+    const result = validateRegistration({
+      client_name: '  Spooky  ',
+      redirect_uris: [OOB_REDIRECT_URI, OOB_REDIRECT_URI],
+      client_uri: 'https://spooky.example',
+    });
+    expect(result).toEqual({
+      ok: true,
+      metadata: {
+        clientName: 'Spooky',
+        clientUri: 'https://spooky.example',
+        redirectUris: [OOB_REDIRECT_URI],
+      },
+    });
+  });
+
+  it('counts the name limit in characters, not UTF-16 units', () => {
+    expect(validateRegistration({ ...base, client_name: '🙂'.repeat(60) }).ok).toBe(true);
+  });
+
+  it.each([
+    ['no name', { redirect_uris: base.redirect_uris }, 'invalid_client_metadata'],
+    [
+      'a name over 60 characters',
+      { ...base, client_name: 'x'.repeat(61) },
+      'invalid_client_metadata',
+    ],
+    [
+      'a right-to-left override in the name',
+      { ...base, client_name: `Lurker${RIGHT_TO_LEFT_OVERRIDE}roi rof` },
+      'invalid_client_metadata',
+    ],
+    [
+      'a control character in the name',
+      { ...base, client_name: `Spoo${BELL}ky` },
+      'invalid_client_metadata',
+    ],
+    ['no redirect_uris', { client_name: 'Spooky' }, 'invalid_redirect_uri'],
+    ['empty redirect_uris', { ...base, redirect_uris: [] }, 'invalid_redirect_uri'],
+    ['a non-string redirect_uri', { ...base, redirect_uris: [42] }, 'invalid_redirect_uri'],
+    [
+      'an unsupported redirect_uri',
+      { ...base, redirect_uris: ['javascript:alert(1)'] },
+      'invalid_redirect_uri',
+    ],
+    [
+      'redirect_uris over the length cap',
+      { ...base, redirect_uris: [`https://app.example.com/${'a'.repeat(2000)}`] },
+      'invalid_redirect_uri',
+    ],
+    [
+      'a non-http client_uri',
+      { ...base, client_uri: 'javascript:alert(1)' },
+      'invalid_client_metadata',
+    ],
+    ['a body that is not an object', 'nope', 'invalid_client_metadata'],
+  ])('refuses %s', (_label, body, error) => {
+    expect(validateRegistration(body)).toMatchObject({ ok: false, error });
+  });
+});
+
+describe('parseAuthorizeRequest', () => {
+  const challenge = crypto
+    .createHash('sha256')
+    .update(crypto.randomBytes(32).toString('base64url'))
+    .digest('base64url');
+  const good = {
+    client_id: 'client-abc',
+    redirect_uri: OOB_REDIRECT_URI,
+    response_type: 'code',
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    state: 'xyz',
+  };
+
+  it('accepts a well-formed request', () => {
+    expect(parseAuthorizeRequest(good)).toEqual({
+      ok: true,
+      request: {
+        clientId: 'client-abc',
+        redirectUri: OOB_REDIRECT_URI,
+        codeChallenge: challenge,
+        state: 'xyz',
+      },
+    });
+  });
+
+  it('lets state be left out', () => {
+    expect(parseAuthorizeRequest({ ...good, state: undefined })).toMatchObject({
+      ok: true,
+      request: { state: undefined },
+    });
+  });
+
+  it.each([
+    ['no client_id', { ...good, client_id: undefined }, 'invalid_request'],
+    ['a repeated client_id', { ...good, client_id: ['a', 'b'] }, 'invalid_request'],
+    ['no redirect_uri', { ...good, redirect_uri: undefined }, 'invalid_request'],
+    ['response_type=token', { ...good, response_type: 'token' }, 'unsupported_response_type'],
+    [
+      'no PKCE',
+      { ...good, code_challenge: undefined, code_challenge_method: undefined },
+      'invalid_request',
+    ],
+    ['plain PKCE', { ...good, code_challenge_method: 'plain' }, 'invalid_request'],
+    ['a malformed challenge', { ...good, code_challenge: 'too-short' }, 'invalid_request'],
+    ['an oversized state', { ...good, state: 's'.repeat(1025) }, 'invalid_request'],
+    ['a repeated state', { ...good, state: ['a', 'b'] }, 'invalid_request'],
+  ])('refuses %s', (_label, source, error) => {
+    expect(parseAuthorizeRequest(source as Record<string, unknown>)).toMatchObject({
+      ok: false,
+      error,
+    });
+  });
+});

--- a/server/services/oauth.ts
+++ b/server/services/oauth.ts
@@ -1,0 +1,280 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import crypto from 'crypto';
+
+// Request validation for the OAuth 2 authorization server (#891). Pure functions,
+// no storage, so every rule here is unit-testable on its own.
+//
+// Registration is open, so anyone can register an app with any name and any
+// redirect it likes. The rules below exist to keep that from becoming a phishing
+// or open-redirect tool: redirect URIs come from a short allowlist of shapes, a
+// requested redirect must match a registered one, and PKCE binds each code to
+// whoever started the flow.
+
+/** RFC 8252's out-of-band redirect: show the code for the member to copy. */
+export const OOB_REDIRECT_URI = 'urn:ietf:wg:oauth:2.0:oob';
+
+export const MAX_CLIENT_NAME_LENGTH = 60;
+export const MAX_REDIRECT_URIS_LENGTH = 2000;
+export const MAX_CLIENT_URI_LENGTH = 2000;
+export const MAX_STATE_LENGTH = 1024;
+
+// Printable ASCII only. The WHATWG URL parser silently strips tabs and newlines
+// and trims leading control characters, so `java\tscript:` would sail past a
+// scheme check done on the raw string and then run as javascript: once a browser
+// navigates to it. Refusing anything outside 0x21-0x7E closes that before the
+// parser gets a say.
+const PRINTABLE_ASCII = /^[\x21-\x7E]+$/;
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '[::1]']);
+const SCHEME = /^[a-z][a-z0-9+.-]*$/;
+const CODE_CHALLENGE = /^[A-Za-z0-9_-]{43}$/;
+const CODE_VERIFIER = /^[A-Za-z0-9._~-]{43,128}$/;
+
+// The approval page leads with the app's name, so a name that reorders or hides
+// text on screen is refused: C0/C1 controls and the bidi embedding, override and
+// isolate characters.
+function hasUnsafeNameChar(name: string): boolean {
+  for (const ch of name) {
+    const cp = ch.codePointAt(0) ?? 0;
+    if (cp <= 0x1f || (cp >= 0x7f && cp <= 0x9f)) return true;
+    if ((cp >= 0x202a && cp <= 0x202e) || (cp >= 0x2066 && cp <= 0x2069)) return true;
+  }
+  return false;
+}
+
+/**
+ * Whether a redirect URI may be registered. An allowlist of four shapes:
+ *
+ *   - `https:` — a claimed https link (Universal Links, App Links) or a web page
+ *   - `http:` on 127.0.0.1 or [::1] — a desktop or CLI app listening locally
+ *   - a reverse-DNS custom scheme such as `com.example.app:` (RFC 8252 §7.1),
+ *     which also keeps out `mailto:`, `javascript:` and every other short scheme
+ *   - the out-of-band URN
+ */
+export function isValidRedirectUri(raw: string): boolean {
+  if (raw === OOB_REDIRECT_URI) return true;
+  if (!PRINTABLE_ASCII.test(raw) || raw.includes('#')) return false;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (url.username || url.password) return false;
+  if (url.protocol === 'https:') return url.hostname !== '';
+  if (url.protocol === 'http:') return LOOPBACK_HOSTS.has(url.hostname);
+  const scheme = url.protocol.slice(0, -1);
+  return SCHEME.test(scheme) && scheme.includes('.');
+}
+
+function parseLoopback(raw: string): URL | null {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' || url.username || url.password) return null;
+  return LOOPBACK_HOSTS.has(url.hostname) ? url : null;
+}
+
+/**
+ * Whether a redirect requested at authorization matches one the app registered.
+ * Exact string equality, with one exception from RFC 8252 §7.3: a loopback
+ * redirect matches on any port, because a CLI picks a free port when it starts.
+ * Everything else about the loopback URI -- host, path, query -- must still be
+ * identical, and it is compared on the PARSED URI so `127.0.0.1.evil.com` or
+ * `127.0.0.1@evil.com` can never pass as a prefix match.
+ */
+export function matchRedirectUri(registered: readonly string[], requested: string): boolean {
+  if (registered.includes(requested)) return true;
+  if (!PRINTABLE_ASCII.test(requested) || requested.includes('#')) return false;
+  const wanted = parseLoopback(requested);
+  if (!wanted) return false;
+  return registered.some((candidate) => {
+    const url = parseLoopback(candidate);
+    return (
+      url !== null &&
+      url.hostname === wanted.hostname &&
+      url.pathname === wanted.pathname &&
+      url.search === wanted.search
+    );
+  });
+}
+
+/** Where an approval lands, for the approval page to say in plain words. */
+export type RedirectDestination =
+  | { kind: 'code' }
+  | { kind: 'loopback' }
+  | { kind: 'app'; scheme: string }
+  | { kind: 'web'; host: string };
+
+export function redirectDestination(uri: string): RedirectDestination {
+  if (uri === OOB_REDIRECT_URI) return { kind: 'code' };
+  const url = new URL(uri);
+  if (url.protocol === 'http:') return { kind: 'loopback' };
+  if (url.protocol === 'https:') return { kind: 'web', host: url.host };
+  return { kind: 'app', scheme: url.protocol.slice(0, -1) };
+}
+
+/** Add query parameters to a redirect URI, keeping any it already carries. */
+export function withQuery(uri: string, params: Record<string, string | undefined>): string {
+  const url = new URL(uri);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) url.searchParams.set(key, value);
+  }
+  return url.toString();
+}
+
+/** The host of an app's `client_uri`, or null. Shown on the approval page, never trusted. */
+export function hostOf(uri: string | null): string | null {
+  if (!uri) return null;
+  try {
+    return new URL(uri).host || null;
+  } catch {
+    return null;
+  }
+}
+
+/** RFC 7636 S256: BASE64URL(SHA256(verifier)) must equal the stored challenge. */
+export function verifyPkceS256(verifier: string, challenge: string): boolean {
+  if (!CODE_VERIFIER.test(verifier) || !CODE_CHALLENGE.test(challenge)) return false;
+  const computed = Buffer.from(crypto.createHash('sha256').update(verifier).digest('base64url'));
+  const expected = Buffer.from(challenge);
+  return computed.length === expected.length && crypto.timingSafeEqual(computed, expected);
+}
+
+export interface ClientMetadata {
+  clientName: string;
+  clientUri: string | null;
+  redirectUris: string[];
+}
+
+export type RegistrationResult =
+  | { ok: true; metadata: ClientMetadata }
+  | { ok: false; error: 'invalid_redirect_uri' | 'invalid_client_metadata'; description: string };
+
+const badMetadata = (description: string): RegistrationResult => ({
+  ok: false,
+  error: 'invalid_client_metadata',
+  description,
+});
+const badRedirect = (description: string): RegistrationResult => ({
+  ok: false,
+  error: 'invalid_redirect_uri',
+  description,
+});
+
+/**
+ * Validate an RFC 7591 registration body. Only the fields Lurker uses are read.
+ * Everything a client may ask for that Lurker has exactly one answer to --
+ * `scope`, `grant_types`, `response_types`, `token_endpoint_auth_method` -- is
+ * ignored rather than refused; RFC 7591 lets the server replace requested
+ * metadata, and the response says what the client actually got.
+ */
+export function validateRegistration(body: unknown): RegistrationResult {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return badMetadata('the registration must be a JSON object');
+  }
+  const fields = body as Record<string, unknown>;
+
+  const clientName = typeof fields.client_name === 'string' ? fields.client_name.trim() : '';
+  if (!clientName) return badMetadata('client_name is required');
+  if ([...clientName].length > MAX_CLIENT_NAME_LENGTH) {
+    return badMetadata(`client_name must be at most ${MAX_CLIENT_NAME_LENGTH} characters`);
+  }
+  if (hasUnsafeNameChar(clientName)) {
+    return badMetadata('client_name contains control or text-direction characters');
+  }
+
+  const uris = fields.redirect_uris;
+  if (!Array.isArray(uris) || uris.length === 0) {
+    return badRedirect('redirect_uris must be a non-empty array');
+  }
+  if (!uris.every((u): u is string => typeof u === 'string')) {
+    return badRedirect('every redirect_uri must be a string');
+  }
+  const redirectUris = [...new Set(uris)];
+  if (redirectUris.join('').length > MAX_REDIRECT_URIS_LENGTH) {
+    return badRedirect(`redirect_uris must total at most ${MAX_REDIRECT_URIS_LENGTH} characters`);
+  }
+  if (!redirectUris.every(isValidRedirectUri)) {
+    return badRedirect(
+      `each redirect_uri must be https, http on 127.0.0.1 or [::1], a reverse-DNS app scheme, or ${OOB_REDIRECT_URI}`,
+    );
+  }
+
+  let clientUri: string | null = null;
+  if (fields.client_uri !== undefined && fields.client_uri !== null) {
+    const raw = fields.client_uri;
+    let valid = false;
+    if (
+      typeof raw === 'string' &&
+      raw.length <= MAX_CLIENT_URI_LENGTH &&
+      PRINTABLE_ASCII.test(raw)
+    ) {
+      try {
+        const protocol = new URL(raw).protocol;
+        valid = protocol === 'https:' || protocol === 'http:';
+      } catch {
+        valid = false;
+      }
+    }
+    if (!valid) return badMetadata('client_uri must be an http or https URL');
+    clientUri = raw as string;
+  }
+
+  return { ok: true, metadata: { clientName, clientUri, redirectUris } };
+}
+
+export interface AuthorizeRequest {
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  state: string | undefined;
+}
+
+export type AuthorizeParse =
+  | { ok: true; request: AuthorizeRequest }
+  | { ok: false; error: string; description: string };
+
+/**
+ * Check the shape of an authorization request (query string or JSON body).
+ * Doesn't look the client up; the route does that. Every parameter must be a
+ * single string -- a repeated query parameter arrives as an array and is refused.
+ */
+const invalidRequest = (description: string): AuthorizeParse => ({
+  ok: false,
+  error: 'invalid_request',
+  description,
+});
+
+export function parseAuthorizeRequest(source: Record<string, unknown>): AuthorizeParse {
+  const str = (key: string): string | undefined =>
+    typeof source[key] === 'string' ? (source[key] as string) : undefined;
+
+  const clientId = str('client_id');
+  if (!clientId) return invalidRequest('client_id is required');
+  const redirectUri = str('redirect_uri');
+  if (!redirectUri) return invalidRequest('redirect_uri is required');
+  if (str('response_type') !== 'code') {
+    return {
+      ok: false,
+      error: 'unsupported_response_type',
+      description: 'response_type must be code',
+    };
+  }
+  if (str('code_challenge_method') !== 'S256') {
+    return invalidRequest('PKCE is required: code_challenge_method must be S256');
+  }
+  const codeChallenge = str('code_challenge');
+  if (!codeChallenge || !CODE_CHALLENGE.test(codeChallenge)) {
+    return invalidRequest('code_challenge must be 43 base64url characters');
+  }
+  const state = source.state === undefined ? undefined : str('state');
+  if (source.state !== undefined && (state === undefined || state.length > MAX_STATE_LENGTH)) {
+    return invalidRequest(`state must be a string of at most ${MAX_STATE_LENGTH} characters`);
+  }
+  return { ok: true, request: { clientId, redirectUri, codeChallenge, state } };
+}

--- a/server/services/oauth.ts
+++ b/server/services/oauth.ts
@@ -26,7 +26,11 @@ export const MAX_STATE_LENGTH = 1024;
 // navigates to it. Refusing anything outside 0x21-0x7E closes that before the
 // parser gets a say.
 const PRINTABLE_ASCII = /^[\x21-\x7E]+$/;
-const LOOPBACK_HOSTS = new Set(['127.0.0.1', '[::1]']);
+// Hosts a desktop or CLI app's local listener may use. RFC 8252 §8.3 prefers the
+// IP literals, but real clients register `localhost` (Claude Code's MCP sign-in
+// does), and browsers treat localhost as the loopback interface, so the code
+// still lands on the machine where the member clicked Approve.
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '[::1]', 'localhost']);
 const SCHEME = /^[a-z][a-z0-9+.-]*$/;
 const CODE_CHALLENGE = /^[A-Za-z0-9_-]{43}$/;
 const CODE_VERIFIER = /^[A-Za-z0-9._~-]{43,128}$/;
@@ -47,7 +51,7 @@ function hasUnsafeNameChar(name: string): boolean {
  * Whether a redirect URI may be registered. An allowlist of four shapes:
  *
  *   - `https:` — a claimed https link (Universal Links, App Links) or a web page
- *   - `http:` on 127.0.0.1 or [::1] — a desktop or CLI app listening locally
+ *   - `http:` on 127.0.0.1, [::1] or localhost — a desktop or CLI app listening locally
  *   - a reverse-DNS custom scheme such as `com.example.app:` (RFC 8252 §7.1),
  *     which also keeps out `mailto:`, `javascript:` and every other short scheme
  *   - the out-of-band URN
@@ -201,7 +205,7 @@ export function validateRegistration(body: unknown): RegistrationResult {
   }
   if (!redirectUris.every(isValidRedirectUri)) {
     return badRedirect(
-      `each redirect_uri must be https, http on 127.0.0.1 or [::1], a reverse-DNS app scheme, or ${OOB_REDIRECT_URI}`,
+      `each redirect_uri must be https, http on 127.0.0.1, [::1] or localhost, a reverse-DNS app scheme, or ${OOB_REDIRECT_URI}`,
     );
   }
 

--- a/server/services/wsHub.oauth.test.ts
+++ b/server/services/wsHub.oauth.test.ts
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Revoking an OAuth app (#891) has to reach the sockets its token already opened:
+// a socket authenticates at the upgrade and is never checked again, so deleting
+// the token alone would leave a revoked app streaming. Real sockets against a real
+// hub, like wsHub.revoke.test.ts, because that is the only way to observe it.
+//
+// Tokens are minted straight from storage here. The HTTP flow that produces them
+// is covered in routes/oauth.test.ts; this file is about what revoking does.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'http';
+import request from 'supertest';
+import { WebSocket } from 'ws';
+import { createTestApp, setupTestDb, TEST_SESSION_SECRET } from '../test-utils/testApp.js';
+import { WS_CLOSE_SESSION_REVOKED } from '../../shared/wsCloseCodes.js';
+
+const testDb = setupTestDb('wshub-oauth');
+
+const OOB = 'urn:ietf:wg:oauth:2.0:oob';
+
+let server: http.Server;
+let url: string;
+let createUser: typeof import('../db/users.js').createUser;
+let createSession: typeof import('../db/sessions.js').createSession;
+let oauth: typeof import('../db/oauth.js');
+
+beforeAll(async () => {
+  ({ createUser } = await import('../db/users.js'));
+  ({ createSession } = await import('../db/sessions.js'));
+  oauth = await import('../db/oauth.js');
+  const wsHub = await import('./wsHub.js');
+  const { oauthRouter } = await import('../routes/oauth.js');
+  const authRouter = (await import('../routes/auth.js')).default;
+
+  // The routes ride the SAME http server as the hub, so a revoke over HTTP and the
+  // socket it has to close are genuinely the same process.
+  server = http.createServer(createTestApp({ '/api/oauth': oauthRouter, '/api/auth': authRouter }));
+  wsHub.attachWsHub(server, TEST_SESSION_SECRET);
+  server.listen(0);
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('test server did not bind synchronously to a TCP port');
+  }
+  server.unref();
+  url = `ws://127.0.0.1:${address.port}/ws`;
+});
+
+afterAll(() => {
+  server.close();
+  testDb.cleanup();
+});
+
+function appToken(userId: number, name = 'Socket app') {
+  const app = oauth.createApp({ clientName: name, clientUri: null, redirectUris: [OOB] });
+  return { app, token: oauth.createToken(app.id, userId) };
+}
+
+// Open a socket and resolve once it has received its first frame, so the server
+// has definitely registered it before anything tries to close it.
+function connect(bearer: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url, { headers: { Authorization: `Bearer ${bearer}` } });
+    const timer = setTimeout(() => {
+      ws.close();
+      reject(new Error('timed out waiting for the first frame'));
+    }, 5000);
+    ws.once('message', () => {
+      clearTimeout(timer);
+      resolve(ws);
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+function closed(ws: WebSocket): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('socket was never closed')), 5000);
+    ws.on('close', (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+}
+
+describe('an OAuth socket', () => {
+  it('opens with an access token and gets the snapshot like any client', async () => {
+    const user = createUser('oauth-ws-open');
+    const ws = await connect(appToken(user.id).token);
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    ws.close();
+  });
+
+  it('is refused once its token is revoked', async () => {
+    const user = createUser('oauth-ws-refused');
+    const { app, token } = appToken(user.id);
+    oauth.deleteTokenForClient(token, app.clientId);
+    await expect(connect(token)).rejects.toThrow(/401/);
+  });
+
+  it('closes when the app revokes its token, leaving the web session connected', async () => {
+    const user = createUser('oauth-ws-revoke');
+    const { app, token } = appToken(user.id);
+    const appSocket = await connect(token);
+    const sessionSocket = await connect(createSession(user.id).token);
+    const evicted = closed(appSocket);
+
+    const res = await request(server)
+      .post('/api/oauth/revoke')
+      .type('form')
+      .send({ client_id: app.clientId, token });
+    expect(res.status).toBe(200);
+
+    expect(await evicted).toBe(WS_CLOSE_SESSION_REVOKED);
+    expect(sessionSocket.readyState).toBe(WebSocket.OPEN);
+    sessionSocket.close();
+  });
+
+  it('closes every socket of an app revoked from Settings, and no other app’s', async () => {
+    const user = createUser('oauth-ws-settings');
+    const revoked = appToken(user.id, 'Revoked app');
+    const kept = appToken(user.id, 'Kept app');
+    const [first, second] = await Promise.all([connect(revoked.token), connect(revoked.token)]);
+    const other = await connect(kept.token);
+    const bothClosed = Promise.all([closed(first), closed(second)]);
+
+    const res = await request(server)
+      .delete(`/api/oauth/apps/${revoked.app.id}`)
+      .set('Authorization', `Bearer ${createSession(user.id).token}`);
+    expect(res.status).toBe(200);
+
+    expect(await bothClosed).toEqual([WS_CLOSE_SESSION_REVOKED, WS_CLOSE_SESSION_REVOKED]);
+    expect(other.readyState).toBe(WebSocket.OPEN);
+    other.close();
+  });
+
+  it('closes when the app signs out with its token', async () => {
+    const user = createUser('oauth-ws-logout');
+    const { token } = appToken(user.id);
+    const ws = await connect(token);
+    const evicted = closed(ws);
+
+    await request(server).post('/api/auth/logout').set('Authorization', `Bearer ${token}`);
+
+    expect(await evicted).toBe(WS_CLOSE_SESSION_REVOKED);
+  });
+});

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -1215,29 +1215,49 @@ describe('eachUserBufferTarget / badge-vs-snapshot parity (#454)', () => {
 describe('authenticateUpgrade', () => {
   let authenticateUpgrade: typeof import('./wsHub.js').authenticateUpgrade;
   let createSession: typeof import('../db/sessions.js').createSession;
+  let oauth: typeof import('../db/oauth.js');
 
   beforeAll(async () => {
     ({ authenticateUpgrade } = await import('./wsHub.js'));
     ({ createSession } = await import('../db/sessions.js'));
+    oauth = await import('../db/oauth.js');
   });
 
   it('authenticates a browser via the signed session cookie', () => {
     const { token } = createSession(userId);
     const signed = encodeURIComponent('s:' + signCookie(token, TEST_SESSION_SECRET));
-    const user = authenticateUpgrade(
+    const auth = authenticateUpgrade(
       upgrade({ cookie: `lurker_session=${signed}` }),
       TEST_SESSION_SECRET,
     );
-    expect(user?.id).toBe(userId);
+    expect(auth?.user.id).toBe(userId);
+    expect(auth?.oauthTokenId).toBeNull();
   });
 
   it('authenticates a native client via a bearer session token', () => {
     const { token } = createSession(userId);
-    const user = authenticateUpgrade(
+    const auth = authenticateUpgrade(
       upgrade({ authorization: `Bearer ${token}` }),
       TEST_SESSION_SECRET,
     );
-    expect(user?.id).toBe(userId);
+    expect(auth?.user.id).toBe(userId);
+    expect(auth?.oauthTokenId).toBeNull();
+  });
+
+  it('authenticates a third-party app via its OAuth token, and says which token', () => {
+    // #891: the token id rides on the socket so revoking the app can find it.
+    const app = oauth.createApp({
+      clientName: 'Upgrade test app',
+      clientUri: null,
+      redirectUris: ['urn:ietf:wg:oauth:2.0:oob'],
+    });
+    const token = oauth.createToken(app.id, userId);
+    const auth = authenticateUpgrade(
+      upgrade({ authorization: `Bearer ${token}` }),
+      TEST_SESSION_SECRET,
+    );
+    expect(auth?.user.id).toBe(userId);
+    expect(auth?.oauthTokenId).toBe(oauth.findTokenByRaw(token)?.id);
   });
 
   it('rejects an upgrade with no credentials at all', () => {
@@ -1245,32 +1265,32 @@ describe('authenticateUpgrade', () => {
   });
 
   it('rejects an unknown bearer token', () => {
-    const user = authenticateUpgrade(
+    const auth = authenticateUpgrade(
       upgrade({ authorization: 'Bearer not-a-real-token' }),
       TEST_SESSION_SECRET,
     );
-    expect(user).toBeNull();
+    expect(auth).toBeNull();
   });
 
   it('rejects a raw (unsigned) session token in the cookie', () => {
     // The cookie path requires the 's:' signature prefix — a bearer token pasted
     // into the cookie must not authenticate.
     const { token } = createSession(userId);
-    const user = authenticateUpgrade(
+    const auth = authenticateUpgrade(
       upgrade({ cookie: `lurker_session=${token}` }),
       TEST_SESSION_SECRET,
     );
-    expect(user).toBeNull();
+    expect(auth).toBeNull();
   });
 
   it('rejects a cookie signed with a different secret', () => {
     const { token } = createSession(userId);
     const signed = encodeURIComponent('s:' + signCookie(token, 'some-other-secret'));
-    const user = authenticateUpgrade(
+    const auth = authenticateUpgrade(
       upgrade({ cookie: `lurker_session=${signed}` }),
       TEST_SESSION_SECRET,
     );
-    expect(user).toBeNull();
+    expect(auth).toBeNull();
   });
 });
 

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -109,7 +109,7 @@ import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject, validate } from './settingsRegistry.js';
 import { setBufferRetentionById } from '../db/bufferRetention.js';
 import { markBufferDirty } from '../db/retention.js';
-import { SESSION_COOKIE, loadBearerSession } from '../middleware/auth.js';
+import { SESSION_COOKIE, loadBearerCredential } from '../middleware/auth.js';
 import { PROTOCOL_VERSION, MIN_PROTOCOL_VERSION } from '../protocol.js';
 import { isAllowedBrowserOrigin } from '../utils/corsOrigins.js';
 import { callVerb } from './verbRegistry.js';
@@ -153,6 +153,10 @@ interface LurkerWebSocket extends WebSocket {
   // the first message; see allowInboundMessage.
   floodTokens?: number;
   floodRefilledAt?: number;
+  // The OAuth access token this socket authenticated with (#891), or undefined
+  // for a session. Access is identical either way; this exists only so revoking
+  // an app can find and close the sockets its token opened, and nothing else.
+  oauthTokenId?: number;
 }
 
 // #574: cap a single inbound WS frame. The library default is 100 MB; client→
@@ -1630,10 +1634,40 @@ export function fanOutToUser(userId: number, payload: WsPayload, opts: FanOutOpt
 const REVOKED_TERMINATE_MS = 2000;
 
 export function closeSocketsForUser(userId: number, reason = 'session revoked'): number {
+  return closeSocketsWhere(userId, reason, () => true);
+}
+
+/**
+ * Close only the sockets a member opened with particular OAuth access tokens
+ * (#891), leaving the rest — the web client, other apps — connected. Revoking an
+ * app deletes its tokens, but a socket authenticated at the upgrade is never
+ * checked again, so without this a revoked app would keep streaming. Same close
+ * code and teardown as closeSocketsForUser. Returns the number of sockets closed.
+ */
+export function closeSocketsForOAuthTokens(
+  userId: number,
+  tokenIds: Iterable<number>,
+  reason = 'app access revoked',
+): number {
+  const ids = new Set(tokenIds);
+  if (ids.size === 0) return 0;
+  return closeSocketsWhere(
+    userId,
+    reason,
+    (ws) => ws.oauthTokenId !== undefined && ids.has(ws.oauthTokenId),
+  );
+}
+
+function closeSocketsWhere(
+  userId: number,
+  reason: string,
+  matches: (ws: LurkerWebSocket) => boolean,
+): number {
   const set = socketsByUser.get(userId);
   if (!set) return 0;
   let closed = 0;
   for (const ws of set) {
+    if (!matches(ws)) continue;
     try {
       // Flag BEFORE closing: from here on the message handler drops anything
       // this socket sends, so the close handshake window is not an authenticated
@@ -1781,17 +1815,24 @@ export function startChanlistRefresh(networkId: number): void {
   chanlistDb.setMeta(networkId, { inProgress: true, totalCount: 0, fetchedAt: null });
 }
 
-// Authenticate a `/ws` upgrade. Two accepted credentials, in order:
+// Authenticate a `/ws` upgrade. Accepted credentials, in order:
 //
 //   1. the signed `lurker_session` cookie — every browser client, unchanged;
-//   2. `Authorization: Bearer <session token>` — native clients, which unlike
-//      browsers can set arbitrary headers on the upgrade request.
+//   2. `Authorization: Bearer <token>` — native and third-party clients, which
+//      unlike browsers can set arbitrary headers on the upgrade request. The
+//      token is a session token or an OAuth access token (#891); see
+//      loadBearerCredential.
 //
-// Both resolve to the same `sessions` row, so everything downstream of the
-// upgrade (and every WS verb) is identical regardless of how the client
-// authenticated. Lives at module scope rather than inside attachWsHub so it is
-// reachable from tests without standing up a real WebSocket server.
-export function authenticateUpgrade(req: IncomingMessage, sessionSecret: string): User | null {
+// Every credential signs in as the member with the same access, so everything
+// downstream of the upgrade (and every WS verb) is identical regardless of how
+// the client authenticated. `oauthTokenId` comes back only so the socket can be
+// found and closed when that app is revoked. Lives at module scope rather than
+// inside attachWsHub so it is reachable from tests without standing up a real
+// WebSocket server.
+export function authenticateUpgrade(
+  req: IncomingMessage,
+  sessionSecret: string,
+): { user: User; oauthTokenId: number | null } | null {
   const header = req.headers.cookie;
   if (header) {
     const cookies = cookie.parse(header);
@@ -1805,12 +1846,13 @@ export function authenticateUpgrade(req: IncomingMessage, sessionSecret: string)
         // all, so in practice only one credential is ever on the request.
         if (session) {
           const user = findUserById(session.user_id);
-          if (user) return user;
+          if (user) return { user, oauthTokenId: null };
         }
       }
     }
   }
-  return loadBearerSession(req.headers.authorization)?.user ?? null;
+  const bearer = loadBearerCredential(req.headers.authorization);
+  return bearer ? { user: bearer.user, oauthTokenId: bearer.oauthToken?.id ?? null } : null;
 }
 
 export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
@@ -2384,12 +2426,13 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       socket.destroy();
       return;
     }
-    const user = authenticateUpgrade(req, sessionSecret);
-    if (!user) {
+    const auth = authenticateUpgrade(req, sessionSecret);
+    if (!auth) {
       socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
       socket.destroy();
       return;
     }
+    const { user, oauthTokenId } = auth;
     // `?since=N` cursors the initial backlog: a reconnecting client passes the
     // highest event id it has, and the server ships only events newer than that
     // for each buffer. The first connect omits it (or sends 0), getting the
@@ -2405,6 +2448,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       lurkerWs.presence = { visible: false };
       lurkerWs.isAlive = true;
       lurkerWs.accountPaused = user.is_paused === 1;
+      if (oauthTokenId !== null) lurkerWs.oauthTokenId = oauthTokenId;
       addSocket(user.id, lurkerWs);
       onConnection(lurkerWs, user);
     });

--- a/server/types/express.d.ts
+++ b/server/types/express.d.ts
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // Ambient augmentation of Express's Request. The auth middleware
-// (middleware/auth.ts) resolves the session cookie once and attaches the
-// account + session here, so downstream route handlers behind requireAuth
-// can read req.user / req.session directly. Both are optional at the type
-// level because handlers in front of the middleware see a bare request.
+// (middleware/auth.ts) resolves the session cookie or bearer token once and
+// attaches the account here, along with the credential it came through — a
+// session row, or the OAuth token of an app the member approved (#891) — so
+// downstream route handlers behind requireAuth can read them directly. All are
+// optional at the type level because handlers in front of the middleware see a
+// bare request.
 
 import type { User } from '../db/users.js';
 import type { Session } from '../db/sessions.js';
@@ -16,6 +18,7 @@ declare global {
       user?: User;
       session?: Session;
       apiToken?: { id: number | bigint; scope: string };
+      oauthToken?: { id: number; appId: number };
     }
   }
 }

--- a/server/utils/publicOrigin.ts
+++ b/server/utils/publicOrigin.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import type { Request } from 'express';
+
+// The instance's public origin, for anything that has to hand out an absolute
+// URL: local-upload links pasted into IRC, and the OAuth discovery document's
+// endpoints. PUBLIC_BASE_URL wins (explicit, proxy-safe); otherwise it's derived
+// from the request, honoring the reverse-proxy forwarding headers a self-hoster's
+// Caddy/nginx sets. Read here rather than via a global `trust proxy` so the rest
+// of the app's request handling is unchanged.
+
+// A forwarding header may be a list ("proto1, proto2"); take the first hop.
+function firstHeaderValue(v: unknown): string {
+  return String(v ?? '')
+    .split(',')[0]
+    .trim();
+}
+
+// A host is hostname[:port] or [ipv6][:port] — reject anything with characters
+// that could break out of the authority (slash, space, userinfo '@', etc.), so a
+// spoofed header can never inject path/scheme into the URL we construct + persist.
+const HOST_RE = /^[A-Za-z0-9.\-:[\]]+$/;
+
+/** The origin the request arrived on, or '' when the Host header is unusable. */
+export function requestOrigin(req: Request): string {
+  // Only http/https are valid schemes; anything else (a spoofed "javascript" or
+  // garbage X-Forwarded-Proto) is ignored so it can never reach the built URL.
+  const rawProto = firstHeaderValue(req.headers['x-forwarded-proto']) || req.protocol;
+  const proto = rawProto === 'http' || rawProto === 'https' ? rawProto : 'https';
+  const rawHost = firstHeaderValue(req.headers['x-forwarded-host']) || req.get('host') || '';
+  const host = HOST_RE.test(rawHost) ? rawHost : '';
+  return host ? `${proto}://${host}` : '';
+}
+
+/** PUBLIC_BASE_URL, else the request origin, without a trailing slash. '' if neither is usable. */
+export function publicBaseUrl(req: Request): string {
+  return (process.env.PUBLIC_BASE_URL || requestOrigin(req)).replace(/\/+$/, '');
+}

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1964,6 +1964,8 @@ export const CATEGORIES: readonly SettingCategory[] = Object.freeze([
   // per-cell proxy, so the server doesn't mount /api/api-tokens or /mcp there
   // (A7). Hide the whole category in the hosted edition.
   { id: 'api-tokens', label: 'API tokens', kind: 'bespoke', selfHostedOnly: true },
+  // Apps approved through OAuth sign-in (#891). Standalone edition only, like API tokens.
+  { id: 'authorized-apps', label: 'Authorized apps', kind: 'bespoke', selfHostedOnly: true },
   { id: 'data', label: 'Data', kind: 'bespoke' },
   { id: 'about', label: 'About', kind: 'bespoke' },
 ]);

--- a/vue_client/src/components/settings-panes/AuthorizedAppsPane.vue
+++ b/vue_client/src/components/settings-panes/AuthorizedAppsPane.vue
@@ -1,0 +1,114 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+
+  Third-party apps the member approved through OAuth sign-in (#891): when each
+  was approved and last used, and a revoke that signs the app out. Built from
+  ApiTokensPane's list. There is no create form — an app only gets here by being
+  approved on /oauth/authorize.
+-->
+
+<template>
+  <section id="authorized-apps" class="settings-pane">
+    <h2>authorized apps</h2>
+    <p class="section-desc">
+      Apps you've approved. Each has full access to your account until you revoke it.
+    </p>
+    <p v-if="error" class="error inline">{{ error }}</p>
+
+    <ul v-if="rows.length" class="device-list">
+      <li v-for="a in rows" :key="a.id" class="device app-row">
+        <span class="ua">
+          <span class="name">{{ a.name }}</span>
+          <span v-if="a.host" class="host">{{ a.host }}</span>
+        </span>
+        <span class="last-seen">
+          <span :title="a.authorizedAt">authorized {{ formatRelative(a.authorizedAt) }}</span>
+          <span :title="a.lastUsedAt ?? undefined">
+            {{ a.lastUsedAt ? `last used ${formatRelative(a.lastUsedAt)}` : 'never used' }}
+          </span>
+        </span>
+        <button class="link danger" :disabled="busy" @click="onRevoke(a)">revoke</button>
+      </li>
+    </ul>
+    <p v-else-if="loaded && !error" class="muted small">No authorized apps.</p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { api } from '../../api.js';
+import { formatRelative } from '../../utils/timestamp.js';
+
+interface AuthorizedApp {
+  id: number;
+  name: string;
+  clientUri: string | null;
+  authorizedAt: string;
+  lastUsedAt: string | null;
+}
+
+const apps = ref<AuthorizedApp[]>([]);
+const loaded = ref(false);
+const busy = ref(false);
+const error = ref('');
+
+// Host only, shown as plain text. The app registered this URL itself and nothing
+// checks it, so it must not read as verified.
+function hostOf(uri: string | null): string | null {
+  if (!uri) return null;
+  try {
+    return new URL(uri).host || null;
+  } catch {
+    return null;
+  }
+}
+
+const rows = computed(() => apps.value.map((app) => ({ ...app, host: hostOf(app.clientUri) })));
+
+onMounted(() => {
+  refresh();
+});
+
+async function refresh() {
+  error.value = '';
+  try {
+    const { apps: list } = await api<{ apps: AuthorizedApp[] }>('/api/oauth/apps');
+    apps.value = list;
+  } catch (e: any) {
+    error.value = e.message || 'failed to load apps';
+  } finally {
+    loaded.value = true;
+  }
+}
+
+async function onRevoke(app: AuthorizedApp) {
+  if (!confirm(`Revoke ${app.name}? It will lose access to your account.`)) return;
+  error.value = '';
+  busy.value = true;
+  try {
+    await api(`/api/oauth/apps/${app.id}`, { method: 'DELETE' });
+    await refresh();
+  } catch (e: any) {
+    // 404: already revoked, e.g. from another device. The list is just stale.
+    if (e.status === 404) await refresh();
+    else error.value = e.message || 'revoke failed';
+  } finally {
+    busy.value = false;
+  }
+}
+</script>
+
+<style src="./panes.css"></style>
+<style scoped>
+.app-row .name {
+  color: var(--fg);
+}
+.app-row .host {
+  color: var(--fg-muted);
+}
+.app-row .last-seen {
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/vue_client/src/router.test.ts
+++ b/vue_client/src/router.test.ts
@@ -3,10 +3,17 @@
 
 // @vitest-environment happy-dom
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { defineComponent, h, onMounted } from 'vue';
 import { mount } from '@vue/test-utils';
-import { createRouter, createMemoryHistory, RouterView } from 'vue-router';
+import {
+  createRouter,
+  createMemoryHistory,
+  RouterView,
+  START_LOCATION,
+  type RouteLocationNormalized,
+  type RouteLocationNormalizedLoaded,
+} from 'vue-router';
 import router from './router.js';
 
 // Shape assertions run against the REAL route table, not a copy. An earlier
@@ -24,6 +31,43 @@ describe('public routes', () => {
     expect(recover?.path).toBe('/recover/:token');
     expect(recover?.meta?.requiresAuth).toBeUndefined();
     expect(router.resolve('/recover/tok123').params).toEqual({ token: 'tok123' });
+  });
+});
+
+const oauthRoute = () => router.getRoutes().find((r) => r.name === 'oauth-authorize');
+
+// Runs the route's beforeEnter directly: navigating the real router would run the
+// global guard, which fetches /api/auth/me.
+function enterOAuthRoute(path: string, from: RouteLocationNormalizedLoaded) {
+  const guard = oauthRoute()?.beforeEnter;
+  if (typeof guard !== 'function') throw new Error('no beforeEnter on the oauth route');
+  const to = router.resolve(path) as unknown as RouteLocationNormalized;
+  return guard.call(undefined, to, from, () => {});
+}
+
+describe('oauth approval route (#891)', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('requires a signed-in member', () => {
+    // The global guard turns this into /login?next=<fullPath> and back.
+    expect(oauthRoute()?.path).toBe('/oauth/authorize');
+    expect(oauthRoute()?.meta?.requiresAuth).toBe(true);
+    expect(router.resolve('/oauth/authorize?client_id=abc').name).toBe('oauth-authorize');
+  });
+
+  it('renders on a document load', () => {
+    const assign = vi.spyOn(window.location, 'assign').mockImplementation(() => {});
+    expect(enterOAuthRoute('/oauth/authorize?client_id=abc', START_LOCATION)).toBe(true);
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  // The frame-ancestors header only rides a document response, so an in-app
+  // navigation (Login.vue's `next` redirect) must become a real page load.
+  it('reloads instead of rendering when reached by in-app navigation', () => {
+    const assign = vi.spyOn(window.location, 'assign').mockImplementation(() => {});
+    const from = router.resolve('/login') as unknown as RouteLocationNormalizedLoaded;
+    expect(enterOAuthRoute('/oauth/authorize?client_id=abc&state=xyz', from)).toBe(false);
+    expect(assign).toHaveBeenCalledWith('/oauth/authorize?client_id=abc&state=xyz');
   });
 });
 

--- a/vue_client/src/router.ts
+++ b/vue_client/src/router.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router';
+import { createRouter, createWebHistory, START_LOCATION, type RouteRecordRaw } from 'vue-router';
 import { useAuthStore } from './stores/auth.js';
 import { useConfigStore } from './stores/config.js';
 import { useToastsStore } from './stores/toasts.js';
@@ -72,6 +72,21 @@ const routes: RouteRecordRaw[] = [
     name: 'admin',
     component: () => import('./views/Admin.vue'),
     meta: { requiresAuth: true, requiresAdmin: true },
+  },
+  {
+    // Approval page for a third-party app's OAuth sign-in (#891). The server
+    // sends frame-ancestors 'none' only on a real document load of this path, so
+    // the page must never render from an in-app navigation — and Login.vue's
+    // `next` redirect is one (router.replace). Reached that way, reload into it.
+    path: '/oauth/authorize',
+    name: 'oauth-authorize',
+    component: () => import('./views/OAuthAuthorize.vue'),
+    meta: { requiresAuth: true },
+    beforeEnter: (to, from) => {
+      if (from === START_LOCATION) return true;
+      window.location.assign(to.fullPath);
+      return false;
+    },
   },
 ];
 

--- a/vue_client/src/utils/settingsRegistry.test.ts
+++ b/vue_client/src/utils/settingsRegistry.test.ts
@@ -47,6 +47,9 @@ describe('categoryVisible', () => {
   it('hides selfHostedOnly categories in node edition only', () => {
     expect(categoryVisible(cat('api-tokens'), standalone)).toBe(true);
     expect(categoryVisible(cat('api-tokens'), node)).toBe(false);
+    // The OAuth server (#891) exists in standalone edition only.
+    expect(categoryVisible(cat('authorized-apps'), standalone)).toBe(true);
+    expect(categoryVisible(cat('authorized-apps'), node)).toBe(false);
   });
 
   it('shows ordinary categories in both editions', () => {

--- a/vue_client/src/views/OAuthAuthorize.test.ts
+++ b/vue_client/src/views/OAuthAuthorize.test.ts
@@ -5,7 +5,9 @@
 
 // The OAuth approval page (#891). What matters here lives in what the page does
 // with a response, which no server test can see: framed, it shows and asks for
-// nothing; a rejected request stays on the page; and only a click navigates.
+// nothing; a rejected request stays on the page; only a click navigates; and the
+// member is told when the page is done with, but never while a redirect is
+// still leaving it.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mount, flushPromises, type VueWrapper } from '@vue/test-utils';
@@ -82,6 +84,7 @@ describe('OAuthAuthorize', () => {
       body: { ...PARAMS, decision: 'approve' },
     });
     expect(wrapper.find('code.code').text()).toBe('the-code');
+    expect(wrapper.text()).toContain('You can close this page after pasting it.');
     expect(assign).not.toHaveBeenCalled();
   });
 
@@ -98,7 +101,32 @@ describe('OAuthAuthorize', () => {
     await button(wrapper, 'Approve').trigger('click');
     await flushPromises();
     expect(assign).toHaveBeenCalledWith(redirect);
+    // This tab is the one navigating; closing it now would cancel the redirect.
+    expect(wrapper.text()).not.toContain('You can close this page');
+    expect(button(wrapper, 'Approve').attributes('disabled')).toBeDefined();
   });
+
+  it.each([
+    ['approve', 'Approved. You can close this page.'],
+    ['deny', 'Denied. You can close this page.'],
+  ])(
+    'says the page can be closed once an app-scheme redirect hands off (%s)',
+    async (decision, message) => {
+      const assign = vi.spyOn(window.location, 'assign').mockImplementation(() => {});
+      const redirect = 'com.example.ivory:/oauth?state=s1';
+      serve({ kind: 'app', scheme: 'com.example.ivory' }, { redirect });
+
+      const wrapper = mount(OAuthAuthorize);
+      await flushPromises();
+      await button(wrapper, decision === 'approve' ? 'Approve' : 'Deny').trigger('click');
+      await flushPromises();
+
+      // Another app takes the redirect and this tab stays put, so it says it's done.
+      expect(assign).toHaveBeenCalledWith(redirect);
+      expect(wrapper.text()).toContain(message);
+      expect(wrapper.findAll('button')).toHaveLength(0);
+    },
+  );
 
   // Registration is open, so a rejected request's redirect could be anyone's.
   it('shows a rejected request on the page and never navigates', async () => {

--- a/vue_client/src/views/OAuthAuthorize.test.ts
+++ b/vue_client/src/views/OAuthAuthorize.test.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+// The OAuth approval page (#891). What matters here lives in what the page does
+// with a response, which no server test can see: framed, it shows and asks for
+// nothing; a rejected request stays on the page; and only a click navigates.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils';
+
+const h = vi.hoisted(() => ({
+  api: vi.fn<(url: string, opts?: { method?: string; body?: unknown }) => Promise<any>>(),
+}));
+vi.mock('../api.js', () => ({ api: h.api }));
+
+import OAuthAuthorize from './OAuthAuthorize.vue';
+
+const OOB = 'urn:ietf:wg:oauth:2.0:oob';
+const PARAMS = {
+  client_id: 'cid',
+  redirect_uri: OOB,
+  response_type: 'code',
+  code_challenge: 'challenge',
+  code_challenge_method: 'S256',
+  state: 's1',
+};
+const QUERY = `?${new URLSearchParams(PARAMS)}`;
+
+// GET answers with the approval details; POST answers with `decision`.
+function serve(destination: object, decision: object) {
+  h.api.mockImplementation(async (_url, opts) =>
+    opts?.method === 'POST'
+      ? decision
+      : { app: { name: 'Ivory', website: 'ivory.example' }, destination },
+  );
+}
+
+function button(wrapper: VueWrapper, label: string) {
+  const found = wrapper.findAll('button').find((b) => b.text() === label);
+  if (!found) throw new Error(`no ${label} button`);
+  return found;
+}
+
+beforeEach(() => {
+  h.api.mockReset();
+  window.history.replaceState(null, '', `/oauth/authorize${QUERY}`);
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('OAuthAuthorize', () => {
+  it('renders nothing and calls no API inside a frame', async () => {
+    vi.spyOn(window, 'top', 'get').mockReturnValue({} as Window);
+    serve({ kind: 'code' }, { code: 'the-code' });
+
+    const wrapper = mount(OAuthAuthorize);
+    await flushPromises();
+
+    expect(wrapper.find('.card').exists()).toBe(false);
+    expect(wrapper.findAll('button')).toHaveLength(0);
+    expect(wrapper.text()).toBe('');
+    expect(h.api).not.toHaveBeenCalled();
+  });
+
+  it('shows the code for an out-of-band approval, without navigating', async () => {
+    const assign = vi.spyOn(window.location, 'assign').mockImplementation(() => {});
+    serve({ kind: 'code' }, { code: 'the-code' });
+
+    const wrapper = mount(OAuthAuthorize);
+    await flushPromises();
+    // The query string reaches the server exactly as the app sent it.
+    expect(h.api).toHaveBeenCalledWith(`/api/oauth/authorize${QUERY}`);
+    expect(wrapper.text()).toContain('Ivory');
+    expect(wrapper.text()).toContain("You'll get a code to paste into the app");
+
+    await button(wrapper, 'Approve').trigger('click');
+    await flushPromises();
+
+    expect(h.api).toHaveBeenLastCalledWith('/api/oauth/authorize', {
+      method: 'POST',
+      body: { ...PARAMS, decision: 'approve' },
+    });
+    expect(wrapper.find('code.code').text()).toBe('the-code');
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the redirect only after a click', async () => {
+    const assign = vi.spyOn(window.location, 'assign').mockImplementation(() => {});
+    const redirect = 'https://app.example/cb?code=c1&state=s1';
+    serve({ kind: 'web', host: 'app.example' }, { redirect });
+
+    const wrapper = mount(OAuthAuthorize);
+    await flushPromises();
+    expect(wrapper.text()).toContain('Returns to app.example');
+    expect(assign).not.toHaveBeenCalled();
+
+    await button(wrapper, 'Approve').trigger('click');
+    await flushPromises();
+    expect(assign).toHaveBeenCalledWith(redirect);
+  });
+
+  // Registration is open, so a rejected request's redirect could be anyone's.
+  it('shows a rejected request on the page and never navigates', async () => {
+    const assign = vi.spyOn(window.location, 'assign').mockImplementation(() => {});
+    h.api.mockRejectedValue(
+      Object.assign(new Error('invalid_redirect_uri'), {
+        status: 400,
+        data: {
+          error: 'invalid_redirect_uri',
+          error_description: 'redirect_uri is not registered for this app',
+        },
+      }),
+    );
+
+    const wrapper = mount(OAuthAuthorize);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('redirect_uri is not registered for this app');
+    expect(wrapper.findAll('button')).toHaveLength(0);
+    expect(assign).not.toHaveBeenCalled();
+  });
+});

--- a/vue_client/src/views/OAuthAuthorize.test.ts
+++ b/vue_client/src/views/OAuthAuthorize.test.ts
@@ -30,12 +30,13 @@ const PARAMS = {
 };
 const QUERY = `?${new URLSearchParams(PARAMS)}`;
 
-// GET answers with the approval details; POST answers with `decision`.
+// GET answers with the approval details and the request it checked; POST answers
+// with `decision`.
 function serve(destination: object, decision: object) {
   h.api.mockImplementation(async (_url, opts) =>
     opts?.method === 'POST'
       ? decision
-      : { app: { name: 'Ivory', website: 'ivory.example' }, destination },
+      : { app: { name: 'Ivory', website: 'ivory.example' }, destination, request: PARAMS },
   );
 }
 
@@ -86,6 +87,25 @@ describe('OAuthAuthorize', () => {
     expect(wrapper.find('code.code').text()).toBe('the-code');
     expect(wrapper.text()).toContain('You can close this page after pasting it.');
     expect(assign).not.toHaveBeenCalled();
+  });
+
+  // A query string padded past Express's 1000-key limit reads as one app on the
+  // server and as another to URLSearchParams. The approval has to be for the app
+  // the page showed, so the page posts the server's reading back, not its own.
+  it('approves the request the server described, not its own reading of the URL', async () => {
+    const smuggled = `&client_id=other&redirect_uri=${encodeURIComponent('https://evil.example/cb')}`;
+    window.history.replaceState(null, '', `/oauth/authorize${QUERY}${smuggled}`);
+    serve({ kind: 'code' }, { code: 'the-code' });
+
+    const wrapper = mount(OAuthAuthorize);
+    await flushPromises();
+    await button(wrapper, 'Approve').trigger('click');
+    await flushPromises();
+
+    expect(h.api).toHaveBeenLastCalledWith('/api/oauth/authorize', {
+      method: 'POST',
+      body: { ...PARAMS, decision: 'approve' },
+    });
   });
 
   it('navigates to the redirect only after a click', async () => {

--- a/vue_client/src/views/OAuthAuthorize.vue
+++ b/vue_client/src/views/OAuthAuthorize.vue
@@ -69,6 +69,11 @@
           <button class="btn-secondary" @click="onCopy">{{ copied ? 'Copied' : 'Copy' }}</button>
         </div>
         <p v-if="copyError" class="error">{{ copyError }}</p>
+        <p class="hint">You can close this page after pasting it.</p>
+      </template>
+
+      <template v-else-if="state === 'approved'">
+        <p class="subtitle">Approved. You can close this page.</p>
       </template>
 
       <template v-else-if="state === 'denied'">
@@ -113,7 +118,7 @@ function isFramed(): boolean {
 }
 
 const framed = isFramed();
-const state = ref<'checking' | 'error' | 'approve' | 'code' | 'denied'>('checking');
+const state = ref<'checking' | 'error' | 'approve' | 'code' | 'approved' | 'denied'>('checking');
 const info = ref<AuthorizeInfo | null>(null);
 const errorText = ref('');
 const code = ref('');
@@ -155,9 +160,15 @@ async function decide(decision: 'approve' | 'deny') {
     return;
   }
   if (typeof result?.redirect === 'string') {
-    // The buttons stay disabled. A custom-scheme redirect opens an app and leaves
-    // this tab where it is, and a second click would only mint a second code.
     window.location.assign(result.redirect);
+    // A custom-scheme redirect hands off to another app and leaves this tab where
+    // it is, so say it's done. Web and loopback redirects navigate this tab away
+    // themselves; until they do, the buttons stay disabled rather than inviting a
+    // close that would cancel the redirect, or a second click that mints a second
+    // code.
+    if (info.value?.destination.kind === 'app') {
+      state.value = decision === 'approve' ? 'approved' : 'denied';
+    }
   } else if (typeof result?.code === 'string') {
     code.value = result.code;
     state.value = 'code';

--- a/vue_client/src/views/OAuthAuthorize.vue
+++ b/vue_client/src/views/OAuthAuthorize.vue
@@ -97,6 +97,8 @@ type Destination =
 interface AuthorizeInfo {
   app: { name: string; website: string | null };
   destination: Destination;
+  // The authorize request exactly as the server read and checked it.
+  request: Record<string, string>;
 }
 
 interface DecisionResult {
@@ -145,14 +147,18 @@ onMounted(async () => {
 });
 
 async function decide(decision: 'approve' | 'deny') {
-  if (working.value) return;
+  const request = info.value?.request;
+  if (working.value || !request) return;
   working.value = true;
   let result: DecisionResult | null;
   try {
-    const params = Object.fromEntries(new URLSearchParams(window.location.search));
+    // Post back the request the server described, never a fresh reading of this
+    // page's URL. A second parser can read a crafted query string differently
+    // (Express stops at 1000 keys, URLSearchParams doesn't), which would show one
+    // app and approve another.
     result = await api<DecisionResult | null>('/api/oauth/authorize', {
       method: 'POST',
-      body: { ...params, decision },
+      body: { ...request, decision },
     });
   } catch (e) {
     working.value = false;

--- a/vue_client/src/views/OAuthAuthorize.vue
+++ b/vue_client/src/views/OAuthAuthorize.vue
@@ -35,7 +35,9 @@
       <template v-else-if="state === 'approve' && info">
         <p class="subtitle">Authorize this app?</p>
         <p class="app-name">{{ info.app.name }}</p>
-        <p v-if="info.app.website" class="hint">{{ info.app.website }}</p>
+        <!-- The app sets its website when it registers and nothing checks it, so
+             it's shown as the app's claim rather than as who made it. -->
+        <p v-if="info.app.website" class="hint">Says it's from {{ info.app.website }}</p>
         <p class="warning">It will have full access to your account.</p>
         <p class="hint">
           <template v-if="info.destination.kind === 'code'">

--- a/vue_client/src/views/OAuthAuthorize.vue
+++ b/vue_client/src/views/OAuthAuthorize.vue
@@ -1,0 +1,265 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<!--
+  Approval page for a third-party app's OAuth sign-in (#891). The app sends the
+  member here with its authorize request in the query string; the server checks
+  the request and says who is asking and where an approval goes.
+
+  Only the member's own Approve or Deny click navigates anywhere. A bad request is
+  shown here and never bounced back: registration is open, so the redirect on a
+  rejected request could belong to anyone.
+
+  Inside a frame it renders nothing and calls nothing. The server's
+  frame-ancestors header is the real defence; this covers a browser that ignores
+  it, so a hostile page can't overlay the Approve button.
+-->
+
+<template>
+  <div v-if="!framed" class="authorize">
+    <WordBackdrop word="authorize" />
+    <div class="card">
+      <h1>lurker</h1>
+
+      <template v-if="state === 'checking'">
+        <p class="subtitle">Checking request…</p>
+      </template>
+
+      <template v-else-if="state === 'error'">
+        <p class="subtitle">This app can't be authorized.</p>
+        <p class="error">{{ errorText }}</p>
+      </template>
+
+      <template v-else-if="state === 'approve' && info">
+        <p class="subtitle">Authorize this app?</p>
+        <p class="app-name">{{ info.app.name }}</p>
+        <p v-if="info.app.website" class="hint">{{ info.app.website }}</p>
+        <p class="warning">It will have full access to your account.</p>
+        <p class="hint">
+          <template v-if="info.destination.kind === 'code'">
+            You'll get a code to paste into the app
+          </template>
+          <template v-else-if="info.destination.kind === 'loopback'">
+            Returns to an app on this computer
+          </template>
+          <template v-else-if="info.destination.kind === 'app'">
+            Opens <code>{{ info.destination.scheme }}:</code>
+          </template>
+          <template v-else-if="info.destination.kind === 'web'">
+            Returns to <code>{{ info.destination.host }}</code>
+          </template>
+        </p>
+        <div class="actions">
+          <button class="btn-primary" :disabled="working" @click="decide('approve')">
+            Approve
+          </button>
+          <button class="btn-secondary" :disabled="working" @click="decide('deny')">Deny</button>
+        </div>
+      </template>
+
+      <template v-else-if="state === 'code'">
+        <p class="subtitle">
+          Paste this code into <strong>{{ info?.app.name }}</strong
+          >.
+        </p>
+        <div class="code-row">
+          <code class="code">{{ code }}</code>
+          <button class="btn-secondary" @click="onCopy">{{ copied ? 'Copied' : 'Copy' }}</button>
+        </div>
+        <p v-if="copyError" class="error">{{ copyError }}</p>
+      </template>
+
+      <template v-else-if="state === 'denied'">
+        <p class="subtitle">Denied. You can close this page.</p>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { api, type ApiError } from '../api.js';
+import WordBackdrop from '../components/WordBackdrop.vue';
+
+type Destination =
+  | { kind: 'code' }
+  | { kind: 'loopback' }
+  | { kind: 'app'; scheme: string }
+  | { kind: 'web'; host: string };
+
+interface AuthorizeInfo {
+  app: { name: string; website: string | null };
+  destination: Destination;
+}
+
+interface DecisionResult {
+  redirect?: string;
+  code?: string;
+  denied?: boolean;
+}
+
+const GENERIC_ERROR = 'Something went wrong. Start again from the app.';
+
+// Any frame counts, same-origin included. Comparing a cross-origin `top` is
+// allowed; the catch is for a browser that throws on it anyway.
+function isFramed(): boolean {
+  try {
+    return window.top !== window.self;
+  } catch {
+    return true;
+  }
+}
+
+const framed = isFramed();
+const state = ref<'checking' | 'error' | 'approve' | 'code' | 'denied'>('checking');
+const info = ref<AuthorizeInfo | null>(null);
+const errorText = ref('');
+const code = ref('');
+const copied = ref(false);
+const copyError = ref('');
+const working = ref(false);
+
+function showError(e: unknown) {
+  const data = (e as ApiError | null)?.data as { error_description?: unknown } | null | undefined;
+  const description = data && typeof data === 'object' ? data.error_description : undefined;
+  errorText.value = typeof description === 'string' && description ? description : GENERIC_ERROR;
+  state.value = 'error';
+}
+
+onMounted(async () => {
+  if (framed) return;
+  try {
+    // The query string goes to the server untouched, exactly as the app sent it.
+    info.value = await api<AuthorizeInfo>(`/api/oauth/authorize${window.location.search}`);
+    state.value = 'approve';
+  } catch (e) {
+    showError(e);
+  }
+});
+
+async function decide(decision: 'approve' | 'deny') {
+  if (working.value) return;
+  working.value = true;
+  let result: DecisionResult | null;
+  try {
+    const params = Object.fromEntries(new URLSearchParams(window.location.search));
+    result = await api<DecisionResult | null>('/api/oauth/authorize', {
+      method: 'POST',
+      body: { ...params, decision },
+    });
+  } catch (e) {
+    working.value = false;
+    showError(e);
+    return;
+  }
+  if (typeof result?.redirect === 'string') {
+    // The buttons stay disabled. A custom-scheme redirect opens an app and leaves
+    // this tab where it is, and a second click would only mint a second code.
+    window.location.assign(result.redirect);
+  } else if (typeof result?.code === 'string') {
+    code.value = result.code;
+    state.value = 'code';
+  } else if (result?.denied === true) {
+    state.value = 'denied';
+  } else {
+    showError(null);
+  }
+}
+
+async function onCopy() {
+  copyError.value = '';
+  try {
+    await navigator.clipboard.writeText(code.value);
+    copied.value = true;
+  } catch (_) {
+    // Clipboard permission denied (rare; mostly insecure-context). The code
+    // stays selectable in the rendered <code>.
+    copyError.value = 'Clipboard unavailable — select and copy the code manually.';
+  }
+}
+</script>
+
+<style scoped>
+.authorize {
+  position: relative;
+  min-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+.card {
+  position: relative;
+  z-index: var(--z-base);
+  width: min(380px, 92vw);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-popover);
+  padding: var(--space-9);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+h1 {
+  margin: 0 0 var(--space-2);
+  color: var(--accent);
+  font-weight: 700;
+  text-transform: lowercase;
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+}
+.subtitle {
+  margin: 0;
+  color: var(--fg-muted);
+}
+/* The app picks its own name, so it can be long and unbroken. */
+.app-name {
+  margin: 0;
+  color: var(--fg);
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+.warning {
+  margin: 0;
+  padding: var(--space-4) var(--space-5);
+  border: 1px solid var(--warn, var(--accent));
+  color: var(--warn, var(--accent));
+  background: transparent;
+}
+.hint {
+  margin: 0;
+  color: var(--fg-muted);
+  overflow-wrap: anywhere;
+}
+.actions {
+  display: flex;
+  gap: var(--space-4);
+}
+.actions button {
+  flex: 1;
+}
+.code-row {
+  display: flex;
+  align-items: center;
+  gap: 1ch;
+  flex-wrap: wrap;
+}
+.code {
+  flex: 1 1 auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  word-break: break-all;
+  user-select: all;
+  background: var(--bg-soft);
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--border);
+  min-width: 0;
+}
+.error {
+  margin: 0;
+  color: var(--bad);
+}
+</style>

--- a/vue_client/src/views/Settings.vue
+++ b/vue_client/src/views/Settings.vue
@@ -61,6 +61,7 @@ import IgnoresPane from '../components/settings-panes/IgnoresPane.vue';
 import NetworksPane from '../components/settings-panes/NetworksPane.vue';
 import AccountPane from '../components/settings-panes/AccountPane.vue';
 import ApiTokensPane from '../components/settings-panes/ApiTokensPane.vue';
+import AuthorizedAppsPane from '../components/settings-panes/AuthorizedAppsPane.vue';
 import UploadsPane from '../components/settings-panes/UploadsPane.vue';
 import DataPane from '../components/settings-panes/DataPane.vue';
 import AboutPane from '../components/settings-panes/AboutPane.vue';
@@ -102,6 +103,7 @@ const BESPOKE_PANES: Record<string, Component> = {
   networks: NetworksPane,
   account: AccountPane,
   'api-tokens': ApiTokensPane,
+  'authorized-apps': AuthorizedAppsPane,
   uploads: UploadsPane,
   data: DataPane,
   about: AboutPane,

--- a/vue_client/vite.config.ts
+++ b/vue_client/vite.config.ts
@@ -68,12 +68,13 @@ export default defineConfig(({ mode }) => {
         // The MCP server and OAuth discovery (#891), so an MCP client pointed at
         // https://<dev host>:5173/mcp signs in the way it would against a real
         // instance behind Caddy. xfwd sends X-Forwarded-Host and -Proto like Caddy
-        // does: the discovery document builds its issuer from them, and MCP clients
-        // refuse an issuer that isn't the origin they were given. Without them it
+        // does. The discovery document builds its issuer from them, and MCP clients
+        // refuse an issuer that isn't the origin they were given; without them it
         // would read http://localhost:8010, the Host that changeOrigin sends.
         '/mcp': {
           target: apiBase,
           changeOrigin: true,
+          xfwd: true,
         },
         '/.well-known': {
           target: apiBase,

--- a/vue_client/vite.config.ts
+++ b/vue_client/vite.config.ts
@@ -65,6 +65,21 @@ export default defineConfig(({ mode }) => {
           ws: true,
           changeOrigin: true,
         },
+        // The MCP server and OAuth discovery (#891), so an MCP client pointed at
+        // https://<dev host>:5173/mcp signs in the way it would against a real
+        // instance behind Caddy. xfwd sends X-Forwarded-Host and -Proto like Caddy
+        // does: the discovery document builds its issuer from them, and MCP clients
+        // refuse an issuer that isn't the origin they were given. Without them it
+        // would read http://localhost:8010, the Host that changeOrigin sends.
+        '/mcp': {
+          target: apiBase,
+          changeOrigin: true,
+        },
+        '/.well-known': {
+          target: apiBase,
+          changeOrigin: true,
+          xfwd: true,
+        },
       },
     },
   };


### PR DESCRIPTION
Closes #891.

Third-party clients can sign in through the browser with OAuth 2 instead of storing the member's password. It follows Mastodon's model: many independent servers, and clients that have no prior relationship with any of them.

## What's in it

- **Discovery and registration.** RFC 8414 discovery at `/.well-known/oauth-authorization-server`. Open RFC 7591 registration at `/api/oauth/register`, limited to 5 per IP per 10 minutes and 1,000 unapproved apps (purged after an hour).
- **Public clients only.** No client secrets, PKCE S256 required, authorization code grant only.
- **Redirect URIs.**
  - https
  - loopback http on `127.0.0.1`, `[::1]` or `localhost`, on any port
  - reverse-DNS app schemes
  - `urn:ietf:wg:oauth:2.0:oob` for a code the member pastes into the app
- **Approval page** at `/oauth/authorize`, shown every time.
  - It accepts only the browser's cookie session and can't be framed.
  - It never redirects on an error: with open registration, that would make Lurker an open redirector.
- **Tokens.**
  - 32 random bytes, stored as SHA-256. They never expire and there are no refresh tokens.
  - A token has the same access as a password sign-in: every REST route, the WebSocket, and `/mcp` (read-write). There are no scopes.
- **Revocation.** Four paths delete a token, close its WebSockets (4001) and drop its push subscriptions:
  - RFC 7009 revoke
  - logging out with the token
  - Settings → Authorized apps
  - account recovery

  A normal password change keeps apps authorized, as on Mastodon.
- **Standalone edition only.** Nothing mounts in node edition; hosted sign-in is separate work.
- **Docs.**
  - New `docs/OAUTH.md`.
  - `docs/CLIENT_PROTOCOL.md` §3.2 covers OAuth sign-in.
  - `docs/MCP.md` shows signing in from Claude Code.

## Review and testing

- **`/code-review high`, twice.** Fixes from those rounds:
  - The approval page now approves the exact request the server checked. Before, a query string padded past Express's 1,000-key limit could show one app and approve another.
  - `/mcp` accepts OAuth tokens. Otherwise MCP clients that discover the OAuth server looped through approval, minting a token each round.
- **Not yet reviewed.** The last commit came after both reviews: localhost redirects, `/.well-known` 404s, the Vite dev proxy, and the MCP docs.
- **Run by hand against the dev server:**
  - The out-of-band flow, end to end with a terminal script: register, approve, exchange, use, revoke, then 401.
  - Claude Code's MCP browser sign-in against `https://irc.local.bradroot.me:5173/mcp`.
- **Not yet checked by hand:**
  - the no-framing headers on a built client
  - revoking from Settings closing a live client
- **Checks:** `npm run check`, `npm test` (323 files, 4,811 tests) and the docs build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013H7SZ5oDRRE5sPBGn4dZq2
