### PR TITLE
An unclaimed 401 no longer badges the server buffer (#904)

### DIFF
--- a/server/services/ctcpWiring.test.ts
+++ b/server/services/ctcpWiring.test.ts
@@ -893,12 +893,13 @@ describe('a /whois between requests is ordered by sequence, not by the clock', (
     conn.publish = publish;
 
     conn.raw('WHOIS bob');
-    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'bob' });
+    conn.client.connection.addReadBuffer(':irc.example.test 401 nick bob :No such nick/channel');
 
     expect(ctcpLines().slice(before)).toHaveLength(0);
+    // Since #904 the raw handler's line is that report, and the only one.
     expect(publish).toHaveBeenCalledTimes(1);
     expect(publish).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'error', target: ':server:1' }),
+      expect.objectContaining({ type: 'motd', target: ':server:1' }),
     );
   });
 

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1355,10 +1355,16 @@ describe('refused-message handler routing (#283)', () => {
     conn.publish = publish;
 
     conn.raw('WHOIS fartboy');
-    conn.client.emit('irc error', { error: 'no_such_nick', nick: 'fartboy' });
+    // A wire line, not a hand-built 'irc error': the server buffer's report of
+    // an unclaimed 401 is the raw handler's line (#904).
+    conn.client.connection.addReadBuffer(
+      ':irc.example.test 401 nick fartboy :No such nick/channel',
+    );
 
     expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: 'fartboy' }));
-    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ target: ':server:1' }));
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'motd', target: ':server:1' }),
+    );
   });
 
   it("doesn't open a query from a /ctcp to a nick that isn't there", () => {

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -45,6 +45,7 @@ import {
 } from '../db/buffers.js';
 import { getPeerPresence, writePeerState } from '../db/peerPresence.js';
 import { setUserSetting, deleteUserSetting } from '../db/settings.js';
+import { typeCountsForUnread } from '../db/messages.js';
 
 // The bare IrcConnections built below carry user_id: 1, and their join/part
 // handlers write system_messages (FK → users.id). Seed user id 1 in the
@@ -1267,6 +1268,37 @@ describe('refused-message handler routing (#283)', () => {
     conn.client.emit('irc error', { error: 'no_such_nick', nick: 'someoneelse' });
 
     expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: '#anime' }));
+  });
+
+  it('reports an unclaimed 401 in the server buffer without badging it (#904)', () => {
+    // A /whois for someone who isn't online. Nothing claims the 401 — no
+    // channel command, no /ctcp, no DM history — and the profile modal already
+    // says they aren't on the network. Fed through irc-framework the way a
+    // socket line is, so both handlers see it: 'raw' first, then the library's
+    // own parsed 'irc error'.
+    const conn = makeConn();
+    conn.client.raw = vi.fn<(line: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.raw('WHOIS fartbarf');
+    conn.client.connection.addReadBuffer(
+      ':irc.example.test 401 nick fartbarf :No such nick/channel',
+    );
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'motd',
+        target: ':server:1',
+        text: 'fartbarf No such nick/channel',
+      }),
+    );
+    // That raw line is the whole report. The generic handler used to add a
+    // second copy as an 'error' row, which the server buffer counts as unread.
+    const badging = publish.mock.calls
+      .map(([event]) => event as { type: string; target: string })
+      .filter((event) => typeCountsForUnread(event.target, event.type));
+    expect(badging).toEqual([]);
   });
 
   it('leaves a command aimed at a channel we are not in in the server buffer', () => {

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -3189,6 +3189,15 @@ export class IrcConnection {
         });
         return;
       }
+      // A 401 nothing above claimed is already reported: the raw handler logged
+      // "<nick> No such nick/channel" in the server buffer. The generic line at
+      // the bottom would be a second copy, and as an 'error' row it counts
+      // toward the server buffer's unread badge — so a /whois for someone
+      // offline, whose miss the profile modal already shows, badged the server
+      // tab (#904). Same call as the command-result tags below. A 401 is only
+      // ever an answer to something we sent, never the killed/banned/dropped
+      // class that badge is for.
+      if (tag === 'no_such_nick') return;
       // Channel-join rejections (full / invite-only / banned / bad key / too
       // many channels) carry the target in event.channel. Route them to that
       // channel as an ephemeral toast so the failure surfaces where the user


### PR DESCRIPTION
A `/whois` for an offline nick marked the server buffer unread.

## Why
- The raw handler logs the 401 and the 318 verbatim as `motd` rows, which don't count toward unread.
- The `irc error` fallback then added a second copy of the 401 (`no_such_nick fartbarf — No such nick/channel`) as an `error` row, and `:server:` buffers count `error` rows toward unread.
- A nick you have DM history with never reached that fallback, because its 401 routes into the DM. That's why some nicks showed three lines and others two.

## Fix
When no routing step claims a 401 (a channel command, a `/ctcp`, or a DM), the raw line is its only report. The 482/441/443 command-result errors already work this way. The routing itself is unchanged.

This also stops the badge for other 401s nothing claims: `/whowas` misses, `/kick`, `/invite` or `/mode` against a channel we're not in, and a raw PRIVMSG to a name that doesn't exist. The raw line still reports each of them. A 401 is always a reply to something we sent, not the killed/banned/disconnected kind of event the server-buffer badge is for.

## Tests
- New test: feeds a real 401 line through irc-framework (`addReadBuffer`) so both handlers run, and asserts nothing counts toward unread. It fails on main with the duplicate row.
- Two existing tests used the removed row as proof that a 401 "stays in the server buffer". They now feed the wire line and assert on the raw `motd` row. What they guard is unchanged: a `/whois` miss opens no DM, and a same-millisecond `/whois` still outranks a `/ctcp`.
- `npm run check` and `npm test` (327 files, 4853 tests) pass. `/code-review high` found one issue, the ctcpWiring test, which the second commit fixes.

## QA
Not yet tried against a live server. On Libera, `/whois` a nick that's offline and that you've never DM'd. The server buffer should show the two raw lines and not mark itself unread.

Closes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013H7SZ5oDRRE5sPBGn4dZq2
