### PR TITLE
OAuth in node edition: hosted cells run the #891 server

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -59,10 +59,11 @@ behind them, and the endpoints aren't mounted, so a toggle would do nothing.
 `linkPreviews` gates `chat.inline_media.enabled`, `chat.link_previews.enabled`,
 and the `/api/link-preview/*` endpoints.
 
-Node edition disables `/api/api-tokens`, `/mcp`, the OAuth endpoints
-(`/api/oauth/*` and `/.well-known/oauth-authorization-server`), and `/uploads/*`
-static serving; standalone has no `/api/node/*`. The WS protocol itself is
-identical in both.
+Node edition disables `/api/api-tokens` and `/uploads/*` static serving;
+standalone has no `/api/node/*`. OAuth (§3.2) and `/mcp` work in both, but in
+node edition the control plane answers OAuth registration and discovery at
+`app.lurker.chat`, and a cell's codes and tokens begin with its name and a `~`.
+The WS protocol itself is identical in both.
 Health check: `GET /api/health` → `{"status":"ok","time":"<ISO 8601>"}` (no
 auth, no version).
 
@@ -96,11 +97,11 @@ Three credentials open every door (REST and WS) with the same access. The cookie
 and the minted token resolve to the same `sessions` row; an OAuth access token
 belongs to an app the member approved:
 
-| Credential                             | Who uses it                      | How                                                                                    |
-| -------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------- |
-| Signed cookie `lurker_session`         | Browsers                         | Set by the login endpoints; `httpOnly`, `SameSite=Lax`, 30-day                         |
-| `Authorization: Bearer <token>`        | Native / TUI clients             | Token from the mint endpoints below; sent on every REST call **and on the WS upgrade** |
-| `Authorization: Bearer <access token>` | Third-party clients, self-hosted | Access token from the OAuth flow (§3.2); sent exactly like the minted token            |
+| Credential                             | Who uses it          | How                                                                                    |
+| -------------------------------------- | -------------------- | -------------------------------------------------------------------------------------- |
+| Signed cookie `lurker_session`         | Browsers             | Set by the login endpoints; `httpOnly`, `SameSite=Lax`, 30-day                         |
+| `Authorization: Bearer <token>`        | Native / TUI clients | Token from the mint endpoints below; sent on every REST call **and on the WS upgrade** |
+| `Authorization: Bearer <access token>` | Third-party clients  | Access token from the OAuth flow (§3.2); sent exactly like the minted token            |
 
 Browsers can't set headers on a WS upgrade, hence the cookie path. Native clients
 should use Bearer exclusively.
@@ -129,15 +130,17 @@ The token is an opaque 32-byte base64url session token (`routes/auth.ts:558`,
   until it sets a password (`PUT /api/auth/password`). Surface that case: the
   mint endpoint just returns 401.
 
-### 3.2 Self-hosted: OAuth for third-party clients
+### 3.2 OAuth for third-party clients
 
-A self-hosted server is also an OAuth 2 authorization server: the app registers
-itself, the member approves it in the browser, and the app exchanges a one-time
-code (PKCE `S256`) for an access token. The token has the same access as the
-minted token above and is sent the same way, but it never expires. The app never
-handles the password, so this is the recommended path for third-party clients,
-and it works for passkey-only accounts — see
-[OAuth for third-party clients](OAUTH.md).
+Self-hosted and hosted servers are both OAuth 2 authorization servers: the app
+registers itself, the member approves it in the browser, and the app exchanges a
+one-time code (PKCE `S256`) for an access token. The token has the same access as
+the minted token above and is sent the same way, but it never expires. The app
+never handles the password, so this is the recommended path for third-party
+clients, and it works for passkey-only accounts — see
+[OAuth for third-party clients](OAUTH.md). On hosted, use `https://app.lurker.chat`
+as the server. The token reaches everything proxied to the member's cell and, like
+the §3.3 token, none of the control plane's account or billing routes.
 
 ### 3.3 Hosted (`app.lurker.chat`): mint at the control plane
 
@@ -1318,7 +1321,7 @@ account_not_empty`). A mobile/TUI client can skip all of this.
 
 - `/api/admin/*` — admin panel (users, invites, presence, instance uploaders/
   networks). Admin-gated; build against it only if you're making an admin tool.
-- `/api/api-tokens` + `/mcp` (standalone only) — API tokens are a _separate_
+- `/api/api-tokens` (standalone only) and `/mcp` — API tokens are a _separate_
   Bearer namespace for MCP/automation. **They cannot open the WS**; don't
   confuse them with session tokens or with OAuth access tokens (§3.2), which
   `/mcp` also accepts.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -12,7 +12,8 @@ MCP-aware client at your Lurker, and what tools are available.
 
 1. **Mint a token** in your settings (`/settings/api-tokens`). Choose
    read-only or read-write at creation time. The raw token is shown
-   exactly once; copy it now.
+   exactly once; copy it now. On lurker.chat there are no API tokens; sign
+   in with OAuth instead (see [below](#api-tokens-and-oauth-sign-in)).
 2. **Configure your MCP client** with the token and the endpoint
    (`https://<your-lurker>/mcp`). See [Claude Desktop](#claude-desktop)
    below for a worked example.
@@ -40,12 +41,14 @@ their own account.
 `/mcp` accepts two bearer credentials:
 
 - **An API token** from your settings, with the scope you chose. API tokens
-  don't open the WebSocket the browser uses.
+  don't open the WebSocket the browser uses. lurker.chat doesn't offer them.
 - **An OAuth access token.** An MCP client that looks for an OAuth server at
   your Lurker's root can skip the token and sign in through your browser: it
   finds the discovery document, registers itself, and you approve it. The token
   is read-write here and works everywhere a password sign-in does. Its redirect
-  URI has to follow the rules in [OAuth for third-party clients](OAUTH.md).
+  URI has to follow the rules in [OAuth for third-party clients](OAUTH.md). On
+  lurker.chat this is the only way in: use `https://app.lurker.chat/mcp` as the
+  endpoint.
 
 While an account is paused, either credential gets the read tools only.
 

--- a/docs/OAUTH.md
+++ b/docs/OAUTH.md
@@ -1,9 +1,9 @@
 # OAuth for third-party clients
 
-A self-hosted Lurker is an OAuth 2 authorization server for third-party apps. It
-follows Mastodon's model: an app registers itself, the member signs in and
-approves it in the browser, and the app exchanges a one-time code for an access
-token. Hosted lurker.chat doesn't offer it.
+Lurker is an OAuth 2 authorization server for third-party apps, self-hosted and
+on lurker.chat (`https://app.lurker.chat`). It follows Mastodon's model: an app
+registers itself, the member signs in and approves it in the browser, and the app
+exchanges a one-time code for an access token. Everything below applies to both.
 
 ## The flow at a glance
 
@@ -200,6 +200,10 @@ Send it on every REST call and on the WebSocket upgrade, exactly like the sessio
 token in [Client Protocol](CLIENT_PROTOCOL.md) §3.1 and §4.1. A `401` means the
 token was revoked: discard it and authorize again.
 
+Treat codes and tokens as opaque strings. On lurker.chat they start with the name
+of the server holding the member's account and a `~`, so don't check them against
+the base64url alphabet.
+
 ## Revoke
 
 RFC 7009. Form-encoded or JSON, no auth.
@@ -311,8 +315,6 @@ curl -s "$SERVER/api/oauth/revoke" \
 
 ## For operators
 
-- OAuth is for self-hosted (standalone) Lurker only. Hosted lurker.chat doesn't
-  offer it.
 - **Set `PUBLIC_BASE_URL` behind a reverse proxy.** The discovery document's
   `issuer` and endpoint URLs come from it, and otherwise from the request's
   `Host` or `X-Forwarded-Host` header.

--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -46,20 +46,19 @@ describe('buildApp route gating by edition', () => {
       expect(res.status).toBe(404);
     });
 
-    it('does not mount the MCP server at /mcp', async () => {
+    it('mounts the MCP server, for OAuth access tokens (requireApiAuth → 401)', async () => {
       const app = await buildFor('node');
       const res = await testRequest(app)
         .post('/mcp')
         .send({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
-      expect(res.status).toBe(404);
+      expect(res.status).toBe(401);
     });
 
-    it('404s GET /mcp too (not swallowed by the SPA fallback)', async () => {
+    it('answers GET /mcp itself rather than handing back the SPA', async () => {
       const app = await buildFor('node');
-      // `mcp` is excluded from the SPA catch-all, so a disabled /mcp is
-      // consistently absent rather than served index.html.
       const res = await testRequest(app).get('/mcp');
-      expect(res.status).toBe(404);
+      expect(res.status).toBe(401);
+      expect(res.text ?? '').not.toContain('id="app"');
     });
 
     it('mounts the orchestrator control surface /api/node', async () => {
@@ -155,12 +154,19 @@ describe('OAuth (#891) mounting', () => {
     expect(res.body.error).toBe('invalid_client_metadata');
   });
 
-  it('is not mounted in node edition, where sign-in happens in front of the cell', async () => {
+  it('is mounted in node edition, apart from registration and discovery', async () => {
     const app = await buildFor('node');
+    // The orchestrator in front of the cells keeps the registry and publishes discovery.
     expect((await testRequest(app).post('/api/oauth/register').send({})).status).toBe(404);
-    expect((await testRequest(app).get('/api/oauth/apps')).status).toBe(404);
     const discovery = await testRequest(app).get('/.well-known/oauth-authorization-server');
+    expect(discovery.status).toBe(404);
     expect(discovery.headers['content-type'] ?? '').not.toMatch(/json/);
+    // Everything else answers as it does self-hosted.
+    expect((await testRequest(app).get('/api/oauth/apps')).status).toBe(401);
+    expect((await testRequest(app).get('/api/oauth/authorize')).status).toBe(401);
+    const token = await testRequest(app).post('/api/oauth/token').type('form').send({});
+    expect(token.status).toBe(400);
+    expect(token.body.error).toBe('invalid_request');
   });
 
   it('serves the discovery document as JSON, ahead of the SPA fallback', async () => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -139,24 +139,26 @@ export function buildApp(sessionSecret: string, options: BuildAppOptions = {}): 
     app.use('/api/link-preview', linkPreviewRouter);
   }
 
-  // The HTTP API-token feature and the MCP server are the two ends of the same
-  // bearer-token model: /api/api-tokens (session-cookie auth) mints the tokens,
-  // and /mcp (bearer auth) consumes them. The hosted service routes a customer
-  // to their cell by the cp_session cookie, but a bearer client carries no such
-  // cookie — so /mcp can't be addressed through the per-cell proxy, which makes
-  // the tokens unusable there. Disable both in node edition (A7); A3 hides the
-  // matching UI. Standalone keeps them fully featured.
+  // API tokens are minted in Settings and sent as a bearer. The hosted service
+  // routes a customer to their cell by the cp_session cookie, and nothing in an API
+  // token says which cell it belongs to, so node edition doesn't mount them (A7; A3
+  // hides the matching UI).
   if (!isNodeMode()) {
     app.use('/api/api-tokens', apiTokensRouter);
-    app.use('/mcp', requireApiAuth, mcpRouter);
   }
+  // The MCP server takes an API token or an OAuth access token. In node edition
+  // only the second exists, and it names the cell that issued it, so the hosted
+  // proxy can route it here.
+  app.use('/mcp', requireApiAuth, mcpRouter);
 
-  // OAuth sign-in for third-party clients (#891). Standalone only: hosted sign-in
-  // happens in front of the cells, so a cell must not mint credentials of its own.
-  // Discovery sits under /.well-known and has to be mounted before express.static
-  // below, or the SPA fallback answers it with index.html.
+  // OAuth sign-in for third-party clients (#891). A cell in node edition approves,
+  // exchanges and revokes exactly as a self-hosted server does, but registration and
+  // discovery belong to the orchestrator in front of the cells: one registration is
+  // valid on every cell, and discovery has to name the public origin (see
+  // routes/oauth.ts). Discovery sits under /.well-known and has to be mounted before
+  // express.static below, or the SPA fallback answers it with index.html.
+  app.use('/api/oauth', oauthRouter);
   if (!isNodeMode()) {
-    app.use('/api/oauth', oauthRouter);
     app.use('/.well-known', wellKnownRouter);
   }
 
@@ -170,10 +172,9 @@ export function buildApp(sessionSecret: string, options: BuildAppOptions = {}): 
     res.json({ status: 'ok', time: new Date().toISOString() });
   });
 
-  // SPA fallback for client-side routes. `mcp` joins `api`/`ws` in the exclusion
-  // so that in node edition — where /mcp isn't mounted — a stray GET /mcp 404s
-  // instead of being served index.html; it's a disabled endpoint, not a page.
-  // (In standalone the mounted /mcp middleware handles it before this anyway.)
+  // SPA fallback for client-side routes. `mcp` joins `api`/`ws` in the exclusion:
+  // it's an endpoint, never a page, and the mounted /mcp middleware answers it
+  // before this anyway.
   //
   // `assets` is excluded for a different reason: everything under it is a real
   // hashed build artifact served by express.static above, never a client route.

--- a/server/db/oauth.ts
+++ b/server/db/oauth.ts
@@ -3,6 +3,7 @@
 
 import crypto from 'crypto';
 import db from './index.js';
+import { oauthRoutingPrefix } from '../utils/edition.js';
 
 // Storage for the OAuth 2 authorization server (#891). A third-party client
 // registers itself (RFC 7591), the member approves it in the browser, and the
@@ -11,7 +12,9 @@ import db from './index.js';
 //
 // Client ids are public. Every other secret here is 32 random bytes stored only
 // as its SHA-256 -- the api_tokens reasoning: unguessable input makes an
-// unsalted hash enough, and reading these tables yields nothing usable. Codes
+// unsalted hash enough, and reading these tables yields nothing usable. In node
+// edition a code or token also starts with the cell's name (oauthRoutingPrefix);
+// the hash covers the whole string, so looking one up needs nothing extra. Codes
 // and tokens are hard-deleted when spent or revoked, so liveness is simply "the
 // row exists" and no revoked-but-present state can be misread later.
 //
@@ -113,6 +116,28 @@ export function findAppByClientId(clientId: string): OAuthApp | null {
   );
 }
 
+/**
+ * Store an app registered with the orchestrator, for a cell in node edition. A cell
+ * takes no registrations there: one is valid on every cell, so the orchestrator
+ * keeps them and hands a cell each app a member is about to approve. An app that
+ * arrives again keeps the metadata it has. If it's still pending, its clock
+ * restarts, so the hourly purge can't delete it while the member is on the
+ * approval page.
+ */
+export function upsertAppFromFleet(
+  clientId: string,
+  input: { clientName: string; clientUri: string | null; redirectUris: string[] },
+  now = Date.now(),
+): OAuthApp {
+  db.prepare(
+    `INSERT INTO oauth_apps (client_id, client_name, client_uri, redirect_uris, created_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(client_id) DO UPDATE SET created_at = excluded.created_at
+      WHERE oauth_apps.first_authorized_at IS NULL`,
+  ).run(clientId, input.clientName, input.clientUri, JSON.stringify(input.redirectUris), iso(now));
+  return findAppByClientId(clientId)!;
+}
+
 /** Registrations nobody has approved yet -- the only ones an anonymous caller can pile up. */
 export function countPendingApps(): number {
   const row = db
@@ -130,7 +155,7 @@ export function createCode(
   input: { appId: number; userId: number; redirectUri: string; codeChallenge: string },
   now = Date.now(),
 ): string {
-  const code = generateSecret();
+  const code = oauthRoutingPrefix() + generateSecret();
   db.transaction(() => {
     db.prepare(
       `INSERT INTO oauth_codes (code_hash, app_id, user_id, redirect_uri, code_challenge, expires_at)
@@ -180,7 +205,7 @@ export function consumeCode(code: string, now = Date.now()): ConsumedCode | null
 
 /** Mint an access token, returning the RAW value. It never expires; revoking deletes it. */
 export function createToken(appId: number, userId: number, now = Date.now()): string {
-  const token = generateSecret();
+  const token = oauthRoutingPrefix() + generateSecret();
   db.prepare(
     'INSERT INTO oauth_tokens (token_hash, app_id, user_id, created_at) VALUES (?, ?, ?, ?)',
   ).run(hashSecret(token), appId, userId, iso(now));

--- a/server/routes/node.test.ts
+++ b/server/routes/node.test.ts
@@ -369,3 +369,161 @@ describe('node control API — upload takedown', () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe('node control API — OAuth apps', () => {
+  const OOB = 'urn:ietf:wg:oauth:2.0:oob';
+  // The orchestrator mints client ids; any base64url string stands in for one here.
+  const clientId = (label: string) => `client_${label}_0123456789abcdef`;
+  const metadata = {
+    client_name: '  Fleet App  ',
+    client_uri: 'https://fleet.example',
+    redirect_uris: [OOB, OOB],
+  };
+
+  it('stores an app the self-hosted registration rules accept, as those rules read it', async () => {
+    const oauth = await import('../db/oauth.js');
+    const id = clientId('stored');
+    const res = await createAnonAgent(app)
+      .put(`/api/node/oauth/apps/${id}`)
+      .set('Authorization', AUTH)
+      .send(metadata);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      client_id: id,
+      client_name: 'Fleet App',
+      client_uri: 'https://fleet.example',
+      redirect_uris: [OOB],
+    });
+    expect(oauth.findAppByClientId(id)).toMatchObject({
+      clientName: 'Fleet App',
+      redirectUris: [OOB],
+      firstAuthorizedAt: null,
+    });
+  });
+
+  it('refuses what a self-hosted server would refuse, and stores nothing', async () => {
+    const oauth = await import('../db/oauth.js');
+    const id = clientId('refused');
+    const res = await createAnonAgent(app)
+      .put(`/api/node/oauth/apps/${id}`)
+      .set('Authorization', AUTH)
+      .send({ client_name: 'Phish', redirect_uris: ['javascript:alert(1)'] });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_redirect_uri');
+    expect(oauth.findAppByClientId(id)).toBeNull();
+  });
+
+  it('refuses a client_id that is not base64url', async () => {
+    const res = await createAnonAgent(app)
+      .put('/api/node/oauth/apps/bad%20id')
+      .set('Authorization', AUTH)
+      .send(metadata);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid client_id');
+  });
+
+  it('keeps the row and metadata it has, and restarts a pending copy’s clock', async () => {
+    const oauth = await import('../db/oauth.js');
+    const id = clientId('pending');
+    const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
+    const stored = oauth.upsertAppFromFleet(
+      id,
+      { clientName: 'Original', clientUri: null, redirectUris: [OOB] },
+      twoHoursAgo,
+    );
+    const res = await createAnonAgent(app)
+      .put(`/api/node/oauth/apps/${id}`)
+      .set('Authorization', AUTH)
+      .send(metadata);
+    expect(res.status).toBe(200);
+    expect(res.body.client_name).toBe('Original');
+    expect(oauth.findAppByClientId(id)?.id).toBe(stored.id);
+    // Two hours old, the copy was due for the purge. Arriving again keeps it for
+    // the member now on the approval page.
+    oauth.purgeOAuth();
+    expect(oauth.findAppByClientId(id)).not.toBeNull();
+  });
+
+  it('leaves an approved app exactly as it is', async () => {
+    const oauth = await import('../db/oauth.js');
+    const id = clientId('approved');
+    const member = createUser('oauth-fleet-approver');
+    const longAgo = Date.now() - 2 * 60 * 60 * 1000;
+    const stored = oauth.upsertAppFromFleet(
+      id,
+      { clientName: 'Approved', clientUri: null, redirectUris: [OOB] },
+      longAgo,
+    );
+    oauth.createCode(
+      { appId: stored.id, userId: member.id, redirectUri: OOB, codeChallenge: 'c'.repeat(43) },
+      longAgo,
+    );
+    const before = oauth.findAppByClientId(id);
+    const res = await createAnonAgent(app)
+      .put(`/api/node/oauth/apps/${id}`)
+      .set('Authorization', AUTH)
+      .send(metadata);
+    expect(res.status).toBe(200);
+    expect(oauth.findAppByClientId(id)).toEqual(before);
+  });
+
+  it('requires the node secret', async () => {
+    const res = await createAnonAgent(app)
+      .put(`/api/node/oauth/apps/${clientId('noauth')}`)
+      .send(metadata);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('node control API — revoke a tenant’s OAuth apps', () => {
+  const OOB = 'urn:ietf:wg:oauth:2.0:oob';
+
+  it('deletes the tenant’s tokens and unexchanged codes, and nobody else’s', async () => {
+    const oauth = await import('../db/oauth.js');
+    const owner = createUser('oauth-revoke-owner');
+    const other = createUser('oauth-revoke-other');
+    const stored = oauth.upsertAppFromFleet('client_revoke_0123456789abcdef', {
+      clientName: 'Revoked',
+      clientUri: null,
+      redirectUris: [OOB],
+    });
+    const ownerToken = oauth.createToken(stored.id, owner.id);
+    const ownerCode = oauth.createCode({
+      appId: stored.id,
+      userId: owner.id,
+      redirectUri: OOB,
+      codeChallenge: 'c'.repeat(43),
+    });
+    const otherToken = oauth.createToken(stored.id, other.id);
+
+    const res = await createAnonAgent(app)
+      .post(`/api/node/users/${owner.id}/oauth/revoke`)
+      .set('Authorization', AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, revoked: 1 });
+    expect(oauth.findTokenByRaw(ownerToken)).toBeNull();
+    expect(oauth.consumeCode(ownerCode)).toBeNull();
+    expect(oauth.findTokenByRaw(otherToken)).not.toBeNull();
+  });
+
+  it('404s an unknown user', async () => {
+    const res = await createAnonAgent(app)
+      .post('/api/node/users/999999/oauth/revoke')
+      .set('Authorization', AUTH);
+    expect(res.status).toBe(404);
+  });
+
+  it('refuses an admin (the operator)', async () => {
+    const admin = createUser('oauth-revoke-admin', { role: 'admin' });
+    const res = await createAnonAgent(app)
+      .post(`/api/node/users/${admin.id}/oauth/revoke`)
+      .set('Authorization', AUTH);
+    expect(res.status).toBe(409);
+  });
+
+  it('requires the node secret', async () => {
+    const owner = createUser('oauth-revoke-noauth');
+    const res = await createAnonAgent(app).post(`/api/node/users/${owner.id}/oauth/revoke`);
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/routes/node.ts
+++ b/server/routes/node.ts
@@ -17,6 +17,9 @@ import {
   setUserPaused,
 } from '../db/users.js';
 import { markUploadRemovedById } from '../db/uploadHistory.js';
+import { deleteOAuthForUser, upsertAppFromFleet } from '../db/oauth.js';
+import { validateRegistration } from '../services/oauth.js';
+import { closeSocketsForOAuthTokens } from '../services/wsHub.js';
 import ircManager from '../services/ircManager.js';
 import { sign as signCookie } from 'cookie-signature';
 import { createSession } from '../db/sessions.js';
@@ -226,6 +229,57 @@ router.post('/uploads/:id/takedown', (req: Request, res: Response) => {
     return;
   }
   res.json({ ok: true });
+});
+
+// OAuth (#891). One registration is valid on every cell, so the orchestrator keeps
+// the registry and a cell takes none itself (routes/oauth.ts). The orchestrator
+// checks each registration here, under the rules a self-hosted server applies,
+// before telling the client it registered, and hands a cell each app a member is
+// about to approve. Idempotent: an app a cell already holds keeps its metadata.
+const CLIENT_ID = /^[A-Za-z0-9_-]{1,256}$/;
+
+router.put('/oauth/apps/:clientId', (req: Request, res: Response) => {
+  const clientId = String(req.params.clientId);
+  if (!CLIENT_ID.test(clientId)) {
+    res.status(400).json({ error: 'invalid client_id' });
+    return;
+  }
+  const result = validateRegistration(req.body);
+  if (!result.ok) {
+    res.status(400).json({ error: result.error, error_description: result.description });
+    return;
+  }
+  const app = upsertAppFromFleet(clientId, result.metadata);
+  res.json({
+    client_id: app.clientId,
+    client_name: app.clientName,
+    ...(app.clientUri ? { client_uri: app.clientUri } : {}),
+    redirect_uris: app.redirectUris,
+  });
+});
+
+// Revoke every app a tenant approved: their tokens, any code not yet exchanged,
+// and the sockets those tokens opened. The orchestrator calls this when the
+// member resets their password, as account recovery does on a self-hosted server.
+// Idempotent; an unknown user is a 404 the orchestrator treats as done.
+router.post('/users/:id/oauth/revoke', (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  const target = findUserById(id);
+  if (!target) {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+  if (target.role === 'admin') {
+    res.status(409).json({ error: 'refusing to revoke apps for an admin account' });
+    return;
+  }
+  const tokenIds = deleteOAuthForUser(id);
+  closeSocketsForOAuthTokens(id, tokenIds, 'app access revoked');
+  res.json({ ok: true, revoked: tokenIds.length });
 });
 
 export default router;

--- a/server/routes/oauth.node.test.ts
+++ b/server/routes/oauth.node.test.ts
@@ -1,0 +1,245 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// OAuth sign-in (#891) on a cell in node edition, through the app as buildApp wires
+// it. The orchestrator in front of the cells keeps the app registry and routes each
+// code and token by the cell name it starts with. This file covers the cell's half:
+// it takes an app from the orchestrator, approves and exchanges exactly as a
+// self-hosted server does, mints codes and tokens the orchestrator can route, and
+// revokes every app a member approved when told to, sockets included.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+// Read when the app is built in beforeAll. vitest gives this file its own process.
+process.env.LURKER_EDITION = 'node';
+process.env.LURKER_NODE_SECRET = 'test-node-secret';
+process.env.LURKER_NODE_NAME = 'cell-1';
+
+import crypto from 'crypto';
+import http from 'http';
+import request from 'supertest';
+import { WebSocket } from 'ws';
+import type { Express } from 'express';
+import { createAuthedAgent, setupTestDb, TEST_SESSION_SECRET } from '../test-utils/testApp.js';
+import { WS_CLOSE_SESSION_REVOKED } from '../../shared/wsCloseCodes.js';
+
+const ctx = setupTestDb('routes-oauth-node');
+
+const FLEET = 'Bearer test-node-secret';
+const OOB = 'urn:ietf:wg:oauth:2.0:oob';
+// The cell's name, a `~`, and the 43-character base64url secret.
+const ROUTABLE = /^cell-1~[A-Za-z0-9_-]{43}$/;
+
+let app: Express;
+let server: http.Server;
+let wsUrl: string;
+let createUser: typeof import('../db/users.js').createUser;
+let createSession: typeof import('../db/sessions.js').createSession;
+
+beforeAll(async () => {
+  ({ createUser } = await import('../db/users.js'));
+  ({ createSession } = await import('../db/sessions.js'));
+  const { buildApp } = await import('../app.js');
+  const wsHub = await import('../services/wsHub.js');
+  app = buildApp(TEST_SESSION_SECRET);
+  // HTTP and the hub on one server, so the sockets a revoke has to close are the
+  // ones this process opened.
+  server = http.createServer(app);
+  wsHub.attachWsHub(server, TEST_SESSION_SECRET);
+  server.listen(0);
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('test server did not bind synchronously to a TCP port');
+  }
+  server.unref();
+  wsUrl = `ws://127.0.0.1:${address.port}/ws`;
+});
+
+afterAll(() => {
+  server.close();
+  ctx.cleanup();
+});
+
+// The orchestrator hands the cell an app it registered.
+async function handOver(name: string): Promise<string> {
+  const clientId = crypto.randomBytes(32).toString('base64url');
+  const res = await request(server)
+    .put(`/api/node/oauth/apps/${clientId}`)
+    .set('Authorization', FLEET)
+    .send({ client_name: name, redirect_uris: [OOB] });
+  expect(res.status).toBe(200);
+  return clientId;
+}
+
+// The member approves the app in the browser, out-of-band.
+async function approve(
+  userId: number,
+  clientId: string,
+): Promise<{ code: string; verifier: string }> {
+  const member = await createAuthedAgent(app, userId);
+  const verifier = crypto.randomBytes(32).toString('base64url');
+  const challenge = crypto.createHash('sha256').update(verifier).digest('base64url');
+  const page = await member.get('/api/oauth/authorize').query({
+    client_id: clientId,
+    redirect_uri: OOB,
+    response_type: 'code',
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+  });
+  expect(page.status).toBe(200);
+  const approved = await member
+    .post('/api/oauth/authorize')
+    .send({ ...page.body.request, decision: 'approve' });
+  expect(approved.status).toBe(200);
+  return { code: approved.body.code, verifier };
+}
+
+function exchange(clientId: string, code: string, verifier: string) {
+  return request(server).post('/api/oauth/token').type('form').send({
+    grant_type: 'authorization_code',
+    client_id: clientId,
+    code,
+    redirect_uri: OOB,
+    code_verifier: verifier,
+  });
+}
+
+async function tokenFor(userId: number, clientId: string): Promise<string> {
+  const { code, verifier } = await approve(userId, clientId);
+  const res = await exchange(clientId, code, verifier);
+  expect(res.status).toBe(200);
+  return res.body.access_token;
+}
+
+function me(token: string) {
+  return request(server).get('/api/auth/me').set('Authorization', `Bearer ${token}`);
+}
+
+// Open a socket and resolve once it has received its first frame, so the server
+// has definitely registered it before anything tries to close it.
+function connect(bearer: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsUrl, { headers: { Authorization: `Bearer ${bearer}` } });
+    const timer = setTimeout(() => {
+      ws.close();
+      reject(new Error('timed out waiting for the first frame'));
+    }, 5000);
+    ws.once('message', () => {
+      clearTimeout(timer);
+      resolve(ws);
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+function closed(ws: WebSocket): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('socket was never closed')), 5000);
+    ws.on('close', (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+}
+
+describe('OAuth on a cell', () => {
+  it('approves and exchanges an app the orchestrator handed over, minting routable codes and tokens', async () => {
+    const user = createUser('node-oauth-flow');
+    const clientId = await handOver('Fleet TUI');
+    const { code, verifier } = await approve(user.id, clientId);
+    expect(code).toMatch(ROUTABLE);
+
+    const res = await exchange(clientId, code, verifier);
+    expect(res.status).toBe(200);
+    expect(res.body.access_token).toMatch(ROUTABLE);
+    expect((await me(res.body.access_token)).status).toBe(200);
+  });
+
+  it('takes no registrations and serves no discovery document of its own', async () => {
+    const register = await request(server)
+      .post('/api/oauth/register')
+      .send({ client_name: 'Direct', redirect_uris: [OOB] });
+    expect(register.status).toBe(404);
+    expect((await request(server).get('/.well-known/oauth-authorization-server')).status).toBe(404);
+  });
+
+  it('refuses an app the orchestrator never handed over', async () => {
+    const user = createUser('node-oauth-unknown');
+    const member = await createAuthedAgent(app, user.id);
+    const res = await member.get('/api/oauth/authorize').query({
+      client_id: crypto.randomBytes(32).toString('base64url'),
+      redirect_uri: OOB,
+      response_type: 'code',
+      code_challenge: 'c'.repeat(43),
+      code_challenge_method: 'S256',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_client');
+  });
+
+  it('lets the token into /mcp', async () => {
+    const user = createUser('node-oauth-mcp');
+    const token = await tokenFor(user.id, await handOver('Fleet agent'));
+    const res = await request(server)
+      .post('/mcp')
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/json')
+      .send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} });
+    expect(res.status).toBe(200);
+    expect(res.body.result.serverInfo.name).toBe('lurker');
+  });
+
+  it('lists the app in Settings, and revokes it with RFC 7009', async () => {
+    const user = createUser('node-oauth-revoke');
+    const clientId = await handOver('Fleet revoked');
+    const token = await tokenFor(user.id, clientId);
+    const member = await createAuthedAgent(app, user.id);
+    const list = await member.get('/api/oauth/apps');
+    expect(list.body.apps.map((a: { name: string }) => a.name)).toEqual(['Fleet revoked']);
+
+    const revoked = await request(server)
+      .post('/api/oauth/revoke')
+      .type('form')
+      .send({ client_id: clientId, token });
+    expect(revoked.status).toBe(200);
+    expect((await me(token)).status).toBe(401);
+  });
+
+  it('revokes every app a member approved when the orchestrator says so', async () => {
+    const user = createUser('node-oauth-revoke-all');
+    const token = await tokenFor(user.id, await handOver('Fleet socket'));
+    const pendingClientId = await handOver('Fleet pending');
+    const unexchanged = await approve(user.id, pendingClientId);
+    const subscribed = await request(server)
+      .post('/api/push/subscriptions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ endpoint: 'https://push.example/fleet-app', keys: { p256dh: 'key', auth: 'auth' } });
+    expect(subscribed.status).toBe(201);
+    const appSocket = await connect(token);
+    const sessionSocket = await connect(createSession(user.id).token);
+    const evicted = closed(appSocket);
+
+    const res = await request(server)
+      .post(`/api/node/users/${user.id}/oauth/revoke`)
+      .set('Authorization', FLEET);
+    expect(res.status).toBe(200);
+    expect(res.body.revoked).toBe(1);
+
+    // The app's socket closes; the member's own session stays connected.
+    expect(await evicted).toBe(WS_CLOSE_SESSION_REVOKED);
+    expect(sessionSocket.readyState).toBe(WebSocket.OPEN);
+    sessionSocket.close();
+    expect((await me(token)).status).toBe(401);
+    // A code approved but not yet exchanged is gone too.
+    const late = await exchange(pendingClientId, unexchanged.code, unexchanged.verifier);
+    expect(late.status).toBe(400);
+    expect(late.body.error).toBe('invalid_grant');
+    const push = await import('../db/pushSubscriptions.js');
+    expect(push.listAllForUser(user.id).map((s) => s.endpoint)).not.toContain(
+      'https://push.example/fleet-app',
+    );
+  });
+});

--- a/server/routes/oauth.ts
+++ b/server/routes/oauth.ts
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import express, { Router } from 'express';
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import { requireAuth, requireCookieSession } from '../middleware/auth.js';
 import { RequestThrottle, limitRequests } from '../middleware/rateLimit.js';
 import { closeSocketsForOAuthTokens } from '../services/wsHub.js';
+import { isNodeMode } from '../utils/edition.js';
 import { publicBaseUrl } from '../utils/publicOrigin.js';
 import {
   MAX_PENDING_APPS,
@@ -43,7 +44,10 @@ import type { AuthorizeRequest } from '../services/oauth.js';
 // expire and there are no refresh tokens; revoking deletes the token and closes
 // every socket it opened.
 //
-// Standalone edition only (app.ts). Hosted sign-in happens in front of the cells.
+// A cell in node edition runs all of this except registration. One registration
+// is valid on every cell, so the orchestrator in front of them keeps the registry
+// (routes/node.ts), and every code and token a cell mints starts with its name so
+// the orchestrator can route it back (oauthRoutingPrefix in utils/edition.ts).
 
 export const oauthRouter = Router();
 
@@ -75,8 +79,19 @@ function param(body: unknown, key: string): string | undefined {
 
 // ---------- registration (RFC 7591) ----------
 
+// A node's orchestrator takes registrations for the whole fleet (see above), so a
+// cell refuses them before they count against anyone's limit.
+function registrationUnavailableInNodeMode(_req: Request, res: Response, next: NextFunction): void {
+  if (!isNodeMode()) {
+    next();
+    return;
+  }
+  res.status(404).json({ error: 'registration is managed by the control plane' });
+}
+
 oauthRouter.post(
   '/register',
+  registrationUnavailableInNodeMode,
   limitRequests(registrationThrottle),
   (req: Request, res: Response) => {
     noStore(res);

--- a/server/utils/edition.ts
+++ b/server/utils/edition.ts
@@ -49,6 +49,19 @@ export function isNodeMode(): boolean {
   return getEdition() === 'node';
 }
 
+/**
+ * What a cell puts in front of the OAuth codes and access tokens it mints (#891):
+ * its fleet name and a `~`. Neither carries a session the orchestrator could route
+ * by, so it reads the name instead. The secret after the last `~` is base64url,
+ * which never contains one. Empty in standalone edition, where there's nothing to
+ * route.
+ */
+export function oauthRoutingPrefix(): string {
+  if (!isNodeMode()) return '';
+  const name = (process.env.LURKER_NODE_NAME ?? '').trim();
+  return name ? `${name}~` : '';
+}
+
 // app_meta keys reserved for node identity. Populated by the orchestrator
 // handshake (A2) and the registration/heartbeat client (A4); never written in
 // standalone. Centralized here so the cell and its control surfaces agree on the

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1960,12 +1960,12 @@ export const CATEGORIES: readonly SettingCategory[] = Object.freeze([
   { id: 'away', label: 'Away', kind: 'registry' },
   { id: 'networks', label: 'Networks', kind: 'bespoke' },
   { id: 'account', label: 'Account', kind: 'bespoke' },
-  // Disabled in node edition: bearer clients can't be routed through the
-  // per-cell proxy, so the server doesn't mount /api/api-tokens or /mcp there
-  // (A7). Hide the whole category in the hosted edition.
+  // Disabled in node edition: an API token can't be routed through the per-cell
+  // proxy, so the server doesn't mount /api/api-tokens there (A7). Hide the whole
+  // category in the hosted edition.
   { id: 'api-tokens', label: 'API tokens', kind: 'bespoke', selfHostedOnly: true },
-  // Apps approved through OAuth sign-in (#891). Standalone edition only, like API tokens.
-  { id: 'authorized-apps', label: 'Authorized apps', kind: 'bespoke', selfHostedOnly: true },
+  // Apps approved through OAuth sign-in (#891), in both editions.
+  { id: 'authorized-apps', label: 'Authorized apps', kind: 'bespoke' },
   { id: 'data', label: 'Data', kind: 'bespoke' },
   { id: 'about', label: 'About', kind: 'bespoke' },
 ]);

--- a/vue_client/src/utils/settingsRegistry.test.ts
+++ b/vue_client/src/utils/settingsRegistry.test.ts
@@ -47,9 +47,11 @@ describe('categoryVisible', () => {
   it('hides selfHostedOnly categories in node edition only', () => {
     expect(categoryVisible(cat('api-tokens'), standalone)).toBe(true);
     expect(categoryVisible(cat('api-tokens'), node)).toBe(false);
-    // The OAuth server (#891) exists in standalone edition only.
+  });
+
+  it('shows Authorized apps in both editions, since a cell runs OAuth too (#891)', () => {
     expect(categoryVisible(cat('authorized-apps'), standalone)).toBe(true);
-    expect(categoryVisible(cat('authorized-apps'), node)).toBe(false);
+    expect(categoryVisible(cat('authorized-apps'), node)).toBe(true);
   });
 
   it('shows ordinary categories in both editions', () => {


### PR DESCRIPTION
Refs #891.

#891 gave self-hosted Lurker an OAuth server and left node edition out. This turns it on for hosted cells. A cell approves, exchanges and revokes with the same code a self-hosted server runs. The orchestrator in front of the cells takes the two parts one cell can't do: discovery at the public origin, and registration, since one client id has to work on every cell.

## What's in it

- **Node edition mounts.**
  - `/api/oauth` is mounted. `POST /api/oauth/register` answers 404 there, and `/.well-known/oauth-authorization-server` isn't served.
  - `/mcp` is mounted, for OAuth tokens. `/api/api-tokens` stays standalone-only.
- **Routable codes and tokens.** In node edition, a cell's codes and access tokens start with `LURKER_NODE_NAME` and a `~`. That lets the orchestrator send a token request or a Bearer to the cell that issued it. The stored hash covers the whole string. Standalone output is unchanged.
- **Two fleet-authenticated node routes.**
  - `PUT /api/node/oauth/apps/:clientId` checks an app under the self-hosted registration rules and stores it. Sending a pending app again restarts its purge clock, so the purge can't remove it while a member is on the approval page. An approved app is left alone.
  - `POST /api/node/users/:id/oauth/revoke` revokes every app a tenant approved, including unexchanged codes, and closes those tokens' sockets. Like the other node routes, it refuses admins.
- **Settings → Authorized apps** shows in both editions.
- **Docs.** `docs/OAUTH.md`, `docs/MCP.md` and `docs/CLIENT_PROTOCOL.md` no longer say hosted lacks OAuth. OAUTH.md tells clients to treat codes and tokens as opaque, since hosted ones contain `~`.

⚠ A cell's tokens never expire and route by its name, so a cell that has issued tokens must keep its `LURKER_NODE_NAME`.

## Review and testing

- **`/code-review high`:** no findings.
- **New `server/routes/oauth.node.test.ts`** runs the whole flow through `buildApp` in node edition, with a real WebSocket hub:
  - hand-over, approval, then exchange, checking the code and token are routable
  - `/api/auth/me` and `/mcp` with the token
  - the Settings list and an RFC 7009 revoke
  - the tenant revoke closing the app's socket, burning an unexchanged code and dropping its push subscription, while the member's own session stays connected
- **Other tests:** `node.test.ts` covers both node routes, and `app.test.ts` the node-edition mounts.
- **Checks:** `npm run check`, `npm test` (4,852 tests) and the docs build pass.
- **By hand:** run with the orchestrator side on a local stack with two cells, and it worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013H7SZ5oDRRE5sPBGn4dZq2
