### PR TITLE
Channel membership belongs to the socket (#908, #873)

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -713,7 +713,7 @@ Also the `type` of rows inside `backlog`/`history` `events[]`. **P** = persisted
 | `channel-topic`               | E   | RPL_TOPIC on join — set state, render nothing                                 |
 | `channel-modes`               | E   | full channel mode string                                                      |
 | `channel-joined`              | E   | **you** are in the channel — the materialization signal (§9.1)                |
-| `channel-parted`              | E   | you left/were removed — mark parted, keep history                             |
+| `channel-parted`              | E   | you left, were removed, or lost the connection — mark parted, keep history    |
 | `join-error`                  | E   | join failed — `text`, `reason`; do **not** create a buffer                    |
 | `names`                       | E   | `members[…]` — full nicklist replace                                          |
 | `member-update`               | E   | `member{…}` — single-nick patch (away/account/host changes)                   |
@@ -1034,7 +1034,12 @@ these signals:
 - **`buffer-reopened` needs no handler** — the message that caused the reopen
   arrives as a normal `irc` event and materializes the buffer via the DM rule.
 - **`channel-parted` → resolve, never materialize**: mark parted, clear members,
-  keep the buffer and history. If you have no such buffer, ignore it.
+  keep the buffer and history. If you have no such buffer, ignore it. It also
+  arrives for every joined channel when the connection to the IRC server drops;
+  each rejoin that lands sends its own `channel-joined`, and one the server
+  refuses leaves the buffer parted.
+- **`names` and `channel-topic` only ever name a channel you are in.** A `/names`
+  or `/topic` for any other comes back as `motd` text in the server buffer.
 - **`membersPending` (on a snapshot channel, or on a `names` event) → keep the
   members you already hold.** The server has not heard the channel's NAMES
   since it last connected or attached — after an engine re-attach that is every

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -1036,7 +1036,7 @@ these signals:
 - **`channel-parted` → resolve, never materialize**: mark parted, clear members,
   keep the buffer and history. If you have no such buffer, ignore it. It also
   arrives for every joined channel when the connection to the IRC server drops;
-  each rejoin that lands sends its own `channel-joined`, and one the server
+  each rejoin that lands sends its own `channel-joined`, and one that the server
   refuses leaves the buffer parted.
 - **`names` and `channel-topic` only ever name a channel you are in.** A `/names`
   or `/topic` for any other comes back as `motd` text in the server buffer.

--- a/server/services/chghostWiring.test.ts
+++ b/server/services/chghostWiring.test.ts
@@ -72,7 +72,12 @@ function harness() {
   const memberIn = (channel: string, nick: string) =>
     conn.channels.get(channel.toLowerCase())?.members.get(nick.toLowerCase());
   // Drive a real JOIN so member state is built the way production builds it.
-  const join = (channel: string, nick: string, extra: Ev = {}) =>
+  // Someone else's JOIN only reaches us for a channel we are in, so ours goes
+  // first (#908).
+  const join = (channel: string, nick: string, extra: Ev = {}) => {
+    if (nick !== 'alice' && !conn.isChannelJoined(channel)) {
+      conn.client.emit('join', { channel, nick: 'alice', ident: 'alice', hostname: 'self.host' });
+    }
     conn.client.emit('join', {
       channel,
       nick,
@@ -80,6 +85,7 @@ function harness() {
       hostname: 'old.host',
       ...extra,
     });
+  };
   return { conn, publish, of, memberIn, join };
 }
 
@@ -206,7 +212,10 @@ describe('extended-join / account-notify (#508)', () => {
   it('puts the account on the join event so the join line can show it', () => {
     const { of, join } = harness();
     join('#one', 'bob', { account: 'bobaccount' });
-    expect(of('join')[0]).toMatchObject({ nick: 'bob', account: 'bobaccount' });
+    expect(of('join').find((e) => e.nick === 'bob')).toMatchObject({
+      nick: 'bob',
+      account: 'bobaccount',
+    });
   });
 
   it('omits account from the join event when there is nothing to show', () => {

--- a/server/services/chghostWiring.test.ts
+++ b/server/services/chghostWiring.test.ts
@@ -163,10 +163,19 @@ describe('chghost fan-out (#591)', () => {
   });
 
   it('keeps the old half of the mask rather than publishing an empty one', () => {
-    const { conn, of, memberIn } = harness();
-    // A member whose ident we never learned (NAMES-derived, no JOIN observed),
-    // then a host-only CHGHOST. Neither side should end up with a bare '@host'.
-    conn.client.emit('userlist', { channel: '#one', users: [{ nick: 'bob', modes: [] }] });
+    const { conn, of, memberIn, join } = harness();
+    // A member whose ident we never learned (NAMES-derived, no JOIN of theirs
+    // observed), then a host-only CHGHOST. Neither side should end up with a
+    // bare '@host'. Our own JOIN comes first: a NAMES reply only fills a channel
+    // we are in (#908).
+    join('#one', 'alice');
+    conn.client.emit('userlist', {
+      channel: '#one',
+      users: [
+        { nick: 'alice', modes: [] },
+        { nick: 'bob', modes: [] },
+      ],
+    });
     conn.client.emit('user updated', {
       nick: 'bob',
       hostname: '',

--- a/server/services/engineChannelMembership.test.ts
+++ b/server/services/engineChannelMembership.test.ts
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The engine's half of #908 (ircChannelMembership.test.ts has the direct
+// socket). The joined set belongs to the IRC socket, so what ends it depends on
+// which socket died:
+//   - the link to the engine blips: the IRC socket lives on in the engine, so
+//     nothing is parted and the re-attach carries on;
+//   - the engine reports the IRC socket closed: every channel is parted, and
+//     the reconnect's rejoin lights it again;
+//   - the IRC socket dies while the link is down: nothing could say so at the
+//     time, so the re-attach that has to dial afresh parts them.
+
+// MUST be first: redirects DATABASE_PATH before anything opens the db.
+import '../test-utils/isolateDb.js';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createUser } from '../db/users.js';
+import { createNetwork } from '../db/networks.js';
+import type { Network } from '../db/networks.js';
+import type { FakeIrcd } from '../test-utils/fakeIrcd.js';
+import type { EngineServer } from '../engine/server.js';
+import type { EngineHarness } from '../test-utils/engineHarness.js';
+import { until } from '../test-utils/until.js';
+
+type Ev = Record<string, unknown>;
+
+let ircManager: typeof import('./ircManager.js').default;
+let EngineLink: typeof import('./engineLink.js').EngineLink;
+let engineConnectionId: typeof import('./engineLink.js').engineConnectionId;
+let harness: EngineHarness;
+let ircd: FakeIrcd;
+let engine: EngineServer;
+let userId: number;
+let seq = 0;
+const events: Ev[] = [];
+
+beforeAll(async () => {
+  // Read once at module load, so set before the imports: a closed IRC socket
+  // redials in tens of ms instead of the production 2–5 s.
+  process.env.LURKER_RECONNECT_BASE_MS = '50';
+  process.env.LURKER_RECONNECT_JITTER_MS = '1';
+  const { startEngineHarness } = await import('../test-utils/engineHarness.js');
+  ircManager = (await import('./ircManager.js')).default;
+  ({ EngineLink, engineConnectionId } = await import('./engineLink.js'));
+  harness = await startEngineHarness({
+    secret: 'membership-secret',
+    // Long enough for the IRC socket to die, and the engine to let go of it,
+    // while the link is still down; well inside the transport's 10 s wait for
+    // the link, so the re-attach dials rather than giving up as unreachable.
+    env: { LURKER_ENGINE_RETRY_BASE_MS: '1500' },
+  });
+  ircd = harness.ircd;
+  engine = harness.engine;
+  userId = createUser('engine-membership').id;
+  ircManager.on('event', (e: Ev) => events.push(e));
+});
+
+afterAll(async () => {
+  await harness.stop();
+  delete process.env.LURKER_RECONNECT_BASE_MS;
+  delete process.env.LURKER_RECONNECT_JITTER_MS;
+});
+
+function makeNetwork(nick: string): Network {
+  return createNetwork(userId, {
+    name: `engine-membership-${seq++}`,
+    host: '127.0.0.1',
+    port: ircd.port,
+    tls: 0,
+    nick,
+    autoconnect: 0,
+  })!;
+}
+
+const since = (mark: number, networkId: number) =>
+  events.slice(mark).filter((e) => e.networkId === networkId);
+const parted = (mark: number, networkId: number, target: string) =>
+  since(mark, networkId).some((e) => e.type === 'channel-parted' && e.target === target);
+
+async function joined(nick: string, channel: string) {
+  const network = makeNetwork(nick);
+  const conn = ircManager.startNetwork(userId, network.id)!;
+  await until(() => conn.state === 'connected', 5000, `${nick} connected`);
+  ircManager.joinChannel(userId, network.id, channel);
+  await until(() => conn.isChannelJoined(channel), 5000, `${nick} joined ${channel}`);
+  return { network, conn };
+}
+
+describe('channel membership through the engine', () => {
+  it('a blip in the link parts nothing: the IRC socket never closed', async () => {
+    const { network, conn } = await joined('blip', '#steady');
+    try {
+      const mark = events.length;
+      EngineLink.shared().simulateLoss();
+      await until(() => conn.state === 'reconnecting', 5000, 'noticed the loss');
+      expect(conn.isChannelJoined('#steady')).toBe(true);
+      await until(
+        () =>
+          conn.state === 'connected' &&
+          since(mark, network.id).some((e) => e.type === 'channel-joined'),
+        10000,
+        're-attached',
+      );
+      expect(conn.isChannelJoined('#steady')).toBe(true);
+      expect(parted(mark, network.id, '#steady')).toBe(false);
+      expect(
+        since(mark, network.id).some((e) => e.type === 'state' && e.state === 'disconnected'),
+      ).toBe(false);
+    } finally {
+      ircManager.disposeNetwork(userId, network.id);
+    }
+  }, 30000);
+
+  it('the engine reporting the IRC socket closed parts it, and the rejoin lights it again', async () => {
+    const { network, conn } = await joined('dropped', '#again');
+    try {
+      const mark = events.length;
+      const registrations = ircd.registrations.length;
+      ircd.drop('dropped', false);
+      await until(
+        () => ircd.registrations.length > registrations && conn.isChannelJoined('#again'),
+        20000,
+        'rejoined on the new socket',
+      );
+      expect(
+        since(mark, network.id)
+          .filter((e) => e.target === '#again')
+          .map((e) => e.type)
+          .filter((t) => t === 'channel-parted' || t === 'channel-joined'),
+      ).toEqual(['channel-parted', 'channel-joined']);
+    } finally {
+      ircManager.disposeNetwork(userId, network.id);
+    }
+  }, 30000);
+
+  it('an IRC socket that died while the link was down is parted when the re-attach has to dial', async () => {
+    const { network, conn } = await joined('outage', '#gap');
+    const id = engineConnectionId(userId, network.id);
+    try {
+      const mark = events.length;
+      EngineLink.shared().simulateLoss();
+      await until(() => conn.state === 'reconnecting', 5000, 'noticed the loss');
+      // Nobody is listening when the IRC socket goes, so the app still
+      // believes it is in #gap — the state only the re-attach can correct.
+      ircd.drop('outage', false);
+      await until(() => !engine.hasConnection(id), 5000, 'the engine let go of the dead socket');
+      expect(conn.isChannelJoined('#gap')).toBe(true);
+      expect(parted(mark, network.id, '#gap')).toBe(false);
+
+      await until(
+        () => parted(mark, network.id, '#gap'),
+        10000,
+        'parted when the re-attach dialed',
+      );
+      await until(() => conn.isChannelJoined('#gap'), 10000, 'rejoined on the fresh dial');
+    } finally {
+      ircManager.disposeNetwork(userId, network.id);
+    }
+  }, 30000);
+});

--- a/server/services/ircChannelMembership.test.ts
+++ b/server/services/ircChannelMembership.test.ts
@@ -18,7 +18,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { createUser } from '../db/users.js';
 import { createNetwork } from '../db/networks.js';
 import type { Network } from '../db/networks.js';
-import { isAutojoin } from '../db/buffers.js';
+import { getBuffer, isAutojoin } from '../db/buffers.js';
 import { FakeIrcd, rawClient } from '../test-utils/fakeIrcd.js';
 import { until } from '../test-utils/until.js';
 
@@ -150,6 +150,38 @@ describe('a dead socket takes its channels with it', () => {
       ircManager.disposeNetwork(userId, network.id);
     }
   }, 30000);
+
+  it('a join key whose echo never came does not outlive the socket', async () => {
+    const { conn, network } = connectDirect('memberkey');
+    try {
+      await until(() => conn.state === 'connected', 5000, 'connected');
+      // The JOIN goes out, and the socket dies before any answer to it.
+      ircd.hold = (cmd, params) => cmd === 'JOIN' && params[0] === '#keyed';
+      conn.stashJoinKey('#keyed', 'stale-key');
+      conn.join('#keyed', 'stale-key');
+      await until(
+        () => (ircd.client('memberkey')?.sent ?? []).some((l) => l.startsWith('JOIN #keyed')),
+        5000,
+        'JOIN sent',
+      );
+      ircd.hold = null;
+      const registrations = ircd.registrations.length;
+      ircd.drop('memberkey', false);
+      await until(
+        () => ircd.registrations.length > registrations && conn.state === 'connected',
+        20000,
+        're-registered on a new socket',
+      );
+
+      // A keyless join on the new socket stores no key.
+      conn.join('#keyed');
+      await until(() => conn.isChannelJoined('#keyed'), 5000, 'joined #keyed');
+      expect(getBuffer(userId, network.id, '#keyed')?.key ?? null).toBeNull();
+    } finally {
+      ircd.hold = null;
+      conn.dispose();
+    }
+  }, 30000);
 });
 
 describe('a reply that names a channel is not membership', () => {
@@ -205,6 +237,28 @@ describe('a reply that names a channel is not membership', () => {
       ).toEqual([]);
     } finally {
       bystander.socket.destroy();
+      conn.dispose();
+    }
+  }, 30000);
+
+  it("someone else's JOIN never makes a channel ours; our own counts in any case", async () => {
+    const { conn, events } = connectDirect('memberfour');
+    try {
+      await until(() => conn.state === 'connected', 5000, 'connected');
+      const mark = events.length;
+      ircd.sendRaw('memberfour', ':stranger!u@h JOIN #elsewhere');
+      // Our own JOIN, echoed with the nick in a different case. Sent second, so
+      // its channel-joined means the stranger's line was handled too.
+      ircd.sendRaw('memberfour', ':MemberFour!u@h JOIN #shouty');
+      await until(
+        () => events.slice(mark).some((e) => e.type === 'channel-joined' && e.target === '#shouty'),
+        5000,
+        'channel-joined for our own JOIN in a different case',
+      );
+      expect(conn.isChannelJoined('#shouty')).toBe(true);
+      expect(conn.isChannelJoined('#elsewhere')).toBe(false);
+      expect(conn.channelState('#elsewhere')).toBeUndefined();
+    } finally {
       conn.dispose();
     }
   }, 30000);

--- a/server/services/ircChannelMembership.test.ts
+++ b/server/services/ircChannelMembership.test.ts
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Channel membership is the current socket's and nothing else's (#908). Two
+// ways it used to outlive the truth, both against a real IrcConnection and the
+// fake ircd:
+//   - the joined set survived the socket dying, so a channel whose rejoin the
+//     server refused (DALnet's 477 before NickServ identifies us, #873) read as
+//     joined forever, and the 477 itself was taken for a speak rejection;
+//   - a NAMES or TOPIC reply for a channel we are not in created the entry,
+//     with a nicklist that did not have us in it.
+// The engine's side of the first (a link blip keeps the set, a dead IRC socket
+// does not) is in engineChannelMembership.test.ts.
+
+// MUST be first: redirects DATABASE_PATH before anything opens the db.
+import '../test-utils/isolateDb.js';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createUser } from '../db/users.js';
+import { createNetwork } from '../db/networks.js';
+import type { Network } from '../db/networks.js';
+import { isAutojoin } from '../db/buffers.js';
+import { FakeIrcd, rawClient } from '../test-utils/fakeIrcd.js';
+import { until } from '../test-utils/until.js';
+
+type Ev = Record<string, unknown>;
+
+let IrcConnection: typeof import('./ircConnection.js').IrcConnection;
+let ircManager: typeof import('./ircManager.js').default;
+let ircd: FakeIrcd;
+let userId: number;
+let seq = 0;
+
+beforeAll(async () => {
+  // Read once at module load, so set before the import: a dropped socket
+  // reconnects in tens of ms instead of the production 2–5 s.
+  process.env.LURKER_RECONNECT_BASE_MS = '50';
+  process.env.LURKER_RECONNECT_JITTER_MS = '1';
+  ({ IrcConnection } = await import('./ircConnection.js'));
+  ircManager = (await import('./ircManager.js')).default;
+  ircd = await FakeIrcd.start({});
+  userId = createUser('channel-membership').id;
+});
+
+afterAll(async () => {
+  await ircd.close();
+  delete process.env.LURKER_RECONNECT_BASE_MS;
+  delete process.env.LURKER_RECONNECT_JITTER_MS;
+});
+
+function makeNetwork(nick: string): Network {
+  return createNetwork(userId, {
+    name: `membership-${seq++}`,
+    host: '127.0.0.1',
+    port: ircd.port,
+    tls: false,
+    nick,
+    autoconnect: false,
+  })!;
+}
+
+// No ircManager, so no rejoin pass: a re-registered socket joins nothing, which
+// is exactly the state a refused rejoin leaves.
+function connectDirect(nick: string) {
+  const network = makeNetwork(nick);
+  const events: Ev[] = [];
+  const conn = new IrcConnection({ network, onEvent: (e) => events.push(e as Ev) });
+  conn.connect();
+  return { conn, events, network };
+}
+
+const isParted = (target: string) => (e: Ev) => e.type === 'channel-parted' && e.target === target;
+
+describe('a dead socket takes its channels with it', () => {
+  it('announces the part, stays parted when no rejoin lands, and keeps autojoin', async () => {
+    const { conn, events, network } = connectDirect('memberone');
+    try {
+      await until(() => conn.state === 'connected', 5000, 'connected');
+      conn.join('#locked');
+      await until(() => conn.isChannelJoined('#locked'), 5000, 'joined #locked');
+
+      const mark = events.length;
+      const registrations = ircd.registrations.length;
+      ircd.drop('memberone', false);
+      await until(() => events.slice(mark).some(isParted('#locked')), 5000, 'channel-parted');
+      expect(conn.isChannelJoined('#locked')).toBe(false);
+      expect(conn.channelState('#locked')).toBeUndefined();
+      // The row is what the reconnect's rejoin reads; losing the socket is not
+      // the user leaving.
+      expect(isAutojoin(userId, network.id, '#locked')).toBe(true);
+
+      await until(
+        () => ircd.registrations.length > registrations && conn.state === 'connected',
+        20000,
+        're-registered on a new socket',
+      );
+      expect(conn.isChannelJoined('#locked')).toBe(false);
+
+      // The DALnet shape: the rejoin refused because services haven't
+      // identified us yet. With the channel no longer (wrongly) joined, this
+      // reads as the failed join it is, not as a message that didn't send.
+      const nick = ircd.registrations.at(-1)!.nick;
+      ircd.sendRaw(nick, `:fake.server 477 ${nick} #locked :You need a registered nick`);
+      await until(
+        () => events.some((e) => e.type === 'join-error' && e.target === '#locked'),
+        5000,
+        'join-error for the refused rejoin',
+      );
+      expect(conn.isChannelJoined('#locked')).toBe(false);
+    } finally {
+      conn.dispose();
+    }
+  }, 30000);
+
+  it('the reconnect rejoin lights the channel again, with us in its nicklist', async () => {
+    const network = makeNetwork('membertwo');
+    const events: Ev[] = [];
+    const onEvent = (e: Ev) => {
+      if (e.networkId === network.id) events.push(e);
+    };
+    ircManager.on('event', onEvent);
+    try {
+      const conn = ircManager.startNetwork(userId, network.id)!;
+      await until(() => conn.state === 'connected', 5000, 'connected');
+      ircManager.joinChannel(userId, network.id, '#back');
+      await until(() => conn.isChannelJoined('#back'), 5000, 'joined #back');
+
+      const mark = events.length;
+      const registrations = ircd.registrations.length;
+      ircd.drop('membertwo', false);
+      await until(
+        () => ircd.registrations.length > registrations && conn.isChannelJoined('#back'),
+        20000,
+        'rejoined #back after the reconnect',
+      );
+      const nick = ircd.registrations.at(-1)!.nick.toLowerCase();
+      await until(
+        () => conn.channelState('#back')?.members.has(nick) === true,
+        5000,
+        'our nick in the fresh nicklist',
+      );
+      expect(
+        events
+          .slice(mark)
+          .filter((e) => e.target === '#back')
+          .map((e) => e.type)
+          .filter((t) => t === 'channel-parted' || t === 'channel-joined'),
+      ).toEqual(['channel-parted', 'channel-joined']);
+    } finally {
+      ircManager.off('event', onEvent);
+      ircManager.disposeNetwork(userId, network.id);
+    }
+  }, 30000);
+});
+
+describe('a reply that names a channel is not membership', () => {
+  it('NAMES and TOPIC for a channel we are not in show in the server buffer and join nothing', async () => {
+    const { conn, events } = connectDirect('memberthree');
+    const bystander = await rawClient(ircd.port, 'bystander');
+    try {
+      await until(() => conn.state === 'connected', 5000, 'connected');
+      await bystander.waitFor(/ 001 /);
+      bystander.send('JOIN #other');
+      await bystander.waitFor(/ 366 /);
+      ircd.topics.set('#third', 'a topic for the curious');
+
+      const mark = events.length;
+      conn.raw('NAMES #other');
+      conn.raw('TOPIC #third');
+      // Replies arrive in order on one socket, so the TOPIC reply's row means
+      // the NAMES reply has been handled too.
+      const serverRows = () =>
+        events
+          .slice(mark)
+          .filter((e) => e.type === 'motd')
+          .map((e) => String(e.text));
+      await until(
+        () => serverRows().some((t) => t.includes('a topic for the curious')),
+        5000,
+        'the TOPIC reply in the server buffer',
+      );
+      expect(serverRows().some((t) => t.includes('#other') && t.includes('bystander'))).toBe(true);
+      expect(conn.isChannelJoined('#other')).toBe(false);
+      expect(conn.isChannelJoined('#third')).toBe(false);
+      // Each of these makes a client materialize a buffer for the channel.
+      expect(
+        events
+          .slice(mark)
+          .filter((e) => ['names', 'channel-topic', 'channel-joined'].includes(e.type as string)),
+      ).toEqual([]);
+
+      // Control: our own join's NAMES still becomes the nicklist, and stays out
+      // of the server buffer.
+      const joinMark = events.length;
+      conn.join('#mine');
+      await until(
+        () => events.slice(joinMark).some((e) => e.type === 'names' && e.target === '#mine'),
+        5000,
+        'names for #mine',
+      );
+      expect(conn.channelState('#mine')?.members.has('memberthree')).toBe(true);
+      expect(
+        events
+          .slice(joinMark)
+          .filter((e) => e.type === 'motd' && /memberthree|NAMES/i.test(String(e.text))),
+      ).toEqual([]);
+    } finally {
+      bystander.socket.destroy();
+      conn.dispose();
+    }
+  }, 30000);
+});

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -2194,6 +2194,7 @@ describe('disconnect-offline sweep + WHO re-light (no-MONITOR presence)', () => 
     conn.client.user.nick = 'me';
     conn.trackDmPeer('chanpal');
     // Peer shares a channel with us…
+    conn.client.emit('join', { channel: '#room', nick: 'me' });
     conn.client.emit('join', { channel: '#room', nick: 'chanpal', ident: 'u', hostname: 'h' });
     // …then our socket drops (peer quit unseen or not — doesn't matter):
     conn.markAllPeersOffline();
@@ -2211,6 +2212,7 @@ describe('disconnect-offline sweep + WHO re-light (no-MONITOR presence)', () => 
     conn.publish = vi.fn<typeof conn.publish>();
     conn.client.user.nick = 'me';
     conn.trackDmPeer('awaychan');
+    conn.client.emit('join', { channel: '#room', nick: 'me' });
     conn.client.emit('join', { channel: '#room', nick: 'awaychan' });
     conn.client.emit('wholist', { target: '#room', users: [{ nick: 'awaychan', away: true }] });
     expect(getPeerPresence(conn.network.id, 'awaychan')?.state).toBe('away');

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -556,8 +556,9 @@ export class IrcConnection {
   joinedFoldedCache: Set<string> | null;
   // Join keys awaiting their echo, keyed by lowercased channel. Nothing is
   // persisted on a join REQUEST (the buffers row is echo-written), so the key
-  // rides here until the join lands; a forward (470) discards it. Lost on a
-  // process restart mid-join — the user just re-/joins with the key.
+  // rides here until the join lands; a forward (470) discards it, and so does
+  // the socket dying (forgetJoinedChannels). Lost on a process restart
+  // mid-join — the user just re-/joins with the key.
   private pendingJoinKeys = new Map<string, string>();
   userModes: Set<string>;
   awayState: AwayState;
@@ -2260,11 +2261,18 @@ export class IrcConnection {
     c.on('join', (event: Record<string, unknown>) => {
       const eventChannel = event.channel as string;
       const eventNick = event.nick as string;
-      const ch = this.upsertChannel(eventChannel);
+      // Case-insensitive, like the part and kick handlers: a server that echoes
+      // our nick in a different case is still telling us about our own join.
+      const isSelf = !!c.user.nick && eventNick.toLowerCase() === c.user.nick.toLowerCase();
+      // Only our own JOIN makes a channel ours (#908). Someone else's updates a
+      // channel we are in and creates nothing for one we are not — a backlog
+      // line replayed for a channel we have since left, say. Fold-aware, like
+      // the NAMES and TOPIC handlers.
+      const ch = isSelf ? this.upsertChannel(eventChannel) : this.channelState(eventChannel);
       // extended-join: irc-framework parses the account param when the cap is
       // enabled, and omits the key when it isn't (#508).
       const joinAccount = normalizeAccount(event.account);
-      ch.members.set(eventNick.toLowerCase(), {
+      ch?.members.set(eventNick.toLowerCase(), {
         nick: eventNick,
         modes: [],
         away: false,
@@ -2283,7 +2291,7 @@ export class IrcConnection {
         // off every join row on networks without the cap.
         ...(joinAccount ? { account: joinAccount } : {}),
       });
-      if (eventNick !== c.user.nick) {
+      if (!isSelf) {
         // JOIN means they're online. If they were marked away and JOIN fires,
         // the away marker stays — markPeerEvent is idempotent against the
         // current state, and 'online' from JOIN doesn't fire if state is
@@ -2291,7 +2299,7 @@ export class IrcConnection {
         // The away-notify 'back' event is the authoritative back signal.
         this.markPeerEvent(eventNick, 'online');
       }
-      if (eventNick === c.user.nick && this.restoring) {
+      if (isSelf && this.restoring) {
         // A synthesised JOIN from the engine's replay. autojoin is lowered only
         // by a part, a kick or a close (db/buffers.ts) — so a channel the socket
         // is still in whose row says autojoin=0 means the user left it while
@@ -2314,7 +2322,7 @@ export class IrcConnection {
         this.publish({ type: 'channel-joined', target: eventChannel });
         return;
       }
-      if (eventNick === c.user.nick) {
+      if (isSelf) {
         // The ECHO is the only signal the join actually landed on the channel
         // we asked for, so this is where the buffers row is written: creation,
         // autojoin, and the key stashed at request time. A forwarded (470) or
@@ -4030,6 +4038,12 @@ export class IrcConnection {
   // autojoin is deliberately untouched: a dropped socket is not the user
   // leaving, and that flag is what the reconnect's rejoin reads.
   private forgetJoinedChannels(): void {
+    // A join key rides until its echo, and no echo comes for a JOIN sent on a
+    // dead socket. Left behind, it would be taken by the next echo for that
+    // name — a keyless /join on the new socket — and stored as the channel's
+    // key. Cleared even with no channels joined: the join that never landed is
+    // exactly the case with none.
+    this.pendingJoinKeys.clear();
     if (this.channels.size === 0) return;
     const names = Array.from(this.channels.values(), (ch) => ch.name);
     this.channels.clear();

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -539,14 +539,20 @@ export class IrcConnection {
   onEvent: (event: EnrichedEvent) => void;
   client: IrcClient;
   state: string;
-  /** Mutate only through setChannel/deleteChannel — never `.set`/`.delete`
-   *  directly — so joinedFoldedCache can't drift from what's actually in
-   *  here. Reads (`.get`, `.values()`, `.has()`, iteration) are fine raw. */
+  /** Mutate only through setChannel/deleteChannel/forgetJoinedChannels —
+   *  never `.set`/`.delete`/`.clear` directly — so joinedFoldedCache can't
+   *  drift from what's actually in here. Reads (`.get`, `.values()`, `.has()`,
+   *  iteration) are fine raw.
+   *
+   *  The CURRENT socket's membership and nothing else (#908): only our own
+   *  JOIN echo (or the engine replay's synthesised one) adds an entry, a reply
+   *  that merely names a channel (NAMES, TOPIC) never does, and every entry
+   *  goes when the socket does. */
   channels: Map<string, ChannelState>;
   /** Lazily-built per-network-folded index over `channels` for
    *  isChannelJoined. null = rebuild on next probe. Nulled by setChannel/
-   *  deleteChannel on every mutation, and separately by a CASEMAPPING change
-   *  (the folds move even though membership doesn't). */
+   *  deleteChannel/forgetJoinedChannels on every mutation, and separately by a
+   *  CASEMAPPING change (the folds move even though membership doesn't). */
   joinedFoldedCache: Set<string> | null;
   // Join keys awaiting their echo, keyed by lowercased channel. Nothing is
   // persisted on a join REQUEST (the buffers row is echo-written), so the key
@@ -1209,7 +1215,14 @@ export class IrcConnection {
       // channel's requests. Before the denylist: 366 is exactly the kind of
       // line the server buffer never shows.
       this.noteRestoreReply(rawCommand, msg?.params?.[1]);
-      if (isServerBufferDeniedNumeric(rawCommand)) return;
+      // NAMES replies are denied because a joined channel's nicklist is where
+      // they show. One for a channel we are not in has no nicklist to land in
+      // (see 'userlist'), so it renders verbatim like any other numeric.
+      const namesChannel =
+        rawCommand === '353' ? msg?.params?.[2] : rawCommand === '366' ? msg?.params?.[1] : null;
+      const namesElsewhere =
+        typeof namesChannel === 'string' && !this.isChannelJoined(namesChannel);
+      if (isServerBufferDeniedNumeric(rawCommand) && !namesElsewhere) return;
       if (
         RESTORE_QUIET_NUMERICS.has(rawCommand) &&
         this.isRestoreQuiet(rawCommand, rawCommand === '221' ? '*' : msg?.params?.[1])
@@ -1514,6 +1527,9 @@ export class IrcConnection {
       }
       this.markAllPeersOffline();
       this.setState('disconnected');
+      // Safety net, like the sweep above: 'socket close' has almost always
+      // forgotten the channels already, and a second call is a no-op.
+      this.forgetJoinedChannels();
       // Decide, now that we know WHEN the socket died, whether a SASL rejection
       // (#617) or a ban-classified ERROR (#651) earlier in this connection is
       // what killed it.
@@ -1691,6 +1707,9 @@ export class IrcConnection {
         return;
       }
       this.setState('disconnected');
+      // The IRC socket itself is gone (the engine-link cases returned above),
+      // and the channels we were in went with it.
+      this.forgetJoinedChannels();
       // Our socket to this network just dropped — from our vantage point every
       // peer we track here is now unreachable, so mark them all offline. This is
       // the fix for the "stuck online" gap on networks without MONITOR: if a
@@ -2632,13 +2651,18 @@ export class IrcConnection {
     c.on('topic', (event: Record<string, unknown>) => {
       const eventChannel = event.channel as string;
       const eventTopic = event.topic as string | undefined;
-      const ch = this.upsertChannel(eventChannel);
+      // A topic for a channel we are not in answers a query (/topic #elsewhere,
+      // which the 'raw' handler already showed in the server buffer); it is not
+      // membership (#908). Fold-aware, so a reply spelled #a{b} lands on the
+      // #a[b] we joined.
+      const ch = this.channelState(eventChannel);
+      if (!ch) return;
       ch.topic = eventTopic ?? null;
       if (event.nick) {
         // Live TOPIC change — persist + render in the message list.
         this.publish({
           type: 'topic',
-          target: eventChannel,
+          target: ch.name,
           nick: event.nick as string,
           text: eventTopic,
           time: event.time,
@@ -2647,7 +2671,7 @@ export class IrcConnection {
         // RPL_TOPIC on join — sync the topic bar without printing a row, so
         // rejoining an already-open buffer doesn't repeat the same topic line
         // every time.
-        this.publishEphemeral({ type: 'channel-topic', target: eventChannel, topic: eventTopic });
+        this.publishEphemeral({ type: 'channel-topic', target: ch.name, topic: eventTopic });
       }
     });
 
@@ -2794,7 +2818,13 @@ export class IrcConnection {
       const tHandler = Date.now();
       const eventChannel = event.channel as string;
       const eventUsers = (event.users as Record<string, unknown>[]) || [];
-      const ch = this.upsertChannel(eventChannel);
+      // Only a channel we are in has a nicklist to replace. A NAMES reply for
+      // any other — a typed /names #elsewhere, a restore step answered after a
+      // KICK — used to create one, and the channel then read as joined with a
+      // nicklist that didn't have us in it (#908). The 'raw' handler shows such
+      // a reply in the server buffer instead.
+      const ch = this.channelState(eventChannel);
+      if (!ch) return;
       // Preserve known away flags AND user/host across re-issued NAMES
       // (e.g. on /NAMES or a fresh join). NAMES doesn't carry ident/host on
       // most ircds — the JOIN event and WHO reply do — so we hold onto
@@ -3990,6 +4020,23 @@ export class IrcConnection {
     return deleted;
   }
 
+  // The joined set belongs to one socket, so it dies with it (#908). Kept, a
+  // channel whose rejoin the server refused — a 477 before services identify
+  // us, a ban set while we were away — read as joined for the life of the
+  // process: the snapshot said joined, nothing arrived, and a 477 for it was
+  // taken for a speak rejection. Each one is announced parted so clients dim
+  // it; a rejoin that lands lights it again through its echo.
+  //
+  // autojoin is deliberately untouched: a dropped socket is not the user
+  // leaving, and that flag is what the reconnect's rejoin reads.
+  private forgetJoinedChannels(): void {
+    if (this.channels.size === 0) return;
+    const names = Array.from(this.channels.values(), (ch) => ch.name);
+    this.channels.clear();
+    this.joinedFoldedCache = null;
+    for (const name of names) this.publish({ type: 'channel-parted', target: name });
+  }
+
   upsertChannel(name: string): ChannelState {
     const key = name.toLowerCase();
     let ch = this.channels.get(key);
@@ -4387,6 +4434,10 @@ export class IrcConnection {
     switch (phase) {
       case 'dialing':
         this.resetRestoreState();
+        // A new socket. Anything we still think we are in belonged to one that
+        // died while our link to the engine was down, so 'socket close' never
+        // saw it go.
+        this.forgetJoinedChannels();
         this.announceConnecting();
         break;
       case 'attached': {

--- a/server/services/ircE2eWiring.test.ts
+++ b/server/services/ircE2eWiring.test.ts
@@ -143,6 +143,10 @@ describe('rekey distribution ship (flushE2eRekeys)', () => {
     const notice = vi.fn<(target: string, text: string) => void>();
     conn.client.notice = notice;
     // A JOIN populates membership so the recipient handle resolves to a nick.
+    // Ours first: someone else's JOIN only reaches us for a channel we are in
+    // (#908).
+    conn.client.user.nick = 'alice';
+    conn.client.emit('join', { channel: '#x', nick: 'alice' });
     conn.client.emit('join', { channel: '#x', nick: 'carol', ident: 'c', hostname: 'c.host' });
     vi.spyOn(e2eManager, 'takePendingRekeySends').mockReturnValue([
       { channel: '#x', targetHandle: 'c@c.host', body: 'RPEE2E REKEY v=1 c=#x' },


### PR DESCRIPTION
Fixes the channels stuck reading as joined in #908 and #873. Neither issue closes on merge; see "Not in this PR". App-side only: `engine-1` does not move.

### What was wrong

Two ways Lurker believed it was in a channel it wasn't:

1. **The joined set outlived the IRC connection.** Nothing cleared `IrcConnection.channels` when the socket died; only the engine's re-attach diff pruned it. A channel whose rejoin the server refused (DALnet's 477 before NickServ identifies us, a ban set while away) stayed joined in every client, with the old nicklist and no messages. The stale entry also made that 477 read as a rejected message rather than a failed join (`isOverloadedSpeakRejection`), so no toast appeared.
2. **NAMES and TOPIC replies created channel entries.** A `/names #elsewhere`, or a restore step's reply landing after a KICK, marked the channel joined with a nicklist that didn't include us. The web client's `names` and `channel-topic` handlers materialize a buffer, so a ghost buffer appeared too.

### Fix

- `forgetJoinedChannels()` clears the set and publishes `channel-parted` for each channel when the IRC socket dies: from `socket close`, from `close` as a safety net, and from the engine's `dialing` phase (the socket died while the app's link to the engine was down, so `socket close` never saw it). autojoin is untouched, so the reconnect still rejoins. A link blip, detach or takeover keeps the set, because that socket is still alive. It also drops join keys still waiting for an echo, which a dead socket will never send.
- The `topic` and `userlist` handlers only update a channel we're in, looked up fold-aware with `channelState()`. A 353/366 for any other channel renders in the server buffer, as 332 already did.
- The `join` handler only creates an entry for our own JOIN, matched case-insensitively like `part` and `kick`. Someone else's JOIN updates a channel we're in and creates nothing otherwise, and our own JOIN echoed in a different case now writes the row and sends `channel-joined`.
- `docs/CLIENT_PROTOCOL.md` §9.1 documents the behaviour.

### Compared with soju and ZNC

Both, and weechat, irssi and The Lounge, keep the wanted-channel list apart from the joined set, drop joined state with the socket, rebuild it only from our own JOIN, and pass through replies for a channel we're not in. Neither bouncer PARTs its clients on an upstream drop; each announces the network state, which Lurker's bouncer already does, so `bouncer.ts` is unchanged.

### Verification

- `ircChannelMembership.test.ts` (direct socket): a drop parts the channel and it stays parted when no rejoin lands; autojoin survives; a 477 afterwards is a `join-error`; ircManager's rejoin lights it again with us in the nicklist; a join key whose echo never came isn't stored by the next keyless join; NAMES/TOPIC for a channel we're not in render in the server buffer and publish no `names`, `channel-topic` or `channel-joined`; someone else's JOIN creates nothing, and our own JOIN in a different case counts.
- `engineChannelMembership.test.ts`: a link blip parts nothing; an engine-reported close parts and the rejoin relights; a socket that died during a link outage parts on `dialing`.
- Mutants killed: no clear on socket death, no clear on `dialing`, clearing before the engine-link early return, `upsertChannel` back in the topic or userlist handler, no server-buffer exception, join keys kept across the socket, `upsertChannel` for every JOIN, an exact-case self match. Removing only the `socket close` call passes, because `close` covers it.
- Fixtures that added someone to a channel we had never joined now join first: `chghostWiring.test.ts`, two presence tests in `ircConnection.test.ts`, and the rekey test in `ircE2eWiring.test.ts`.
- `npm run check` and the full `npm test` (325 files, 4825 tests) green. `/code-review high` on the first commit: no findings. Copilot's review is addressed in the second commit.
- Manual QA on the first commit, without the engine (socat in front of ergo): a drop parts and the rejoin relights; a `+R` channel refusing the rejoin stays parted with a toast; `/names` for a channel we're not in shows in the server buffer and opens no buffer.
- Manual QA on the first commit, with the engine: restarting the app keeps channels lit; killing socat parts and relights; restarting the engine parts and relights.

### Not in this PR

- lurker-ios ignores a live `channel-parted` and never shows a parted state: amiantos/lurker-ios#163.
- #873's Join Channel affordance.
- #908's SVSJOIN report wasn't reproduced on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fDQVryuU3wtpk9s19XHQF
