### PR TITLE
Docs: CertFP and proxies need an engine from 2.3.0, not 2.2.2

### DIFF
--- a/docs/MIGRATION_ENGINE.md
+++ b/docs/MIGRATION_ENGINE.md
@@ -170,13 +170,16 @@ Only `lurker` is replaced. `pull` fetches nothing new for the engine, and `up -d
 **Features that need a newer engine.** The wire between app and engine is
 versioned separately from either one, and it only ever gains optional fields — so
 a newer app talks to an older engine happily, right up to a feature that needs a
-field the engine has never heard of. Today that is one thing: **CertFP** (a TLS
-client certificate on a network) needs an engine from Lurker 2.2.2 or later,
-because the engine is what dials and so the engine is what presents it. An app
-that finds itself pointed at an older engine refuses to connect that network and
-says so, rather than connecting without the certificate — which would log the
-user in as nobody. Pull the engine image (its tag doesn't move; its contents do)
-and restart it.
+field the engine has never heard of. Today that is two things, and both need an
+engine from Lurker 2.3.0 or later, because the engine is what dials:
+
+- **CertFP** (a TLS client certificate on a network). Connecting without the certificate would log the user in as nobody.
+- **A proxy** on a network. Connecting without it would put the user's real address on the wire while their settings say otherwise.
+
+An app that finds itself pointed at an older engine refuses to connect that
+network and says so, rather than connecting without it. Settings → About shows
+which engine you have. Pull the engine image (its tag doesn't move; its contents
+do) and restart it.
 
 **While the app is down**, the engine keeps what arrives: 4 MiB per connection, 256 MiB in total, tunable with `LURKER_ENGINE_BUFFER_BYTES` and `LURKER_ENGINE_BUFFER_TOTAL_BYTES`. Past the cap the oldest lines go and the app notes where the hole is. Deploys take seconds; the buffer covers hours of ordinary traffic.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -98,9 +98,9 @@ address on the wire while everything on screen said otherwise.
 
 ::: tip Self-hosting without a proxy setting
 If you run Lurker behind the IRC engine, the engine is what dials — so it needs
-to be new enough to understand proxies (protocol minor 5). An older engine is
-refused rather than allowed to connect directly; update the engine image and
-restart it.
+to be from Lurker 2.3.0 or later to understand proxies. Settings → About shows
+which engine you have. An older engine is refused rather than allowed to connect
+directly; update the engine image and restart it.
 :::
 
 ## Joining channels


### PR DESCRIPTION
`docs/MIGRATION_ENGINE.md` said CertFP needs "an engine from Lurker 2.2.2 or later". There was never a 2.2.2 release. CertFP (#459) and proxies (#303) both first ship in 2.3.0, and the paragraph didn't mention proxies.

- **`docs/MIGRATION_ENGINE.md`:** lists both features, says 2.3.0, and points at Settings → About (#923) for checking which engine you have.
- **`docs/guide/getting-started.md`:** the proxy tip said "protocol minor 5", which users can't see anywhere. It now names the release and gives the same About pointer.

Docs only, with no app or engine change, so it doesn't affect the `v2.3.0` tag or image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013H7SZ5oDRRE5sPBGn4dZq2
