### PR TITLE
Bump Lurker version to 2.3.0 — CertFP, proxies, OAuth for third-party clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "2.2.1",
+  "version": "2.3.0",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Version bump for the 2.3.0 release: `2.2.1` → `2.3.0` across the root and `vue_client` manifests and lockfiles. No code.

## What's in the release

**IRC engine** (protocol minor 5; `engine-1` moves on this release)
- #893 Follow RENAME in the tracked channel set (#889)
- #895 Keep the negotiated cap set faithful across re-attach (#888)
- #897 Offer a session released after hello; the link half-closes on stop (#894)
- #909 Fix a stale `isChannelJoined` cache during an engine-restore late PART (@sparkhom)
- #923 Hand-set `ENGINE_VERSION`, checked by the release workflow (#920)

**CertFP** (#459): #878, #879, #880, #881. Store a client certificate per network, present it and speak SASL EXTERNAL, carry it through the engine, and the form block, `/network cert` and guide.

**SOCKS5 / HTTP CONNECT proxies** (#303): #899, #900, #901, #902, #903.

**OAuth for third-party clients** (#891): #913, plus #921 for hosted cells.

**Channel membership**
- #869 Stop auto-joining a channel the server durably refuses
- #898 Lower autojoin when the server confirms a part (@Fastidious)
- #915 Channel membership belongs to the socket (#908, #873)
- #918 Join Channel on a parted channel, and rejoin +k channels with the stored key (#873)

**Bouncer**
- #887 Register a selector-less login instead of 464ing it
- #907 Trim the replayed welcome burst's tags to the client's caps

**Client**
- #874 Option to keep inline media URLs visible (@tzvetkoff)
- #877 Fix an empty status bar timestamp format (@tzvetkoff)
- #922 An unclaimed 401 no longer badges the server buffer (#904)
- #923 Settings → About shows the engine's version; the discuss link is gone (#920)

**Docs:** #871 `whois_result` and the nick-note row shape; #882 bouncer TLS options; #916 luir in the README.

Plus Dependabot dependency batches.

## Before tagging

- Tag `v2.3.0` after this merges. The engine changed since v2.2.1, so `engine-1` moves, and the release workflow (since #923) requires `ENGINE_VERSION` to match the release. It is already `2.3.0` on main.
- `engine-1` moving means one IRC reconnect for engine users. Self-hosters on the engine overlay get the engine recreated by `docker compose pull && up -d`. Hosted cells need `update-cell.sh --engine`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013H7SZ5oDRRE5sPBGn4dZq2
