### PR TITLE
Settings → About: the engine's version, and a hand-set ENGINE_VERSION (#920)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -113,6 +113,18 @@ jobs:
               changed=false
               echo "engine tag PINNED for ${GITHUB_REF_NAME} by ENGINE_TAG_PINNED_RELEASES"
             fi
+            # The engine names its own version, set by hand in
+            # server/engine/version.ts. A release that moves the tag has changed
+            # the engine, so it must have set that to this release too — or every
+            # engine it publishes names the one before, in Settings → About and
+            # in the app's log. Checked before anything is built or pushed.
+            if [ "$changed" = "true" ]; then
+              ENGINE_VERSION="$(sed -nE "s/^export const ENGINE_VERSION = '([^']+)';/\1/p" server/engine/version.ts)"
+              if [ "$ENGINE_VERSION" != "$version" ]; then
+                echo "the engine changed since ${prev:-<none>}, but server/engine/version.ts has ENGINE_VERSION = '${ENGINE_VERSION}' — set it to '${version}', or pin ${GITHUB_REF_NAME} in ENGINE_TAG_PINNED_RELEASES if the engine's behaviour did not change" >&2
+                exit 1
+              fi
+            fi
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish_engine }}" = "true" ]; then
             changed=true
             version="manual-$(git rev-parse --short HEAD)"

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -1231,6 +1231,11 @@ during the TLS handshake, so there is nothing to renegotiate on a live socket.
 `GET /api/network-presets` → `{presets, allowUserDefined}` for the add-network
 form.
 
+`GET /api/about` → `{engine}` for an About screen: `null` when this instance
+dials IRC itself, otherwise `{connected, version}` for the IRC engine holding its
+sockets. `version` is the Lurker release that last changed the engine, so it can
+trail the server's own; it is `null` until the engine has answered once.
+
 ### Settings & personalization
 
 | Endpoint                      | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |

--- a/server/app.ts
+++ b/server/app.ts
@@ -33,6 +33,7 @@ import draftsRouter from './routes/drafts.js';
 import { exportsRouter, importRouter } from './routes/exports.js';
 import apiTokensRouter from './routes/apiTokens.js';
 import configRouter from './routes/config.js';
+import aboutRouter from './routes/about.js';
 import linkPreviewRouter from './routes/linkPreview.js';
 import nodeRouter from './routes/node.js';
 import { oauthRouter, wellKnownRouter } from './routes/oauth.js';
@@ -132,6 +133,7 @@ export function buildApp(sessionSecret: string, options: BuildAppOptions = {}): 
   app.use('/api/exports', exportsRouter);
   app.use('/api/imports', importRouter);
   app.use('/api/config', configRouter);
+  app.use('/api/about', aboutRouter);
   // ⚠ Not mounted at all when the feature is off, so both endpoints 404 rather than existing
   // and refusing. The in-route and resolver guards stay as defence in depth — this is the outer
   // one, and it's what makes "off" mean the surface isn't there.

--- a/server/engine.ts
+++ b/server/engine.ts
@@ -14,6 +14,7 @@ import 'dotenv/config';
 import { loadEngineConfig } from './engine/config.js';
 import { EngineServer } from './engine/server.js';
 import { PROTOCOL_MAJOR, PROTOCOL_MINOR } from './engine/protocol.js';
+import { ENGINE_VERSION } from './engine/version.js';
 import { APP_VERSION } from './utils/userAgent.js';
 import {
   startIdentd,
@@ -54,7 +55,7 @@ const engine = new EngineServer({
   bufferBytes: config.bufferBytes,
   bufferTotalBytes: config.bufferTotalBytes,
   orphanMs: config.orphanMs,
-  version: APP_VERSION,
+  version: ENGINE_VERSION,
 });
 
 // Say which ident mode this process resolved, because the variables that
@@ -71,7 +72,7 @@ void (async () => {
   try {
     const { host, port } = await engine.listen(config.listenPort, config.listenHost);
     console.log(
-      `[engine] listening on ${host}:${port} — protocol ${PROTOCOL_MAJOR}.${PROTOCOL_MINOR}, lurker ${APP_VERSION}; per-connection buffer ${config.bufferBytes} bytes, total ${config.bufferTotalBytes}`,
+      `[engine] listening on ${host}:${port} — engine ${ENGINE_VERSION}, protocol ${PROTOCOL_MAJOR}.${PROTOCOL_MINOR}, lurker ${APP_VERSION}; per-connection buffer ${config.bufferBytes} bytes, total ${config.bufferTotalBytes}`,
     );
   } catch (err) {
     console.error(

--- a/server/engine/topology.test.ts
+++ b/server/engine/topology.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { PROTOCOL_MAJOR } from './protocol.js';
+import { ENGINE_VERSION } from './version.js';
 
 const root = path.join(import.meta.dirname, '..', '..');
 
@@ -30,6 +31,22 @@ describe('engine topology artefacts', () => {
     expect(wf).not.toMatch(/^\s*MAJOR=\d+\s*$/m);
     // And it never trips on the version bump every release makes.
     expect(wf).not.toMatch(/git diff --quiet[^\n]*package\.json/);
+  });
+
+  // The engine's version is set by hand (server/engine/version.ts), and the
+  // release workflow refuses to move the engine tag unless it names that
+  // release. The workflow reads the constant with a sed, so this pins both ends:
+  // the pattern still matches the file, and the engine still reports the
+  // constant — not package.json's version, which a later checkout would carry.
+  it('the publish workflow checks ENGINE_VERSION, and the engine reports it', () => {
+    const wf = fs.readFileSync(path.join(root, '.github/workflows/docker-publish.yml'), 'utf8');
+    expect(wf).toContain(
+      `sed -nE "s/^export const ENGINE_VERSION = '([^']+)';/\\1/p" server/engine/version.ts`,
+    );
+    const src = fs.readFileSync(path.join(root, 'server/engine/version.ts'), 'utf8');
+    expect(/^export const ENGINE_VERSION = '([^']+)';$/m.exec(src)?.[1]).toBe(ENGINE_VERSION);
+    const entry = fs.readFileSync(path.join(root, 'server/engine.ts'), 'utf8');
+    expect(entry).toMatch(/^\s*version: ENGINE_VERSION,$/m);
   });
 
   // The engine binds loopback unless told otherwise (server/engine/config.ts),

--- a/server/engine/version.ts
+++ b/server/engine/version.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The engine's own version: the Lurker release that last changed it. Set by
+// hand rather than read from package.json, because the engine is the process
+// that does NOT move with the app — a later image or checkout carries the same
+// engine, and it should keep saying which one (Settings → About shows it beside
+// the app's version).
+//
+// ⚠ A release that changes the engine sets this to that release's version.
+// "Changes the engine" is whatever docker-publish.yml diffs to decide that
+// `engine-<major>` moves, and that workflow refuses to publish a moved tag
+// whose ENGINE_VERSION doesn't match the release — a forgotten bump fails the
+// release build rather than shipping an engine that names the wrong version.
+export const ENGINE_VERSION = '2.3.0';

--- a/server/routes/about.test.ts
+++ b/server/routes/about.test.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// GET /api/about — what Settings → About says about the IRC engine. Everything
+// but "there is none" is read off the live link, so these run against a real
+// engine on an ephemeral port rather than a stubbed link.
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import type { Express } from 'express';
+import {
+  setupTestDb,
+  createTestApp,
+  createAuthedAgent,
+  createAnonAgent,
+} from '../test-utils/testApp.js';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+import { setEnv, setEnvAll } from '../test-utils/env.js';
+import { until } from '../test-utils/until.js';
+
+const ctx = setupTestDb('routes-about');
+
+const SECRET = 'about-engine-secret';
+
+let app: Express;
+let agent: LurkerTestAgent;
+let EngineLink: typeof import('../services/engineLink.js').EngineLink;
+let EngineServer: typeof import('../engine/server.js').EngineServer;
+
+// Undone after each test, last first: the link stops before the env it read is
+// put back, and before the engine it was talking to goes away.
+const undo: Array<() => unknown> = [];
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  ({ EngineLink } = await import('../services/engineLink.js'));
+  ({ EngineServer } = await import('../engine/server.js'));
+  const router = (await import('./about.js')).default;
+  app = createTestApp({ '/api/about': router });
+  agent = await createAuthedAgent(app, createUser('about-alice').id);
+});
+
+afterEach(async () => {
+  for (let fn = undo.pop(); fn; fn = undo.pop()) await fn();
+});
+
+afterAll(() => ctx.cleanup());
+
+async function startEngine(version: string) {
+  const engine = new EngineServer({
+    secret: SECRET,
+    bufferBytes: 64 * 1024,
+    bufferTotalBytes: 1024 * 1024,
+    version,
+    log: () => {},
+  });
+  const { port } = await engine.listen(0, '127.0.0.1');
+  undo.push(() => engine.shutdown('test done', 500));
+  return { engine, port };
+}
+
+// Switch this process into engine mode against `port` and start the link, as
+// server.ts does at boot.
+async function linkTo(port: number, secret = SECRET) {
+  undo.push(
+    setEnvAll({
+      LURKER_ENGINE_URL: `tcp://127.0.0.1:${port}`,
+      LURKER_ENGINE_SECRET: secret,
+      LURKER_ENGINE_RETRY_BASE_MS: '100',
+      LURKER_ENGINE_HEARTBEAT_MS: '600000',
+    }),
+  );
+  await EngineLink.resetForTests();
+  undo.push(() => EngineLink.resetForTests());
+  const link = EngineLink.shared();
+  link.start();
+  return link;
+}
+
+async function about() {
+  const res = await agent.get('/api/about');
+  expect(res.status).toBe(200);
+  return res.body as { engine: { connected: boolean; version: string | null } | null };
+}
+
+describe('GET /api/about', () => {
+  it('requires a session', async () => {
+    expect((await createAnonAgent(app).get('/api/about')).status).toBe(401);
+  });
+
+  it('reports no engine when this process dials IRC itself', async () => {
+    undo.push(setEnv('LURKER_ENGINE_URL', ''));
+    expect(await about()).toEqual({ engine: null });
+  });
+
+  it("reports the engine's own version once it has said hello", async () => {
+    const { port } = await startEngine('1.2.3');
+    const link = await linkTo(port);
+    await until(() => link.state === 'ready', 3000, 'link ready');
+    expect(await about()).toEqual({ engine: { connected: true, version: '1.2.3' } });
+  });
+
+  // The version outlives the link — it is what the last hello said — so
+  // `connected` has to come from the link's state, not from having a version.
+  it('reports the engine not connected once the link drops', async () => {
+    const { engine, port } = await startEngine('1.2.3');
+    const link = await linkTo(port);
+    await until(() => link.state === 'ready', 3000, 'link ready');
+    await engine.shutdown('going away', 500);
+    await until(() => link.state !== 'ready', 3000, 'link dropped');
+    expect(await about()).toEqual({ engine: { connected: false, version: '1.2.3' } });
+  });
+
+  // A refusal turns engine mode off for the run and the app dials IRC itself,
+  // so no engine is in use, whatever LURKER_ENGINE_URL says.
+  it('reports no engine when the engine refused this app', async () => {
+    const { port } = await startEngine('1.2.3');
+    const link = await linkTo(port, 'the-wrong-secret');
+    await until(() => link.state === 'refused', 3000, 'link refused');
+    expect(await about()).toEqual({ engine: null });
+  });
+});

--- a/server/routes/about.ts
+++ b/server/routes/about.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { requireAuth } from '../middleware/auth.js';
+import { EngineLink, engineConfigured } from '../services/engineLink.js';
+
+const router = Router();
+router.use(requireAuth);
+
+// What Settings → About says about this instance beyond the client's own build.
+//
+// `engine` is null when this process dials IRC itself: no LURKER_ENGINE_URL, or
+// an engine that refused us, which turns engine mode off for the run. Otherwise
+// it is the engine as of its last hello. Its `version` is the engine's own
+// ENGINE_VERSION (server/engine/version.ts), the release that last changed the
+// engine, so it can trail the app's version — which is the point of showing it.
+// null until the engine has answered once.
+router.get('/', (_req: Request, res: Response) => {
+  if (!engineConfigured()) {
+    res.json({ engine: null });
+    return;
+  }
+  const link = EngineLink.shared();
+  res.json({ engine: { connected: link.state === 'ready', version: link.engineVersion } });
+});
+
+export default router;

--- a/vue_client/src/components/settings-panes/AboutPane.test.ts
+++ b/vue_client/src/components/settings-panes/AboutPane.test.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+// The engine line in Settings → About (#920): what GET /api/about's answer
+// turns into, including the answers that should leave no line at all.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+
+const h = vi.hoisted(() => ({
+  api: vi.fn<(url: string) => Promise<unknown>>(),
+}));
+vi.mock('../../api.js', () => ({ api: h.api }));
+// Injected by vite's `define` in a build; the test project has no such step.
+vi.stubGlobal('APP_VERSION', '2.3.1');
+
+import AboutPane from './AboutPane.vue';
+
+async function mountWith(answer: () => Promise<unknown>) {
+  h.api.mockImplementation(answer);
+  const wrapper = mount(AboutPane);
+  await flushPromises();
+  return wrapper;
+}
+
+beforeEach(() => {
+  h.api.mockReset();
+});
+
+describe('AboutPane engine line', () => {
+  it("shows the engine's own version beside the app's", async () => {
+    const w = await mountWith(async () => ({ engine: { connected: true, version: '2.3.0' } }));
+    expect(h.api).toHaveBeenCalledWith('/api/about');
+    expect(w.text()).toContain('version 2.3.1');
+    expect(w.find('.engine-version').text()).toBe('engine 2.3.0');
+  });
+
+  // The server keeps the last version a dropped engine reported; naming it
+  // here would read as an engine that is running fine.
+  it('says the engine is not connected rather than naming the version it last had', async () => {
+    const w = await mountWith(async () => ({ engine: { connected: false, version: '2.3.0' } }));
+    expect(w.find('.engine-version').text()).toBe('engine not connected');
+  });
+
+  it('shows no engine line when the instance runs without one', async () => {
+    const w = await mountWith(async () => ({ engine: null }));
+    expect(w.find('.engine-version').exists()).toBe(false);
+  });
+
+  it('shows no engine line when the request fails', async () => {
+    const w = await mountWith(() => Promise.reject(new Error('offline')));
+    expect(w.find('.engine-version').exists()).toBe(false);
+    expect(w.text()).toContain('version 2.3.1');
+  });
+});

--- a/vue_client/src/components/settings-panes/AboutPane.vue
+++ b/vue_client/src/components/settings-panes/AboutPane.vue
@@ -11,20 +11,14 @@
       server, and every device picks up where you left off.
     </p>
     <p class="muted small">version {{ appVersion }}</p>
+    <p v-if="engine" class="muted small engine-version">
+      {{ engine.connected ? `engine ${engine.version}` : 'engine not connected' }}
+    </p>
     <ul class="about-links">
       <li>
         <span class="about-label">source</span>
         <a href="https://github.com/amiantos/lurker" target="_blank" rel="noopener noreferrer"
           >github.com/amiantos/lurker</a
-        >
-      </li>
-      <li>
-        <span class="about-label">discuss</span>
-        <a
-          href="https://discuss.bradroot.me/tags/c/projects/13/lurker/39"
-          target="_blank"
-          rel="noopener noreferrer"
-          >discuss.bradroot.me</a
         >
       </li>
       <li>
@@ -42,8 +36,26 @@
 </template>
 
 <script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { api } from '../../api.js';
+
 // Build-time constant injected by vite.config.js (define).
 const appVersion = APP_VERSION;
+
+// The IRC engine holding this instance's sockets, if it runs one. Its version
+// is the release that last changed the engine, so it can trail appVersion.
+interface EngineInfo {
+  connected: boolean;
+  version: string | null;
+}
+const engine = ref<EngineInfo | null>(null);
+onMounted(async () => {
+  try {
+    engine.value = (await api<{ engine: EngineInfo | null }>('/api/about')).engine;
+  } catch {
+    /* no engine line; nothing else in the pane depends on it */
+  }
+});
 </script>
 
 <style src="./panes.css"></style>


### PR DESCRIPTION
Closes #920.

## What

- **Settings → About** shows the IRC engine's version under the app's: `engine 2.3.0`, or `engine not connected` while the link is down. There is no line on an instance that dials IRC itself. The discuss.bradroot.me link is gone.
- **`GET /api/about`** (session required) → `{engine: null | {connected, version}}`, read off the live engine link. `null` means no `LURKER_ENGINE_URL`, or an engine that refused the app, which turns engine mode off for the run. Documented in `docs/CLIENT_PROTOCOL.md` §10. The control plane forwards all of `/api/*` to cells, so hosted needs no CP change.

## A hand-set engine version

The engine reported `package.json`'s version. That is right in a container, where `engine-1` is the release image, and wrong without one: an engine restarted from a 2.3.1 checkout runs 2.3.0's engine code and said 2.3.1.

- `server/engine/version.ts`: `ENGINE_VERSION = '2.3.0'`, the release that last changed the engine. The hello carries it, and the startup log reads `engine 2.3.0, protocol 1.5, lurker <package version>`.
- `docker-publish.yml`: when a release moves `engine-<major>` and `ENGINE_VERSION` isn't that release's version, the "Decide whether the engine tag moves" step exits 1 before anything is built or pushed, and says what to set. Pinned releases (`ENGINE_TAG_PINNED_RELEASES`) are exempt. Manual `publish_engine` runs are not checked.
- `topology.test.ts` pins the workflow's sed against the file, and `version: ENGINE_VERSION` in `engine.ts`.

⚠ From now on, a release that changes the engine sets `ENGINE_VERSION` in its version-bump PR. For 2.3.0 that is already done: the engine changed since v2.2.1 (`protocol.ts`, `server.ts`, `upstream.ts`), so `engine-1` moves and the check passes on a `v2.3.0` tag.

## Verification

- `npm run check` exit 0; `npm test` 329 files / 4863 tests, exit 0.
- `server/routes/about.test.ts` runs against a real `EngineServer`: no engine, ready, link dropped (version kept, `connected: false`), refused → `null`, and 401 without a session. Mutation-checked: deriving `connected` from having a version fails the link-drop case, and gating on the env var alone fails the refused case.
- `AboutPane.test.ts` (happy-dom): the three answers, plus a failed request.
- The workflow step, extracted and run in a scratch clone: matching `ENGINE_VERSION` → tag moves; stale → exit 1 with the message; stale + pinned → passes, tag stays; a later release touching no engine file → unchecked, tag stays.

## Review

`/code-review high` found one low-severity issue: `ENGINE_VERSION` is `2.3.0` before v2.3.0 exists, so images built from main until the release show "version 2.2.1 / engine 2.3.0". Kept on purpose. This lands right before the 2.3.0 cut, and 2.3.0 is the chosen number. If the release were numbered differently, the guard fails the build and says what to set.

## QA

After deploy, open Settings → About:
- On an engine-mode instance: `engine 2.3.0` once its engine is updated. Until then it shows whatever the current engine image reports.
- On an instance without an engine: no engine line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013H7SZ5oDRRE5sPBGn4dZq2
