### PR TITLE
Bouncer: honor each client's negotiated caps (#926)

### DIFF
--- a/docs/IRCV3.md
+++ b/docs/IRCV3.md
@@ -165,7 +165,7 @@ we advertise only what we actually implement.
 | Message metadata passed through from upstream                                                   | `message-tags`                                                |
 | Network list delivered as one grouped burst                                                     | `batch`                                                       |
 
-Two implementation notes worth knowing if you're writing against it:
+Implementation notes worth knowing if you're writing against it:
 
 - Scrollback is capped at 1000 messages per request, advertised via the
   `CHATHISTORY` ISUPPORT token. Over-limit requests are **rejected, not silently
@@ -173,11 +173,17 @@ Two implementation notes worth knowing if you're writing against it:
   Message references are `timestamp` only, deliberately not `msgid`, because
   Lurker's stored history IDs and an upstream network's message IDs are different
   namespaces and mixing them would break paging across the boundary.
-  <br>`server/services/bouncer.ts:110`, `:457`
+  <br>`server/services/bouncer.ts:124`, `:493`
 - Tags that only a server may set — `time`, `account`, `msgid`, `label`, `batch` —
   are stripped from anything an attached client sends, so a downstream client can't
   forge them.
-  <br>`server/services/bouncer.ts:246`
+  <br>`server/services/bouncer.ts:256`
+- What the network sends is trimmed to the caps your client negotiated, as soju and ZNC
+  do: no `AWAY` without `away-notify`, a bare `JOIN` without `extended-join`, one prefix
+  per nick in NAMES and WHO without `multi-prefix`, and so on. Without `chghost`, a host
+  change arrives as the `QUIT`, `JOIN` and `MODE` a network sends in its place. Lurker
+  never offers `draft/multiline`, so multiline messages arrive as separate lines.
+  <br>`server/services/bouncerClientFilter.ts`
 
 ---
 

--- a/docs/IRCV3.md
+++ b/docs/IRCV3.md
@@ -154,16 +154,20 @@ to the same always-on connection your browser uses (see
 capabilities Lurker offers _downstream_ are a deliberately short, honest list —
 we advertise only what we actually implement.
 
-| You get                                                                                         | Powered by                                                    |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| Log in with SASL instead of a server password                                                   | `sasl` (PLAIN)                                                |
-| Backlog replays at its original timestamps, not at attach time                                  | `server-time`                                                 |
-| Scrollback on demand — page back through Lurker's full stored history from your terminal client | `draft/chathistory`                                           |
-| Your own sent messages echoed back, if your client wants them                                   | `echo-message`                                                |
-| Your outgoing DMs attributed to you correctly in replay                                         | `znc.in/self-message`                                         |
-| Pick your network from a list instead of hardcoding `username/networkname`                      | `soju.im/bouncer-networks`, `soju.im/bouncer-networks-notify` |
-| Message metadata passed through from upstream                                                   | `message-tags`                                                |
-| Network list delivered as one grouped burst                                                     | `batch`                                                       |
+| You get                                                                                         | Powered by                                                          |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Log in with SASL instead of a server password                                                   | `sasl` (PLAIN)                                                      |
+| Backlog replays at its original timestamps, not at attach time                                  | `server-time`                                                       |
+| Scrollback on demand — page back through Lurker's full stored history from your terminal client | `draft/chathistory`                                                 |
+| Your own sent messages echoed back, if your client wants them                                   | `echo-message`                                                      |
+| Your outgoing DMs attributed to you correctly in replay                                         | `znc.in/self-message`                                               |
+| Pick your network from a list instead of hardcoding `username/networkname`                      | `soju.im/bouncer-networks`, `soju.im/bouncer-networks-notify`       |
+| Message metadata passed through from upstream                                                   | `message-tags`                                                      |
+| Network list delivered as one grouped burst                                                     | `batch`                                                             |
+| People's away, account and host changes, when your network sends them                           | `away-notify`, `account-notify`, `chghost`                          |
+| Accounts on JOINs, every prefix and full hostmasks in NAMES, when your network sends them       | `extended-join`, `account-tag`, `multi-prefix`, `userhost-in-names` |
+| Invites other people get to your channels                                                       | `invite-notify`                                                     |
+| Told when a capability comes or goes, such as while your network reconnects                     | `cap-notify`                                                        |
 
 Implementation notes worth knowing if you're writing against it:
 
@@ -173,11 +177,17 @@ Implementation notes worth knowing if you're writing against it:
   Message references are `timestamp` only, deliberately not `msgid`, because
   Lurker's stored history IDs and an upstream network's message IDs are different
   namespaces and mixing them would break paging across the boundary.
-  <br>`server/services/bouncer.ts:124`, `:493`
+  <br>`server/services/bouncer.ts:146`, `:537`
 - Tags that only a server may set — `time`, `account`, `msgid`, `label`, `batch` —
   are stripped from anything an attached client sends, so a downstream client can't
   forge them.
-  <br>`server/services/bouncer.ts:256`
+  <br>`server/services/bouncer.ts:278`
+- Caps whose lines come from the network (`away-notify`, `account-notify`,
+  `account-tag`, `chghost`, `extended-join`, `multi-prefix`, `userhost-in-names`) are
+  offered only while the network you bind has them, as soju does. `CAP LS 302` lists
+  them before you pick a network, then `CAP DEL` takes back any that network lacks, and
+  `CAP NEW` offers them again when it reconnects.
+  <br>`server/services/bouncer.ts:917`
 - What the network sends is trimmed to the caps your client negotiated, as soju and ZNC
   do: no `AWAY` without `away-notify`, a bare `JOIN` without `extended-join`, one prefix
   per nick in NAMES and WHO without `multi-prefix`, and so on. Without `chghost`, a host
@@ -196,7 +206,7 @@ attaching to Lurker.
 | Capability                              | Client | Bouncer |
 | --------------------------------------- | :----: | :-----: |
 | `cap-3.1`, `cap-3.2`                    |   ✅   |   ✅    |
-| `cap-notify`                            |   ✅   |    —    |
+| `cap-notify`                            |   ✅   |   ✅    |
 | `sasl-3.1`, `sasl-3.2` (PLAIN)          |   ✅   |   ✅    |
 | `server-time`                           |   ✅   |   ✅    |
 | `message-tags`                          |   ✅   |   ✅    |
@@ -206,13 +216,13 @@ attaching to Lurker.
 | `draft/multiline`                       |   ✅   |    —    |
 | `+typing`                               |   ✅   |    —    |
 | `draft/chathistory`                     |   —    |   ✅    |
-| `multi-prefix`                          |   ✅   |    —    |
-| `userhost-in-names`                     |   ✅   |    —    |
-| `away-notify`                           |   ✅   |    —    |
-| `extended-join`                         |   ✅   |    —    |
-| `account-notify`                        |   ✅   |    —    |
-| `chghost`                               |   ✅   |    —    |
-| `invite-notify`                         |   ✅   |    —    |
+| `multi-prefix`                          |   ✅   |   ✅    |
+| `userhost-in-names`                     |   ✅   |   ✅    |
+| `away-notify`                           |   ✅   |   ✅    |
+| `extended-join`                         |   ✅   |   ✅    |
+| `account-notify`                        |   ✅   |   ✅    |
+| `chghost`                               |   ✅   |   ✅    |
+| `invite-notify`                         |   ✅   |   ✅    |
 | `monitor`                               |   ✅   |    —    |
 | `extended-monitor`                      |   ✅   |    —    |
 | `whox`                                  |   ✅   |    —    |

--- a/docs/IRCV3.md
+++ b/docs/IRCV3.md
@@ -154,20 +154,21 @@ to the same always-on connection your browser uses (see
 capabilities Lurker offers _downstream_ are a deliberately short, honest list —
 we advertise only what we actually implement.
 
-| You get                                                                                         | Powered by                                                          |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| Log in with SASL instead of a server password                                                   | `sasl` (PLAIN)                                                      |
-| Backlog replays at its original timestamps, not at attach time                                  | `server-time`                                                       |
-| Scrollback on demand — page back through Lurker's full stored history from your terminal client | `draft/chathistory`                                                 |
-| Your own sent messages echoed back, if your client wants them                                   | `echo-message`                                                      |
-| Your outgoing DMs attributed to you correctly in replay                                         | `znc.in/self-message`                                               |
-| Pick your network from a list instead of hardcoding `username/networkname`                      | `soju.im/bouncer-networks`, `soju.im/bouncer-networks-notify`       |
-| Message metadata passed through from upstream                                                   | `message-tags`                                                      |
-| Network list delivered as one grouped burst                                                     | `batch`                                                             |
-| People's away, account and host changes, when your network sends them                           | `away-notify`, `account-notify`, `chghost`                          |
-| Accounts on JOINs, every prefix and full hostmasks in NAMES, when your network sends them       | `extended-join`, `account-tag`, `multi-prefix`, `userhost-in-names` |
-| Invites other people get to your channels                                                       | `invite-notify`                                                     |
-| Told when a capability comes or goes, such as while your network reconnects                     | `cap-notify`                                                        |
+| You get                                                                                         | Powered by                                                    |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Log in with SASL instead of a server password                                                   | `sasl` (PLAIN)                                                |
+| Backlog replays at its original timestamps, not at attach time                                  | `server-time`                                                 |
+| Scrollback on demand — page back through Lurker's full stored history from your terminal client | `draft/chathistory`                                           |
+| Your own sent messages echoed back, if your client wants them                                   | `echo-message`                                                |
+| Your outgoing DMs attributed to you correctly in replay                                         | `znc.in/self-message`                                         |
+| Pick your network from a list instead of hardcoding `username/networkname`                      | `soju.im/bouncer-networks`, `soju.im/bouncer-networks-notify` |
+| Message metadata passed through from upstream                                                   | `message-tags`                                                |
+| Network list delivered as one grouped burst                                                     | `batch`                                                       |
+| People's away, account and host changes, when your network sends them                           | `away-notify`, `account-notify`, `chghost`                    |
+| Accounts on JOINs and on each message, when your network sends them                             | `extended-join`, `account-tag`                                |
+| Every prefix and full hostmasks in NAMES, when your network sends them                          | `multi-prefix`, `userhost-in-names`                           |
+| Invites other people get to your channels                                                       | `invite-notify`                                               |
+| Told when a capability comes or goes, such as while your network reconnects                     | `cap-notify`                                                  |
 
 Implementation notes worth knowing if you're writing against it:
 
@@ -177,7 +178,7 @@ Implementation notes worth knowing if you're writing against it:
   Message references are `timestamp` only, deliberately not `msgid`, because
   Lurker's stored history IDs and an upstream network's message IDs are different
   namespaces and mixing them would break paging across the boundary.
-  <br>`server/services/bouncer.ts:146`, `:537`
+  <br>`server/services/bouncer.ts:146`, `:520`
 - Tags that only a server may set — `time`, `account`, `msgid`, `label`, `batch` —
   are stripped from anything an attached client sends, so a downstream client can't
   forge them.
@@ -187,7 +188,7 @@ Implementation notes worth knowing if you're writing against it:
   offered only while the network you bind has them, as soju does. `CAP LS 302` lists
   them before you pick a network, then `CAP DEL` takes back any that network lacks, and
   `CAP NEW` offers them again when it reconnects.
-  <br>`server/services/bouncer.ts:917`
+  <br>`server/services/bouncer.ts:905`
 - What the network sends is trimmed to the caps your client negotiated, as soju and ZNC
   do: no `AWAY` without `away-notify`, a bare `JOIN` without `extended-join`, one prefix
   per nick in NAMES and WHO without `multi-prefix`, and so on. Without `chghost`, a host
@@ -234,10 +235,10 @@ attaching to Lurker.
 In the interest of not padding the list: these are requested and acknowledged, but
 nothing in Lurker reads them yet. We'd rather say so than count them.
 
-| Capability                                                               | Status                                                                                                                                    |
-| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `account-tag`                                                            | Acknowledged, but nothing reads the per-message account tag. Account information comes from `extended-join` and `account-notify` instead. |
-| `draft/message-tags-0.2`, `znc.in/server-time-iso`, `znc.in/server-time` | Pre-standardisation aliases requested by irc-framework for older servers. Superseded by `message-tags` and `server-time`.                 |
+| Capability                                                               | Status                                                                                                                                                                                                          |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `account-tag`                                                            | Acknowledged, but nothing reads the per-message account tag. Account information comes from `extended-join` and `account-notify` instead. The bouncer does pass the tag on to attached clients that ask for it. |
+| `draft/message-tags-0.2`, `znc.in/server-time-iso`, `znc.in/server-time` | Pre-standardisation aliases requested by irc-framework for older servers. Superseded by `message-tags` and `server-time`.                                                                                       |
 
 ---
 

--- a/server/services/bouncer.integration.test.ts
+++ b/server/services/bouncer.integration.test.ts
@@ -490,6 +490,28 @@ describe("relayed lines follow the client's caps", () => {
     expect(await relay(batched, c2, netsplit)).toEqual(netsplit);
   });
 
+  it('ends a batch for a client that gives up batch, even if it asks for it again', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'unbatcher' });
+    const c = await attach(acct, ['message-tags', 'batch']);
+    const start = ':irc.example.test BATCH +ns netsplit a.example.test b.example.test';
+    expect(await relay(acct, c, [start])).toEqual([start]);
+
+    c.send('CAP REQ :-batch');
+    await sync(c);
+    expect(
+      await relay(acct, c, ['@batch=ns :carol!c@h QUIT :a.example.test b.example.test']),
+    ).toEqual([':carol!c@h QUIT :a.example.test b.example.test']);
+
+    c.send('CAP REQ :batch');
+    await sync(c);
+    expect(
+      await relay(acct, c, [
+        '@batch=ns :dave!d@h QUIT :a.example.test b.example.test',
+        ':irc.example.test BATCH -ns',
+      ]),
+    ).toEqual([':dave!d@h QUIT :a.example.test b.example.test']);
+  });
+
   it('unwraps a multiline batch for a client, which never has draft/multiline', async () => {
     const acct = harnessMod.seedAccount({ nick: 'reader' });
     const c = await attach(acct, ['message-tags', 'batch']);

--- a/server/services/bouncer.integration.test.ts
+++ b/server/services/bouncer.integration.test.ts
@@ -362,42 +362,57 @@ describe('live relay', () => {
   });
 });
 
+// Helpers for the cap tests below.
+type Account = import('../test-utils/bouncerHarness.js').HarnessAccount;
+type Client = import('../test-utils/bouncerHarness.js').BouncerClient;
+let syncs = 0;
+
+// Lines reach a client in the order they were written, so once the PONG to a
+// fresh PING arrives, everything written before it has arrived too.
+async function sync(c: Client): Promise<void> {
+  const token = `sync-${++syncs}`;
+  c.send(`PING ${token}`);
+  await c.waitFor((l) => l.includes('PONG') && l.endsWith(`:${token}`));
+}
+
+// Register with `ls` (CAP LS 302 by default) and `caps` requested, and return
+// once the attach burst is through, so it can't land in what relay() returns.
+async function attach(acct: Account, caps: string[] = [], ls = 'CAP LS 302'): Promise<Client> {
+  const c = await harness.connect();
+  c.send(ls);
+  if (caps.length > 0) c.send(`CAP REQ :${caps.join(' ')}`);
+  c.send(`PASS ${acct.user.username}:${acct.password}`);
+  c.send('NICK client');
+  c.send('USER client 0 * :client');
+  c.send('CAP END');
+  await sync(c);
+  return c;
+}
+
+// Push `lines` from the network, then a sentinel, and return what the client
+// got in between. Anything filtered out never arrives before the sentinel.
+async function relay(acct: Account, c: Client, lines: string[]): Promise<string[]> {
+  const from = c.lines.length;
+  const sentinel = `sentinel-${++syncs}`;
+  for (const line of lines) acct.upstream.pushUpstream(line);
+  acct.upstream.pushUpstream(`:bot!b@h PRIVMSG #chan :${sentinel}`);
+  await c.waitFor((l) => l.endsWith(`:${sentinel}`));
+  return c.lines.slice(from).filter((l) => !l.endsWith(`:${sentinel}`));
+}
+
+// The cap names in a CAP LS / LIST / NEW / DEL line, without values.
+function capsIn(line: string): string[] {
+  return line
+    .slice(line.lastIndexOf(':') + 1)
+    .split(' ')
+    .filter(Boolean)
+    .map((cap) => cap.split('=')[0]);
+}
+
 // #926. The network talks to Lurker with the caps Lurker negotiated upstream,
 // and the relay used to pass what it sent straight on. A client now gets only
 // what it negotiated itself: soju's SendMessage and ZNC's PutClient rules.
 describe("relayed lines follow the client's caps", () => {
-  type Account = import('../test-utils/bouncerHarness.js').HarnessAccount;
-  type Client = import('../test-utils/bouncerHarness.js').BouncerClient;
-  let syncs = 0;
-
-  async function attach(acct: Account, caps: string[] = []): Promise<Client> {
-    const c = await harness.connect();
-    c.send('CAP LS 302');
-    if (caps.length > 0) c.send(`CAP REQ :${caps.join(' ')}`);
-    c.send(`PASS ${acct.user.username}:${acct.password}`);
-    c.send('NICK client');
-    c.send('USER client 0 * :client');
-    c.send('CAP END');
-    // The attach burst goes out in one piece at registration; a PONG comes back
-    // after all of it, so nothing from the burst lands in what relay() returns.
-    const token = `attached-${++syncs}`;
-    c.send(`PING ${token}`);
-    await c.waitFor((l) => l.includes('PONG') && l.endsWith(`:${token}`));
-    return c;
-  }
-
-  // Push `lines` from the network, then a sentinel. The client receives lines
-  // in the order they were relayed, so once the sentinel arrives, anything that
-  // didn't come before it was filtered out. Returns what arrived in between.
-  async function relay(acct: Account, c: Client, lines: string[]): Promise<string[]> {
-    const from = c.lines.length;
-    const sentinel = `sentinel-${++syncs}`;
-    for (const line of lines) acct.upstream.pushUpstream(line);
-    acct.upstream.pushUpstream(`:bot!b@h PRIVMSG #chan :${sentinel}`);
-    await c.waitFor((l) => l.endsWith(`:${sentinel}`));
-    return c.lines.slice(from).filter((l) => !l.endsWith(`:${sentinel}`));
-  }
-
   it('sends no AWAY to a client that asked only for echo-message', async () => {
     const acct = harnessMod.seedAccount({ nick: 'slakker' });
     const c = await attach(acct, ['echo-message']);
@@ -491,5 +506,150 @@ describe("relayed lines follow the client's caps", () => {
       '@account=bob :bob!b@h PRIVMSG #chan :how is ',
       '@account=bob :bob!b@h PRIVMSG #chan :everyone?',
     ]);
+  });
+});
+
+// soju's pass-through caps: offered while the bound network has them, so a
+// client that supports away-notify, extended-join and the rest gets those lines,
+// and a client on a network without them is told so with CAP DEL.
+describe('pass-through caps follow the bound network', () => {
+  const PASSTHROUGH = [
+    'away-notify',
+    'account-notify',
+    'account-tag',
+    'chghost',
+    'extended-join',
+    'multi-prefix',
+    'userhost-in-names',
+  ];
+
+  it('lists them for CAP LS 302 before registration, and not for a plain CAP LS', async () => {
+    const c302 = await harness.connect();
+    c302.send('CAP LS 302');
+    const offered = capsIn(await c302.waitFor((l) => l.includes(' LS ')));
+    for (const cap of [...PASSTHROUGH, 'cap-notify', 'invite-notify']) {
+      expect(offered).toContain(cap);
+    }
+    c302.close();
+
+    const c301 = await harness.connect();
+    c301.send('CAP LS');
+    const plain = capsIn(await c301.waitFor((l) => l.includes(' LS ')));
+    expect(plain).toContain('invite-notify');
+    expect(plain).not.toContain('away-notify');
+    c301.close();
+  });
+
+  it('delivers what a client asked for when the network has it', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'capable' });
+    const c = await attach(acct, ['away-notify', 'account-notify', 'extended-join']);
+    const lines = [
+      ':alice!a@h AWAY :lunch',
+      ':alice!a@h ACCOUNT alice',
+      ':alice!a@h JOIN #chan alice :Alice A',
+    ];
+    expect(await relay(acct, c, lines)).toEqual(lines);
+  });
+
+  it('takes back what the network lacks with CAP DEL, before the welcome', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'sparse' });
+    acct.upstream.client.network.cap.enabled = ['message-tags', 'server-time'];
+    const c = await attach(acct, ['away-notify', 'server-time']);
+    const del = c.lines.findIndex((l) => harnessMod.commandOf(l) === 'CAP' && l.includes(' DEL '));
+    const welcome = c.lines.findIndex((l) => harnessMod.commandOf(l) === '001');
+    expect(del).toBeGreaterThan(-1);
+    expect(del).toBeLessThan(welcome);
+    expect(capsIn(c.lines[del])).toEqual(PASSTHROUGH);
+
+    c.send('CAP LIST');
+    const list = capsIn(await c.waitFor((l) => l.includes(' LIST ')));
+    expect(list).toContain('server-time');
+    expect(list).not.toContain('away-notify');
+    expect(await relay(acct, c, [':alice!a@h AWAY :lunch'])).toEqual([]);
+  });
+
+  it('takes every one back from a control connection, which has no network', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'controller' });
+    harnessMod.seedNetwork(acct.user, { networkName: 'second' });
+    const c = await attach(acct, ['away-notify']);
+    const del = c.lines.find((l) => harnessMod.commandOf(l) === 'CAP' && l.includes(' DEL '));
+    expect(del && capsIn(del)).toEqual(PASSTHROUGH);
+  });
+
+  it('offers them with CAP NEW once a connecting network connects', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'latecomer' });
+    acct.upstream.state = 'connecting';
+    const c = await attach(acct, ['away-notify']);
+    expect(c.lines.some((l) => l.includes(' DEL ') && l.includes('away-notify'))).toBe(true);
+
+    acct.upstream.state = 'connected';
+    harnessMod.emitNetworkState(acct.user.id, acct.network.id, 'connected');
+    const added = await c.waitFor((l) => harnessMod.commandOf(l) === 'CAP' && l.includes(' NEW '));
+    expect(capsIn(added)).toEqual(PASSTHROUGH);
+    c.send('CAP REQ :away-notify');
+    // Not waitFor(ACK): the ACK from registration is already there to match.
+    await sync(c);
+    expect(c.lines.filter((l) => l.includes(' ACK ') && l.includes('away-notify'))).toHaveLength(2);
+    expect(await relay(acct, c, [':alice!a@h AWAY :lunch'])).toEqual([':alice!a@h AWAY :lunch']);
+  });
+
+  it('offers a cap the network grants after registration', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'grantee' });
+    acct.upstream.client.network.cap.enabled = ['server-time'];
+    const c = await attach(acct, ['server-time']);
+    acct.upstream.client.network.cap.enabled = ['server-time', 'away-notify'];
+    acct.upstream.client.emit('cap ack', { command: 'ACK', capabilities: { 'away-notify': '' } });
+    const added = await c.waitFor((l) => harnessMod.commandOf(l) === 'CAP' && l.includes(' NEW '));
+    expect(capsIn(added)).toEqual(['away-notify']);
+  });
+
+  it('lets a pre-302 client ask for them once it has registered', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'oldclient' });
+    const c = await attach(acct, [], 'CAP LS');
+    c.send('CAP LS');
+    const offered = capsIn(await c.waitFor((l) => l.includes(' LS ') && l.includes('away-notify')));
+    expect(offered).toContain('extended-join');
+    c.send('CAP REQ :away-notify');
+    await c.waitFor((l) => l.includes(' ACK ') && l.includes('away-notify'));
+  });
+
+  it('keeps cap-notify on once CAP LS 302 turned it on', async () => {
+    const c = await harness.connect();
+    c.send('CAP LS 302');
+    c.send('CAP REQ :-cap-notify');
+    expect(await c.waitFor((l) => l.includes(' NAK '))).toContain('-cap-notify');
+    c.close();
+  });
+
+  it('sends CHGHOST itself to a chghost client, with no fallback', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'hostwatch' });
+    acct.upstream.addChannel('#ops', { members: ['hostwatch', '@alice'] });
+    const c = await attach(acct, ['chghost']);
+    const change = ':alice!old@old.host CHGHOST new new.host';
+    expect(await relay(acct, c, [change])).toEqual([change]);
+  });
+
+  it('replays channels with an extended JOIN, every prefix and hostmasks, trimmed per client', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'replayer' });
+    const room = acct.upstream.addChannel('#room', { members: ['replayer', '@carol'] });
+    room.members.set('replayer', { nick: 'replayer', modes: [], account: 'replayacct' });
+    room.members.set('carol', { nick: 'carol', modes: ['o', 'v'], user: 'c', host: 'carol.host' });
+
+    const full = await attach(acct, ['extended-join', 'multi-prefix', 'userhost-in-names']);
+    expect(full.lines).toContain(':replayer!replayer@fake.host JOIN #room replayacct :replayer');
+    expect(full.lines).toContain(
+      ':lurker.bouncer 353 replayer = #room :replayer @+carol!c@carol.host',
+    );
+
+    const plain = await attach(acct);
+    expect(plain.lines).toContain(':replayer!replayer@fake.host JOIN #room');
+    expect(plain.lines).toContain(':lurker.bouncer 353 replayer = #room :replayer @carol');
+  });
+
+  it('stamps a time on relayed lines that arrive without one, for a server-time client', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'stamped' });
+    const c = await attach(acct, ['server-time']);
+    const [line] = await relay(acct, c, [':alice!a@h PRIVMSG #chan :no time on this']);
+    expect(line).toMatch(/^@time=[0-9-]+T[0-9:.]+Z :alice!a@h PRIVMSG #chan :no time on this$/);
   });
 });

--- a/server/services/bouncer.integration.test.ts
+++ b/server/services/bouncer.integration.test.ts
@@ -361,3 +361,135 @@ describe('live relay', () => {
     expect(acct.upstream.rawSent.some((l) => l.includes('AUTHENTICATE'))).toBe(false);
   });
 });
+
+// #926. The network talks to Lurker with the caps Lurker negotiated upstream,
+// and the relay used to pass what it sent straight on. A client now gets only
+// what it negotiated itself: soju's SendMessage and ZNC's PutClient rules.
+describe("relayed lines follow the client's caps", () => {
+  type Account = import('../test-utils/bouncerHarness.js').HarnessAccount;
+  type Client = import('../test-utils/bouncerHarness.js').BouncerClient;
+  let syncs = 0;
+
+  async function attach(acct: Account, caps: string[] = []): Promise<Client> {
+    const c = await harness.connect();
+    c.send('CAP LS 302');
+    if (caps.length > 0) c.send(`CAP REQ :${caps.join(' ')}`);
+    c.send(`PASS ${acct.user.username}:${acct.password}`);
+    c.send('NICK client');
+    c.send('USER client 0 * :client');
+    c.send('CAP END');
+    // The attach burst goes out in one piece at registration; a PONG comes back
+    // after all of it, so nothing from the burst lands in what relay() returns.
+    const token = `attached-${++syncs}`;
+    c.send(`PING ${token}`);
+    await c.waitFor((l) => l.includes('PONG') && l.endsWith(`:${token}`));
+    return c;
+  }
+
+  // Push `lines` from the network, then a sentinel. The client receives lines
+  // in the order they were relayed, so once the sentinel arrives, anything that
+  // didn't come before it was filtered out. Returns what arrived in between.
+  async function relay(acct: Account, c: Client, lines: string[]): Promise<string[]> {
+    const from = c.lines.length;
+    const sentinel = `sentinel-${++syncs}`;
+    for (const line of lines) acct.upstream.pushUpstream(line);
+    acct.upstream.pushUpstream(`:bot!b@h PRIVMSG #chan :${sentinel}`);
+    await c.waitFor((l) => l.endsWith(`:${sentinel}`));
+    return c.lines.slice(from).filter((l) => !l.endsWith(`:${sentinel}`));
+  }
+
+  it('sends no AWAY to a client that asked only for echo-message', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'slakker' });
+    const c = await attach(acct, ['echo-message']);
+    // The reporter's lines, plus one going away rather than coming back.
+    const got = await relay(acct, c, [
+      ':meidam!meidam@FXNet.qylxi4wx.cagf6i3v.yehsgrdh.fx AWAY',
+      ':Dark77!Dark77@outofspace.1337 AWAY',
+      ':okawari!okawari@FXNet.oiri6mtj.nqjxkq3z.m7abhdem.fx AWAY',
+      ':alice!a@h AWAY :lunch',
+    ]);
+    expect(got).toEqual([]);
+  });
+
+  it('trims extended-join, multi-prefix and userhost-in-names from relayed lines', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'trimmer' });
+    const c = await attach(acct);
+    const got = await relay(acct, c, [
+      ':alice!a@h JOIN #chan alice :Alice A',
+      ':irc.example.test 353 trimmer = #chan :@+alice!a@h bob!b@h',
+      ':irc.example.test 366 trimmer #chan :End of /NAMES list.',
+      ':irc.example.test 352 trimmer #chan a h irc.example.test alice H@+ :0 Alice A',
+    ]);
+    expect(got).toEqual([
+      ':alice!a@h JOIN #chan',
+      ':irc.example.test 353 trimmer = #chan :@alice bob',
+      ':irc.example.test 366 trimmer #chan :End of /NAMES list.',
+      ':irc.example.test 352 trimmer #chan a h irc.example.test alice H@ :0 Alice A',
+    ]);
+  });
+
+  it('drops ACCOUNT and invites for other people, but not an invite for us', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'invitee' });
+    const c = await attach(acct);
+    const got = await relay(acct, c, [
+      ':alice!a@h ACCOUNT alice',
+      ':op!o@h INVITE someone #chan',
+      ':op!o@h INVITE invitee #chan',
+    ]);
+    expect(got).toEqual([':op!o@h INVITE invitee #chan']);
+  });
+
+  it("sends another user's host change as the QUIT, JOIN and MODE a network would", async () => {
+    const acct = harnessMod.seedAccount({ nick: 'watcher' });
+    acct.upstream.addChannel('#ops', { members: ['watcher', '@alice'] });
+    acct.upstream.addChannel('#lounge', { members: ['watcher', 'alice'] });
+    const c = await attach(acct, ['server-time']);
+    const TIME = '2026-09-12T19:33:25.000Z';
+    const got = await relay(acct, c, [
+      `@time=${TIME};msgid=h1 :alice!old@old.host CHGHOST new new.host`,
+      // Our own change gets no fallback: the network reports it with a 396.
+      ':watcher!w@fake.host CHGHOST w cloak/watcher',
+    ]);
+    expect(got).toEqual([
+      `@time=${TIME} :alice!old@old.host QUIT :Changing hostname`,
+      `@time=${TIME} :alice!new@new.host JOIN #ops`,
+      `@time=${TIME} :lurker.bouncer MODE #ops +o alice`,
+      `@time=${TIME} :alice!new@new.host JOIN #lounge`,
+    ]);
+  });
+
+  it('opens a network batch only for a client that negotiated batch', async () => {
+    const netsplit = [
+      ':irc.example.test BATCH +ns netsplit a.example.test b.example.test',
+      '@batch=ns :carol!c@h QUIT :a.example.test b.example.test',
+      ':irc.example.test BATCH -ns',
+    ];
+    const tagsOnly = harnessMod.seedAccount({ nick: 'tagsonly' });
+    const c1 = await attach(tagsOnly, ['message-tags']);
+    expect(await relay(tagsOnly, c1, netsplit)).toEqual([
+      ':carol!c@h QUIT :a.example.test b.example.test',
+    ]);
+
+    const batched = harnessMod.seedAccount({ nick: 'batched' });
+    const c2 = await attach(batched, ['message-tags', 'batch']);
+    expect(await relay(batched, c2, netsplit)).toEqual(netsplit);
+  });
+
+  it('unwraps a multiline batch for a client, which never has draft/multiline', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'reader' });
+    const c = await attach(acct, ['message-tags', 'batch']);
+    const got = await relay(acct, c, [
+      '@msgid=ml1;account=bob :bob!b@h BATCH +ml draft/multiline #chan',
+      '@batch=ml :bob!b@h PRIVMSG #chan hello',
+      '@batch=ml :bob!b@h PRIVMSG #chan :',
+      '@batch=ml :bob!b@h PRIVMSG #chan :how is ',
+      '@batch=ml;draft/multiline-concat :bob!b@h PRIVMSG #chan :everyone?',
+      ':irc.example.test BATCH -ml',
+    ]);
+    expect(got).toEqual([
+      '@msgid=ml1;account=bob :bob!b@h PRIVMSG #chan hello',
+      '@account=bob :bob!b@h PRIVMSG #chan :how is ',
+      '@account=bob :bob!b@h PRIVMSG #chan :everyone?',
+    ]);
+  });
+});

--- a/server/services/bouncer.integration.test.ts
+++ b/server/services/bouncer.integration.test.ts
@@ -507,6 +507,22 @@ describe("relayed lines follow the client's caps", () => {
       '@account=bob :bob!b@h PRIVMSG #chan :everyone?',
     ]);
   });
+
+  it("keeps the network's time on unwrapped multiline lines for a server-time client", async () => {
+    const acct = harnessMod.seedAccount({ nick: 'timely' });
+    const c = await attach(acct, ['server-time']);
+    const TIME = '2026-09-12T08:00:00.000Z';
+    const got = await relay(acct, c, [
+      `@time=${TIME};msgid=ml2 :bob!b@h BATCH +ml2 draft/multiline #chan`,
+      '@batch=ml2 :bob!b@h PRIVMSG #chan :first',
+      '@batch=ml2 :bob!b@h PRIVMSG #chan :second',
+      ':irc.example.test BATCH -ml2',
+    ]);
+    expect(got).toEqual([
+      `@time=${TIME} :bob!b@h PRIVMSG #chan :first`,
+      `@time=${TIME} :bob!b@h PRIVMSG #chan :second`,
+    ]);
+  });
 });
 
 // soju's pass-through caps: offered while the bound network has them, so a

--- a/server/services/bouncer.test.ts
+++ b/server/services/bouncer.test.ts
@@ -277,61 +277,37 @@ describe('rewriteNumericTarget', () => {
 });
 
 describe('filterRelayLine', () => {
-  const noCaps = new Set<string>();
-
   it('passes ordinary conversation through untouched', () => {
     const line = ':nick!u@h PRIVMSG #chan :hello';
-    expect(filterRelayLine(line, noCaps)).toBe(line);
+    expect(filterRelayLine(line)).toBe(line);
   });
 
   it('strips the trailing CR irc-framework leaves on raw lines', () => {
-    expect(filterRelayLine(':nick!u@h PRIVMSG #chan :hello\r', noCaps)).toBe(
+    expect(filterRelayLine(':nick!u@h PRIVMSG #chan :hello\r')).toBe(
       ':nick!u@h PRIVMSG #chan :hello',
     );
   });
 
   it('drops connection plumbing', () => {
-    expect(filterRelayLine('PING :irc.libera.chat', noCaps)).toBeNull();
-    expect(filterRelayLine(':irc.libera.chat PONG server :token', noCaps)).toBeNull();
-    expect(filterRelayLine(':irc.libera.chat CAP * LS :sasl', noCaps)).toBeNull();
-    expect(filterRelayLine('AUTHENTICATE +', noCaps)).toBeNull();
-    expect(filterRelayLine('ERROR :Closing Link', noCaps)).toBeNull();
-    expect(filterRelayLine(':server 001 me :Welcome', noCaps)).toBeNull();
-    expect(filterRelayLine(':server 005 me CHANTYPES=# :are supported', noCaps)).toBeNull();
-    expect(filterRelayLine(':server 903 me :SASL successful', noCaps)).toBeNull();
+    expect(filterRelayLine('PING :irc.libera.chat')).toBeNull();
+    expect(filterRelayLine(':irc.libera.chat PONG server :token')).toBeNull();
+    expect(filterRelayLine(':irc.libera.chat CAP * LS :sasl')).toBeNull();
+    expect(filterRelayLine('AUTHENTICATE +')).toBeNull();
+    expect(filterRelayLine('ERROR :Closing Link')).toBeNull();
+    expect(filterRelayLine(':server 001 me :Welcome')).toBeNull();
+    expect(filterRelayLine(':server 005 me CHANTYPES=# :are supported')).toBeNull();
+    expect(filterRelayLine(':server 903 me :SASL successful')).toBeNull();
   });
 
   it('relays MOTD and other numerics', () => {
     const line = ':server 372 me :- welcome to the network';
-    expect(filterRelayLine(line, noCaps)).toBe(line);
+    expect(filterRelayLine(line)).toBe(line);
   });
 
-  it('strips all tags for a capless client', () => {
-    expect(filterRelayLine('@time=2026-01-01T00:00:00.000Z :n!u@h PRIVMSG #c :hi', noCaps)).toBe(
-      ':n!u@h PRIVMSG #c :hi',
-    );
-  });
-
-  it('keeps only the time tag for a server-time client', () => {
-    const caps = new Set(['server-time']);
-    expect(
-      filterRelayLine('@msgid=abc;time=2026-01-01T00:00:00.000Z :n!u@h PRIVMSG #c :hi', caps),
-    ).toBe('@time=2026-01-01T00:00:00.000Z :n!u@h PRIVMSG #c :hi');
-  });
-
-  it('keeps every tag for a message-tags client', () => {
-    const caps = new Set(['message-tags']);
-    const line = '@msgid=abc;time=x :n!u@h PRIVMSG #c :hi';
-    expect(filterRelayLine(line, caps)).toBe(line);
-  });
-
-  it('drops TAGMSG and BATCH unless the client negotiated message-tags', () => {
-    expect(filterRelayLine('@+typing=active :n!u@h TAGMSG #c', noCaps)).toBeNull();
-    expect(filterRelayLine(':server BATCH +ref draft/multiline #c', noCaps)).toBeNull();
-    const caps = new Set(['message-tags']);
-    expect(filterRelayLine('@+typing=active :n!u@h TAGMSG #c', caps)).toBe(
-      '@+typing=active :n!u@h TAGMSG #c',
-    );
+  it("leaves tags and cap-gated commands to each client's filter", () => {
+    // What one client may receive is bouncerClientFilter.ts's call, per client.
+    const line = '@time=2026-01-01T00:00:00.000Z :n!u@h AWAY :gone';
+    expect(filterRelayLine(line)).toBe(line);
   });
 });
 

--- a/server/services/bouncer.test.ts
+++ b/server/services/bouncer.test.ts
@@ -15,7 +15,6 @@ let unmarshalLogin: typeof import('./bouncer.js').unmarshalLogin;
 let rewriteNumericTarget: typeof import('./bouncer.js').rewriteNumericTarget;
 let filterRelayLine: typeof import('./bouncer.js').filterRelayLine;
 let memberPrefixSymbols: typeof import('./bouncer.js').memberPrefixSymbols;
-let stampTime: typeof import('./bouncer.js').stampTime;
 let buildNamesLines: typeof import('./bouncer.js').buildNamesLines;
 let withNetworkList: typeof import('./bouncer.js').withNetworkList;
 let isServicesNick: typeof import('./bouncer.js').isServicesNick;
@@ -36,7 +35,6 @@ beforeAll(async () => {
   rewriteNumericTarget = mod.rewriteNumericTarget;
   filterRelayLine = mod.filterRelayLine;
   memberPrefixSymbols = mod.memberPrefixSymbols;
-  stampTime = mod.stampTime;
   buildNamesLines = mod.buildNamesLines;
   withNetworkList = mod.withNetworkList;
   isServicesNick = mod.isServicesNick;
@@ -408,25 +406,6 @@ describe('memberPrefixSymbols', () => {
     ];
     expect(memberPrefixSymbols(['o', 'y'], prefixes)).toBe('!@');
     expect(memberPrefixSymbols(['q'], prefixes)).toBe('');
-  });
-});
-
-describe('stampTime', () => {
-  const now = new Date('2026-09-12T19:33:25.000Z');
-  const time = '@time=2026-09-12T19:33:25.000Z';
-
-  it('adds a time tag to a line that has none', () => {
-    expect(stampTime(':n!u@h PRIVMSG #c :hi', now)).toBe(`${time} :n!u@h PRIVMSG #c :hi`);
-    expect(stampTime('@msgid=m :n!u@h PRIVMSG #c :hi', now)).toBe(
-      `${time};msgid=m :n!u@h PRIVMSG #c :hi`,
-    );
-    expect(stampTime('@ :n!u@h PRIVMSG #c :hi', now)).toBe(`${time} :n!u@h PRIVMSG #c :hi`);
-  });
-
-  it('leaves a line that has a time, and numerics, alone', () => {
-    const timed = '@time=2026-01-01T00:00:00.000Z :n!u@h PRIVMSG #c :hi';
-    expect(stampTime(timed, now)).toBe(timed);
-    expect(stampTime(':irc.test 372 me :- welcome', now)).toBe(':irc.test 372 me :- welcome');
   });
 });
 

--- a/server/services/bouncer.test.ts
+++ b/server/services/bouncer.test.ts
@@ -14,7 +14,8 @@ let parseBouncerCredentials: typeof import('./bouncer.js').parseBouncerCredentia
 let unmarshalLogin: typeof import('./bouncer.js').unmarshalLogin;
 let rewriteNumericTarget: typeof import('./bouncer.js').rewriteNumericTarget;
 let filterRelayLine: typeof import('./bouncer.js').filterRelayLine;
-let memberPrefixSymbol: typeof import('./bouncer.js').memberPrefixSymbol;
+let memberPrefixSymbols: typeof import('./bouncer.js').memberPrefixSymbols;
+let stampTime: typeof import('./bouncer.js').stampTime;
 let buildNamesLines: typeof import('./bouncer.js').buildNamesLines;
 let withNetworkList: typeof import('./bouncer.js').withNetworkList;
 let isServicesNick: typeof import('./bouncer.js').isServicesNick;
@@ -34,7 +35,8 @@ beforeAll(async () => {
   unmarshalLogin = mod.unmarshalLogin;
   rewriteNumericTarget = mod.rewriteNumericTarget;
   filterRelayLine = mod.filterRelayLine;
-  memberPrefixSymbol = mod.memberPrefixSymbol;
+  memberPrefixSymbols = mod.memberPrefixSymbols;
+  stampTime = mod.stampTime;
   buildNamesLines = mod.buildNamesLines;
   withNetworkList = mod.withNetworkList;
   isServicesNick = mod.isServicesNick;
@@ -392,11 +394,11 @@ describe('bouncerNetworkState', () => {
   });
 });
 
-describe('memberPrefixSymbol', () => {
-  it('maps the highest-ranked mode to its symbol', () => {
-    expect(memberPrefixSymbol(['v', 'o'])).toBe('@');
-    expect(memberPrefixSymbol(['v'])).toBe('+');
-    expect(memberPrefixSymbol([])).toBe('');
+describe('memberPrefixSymbols', () => {
+  it('maps every mode to its symbol, highest rank first', () => {
+    expect(memberPrefixSymbols(['v', 'o'])).toBe('@+');
+    expect(memberPrefixSymbols(['v'])).toBe('+');
+    expect(memberPrefixSymbols([])).toBe('');
   });
 
   it('honors a network-supplied prefix table', () => {
@@ -404,8 +406,27 @@ describe('memberPrefixSymbol', () => {
       { mode: 'y', symbol: '!' },
       { mode: 'o', symbol: '@' },
     ];
-    expect(memberPrefixSymbol(['y'], prefixes)).toBe('!');
-    expect(memberPrefixSymbol(['q'], prefixes)).toBe('');
+    expect(memberPrefixSymbols(['o', 'y'], prefixes)).toBe('!@');
+    expect(memberPrefixSymbols(['q'], prefixes)).toBe('');
+  });
+});
+
+describe('stampTime', () => {
+  const now = new Date('2026-09-12T19:33:25.000Z');
+  const time = '@time=2026-09-12T19:33:25.000Z';
+
+  it('adds a time tag to a line that has none', () => {
+    expect(stampTime(':n!u@h PRIVMSG #c :hi', now)).toBe(`${time} :n!u@h PRIVMSG #c :hi`);
+    expect(stampTime('@msgid=m :n!u@h PRIVMSG #c :hi', now)).toBe(
+      `${time};msgid=m :n!u@h PRIVMSG #c :hi`,
+    );
+    expect(stampTime('@ :n!u@h PRIVMSG #c :hi', now)).toBe(`${time} :n!u@h PRIVMSG #c :hi`);
+  });
+
+  it('leaves a line that has a time, and numerics, alone', () => {
+    const timed = '@time=2026-01-01T00:00:00.000Z :n!u@h PRIVMSG #c :hi';
+    expect(stampTime(timed, now)).toBe(timed);
+    expect(stampTime(':irc.test 372 me :- welcome', now)).toBe(':irc.test 372 me :- welcome');
   });
 });
 

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -32,8 +32,11 @@
 //
 // Design notes / v1 limitations, all deliberate:
 // - Upstream→client traffic is relayed as the RAW wire lines the network sent
-//   (minus registration/PING plumbing), so semantics stay exact. That means
-//   Lurker-level ignore rules and RPE2E decryption do NOT apply to live relay:
+//   (minus registration/PING plumbing), so semantics stay exact, then trimmed
+//   per client to the caps that client negotiated: the network speaks to Lurker
+//   with Lurker's caps, not the client's (see bouncerClientFilter.ts, which
+//   every line to a client passes through). Raw relay also means Lurker-level
+//   ignore rules and RPE2E decryption do NOT apply to live relay:
 //   an ignored sender is still visible in an attached client, and E2E channel
 //   traffic shows as ciphertext there (your own sends echo as plaintext).
 // - Numeric replies to one attached client's query (WHOIS, LIST, …) are
@@ -73,6 +76,7 @@ import {
   keyMatchesCert,
 } from '../utils/bouncerCert.js';
 import { isChannelTarget } from '../../shared/channels.js';
+import { ClientLineFilter, restrictTags } from './bouncerClientFilter.js';
 
 const SERVER_NAME = 'lurker.bouncer';
 
@@ -373,29 +377,12 @@ export function rewriteNumericTarget(line: string, nick: string): string {
   return `${m[1]}${nick}${m[2]}`;
 }
 
-// Trim a line's IRCv3 tag block to what the client negotiated: everything for
-// message-tags, just `time` for server-time, nothing otherwise. Returns null for
-// a tag block with no message after it.
-function trimTagsForClient(line: string, caps: ReadonlySet<string>): string | null {
-  if (!line.startsWith('@')) return line;
-  const sp = line.indexOf(' ');
-  if (sp === -1) return null;
-  if (caps.has('message-tags')) return line;
-  const tags = line.slice(1, sp);
-  const rest = line.slice(sp + 1);
-  if (caps.has('server-time')) {
-    const time = tags.split(';').find((t) => t === 'time' || t.startsWith('time='));
-    if (time) return `@${time} ${rest}`;
-  }
-  return rest;
-}
-
 /**
- * Filter one raw upstream line for an attached client: drop connection
- * plumbing, drop tag-only commands the client can't parse, and trim message
- * tags to what the client negotiated. Returns null to drop the line.
+ * Filter one raw upstream line before it is relayed: drop the connection
+ * plumbing Lurker handles itself. What each client may then receive is up to
+ * its ClientLineFilter. Returns null to drop the line.
  */
-export function filterRelayLine(line: string, caps: ReadonlySet<string>): string | null {
+export function filterRelayLine(line: string): string | null {
   // irc-framework's raw event line keeps its trailing CR — strip it so the
   // relayed copy doesn't carry a stray control char into our own CRLF framing.
   line = line.replace(/[\r\n]+$/, '');
@@ -412,8 +399,7 @@ export function filterRelayLine(line: string, caps: ReadonlySet<string>): string
   }
   const command = (afterPrefix.split(' ', 1)[0] || '').toUpperCase();
   if (RELAY_DROP.has(command)) return null;
-  if ((command === 'TAGMSG' || command === 'BATCH') && !caps.has('message-tags')) return null;
-  return trimTagsForClient(line, caps);
+  return line;
 }
 
 // Default IRC prefix ladder, used when the network's ISUPPORT PREFIX isn't
@@ -627,6 +613,8 @@ class BouncerSession {
   // Decode incrementally so a multi-byte UTF-8 character split across two TCP
   // segments isn't corrupted (chunk.toString() per packet would mangle it).
   private readonly decoder = new StringDecoder('utf8');
+  // Every line written to this client passes through it (see write()).
+  private readonly clientFilter: ClientLineFilter;
   private capNegotiating = false;
   // SASL PLAIN state: the requested mechanism (null until AUTHENTICATE <mech>),
   // an accumulator for base64 payloads that arrive in 400-byte chunks, and the
@@ -664,6 +652,13 @@ class BouncerSession {
   constructor(socket: net.Socket) {
     this.socket = socket;
     this.remoteIp = socket.remoteAddress || 'unknown';
+    this.clientFilter = new ClientLineFilter({
+      caps: this.caps,
+      serverName: SERVER_NAME,
+      nick: () => this.currentNick() || this.clientNick,
+      prefixes: () => this.isupportPrefixes(),
+      sharedChannels: (nick) => this.sharedChannels(nick),
+    });
     socket.setNoDelay(true);
     socket.on('data', (chunk) => this.onData(chunk));
     socket.on('error', () => this.destroy());
@@ -685,7 +680,10 @@ class BouncerSession {
       // let an embedded newline in interpolated text split into a second
       // injected command. Matching control chars is the point of the regex.
       // eslint-disable-next-line no-control-regex
-      this.socket.write(line.replace(/[\r\n\u0000]/g, ' ') + '\r\n');
+      const scrubbed = line.replace(/[\r\n\u0000]/g, ' ');
+      // The one exit point: whatever wrote the line, the client gets only what
+      // its caps allow (#926).
+      for (const out of this.clientFilter.apply(scrubbed)) this.socket.write(out + '\r\n');
     } catch {
       this.destroy();
     }
@@ -1175,10 +1173,10 @@ class BouncerSession {
     if (conn.state === 'connected' && conn.registrationLines.length > 0) {
       // Saved at registration with the upstream's tags, so any per-delivery tag
       // on them (msgid, batch) is stale by now. Like ZNC, the replay keeps at
-      // most `time`, and only for a server-time client (#892).
-      const burstCaps = new Set(this.caps.has('server-time') ? ['server-time'] : []);
+      // most `time`, and write() drops that too unless the client negotiated
+      // server-time (#892).
       for (const line of conn.registrationLines) {
-        const out = trimTagsForClient(line, burstCaps);
+        const out = restrictTags(line, (key) => key === 'time');
         if (out) this.write(rewriteNumericTarget(out, requested));
       }
     } else {
@@ -1225,7 +1223,7 @@ class BouncerSession {
       // reflect our OWN PRIVMSG/NOTICE back. dispatchIrcEvent already synthesizes
       // the self-echo, so drop the reflected copy to avoid a duplicate line.
       if (this.isReflectedSelfLine(event.line)) return;
-      const out = filterRelayLine(event.line, this.caps);
+      const out = filterRelayLine(event.line);
       if (out) this.write(out);
     };
     // irc-framework's Client is an eventemitter3, which has no listener-count
@@ -1587,6 +1585,19 @@ class BouncerSession {
     return DEFAULT_PREFIXES;
   }
 
+  // The channels `nick` shares with us and its modes in each, for the client
+  // filter's CHGHOST fallback. Members are keyed by lowercased nick, the way
+  // IrcConnection stores them.
+  private sharedChannels(nick: string): Array<{ channel: string; modes: string[] }> {
+    const key = nick.toLowerCase();
+    const shared: Array<{ channel: string; modes: string[] }> = [];
+    for (const ch of this.conn?.channels.values() ?? []) {
+      const member = ch.members.get(key);
+      if (member) shared.push({ channel: ch.name, modes: member.modes || [] });
+    }
+    return shared;
+  }
+
   private sendJoinBurst(): void {
     const conn = this.conn!;
     const nick = this.currentNick() || '*';
@@ -1944,6 +1955,8 @@ class BouncerSession {
 
   onUpstreamState(state: string): void {
     if (this.closed) return;
+    // Batches the old upstream connection left open will never close.
+    this.clientFilter.resetBatches();
     // liveConn() closes us if the connection object was swapped out.
     if (!this.liveConn() || this.closed) return;
     if (state === 'connected') this.notice(`Upstream reconnected to '${this.network?.name}'.`);

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -76,7 +76,7 @@ import {
   keyMatchesCert,
 } from '../utils/bouncerCert.js';
 import { isChannelTarget } from '../../shared/channels.js';
-import { ClientLineFilter, restrictTags } from './bouncerClientFilter.js';
+import { ClientLineFilter, parseLine, restrictTags } from './bouncerClientFilter.js';
 
 const SERVER_NAME = 'lurker.bouncer';
 
@@ -90,12 +90,12 @@ function timingEqualizerHash(): string {
   return timingDummyHash;
 }
 
-// Caps we can honestly offer an attaching client. server-time stamps playback
-// and relayed lines; message-tags passes upstream tags through verbatim;
-// echo-message opts the client into receiving its own sends back (otherwise we
-// suppress the echo, since the client already rendered the message locally);
-// znc.in/self-message is a marker cap — clients that know it render
-// `:you PRIVMSG peer` playback/sync lines as *your* outgoing DMs.
+// Caps we can honestly offer an attaching client, whatever network it binds.
+// server-time stamps playback and relayed lines; message-tags passes upstream
+// tags through verbatim; echo-message opts the client into receiving its own
+// sends back (otherwise we suppress the echo, since the client already rendered
+// the message locally); znc.in/self-message is a marker cap — clients that know
+// it render `:you PRIVMSG peer` playback/sync lines as *your* outgoing DMs.
 const SUPPORTED_CAPS = [
   'sasl',
   'server-time',
@@ -112,6 +112,28 @@ const SUPPORTED_CAPS = [
   'soju.im/bouncer-networks-notify',
   // draft/chathistory: on-demand scrollback fetch (CHATHISTORY BEFORE/AFTER/…).
   'draft/chathistory',
+  // cap-notify: CAP NEW/DEL as the bound network's caps come and go (see
+  // updateSupportedCaps). CAP LS 302 turns it on without a REQ.
+  'cap-notify',
+  // invite-notify: other people's INVITEs. A network that doesn't send them
+  // just means fewer, which the spec allows; soju offers it regardless too.
+  'invite-notify',
+];
+
+// Caps offered only while the bound network has them, because the lines they
+// promise come from the network (soju's passthroughDownstreamCaps). Without the
+// cap, the client filter keeps those lines away from the client.
+// userhost-in-names is ZNC's addition; soju doesn't offer it. Not offered yet:
+// extended-monitor (a client's MONITOR is relayed raw, into Lurker's own list)
+// and labeled-response (needs per-request reply routing, #493).
+const PASSTHROUGH_CAPS = [
+  'away-notify',
+  'account-notify',
+  'account-tag',
+  'chghost',
+  'extended-join',
+  'multi-prefix',
+  'userhost-in-names',
 ];
 
 const CAP_BOUNCER_NETWORKS = 'soju.im/bouncer-networks';
@@ -128,10 +150,10 @@ const MAX_CHATHISTORY = 1000;
 const SASL_MECHANISMS = ['PLAIN'];
 
 /** Build the CAP LS token list, attaching cap values when the client sent 302. */
-function capLsList(version: number): string {
-  return SUPPORTED_CAPS.map((c) =>
-    c === 'sasl' && version >= 302 ? `sasl=${SASL_MECHANISMS.join(',')}` : c,
-  ).join(' ');
+function capLsList(caps: Iterable<string>, version: number): string {
+  return [...caps]
+    .map((c) => (c === 'sasl' && version >= 302 ? `sasl=${SASL_MECHANISMS.join(',')}` : c))
+    .join(' ');
 }
 
 // Upstream wire commands never relayed to attached clients: connection
@@ -402,6 +424,23 @@ export function filterRelayLine(line: string): string | null {
   return line;
 }
 
+/**
+ * `line` with a `time` tag of `now` if it has none, the way soju stamps what it
+ * relays (upstream.go), so a server-time client has a time on every message.
+ * Numerics are left alone, as soju leaves them.
+ */
+export function stampTime(line: string, now: Date = new Date()): string {
+  const msg = parseLine(line);
+  if (!msg || /^[0-9]{3}$/.test(msg.command)) return line;
+  if (msg.tags.some((tag) => tag === 'time' || tag.startsWith('time='))) return line;
+  const time = `time=${now.toISOString()}`;
+  if (!line.startsWith('@')) return `@${time} ${line}`;
+  // An empty tag block (`@ …`) is replaced rather than extended.
+  return msg.tags.length === 0
+    ? `@${time} ${line.slice(line.indexOf(' ') + 1)}`
+    : `@${time};${line.slice(1)}`;
+}
+
 // Default IRC prefix ladder, used when the network's ISUPPORT PREFIX isn't
 // available (attached while upstream is still registering).
 const DEFAULT_PREFIXES: Array<{ mode: string; symbol: string }> = [
@@ -412,14 +451,19 @@ const DEFAULT_PREFIXES: Array<{ mode: string; symbol: string }> = [
   { mode: 'v', symbol: '+' },
 ];
 
-export function memberPrefixSymbol(
+/**
+ * Every prefix symbol a member's modes earn, highest rank first (`@+` for +ov).
+ * The client filter cuts it to the highest one for a client without
+ * multi-prefix.
+ */
+export function memberPrefixSymbols(
   memberModes: string[],
   prefixes: Array<{ mode: string; symbol: string }> = DEFAULT_PREFIXES,
 ): string {
-  for (const p of prefixes) {
-    if (memberModes.includes(p.mode)) return p.symbol;
-  }
-  return '';
+  return prefixes
+    .filter((p) => memberModes.includes(p.mode))
+    .map((p) => p.symbol)
+    .join('');
 }
 
 /** Chunk a NAMES membership list into 353 lines under the 512-byte wire cap. */
@@ -603,6 +647,11 @@ export function attachedSessionCount(userId?: number, networkId?: number): numbe
 
 class BouncerSession {
   readonly caps = new Set<string>();
+  // What the client may request right now: SUPPORTED_CAPS, plus whichever
+  // pass-through caps apply (see handleCap and updateSupportedCaps).
+  private readonly availableCaps = new Set<string>(SUPPORTED_CAPS);
+  // The highest CAP LS version the client sent; 301 until it sends 302.
+  private capVersion = 301;
   userId = 0;
   networkId = 0;
   lastActivityAt = Date.now();
@@ -647,6 +696,7 @@ class BouncerSession {
   // mismatch cases) can't suppress an identical message sent much later.
   private pendingEcho: Array<{ key: string; at: number }> = [];
   private onRawUpstream: ((event: { from_server: boolean; line: string }) => void) | null = null;
+  private onUpstreamCaps: (() => void) | null = null;
   private regTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(socket: net.Socket) {
@@ -815,7 +865,16 @@ class BouncerSession {
         // 302 = versioned LS (advertise cap values); a bare/absent token is 301.
         const version = Number(msg.params[1]);
         const capVersion = Number.isFinite(version) && version >= 302 ? 302 : 301;
-        this.write(`:${SERVER_NAME} CAP ${nick} LS :${capLsList(capVersion)}`);
+        this.capVersion = Math.max(this.capVersion, capVersion);
+        if (capVersion >= 302) {
+          // Before registration the network isn't known, so a 302 client is
+          // shown the pass-through caps too, and binding takes back the ones
+          // the network lacks with a CAP DEL (soju does the same). 302 also
+          // turns on cap-notify, which is what carries that DEL to the client.
+          if (!this.registered) for (const cap of PASSTHROUGH_CAPS) this.availableCaps.add(cap);
+          this.caps.add('cap-notify');
+        }
+        this.write(`:${SERVER_NAME} CAP ${nick} LS :${capLsList(this.availableCaps, capVersion)}`);
         break;
       }
       case 'LIST':
@@ -827,8 +886,10 @@ class BouncerSession {
           .split(' ')
           .map((c) => c.trim())
           .filter(Boolean);
-        const supported = requested.every((c) => SUPPORTED_CAPS.includes(c.replace(/^-/, '')));
-        if (!supported || requested.length === 0) {
+        const supported = requested.every((c) => this.availableCaps.has(c.replace(/^-/, '')));
+        // cap-notify can't be turned off once CAP LS 302 has turned it on.
+        const dropsCapNotify = this.capVersion >= 302 && requested.includes('-cap-notify');
+        if (!supported || dropsCapNotify || requested.length === 0) {
           this.write(`:${SERVER_NAME} CAP ${nick} NAK :${requested.join(' ')}`);
           break;
         }
@@ -846,6 +907,34 @@ class BouncerSession {
         this.write(`:${SERVER_NAME} 410 ${nick} ${sub || '*'} :Invalid CAP command`);
         break;
     }
+  }
+
+  // soju's updateSupportedCaps: the pass-through caps follow the bound network.
+  // Runs once registration settles on a network (or on none, for a control
+  // connection) and again whenever that network's caps may have changed. A cap
+  // the network lacks leaves both sets, or the client would wait for lines that
+  // never come. `nick` is the one the client knows itself by at that moment.
+  private updateSupportedCaps(nick: string): void {
+    const upstream = new Set<string>(
+      !this.isControl && this.conn?.state === 'connected'
+        ? (this.conn.client.network?.cap?.enabled ?? [])
+        : [],
+    );
+    const added: string[] = [];
+    const removed: string[] = [];
+    for (const cap of PASSTHROUGH_CAPS) {
+      if (upstream.has(cap) && !this.availableCaps.has(cap)) {
+        this.availableCaps.add(cap);
+        added.push(cap);
+      } else if (!upstream.has(cap) && this.availableCaps.has(cap)) {
+        this.availableCaps.delete(cap);
+        this.caps.delete(cap);
+        removed.push(cap);
+      }
+    }
+    if (!this.caps.has('cap-notify')) return;
+    if (added.length > 0) this.write(`:${SERVER_NAME} CAP ${nick} NEW :${added.join(' ')}`);
+    if (removed.length > 0) this.write(`:${SERVER_NAME} CAP ${nick} DEL :${removed.join(' ')}`);
   }
 
   // SASL PLAIN (IRCv3). Reuses the same credential backend as PASS — the only
@@ -1097,6 +1186,8 @@ class BouncerSession {
     this.registered = true;
     this.clearRegTimer();
     attachToRegistry(this);
+    // Before the burst, so everything in it already follows the settled caps.
+    this.updateSupportedCaps(this.clientNick || '*');
     this.sendAttachBurst();
     systemLog.log({
       userId: this.userId,
@@ -1121,6 +1212,7 @@ class BouncerSession {
     this.isControl = true;
     this.registered = true;
     this.clearRegTimer();
+    this.updateSupportedCaps(this.clientNick || '*');
     this.sendControlBurst(user, networks);
     // failRegistration used to console.warn the reason for the commonest
     // misconfiguration (bare username, several networks). It no longer fails,
@@ -1224,11 +1316,18 @@ class BouncerSession {
       // the self-echo, so drop the reflected copy to avoid a duplicate line.
       if (this.isReflectedSelfLine(event.line)) return;
       const out = filterRelayLine(event.line);
-      if (out) this.write(out);
+      if (out) this.write(this.caps.has('server-time') ? stampTime(out) : out);
     };
     // irc-framework's Client is an eventemitter3, which has no listener-count
     // cap — several attached clients can listen on one upstream client freely.
     conn.client.on('raw', this.onRawUpstream);
+    // The network's caps can change under a live connection: its own CAP
+    // NEW/DEL, or a REQ Lurker sends after registration (#888).
+    this.onUpstreamCaps = () => {
+      if (!this.closed) this.updateSupportedCaps(this.currentNick() || '*');
+    };
+    conn.client.on('cap ack', this.onUpstreamCaps);
+    conn.client.on('cap del', this.onUpstreamCaps);
   }
 
   // --- control (unbound) connection ------------------------------------------
@@ -1585,29 +1684,41 @@ class BouncerSession {
     return DEFAULT_PREFIXES;
   }
 
-  // The channels `nick` shares with us and its modes in each, for the client
-  // filter's CHGHOST fallback. Members are keyed by lowercased nick, the way
-  // IrcConnection stores them.
-  private sharedChannels(nick: string): Array<{ channel: string; modes: string[] }> {
+  // The channels `nick` shares with us, with its modes and account in each, for
+  // the client filter's CHGHOST fallback. Members are keyed by lowercased nick,
+  // the way IrcConnection stores them.
+  private sharedChannels(
+    nick: string,
+  ): Array<{ channel: string; modes: string[]; account?: string | null }> {
     const key = nick.toLowerCase();
-    const shared: Array<{ channel: string; modes: string[] }> = [];
+    const shared: Array<{ channel: string; modes: string[]; account?: string | null }> = [];
     for (const ch of this.conn?.channels.values() ?? []) {
       const member = ch.members.get(key);
-      if (member) shared.push({ channel: ch.name, modes: member.modes || [] });
+      if (member) {
+        shared.push({ channel: ch.name, modes: member.modes || [], account: member.account });
+      }
     }
     return shared;
   }
 
+  // Each channel's JOIN, topic and NAMES, built in their fullest form: an
+  // extended-join JOIN, every prefix, hostmasks where known. write() trims them
+  // to what the client negotiated, as it trims the network's own lines.
   private sendJoinBurst(): void {
     const conn = this.conn!;
     const nick = this.currentNick() || '*';
     const prefixes = this.isupportPrefixes();
+    const realname = conn.client.user?.gecos || this.network?.realname || nick;
     for (const ch of conn.channels.values()) {
-      this.write(`:${this.selfPrefix()} JOIN ${ch.name}`);
+      // Our own account as this channel knows it, from our extended JOIN or ACCOUNT.
+      const account = ch.members.get(nick.toLowerCase())?.account;
+      const accountParam = typeof account === 'string' ? account : '*';
+      this.write(`:${this.selfPrefix()} JOIN ${ch.name} ${accountParam} :${realname}`);
       if (ch.topic) this.write(`:${SERVER_NAME} 332 ${nick} ${ch.name} :${ch.topic}`);
-      const names = Array.from(ch.members.values()).map(
-        (m) => memberPrefixSymbol(m.modes || [], prefixes) + m.nick,
-      );
+      const names = Array.from(ch.members.values()).map((m) => {
+        const mask = m.user && m.host ? `!${m.user}@${m.host}` : '';
+        return memberPrefixSymbols(m.modes || [], prefixes) + m.nick + mask;
+      });
       for (const line of buildNamesLines(nick, ch.name, names)) this.write(line);
     }
   }
@@ -1959,6 +2070,8 @@ class BouncerSession {
     this.clientFilter.resetBatches();
     // liveConn() closes us if the connection object was swapped out.
     if (!this.liveConn() || this.closed) return;
+    // A connect brings the network's caps; a disconnect takes them away.
+    this.updateSupportedCaps(this.currentNick() || '*');
     if (state === 'connected') this.notice(`Upstream reconnected to '${this.network?.name}'.`);
     else if (state === 'reconnecting' || state === 'disconnected') {
       this.notice(`Upstream ${state} ('${this.network?.name}') — Lurker will keep retrying.`);
@@ -2006,11 +2119,16 @@ class BouncerSession {
     if (this.onRawUpstream && this.conn) {
       try {
         this.conn.client.off('raw', this.onRawUpstream);
+        if (this.onUpstreamCaps) {
+          this.conn.client.off('cap ack', this.onUpstreamCaps);
+          this.conn.client.off('cap del', this.onUpstreamCaps);
+        }
       } catch {
         /* ignore */
       }
     }
     this.onRawUpstream = null;
+    this.onUpstreamCaps = null;
     sessions.delete(this);
     if (this.registered && this.isControl) {
       systemLog.log({

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -76,7 +76,7 @@ import {
   keyMatchesCert,
 } from '../utils/bouncerCert.js';
 import { isChannelTarget } from '../../shared/channels.js';
-import { ClientLineFilter, parseLine, restrictTags } from './bouncerClientFilter.js';
+import { ClientLineFilter, restrictTags } from './bouncerClientFilter.js';
 
 const SERVER_NAME = 'lurker.bouncer';
 
@@ -424,23 +424,6 @@ export function filterRelayLine(line: string): string | null {
   return line;
 }
 
-/**
- * `line` with a `time` tag of `now` if it has none, the way soju stamps what it
- * relays (upstream.go), so a server-time client has a time on every message.
- * Numerics are left alone, as soju leaves them.
- */
-export function stampTime(line: string, now: Date = new Date()): string {
-  const msg = parseLine(line);
-  if (!msg || /^[0-9]{3}$/.test(msg.command)) return line;
-  if (msg.tags.some((tag) => tag === 'time' || tag.startsWith('time='))) return line;
-  const time = `time=${now.toISOString()}`;
-  if (!line.startsWith('@')) return `@${time} ${line}`;
-  // An empty tag block (`@ …`) is replaced rather than extended.
-  return msg.tags.length === 0
-    ? `@${time} ${line.slice(line.indexOf(' ') + 1)}`
-    : `@${time};${line.slice(1)}`;
-}
-
 // Default IRC prefix ladder, used when the network's ISUPPORT PREFIX isn't
 // available (attached while upstream is still registering).
 const DEFAULT_PREFIXES: Array<{ mode: string; symbol: string }> = [
@@ -723,7 +706,8 @@ class BouncerSession {
     return this.registered;
   }
 
-  private write(line: string): void {
+  // `relayedAt` marks a line the network sent (see ClientLineFilter.apply).
+  private write(line: string, relayedAt?: Date): void {
     if (this.closed) return;
     try {
       // No generated line legitimately contains CR/LF/NUL; scrub rather than
@@ -733,7 +717,8 @@ class BouncerSession {
       const scrubbed = line.replace(/[\r\n\u0000]/g, ' ');
       // The one exit point: whatever wrote the line, the client gets only what
       // its caps allow (#926).
-      for (const out of this.clientFilter.apply(scrubbed)) this.socket.write(out + '\r\n');
+      for (const out of this.clientFilter.apply(scrubbed, relayedAt))
+        this.socket.write(out + '\r\n');
     } catch {
       this.destroy();
     }
@@ -1316,7 +1301,7 @@ class BouncerSession {
       // the self-echo, so drop the reflected copy to avoid a duplicate line.
       if (this.isReflectedSelfLine(event.line)) return;
       const out = filterRelayLine(event.line);
-      if (out) this.write(this.caps.has('server-time') ? stampTime(out) : out);
+      if (out) this.write(out, new Date());
     };
     // irc-framework's Client is an eventemitter3, which has no listener-count
     // cap — several attached clients can listen on one upstream client freely.

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -882,6 +882,9 @@ class BouncerSession {
           if (cap.startsWith('-')) this.caps.delete(cap.slice(1));
           else this.caps.add(cap);
         }
+        // A client that gives up batch is done with every batch it was sent,
+        // even if it asks for batch again before one ends.
+        if (requested.includes('-batch')) this.clientFilter.forgetSentBatches();
         this.write(`:${SERVER_NAME} CAP ${nick} ACK :${requested.join(' ')}`);
         break;
       }

--- a/server/services/bouncerClientFilter.test.ts
+++ b/server/services/bouncerClientFilter.test.ts
@@ -317,6 +317,18 @@ describe('ClientLineFilter', () => {
       ]);
     });
 
+    it('sends the fallback JOIN in extended form to an extended-join client', () => {
+      const withAccounts = [
+        { channel: '#ops', modes: [], account: 'alice' },
+        { channel: '#lounge', modes: [], account: null },
+      ];
+      expect(filterFor(['extended-join'], { shared: withAccounts }).apply(change)).toEqual([
+        ':alice!old@old.host QUIT :Changing hostname',
+        ':alice!new@new.host JOIN #ops alice :',
+        ':alice!new@new.host JOIN #lounge * :',
+      ]);
+    });
+
     it('sends nothing for our own change, or for a nick we share no channel with', () => {
       expect(filterFor([], { nick: 'Alice', shared }).apply(change)).toEqual([]);
       expect(filterFor([], { shared: [] }).apply(change)).toEqual([]);

--- a/server/services/bouncerClientFilter.test.ts
+++ b/server/services/bouncerClientFilter.test.ts
@@ -237,6 +237,51 @@ describe('ClientLineFilter', () => {
       expect(filter.apply(netsplit[2])).toEqual([]);
     });
 
+    // A client can give up batch part-way through one with CAP REQ :-batch.
+    function filterWithCaps(caps: Set<string>): ClientLineFilter {
+      return new ClientLineFilter({
+        caps,
+        serverName: 'lurker.bouncer',
+        nick: () => 'me',
+        prefixes: () => PREFIXES,
+        sharedChannels: () => [],
+      });
+    }
+
+    it('ends a batch for a client that gives up batch, even if it asks for it again', () => {
+      const caps = new Set(['message-tags', 'batch']);
+      const filter = filterWithCaps(caps);
+      expect(filter.apply(netsplit[0])).toEqual([netsplit[0]]);
+      caps.delete('batch');
+      filter.forgetSentBatches();
+      expect(filter.apply(netsplit[1])).toEqual([':carol!c@h QUIT :a.test b.test']);
+      caps.add('batch');
+      expect(filter.apply('@batch=ns :dave!d@h QUIT :a.test b.test')).toEqual([
+        ':dave!d@h QUIT :a.test b.test',
+      ]);
+      expect(filter.apply(netsplit[2])).toEqual([]);
+    });
+
+    it('keeps no batch tag once the batch cap is gone, even before being told', () => {
+      const caps = new Set(['message-tags', 'batch']);
+      const filter = filterWithCaps(caps);
+      filter.apply(netsplit[0]);
+      caps.delete('batch');
+      expect(filter.apply(netsplit[1])).toEqual([':carol!c@h QUIT :a.test b.test']);
+    });
+
+    it('drops the enclosing batch from unwrapped multiline lines once batch is given up', () => {
+      const caps = new Set(['message-tags', 'batch']);
+      const filter = filterWithCaps(caps);
+      filter.apply(':irc.test BATCH +hist chathistory #c');
+      filter.apply('@batch=hist;msgid=m1 :n!u@h BATCH +ml draft/multiline #c');
+      caps.delete('batch');
+      filter.forgetSentBatches();
+      expect(filter.apply('@batch=ml :n!u@h PRIVMSG #c :one')).toEqual([
+        '@msgid=m1 :n!u@h PRIVMSG #c :one',
+      ]);
+    });
+
     it('keeps a nested batch inside an open one', () => {
       const filter = filterFor(['message-tags', 'batch']);
       const lines = [

--- a/server/services/bouncerClientFilter.test.ts
+++ b/server/services/bouncerClientFilter.test.ts
@@ -290,6 +290,81 @@ describe('ClientLineFilter', () => {
       ];
       expect(lines.flatMap((l) => filter.apply(l))).toEqual(['@msgid=m1 :n!u@h PRIVMSG #c :text']);
     });
+
+    // A network's reconnect replay can hold a multiline message inside its
+    // chathistory batch. Unwrapped, its lines still belong to that batch.
+    it('keeps an enclosing batch the client was sent on the unwrapped lines', () => {
+      const filter = filterFor(['message-tags', 'batch']);
+      const lines = [
+        ':irc.test BATCH +hist chathistory #c',
+        '@batch=hist;msgid=m1;time=T :n!u@h BATCH +ml draft/multiline #c',
+        '@batch=ml :n!u@h PRIVMSG #c :one',
+        '@batch=ml :n!u@h PRIVMSG #c :two',
+        '@batch=hist :irc.test BATCH -ml',
+        ':irc.test BATCH -hist',
+      ];
+      expect(lines.flatMap((l) => filter.apply(l))).toEqual([
+        ':irc.test BATCH +hist chathistory #c',
+        '@batch=hist;msgid=m1;time=T :n!u@h PRIVMSG #c :one',
+        '@batch=hist;time=T :n!u@h PRIVMSG #c :two',
+        ':irc.test BATCH -hist',
+      ]);
+    });
+
+    it("gives the lines their batch's time, not the time they were relayed", () => {
+      const filter = filterFor(['message-tags', 'batch', 'server-time']);
+      const relayedAt = new Date('2026-09-12T19:33:25.000Z');
+      const lines = [
+        '@msgid=m1;time=2026-01-01T00:00:00.000Z :n!u@h BATCH +b draft/multiline #c',
+        '@batch=b :n!u@h PRIVMSG #c :one',
+        '@batch=b :n!u@h PRIVMSG #c :two',
+        ':irc.test BATCH -b',
+      ];
+      expect(lines.flatMap((l) => filter.apply(l, relayedAt))).toEqual([
+        '@msgid=m1;time=2026-01-01T00:00:00.000Z :n!u@h PRIVMSG #c :one',
+        '@time=2026-01-01T00:00:00.000Z :n!u@h PRIVMSG #c :two',
+      ]);
+    });
+  });
+
+  // soju stamps what it relays, so a server-time client has a time on every
+  // message. apply() does it for a line given the time it was relayed.
+  describe('time on relayed lines', () => {
+    const relayedAt = new Date('2026-09-12T19:33:25.000Z');
+    const stamp = 'time=2026-09-12T19:33:25.000Z';
+
+    it('stamps a relayed line that has no time, for a server-time client', () => {
+      const filter = filterFor(['server-time', 'message-tags']);
+      expect(filter.apply(':n!u@h PRIVMSG #c :hi', relayedAt)).toEqual([
+        `@${stamp} :n!u@h PRIVMSG #c :hi`,
+      ]);
+      expect(filter.apply('@msgid=m :n!u@h PRIVMSG #c :hi', relayedAt)).toEqual([
+        `@${stamp};msgid=m :n!u@h PRIVMSG #c :hi`,
+      ]);
+    });
+
+    it('leaves timed lines, numerics, unrelayed lines and other clients alone', () => {
+      const filter = filterFor(['server-time']);
+      const timed = '@time=T :n!u@h PRIVMSG #c :hi';
+      expect(filter.apply(timed, relayedAt)).toEqual([timed]);
+      expect(filter.apply(':irc.test 372 me :- welcome', relayedAt)).toEqual([
+        ':irc.test 372 me :- welcome',
+      ]);
+      expect(filter.apply(':lurker.bouncer NOTICE me :hi')).toEqual([
+        ':lurker.bouncer NOTICE me :hi',
+      ]);
+      expect(filterFor([]).apply(':n!u@h PRIVMSG #c :hi', relayedAt)).toEqual([
+        ':n!u@h PRIVMSG #c :hi',
+      ]);
+    });
+
+    it('stamps the CHGHOST fallback too, when the change has no time', () => {
+      const filter = filterFor(['server-time'], { shared: [{ channel: '#ops', modes: [] }] });
+      expect(filter.apply(':alice!old@old.host CHGHOST new new.host', relayedAt)).toEqual([
+        `@${stamp} :alice!old@old.host QUIT :Changing hostname`,
+        `@${stamp} :alice!new@new.host JOIN #ops`,
+      ]);
+    });
   });
 
   describe('CHGHOST fallback', () => {

--- a/server/services/bouncerClientFilter.test.ts
+++ b/server/services/bouncerClientFilter.test.ts
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The per-client line filter's rules, case by case. The same behaviour end to
+// end, over a real socket, is in bouncer.integration.test.ts.
+
+import { describe, it, expect } from 'vitest';
+import {
+  ClientLineFilter,
+  formatLine,
+  highestPrefixOnly,
+  parseLine,
+  restrictTags,
+  whoFlagsHighestPrefixOnly,
+} from './bouncerClientFilter.js';
+import type { ClientView } from './bouncerClientFilter.js';
+
+const PREFIXES = [
+  { mode: 'q', symbol: '~' },
+  { mode: 'o', symbol: '@' },
+  { mode: 'v', symbol: '+' },
+];
+
+function filterFor(
+  caps: string[],
+  opts: { nick?: string; shared?: ReturnType<ClientView['sharedChannels']> } = {},
+): ClientLineFilter {
+  return new ClientLineFilter({
+    caps: new Set(caps),
+    serverName: 'lurker.bouncer',
+    nick: () => opts.nick ?? 'me',
+    prefixes: () => PREFIXES,
+    sharedChannels: () => opts.shared ?? [],
+  });
+}
+
+describe('parseLine / formatLine', () => {
+  it.each([
+    ':n!u@h PRIVMSG #c :hello world',
+    '@time=2026-01-01T00:00:00.000Z;msgid=abc :n!u@h PRIVMSG #c :hi',
+    ':irc.test 353 me = #c :@alice bob',
+    ':irc.test 005 me CHANTYPES=# PREFIX=(ov)@+ :are supported by this server',
+    ':n!u@h JOIN #c',
+    'PING :irc.test',
+    'AUTHENTICATE +',
+    ':irc.test 001 me :',
+    ':n!u@h PRIVMSG #c word',
+  ])('round-trips %s', (line) => {
+    expect(formatLine(parseLine(line)!)).toBe(line);
+  });
+
+  it('keeps a trailing param trailing when it no longer needs the colon', () => {
+    const msg = parseLine(':irc.test 353 me = #c :@alice bob')!;
+    msg.params[3] = '@alice';
+    expect(formatLine(msg)).toBe(':irc.test 353 me = #c :@alice');
+  });
+
+  it('has no command for a bare tag block or source', () => {
+    expect(parseLine('@time=x')).toBeNull();
+    expect(parseLine(':irc.test')).toBeNull();
+    expect(parseLine('')).toBeNull();
+  });
+});
+
+const onlyTime = (key: string) => key === 'time';
+
+describe('restrictTags', () => {
+  it('keeps the tags asked for', () => {
+    expect(restrictTags('@time=T;msgid=m :s 001 me :hi', onlyTime)).toBe('@time=T :s 001 me :hi');
+  });
+
+  it('drops an emptied tag block entirely', () => {
+    expect(restrictTags('@msgid=m :s 001 me :hi', onlyTime)).toBe(':s 001 me :hi');
+    expect(restrictTags('@ :s 001 me :hi', onlyTime)).toBe(':s 001 me :hi');
+  });
+
+  it('returns an untagged line unchanged', () => {
+    const line = ':s  001 me :hi';
+    expect(restrictTags(line, onlyTime)).toBe(line);
+  });
+});
+
+describe('highestPrefixOnly / whoFlagsHighestPrefixOnly', () => {
+  it('keeps the highest prefix of a NAMES entry', () => {
+    expect(highestPrefixOnly('~@+alice', '~@+')).toBe('~alice');
+    expect(highestPrefixOnly('+alice', '~@+')).toBe('+alice');
+    expect(highestPrefixOnly('alice', '~@+')).toBe('alice');
+    expect(highestPrefixOnly('@+alice', '')).toBe('@+alice');
+  });
+
+  it('keeps the highest prefix inside WHO flags', () => {
+    expect(whoFlagsHighestPrefixOnly('H@+', '~@+')).toBe('H@');
+    expect(whoFlagsHighestPrefixOnly('G*~@', '~@+')).toBe('G*~');
+    expect(whoFlagsHighestPrefixOnly('H+', '~@+')).toBe('H+');
+    expect(whoFlagsHighestPrefixOnly('H*', '~@+')).toBe('H*');
+  });
+});
+
+describe('ClientLineFilter', () => {
+  it('writes a line no rule touches byte-for-byte', () => {
+    const line = ':n!u@h  PRIVMSG #c :hi';
+    expect(filterFor([]).apply(line)).toEqual([line]);
+  });
+
+  // soju's SendMessage table. Without the cap the command never goes out; with
+  // it, the line does.
+  it.each([
+    ['away-notify', ':n!u@h AWAY :gone to lunch'],
+    ['away-notify', ':n!u@h AWAY'],
+    ['account-notify', ':n!u@h ACCOUNT alice'],
+    ['setname', ':n!u@h SETNAME :New Name'],
+    ['message-tags', '@+typing=active :n!u@h TAGMSG #c'],
+    ['draft/message-redaction', ':n!u@h REDACT #c abc'],
+    ['draft/read-marker', ':irc.test MARKREAD #c timestamp=2026-01-01T00:00:00.000Z'],
+    ['draft/metadata-2', ':irc.test METADATA me avatar * :https://example.test/a.png'],
+    ['chghost', ':n!u@h CHGHOST u2 h2'],
+  ])('sends a line gated on %s only to a client that has it', (cap, line) => {
+    expect(filterFor([]).apply(line)).toEqual([]);
+    expect(filterFor([cap]).apply(line)).toEqual([line]);
+  });
+
+  describe('INVITE', () => {
+    it('without invite-notify, delivers only an invite for us', () => {
+      const filter = filterFor([], { nick: 'Me' });
+      expect(filter.apply(':op!o@h INVITE someone #c')).toEqual([]);
+      expect(filter.apply(':op!o@h INVITE me #c')).toEqual([':op!o@h INVITE me #c']);
+    });
+
+    it('with invite-notify, delivers every invite', () => {
+      const line = ':op!o@h INVITE someone #c';
+      expect(filterFor(['invite-notify']).apply(line)).toEqual([line]);
+    });
+  });
+
+  describe('JOIN', () => {
+    it('trims the account and realname without extended-join', () => {
+      expect(filterFor([]).apply(':n!u@h JOIN #c alice :Alice A')).toEqual([':n!u@h JOIN #c']);
+      expect(filterFor(['server-time']).apply('@time=T :n!u@h JOIN #c * :Alice A')).toEqual([
+        '@time=T :n!u@h JOIN #c',
+      ]);
+    });
+
+    it('leaves an extended JOIN for a client that has extended-join', () => {
+      const line = ':n!u@h JOIN #c alice :Alice A';
+      expect(filterFor(['extended-join']).apply(line)).toEqual([line]);
+    });
+  });
+
+  describe('NAMES (353)', () => {
+    const line = ':irc.test 353 me = #c :~@+alice!a@h @bob!b@h carol!c@h';
+
+    it('keeps one prefix and bare nicks for a client with neither cap', () => {
+      expect(filterFor([]).apply(line)).toEqual([':irc.test 353 me = #c :~alice @bob carol']);
+    });
+
+    it('trims only what the client lacks', () => {
+      expect(filterFor(['multi-prefix']).apply(line)).toEqual([
+        ':irc.test 353 me = #c :~@+alice @bob carol',
+      ]);
+      expect(filterFor(['userhost-in-names']).apply(line)).toEqual([
+        ':irc.test 353 me = #c :~alice!a@h @bob!b@h carol!c@h',
+      ]);
+      expect(filterFor(['multi-prefix', 'userhost-in-names']).apply(line)).toEqual([line]);
+    });
+
+    it('keeps a single entry trailing', () => {
+      expect(filterFor([]).apply(':irc.test 353 me = #c :@+solo')).toEqual([
+        ':irc.test 353 me = #c :@solo',
+      ]);
+    });
+  });
+
+  describe('WHO (352)', () => {
+    const line = ':irc.test 352 me #c user host irc.test alice H*@+ :0 Alice A';
+
+    it('keeps one prefix in the flags without multi-prefix', () => {
+      expect(filterFor([]).apply(line)).toEqual([
+        ':irc.test 352 me #c user host irc.test alice H*@ :0 Alice A',
+      ]);
+      expect(filterFor(['multi-prefix']).apply(line)).toEqual([line]);
+    });
+  });
+
+  describe('tags', () => {
+    const line = '@time=T;msgid=m;account=alice;+draft/react=x :n!u@h PRIVMSG #c :hi';
+
+    it('keeps every tag for a message-tags client', () => {
+      expect(filterFor(['message-tags']).apply(line)).toEqual([line]);
+    });
+
+    it('keeps only the tags whose own cap the client has, without message-tags', () => {
+      expect(filterFor([]).apply(line)).toEqual([':n!u@h PRIVMSG #c :hi']);
+      expect(filterFor(['server-time']).apply(line)).toEqual(['@time=T :n!u@h PRIVMSG #c :hi']);
+      expect(filterFor(['server-time', 'account-tag']).apply(line)).toEqual([
+        '@time=T;account=alice :n!u@h PRIVMSG #c :hi',
+      ]);
+    });
+
+    it('drops an empty tag block for a client without message-tags', () => {
+      expect(filterFor([]).apply('@ :n!u@h PRIVMSG #c :hi')).toEqual([':n!u@h PRIVMSG #c :hi']);
+    });
+  });
+
+  describe('batches', () => {
+    const netsplit = [
+      ':irc.test BATCH +ns netsplit a.test b.test',
+      '@batch=ns :carol!c@h QUIT :a.test b.test',
+      ':irc.test BATCH -ns',
+    ];
+
+    it('passes a batch through to a client that has batch', () => {
+      const filter = filterFor(['message-tags', 'batch']);
+      expect(netsplit.flatMap((l) => filter.apply(l))).toEqual(netsplit);
+    });
+
+    it('keeps the batch tag for a batch client without message-tags', () => {
+      const filter = filterFor(['batch']);
+      expect(netsplit.flatMap((l) => filter.apply(l))).toEqual(netsplit);
+    });
+
+    it('never opens a batch for a client without batch, and strips the tag', () => {
+      const filter = filterFor(['message-tags']);
+      expect(netsplit.flatMap((l) => filter.apply(l))).toEqual([':carol!c@h QUIT :a.test b.test']);
+    });
+
+    it('strips the tag of a batch the client never saw start', () => {
+      const filter = filterFor(['message-tags', 'batch']);
+      expect(filter.apply('@batch=zz :carol!c@h QUIT :bye')).toEqual([':carol!c@h QUIT :bye']);
+      expect(filter.apply(':irc.test BATCH -zz')).toEqual([]);
+    });
+
+    it('forgets open batches on resetBatches', () => {
+      const filter = filterFor(['message-tags', 'batch']);
+      filter.apply(netsplit[0]);
+      filter.resetBatches();
+      expect(filter.apply(netsplit[1])).toEqual([':carol!c@h QUIT :a.test b.test']);
+      expect(filter.apply(netsplit[2])).toEqual([]);
+    });
+
+    it('keeps a nested batch inside an open one', () => {
+      const filter = filterFor(['message-tags', 'batch']);
+      const lines = [
+        ':irc.test BATCH +outer example.test/outer',
+        '@batch=outer :irc.test BATCH +inner netjoin a.test b.test',
+        '@batch=inner :carol!c@h JOIN #c',
+        '@batch=outer :irc.test BATCH -inner',
+        ':irc.test BATCH -outer',
+      ];
+      expect(lines.flatMap((l) => filter.apply(l))).toEqual(lines);
+    });
+  });
+
+  // The spec's own example: draft/multiline, "Server sending messages to clients
+  // without multiline support".
+  describe('draft/multiline fallback', () => {
+    const batch = [
+      '@msgid=xxx;account=account :n!u@h BATCH +123 draft/multiline #channel',
+      '@batch=123 :n!u@h PRIVMSG #channel hello',
+      '@batch=123 :n!u@h PRIVMSG #channel :',
+      '@batch=123 :n!u@h PRIVMSG #channel :how is ',
+      '@batch=123;draft/multiline-concat :n!u@h PRIVMSG #channel :everyone?',
+      'BATCH -123',
+    ];
+
+    it('sends the lines unbatched, without blanks, msgid on the first line only', () => {
+      const filter = filterFor(['message-tags', 'batch']);
+      expect(batch.flatMap((l) => filter.apply(l))).toEqual([
+        '@msgid=xxx;account=account :n!u@h PRIVMSG #channel hello',
+        '@account=account :n!u@h PRIVMSG #channel :how is ',
+        '@account=account :n!u@h PRIVMSG #channel :everyone?',
+      ]);
+    });
+
+    it('sends plain lines to a client without message-tags', () => {
+      const filter = filterFor([]);
+      expect(batch.flatMap((l) => filter.apply(l))).toEqual([
+        ':n!u@h PRIVMSG #channel hello',
+        ':n!u@h PRIVMSG #channel :how is ',
+        ':n!u@h PRIVMSG #channel :everyone?',
+      ]);
+    });
+
+    it('carries msgid to the first line that is not blank', () => {
+      const filter = filterFor(['message-tags']);
+      const lines = [
+        '@msgid=m1 :n!u@h BATCH +b draft/multiline #c',
+        '@batch=b :n!u@h PRIVMSG #c :',
+        '@batch=b :n!u@h PRIVMSG #c :text',
+        ':irc.test BATCH -b',
+      ];
+      expect(lines.flatMap((l) => filter.apply(l))).toEqual(['@msgid=m1 :n!u@h PRIVMSG #c :text']);
+    });
+  });
+
+  describe('CHGHOST fallback', () => {
+    const shared = [
+      { channel: '#ops', modes: ['v', 'o'] },
+      { channel: '#lounge', modes: [] },
+    ];
+    const change = '@time=T;msgid=h1 :alice!old@old.host CHGHOST new new.host';
+
+    it('sends the QUIT, JOIN and MODE the network would have sent', () => {
+      expect(filterFor([], { shared }).apply(change)).toEqual([
+        ':alice!old@old.host QUIT :Changing hostname',
+        ':alice!new@new.host JOIN #ops',
+        ':lurker.bouncer MODE #ops +ov alice alice',
+        ':alice!new@new.host JOIN #lounge',
+      ]);
+    });
+
+    it('stamps each fallback line with the change time for a server-time client', () => {
+      expect(filterFor(['server-time'], { shared }).apply(change)).toEqual([
+        '@time=T :alice!old@old.host QUIT :Changing hostname',
+        '@time=T :alice!new@new.host JOIN #ops',
+        '@time=T :lurker.bouncer MODE #ops +ov alice alice',
+        '@time=T :alice!new@new.host JOIN #lounge',
+      ]);
+    });
+
+    it('sends nothing for our own change, or for a nick we share no channel with', () => {
+      expect(filterFor([], { nick: 'Alice', shared }).apply(change)).toEqual([]);
+      expect(filterFor([], { shared: [] }).apply(change)).toEqual([]);
+    });
+  });
+});

--- a/server/services/bouncerClientFilter.ts
+++ b/server/services/bouncerClientFilter.ts
@@ -193,9 +193,10 @@ export class ClientLineFilter {
 
   /**
    * The lines to write for `line`: none, the line itself (rewritten if a rule
-   * applies), or the fallback lines that stand in for it.
+   * applies), or the fallback lines that stand in for it. `relayedAt` marks a
+   * line the network sent, and is the time it gets if it has none of its own.
    */
-  apply(line: string): string[] {
+  apply(line: string, relayedAt?: Date): string[] {
     const msg = parseLine(line);
     if (!msg) return [];
     const { caps } = this.view;
@@ -217,7 +218,10 @@ export class ClientLineFilter {
         this.batches.set(refParam.slice(1), {
           type,
           opened,
-          tags: msg.tags.filter((tag) => tagKey(tag) !== 'batch'),
+          // The line's tags as they stand: a batch tag is still here only if it
+          // names a batch this client was sent, so a multiline batch inside a
+          // chathistory replay carries that reference onto its unwrapped lines.
+          tags: [...msg.tags],
           first: true,
         });
         if (!opened) return [];
@@ -230,7 +234,7 @@ export class ClientLineFilter {
 
     const gate = CAP_GATED_COMMANDS[msg.command];
     if (gate && !caps.has(gate)) {
-      return msg.command === 'CHGHOST' ? this.chghostFallback(msg) : [];
+      return msg.command === 'CHGHOST' ? this.chghostFallback(msg, relayedAt) : [];
     }
 
     if (msg.command === 'INVITE' && !caps.has('invite-notify')) {
@@ -300,6 +304,20 @@ export class ClientLineFilter {
       dirty = true;
     }
 
+    // soju stamps what it relays (upstream.go) so a server-time client has a
+    // time on every message; numerics are left alone, as soju leaves them. This
+    // runs after the multiline fallback, so an unwrapped line takes its batch's
+    // time before it would take the time it was relayed.
+    if (
+      relayedAt &&
+      caps.has('server-time') &&
+      !/^[0-9]{3}$/.test(msg.command) &&
+      !msg.tags.some((tag) => tagKey(tag) === 'time')
+    ) {
+      msg.tags = [`time=${relayedAt.toISOString()}`, ...msg.tags];
+      dirty = true;
+    }
+
     if (!caps.has('message-tags')) {
       const kept = msg.tags.filter((tag) => {
         const cap = TAG_CAPS[tagKey(tag)];
@@ -335,7 +353,7 @@ export class ClientLineFilter {
   // chghost. A QUIT, then a JOIN in each shared channel and a MODE restoring the
   // prefix modes there. soju just drops the line, which leaves the client
   // holding a stale hostmask.
-  private chghostFallback(msg: ClientLine): string[] {
+  private chghostFallback(msg: ClientLine, relayedAt?: Date): string[] {
     const source = msg.source ?? '';
     const bang = source.indexOf('!');
     const nick = bang === -1 ? source : source.slice(0, bang);
@@ -366,6 +384,6 @@ export class ClientLineFilter {
         );
       }
     }
-    return lines.flatMap((l) => this.apply(l));
+    return lines.flatMap((l) => this.apply(l, relayedAt));
   }
 }

--- a/server/services/bouncerClientFilter.ts
+++ b/server/services/bouncerClientFilter.ts
@@ -1,0 +1,363 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// What an attached bouncer client may receive, given the caps it negotiated.
+//
+// Lurker's connection to a network negotiates caps of its own (irc-framework
+// asks for away-notify, extended-join, multi-prefix, userhost-in-names, … by
+// default), and the relay forwards what the network then sends. A client that
+// never asked for those caps must not get the lines they bring (#892, #926). So
+// every line the bouncer writes to a client (the live relay, the welcome and
+// channel replay, playback, CHATHISTORY, self-echoes, our own notices) goes
+// through that client's ClientLineFilter. One exit point is what stops a new
+// write path from skipping the rules.
+//
+// The rules are soju's downstreamConn.SendMessage (downstream.go) and ZNC's
+// CClient::PutClient (src/Client.cpp), plus two fallbacks for lines a client
+// can't take as they are: ZNC's for CHGHOST (CIRCSock::OnChgHostMessage), and
+// the draft/multiline spec's, since Lurker asks networks for multiline and never
+// offers it to clients.
+//
+// Lines are parsed only as far as those rules need. A line no rule touches is
+// written byte-for-byte; only a rewritten line is serialized again.
+
+/** A server→client line, split into the parts the rules read. */
+export interface ClientLine {
+  // `key` or `key=value` items in wire order, still escaped. Rules keep or drop
+  // whole tags, so a value is never decoded.
+  tags: string[];
+  source: string | null;
+  command: string;
+  params: string[];
+  // Whether the last param arrived as a `:` trailing param, so a rewrite keeps
+  // the line's shape: a NAMES reply trimmed to one name still ends `:name`.
+  trailing: boolean;
+}
+
+/** Parse a server→client line. Null when it has no command. */
+export function parseLine(line: string): ClientLine | null {
+  let rest = line;
+  let tags: string[] = [];
+  if (rest.startsWith('@')) {
+    const sp = rest.indexOf(' ');
+    if (sp === -1) return null;
+    tags = rest.slice(1, sp).split(';').filter(Boolean);
+    rest = rest.slice(sp + 1);
+  }
+  rest = rest.replace(/^ +/, '');
+  let source: string | null = null;
+  if (rest.startsWith(':')) {
+    const sp = rest.indexOf(' ');
+    if (sp === -1) return null;
+    source = rest.slice(1, sp);
+    rest = rest.slice(sp + 1);
+  }
+  let head = rest;
+  let trailing: string | null = null;
+  const ti = rest.indexOf(' :');
+  if (ti !== -1) {
+    head = rest.slice(0, ti);
+    trailing = rest.slice(ti + 2);
+  }
+  const params = head.split(' ').filter(Boolean);
+  const command = params.shift()?.toUpperCase();
+  if (!command) return null;
+  if (trailing !== null) params.push(trailing);
+  return { tags, source, command, params, trailing: trailing !== null };
+}
+
+/** Serialize a parsed line back to the wire form (no CRLF). */
+export function formatLine(msg: ClientLine): string {
+  const parts: string[] = [];
+  if (msg.tags.length > 0) parts.push(`@${msg.tags.join(';')}`);
+  if (msg.source !== null) parts.push(`:${msg.source}`);
+  parts.push(msg.command);
+  msg.params.forEach((param, i) => {
+    const last = i === msg.params.length - 1;
+    const colon =
+      last && (msg.trailing || param === '' || param.includes(' ') || param.startsWith(':'));
+    parts.push(colon ? `:${param}` : param);
+  });
+  return parts.join(' ');
+}
+
+function tagKey(tag: string): string {
+  const eq = tag.indexOf('=');
+  return eq === -1 ? tag : tag.slice(0, eq);
+}
+
+function tagValue(tags: readonly string[], key: string): string | undefined {
+  for (const tag of tags) {
+    if (tagKey(tag) === key) return tag.slice(key.length + 1);
+  }
+  return undefined;
+}
+
+/** `line` keeping only the tags whose key `keep` accepts. Null when it has no command. */
+export function restrictTags(line: string, keep: (key: string) => boolean): string | null {
+  const msg = parseLine(line);
+  if (!msg) return null;
+  const kept = msg.tags.filter((tag) => keep(tagKey(tag)));
+  // An emptied (or already empty) tag block goes entirely, never as a bare `@`.
+  if (kept.length === msg.tags.length && (kept.length > 0 || !line.startsWith('@'))) return line;
+  msg.tags = kept;
+  return formatLine(msg);
+}
+
+/**
+ * A NAMES entry with only its highest prefix, for a client without multi-prefix:
+ * `@+nick` → `@nick`. `symbols` is the network's PREFIX symbols, highest first.
+ */
+export function highestPrefixOnly(entry: string, symbols: string): string {
+  let end = 0;
+  while (end < entry.length && symbols.includes(entry[end])) end++;
+  return end > 1 ? entry[0] + entry.slice(end) : entry;
+}
+
+/** The same for RPL_WHOREPLY's flags, where the prefixes follow H/G and `*`: `H*@+` → `H*@`. */
+export function whoFlagsHighestPrefixOnly(flags: string, symbols: string): string {
+  let start = 0;
+  while (start < flags.length && !symbols.includes(flags[start])) start++;
+  let end = start;
+  while (end < flags.length && symbols.includes(flags[end])) end++;
+  return end - start > 1 ? flags.slice(0, start + 1) + flags.slice(end) : flags;
+}
+
+/** What the filter needs to know about one attached client and its network. */
+export interface ClientView {
+  // The caps the client negotiated. Read on every line, so a later CAP REQ
+  // takes effect at once.
+  readonly caps: ReadonlySet<string>;
+  // Source of the lines the bouncer makes up itself (the fallback MODE).
+  readonly serverName: string;
+  // Our nick on the network. An INVITE naming it arrives with or without
+  // invite-notify.
+  nick(): string | null;
+  // The network's ISUPPORT PREFIX, highest rank first.
+  prefixes(): ReadonlyArray<{ mode: string; symbol: string }>;
+  // The channels `nick` shares with us, with its prefix modes in each.
+  sharedChannels(nick: string): Array<{ channel: string; modes: readonly string[] }>;
+}
+
+const MULTILINE_BATCH = 'draft/multiline';
+const MULTILINE_CONCAT = 'draft/multiline-concat';
+
+// Commands a client gets only after negotiating the cap (soju's SendMessage).
+// Lurker doesn't ask networks for some of these caps, so their commands can't
+// arrive today. They're listed anyway: asking a network for a cap changes what
+// it sends (#591), and doing that later must not reopen this leak.
+const CAP_GATED_COMMANDS: Record<string, string> = {
+  TAGMSG: 'message-tags',
+  BATCH: 'batch',
+  AWAY: 'away-notify',
+  ACCOUNT: 'account-notify',
+  CHGHOST: 'chghost',
+  SETNAME: 'setname',
+  REDACT: 'draft/message-redaction',
+  MARKREAD: 'draft/read-marker',
+  METADATA: 'draft/metadata-2',
+};
+
+// The tags a client without message-tags may still get, each behind its own cap.
+const TAG_CAPS: Record<string, string> = {
+  time: 'server-time',
+  batch: 'batch',
+  account: 'account-tag',
+};
+
+interface OpenBatch {
+  type: string;
+  // Whether this client was sent the `BATCH +` line. Lines inside keep their
+  // batch tag only then.
+  opened: boolean;
+  // The `BATCH +` line's own tags. The multiline fallback puts them on the lines
+  // instead: all of them on the first, all but msgid after that.
+  tags: string[];
+  first: boolean;
+}
+
+export class ClientLineFilter {
+  private readonly view: ClientView;
+  // Batches this client has seen start, by reference. Lurker's own batches
+  // (network lists, CHATHISTORY) open and close within one write burst; the
+  // network's live until its `BATCH -` or resetBatches().
+  private readonly batches = new Map<string, OpenBatch>();
+
+  constructor(view: ClientView) {
+    this.view = view;
+  }
+
+  /**
+   * The lines to write for `line`: none, the line itself (rewritten if a rule
+   * applies), or the fallback lines that stand in for it.
+   */
+  apply(line: string): string[] {
+    const msg = parseLine(line);
+    if (!msg) return [];
+    const { caps } = this.view;
+    let dirty = false;
+
+    // A batch tag survives only if this client was sent that batch's start.
+    // That also covers a client that attached part-way through a batch.
+    const ref = tagValue(msg.tags, 'batch');
+    const batch = ref === undefined ? undefined : this.batches.get(ref);
+    if (ref !== undefined && !batch?.opened) {
+      msg.tags = msg.tags.filter((tag) => tagKey(tag) !== 'batch');
+      dirty = true;
+    }
+
+    if (msg.command === 'BATCH') {
+      const [refParam = '', type = ''] = msg.params;
+      if (refParam.startsWith('+')) {
+        const opened = caps.has('batch') && type !== MULTILINE_BATCH;
+        this.batches.set(refParam.slice(1), {
+          type,
+          opened,
+          tags: msg.tags.filter((tag) => tagKey(tag) !== 'batch'),
+          first: true,
+        });
+        if (!opened) return [];
+      } else if (refParam.startsWith('-')) {
+        const open = this.batches.get(refParam.slice(1));
+        this.batches.delete(refParam.slice(1));
+        if (!open?.opened) return [];
+      }
+    }
+
+    const gate = CAP_GATED_COMMANDS[msg.command];
+    if (gate && !caps.has(gate)) {
+      return msg.command === 'CHGHOST' ? this.chghostFallback(msg) : [];
+    }
+
+    if (msg.command === 'INVITE' && !caps.has('invite-notify')) {
+      const nick = this.view.nick();
+      if (!nick || (msg.params[0] ?? '').toLowerCase() !== nick.toLowerCase()) return [];
+    }
+
+    if (msg.command === 'JOIN' && msg.params.length > 1 && !caps.has('extended-join')) {
+      msg.params = msg.params.slice(0, 1);
+      msg.trailing = false;
+      dirty = true;
+    }
+
+    // RPL_NAMREPLY: `<client> <symbol> <channel> :<entries>`.
+    if (msg.command === '353' && msg.params.length >= 3) {
+      const multiPrefix = caps.has('multi-prefix');
+      const userhosts = caps.has('userhost-in-names');
+      if (!multiPrefix || !userhosts) {
+        const symbols = this.prefixSymbols();
+        const last = msg.params.length - 1;
+        const entries = msg.params[last]
+          .split(' ')
+          .map((entry) => {
+            const name = multiPrefix ? entry : highestPrefixOnly(entry, symbols);
+            const bang = userhosts ? -1 : name.indexOf('!');
+            return bang === -1 ? name : name.slice(0, bang);
+          })
+          .join(' ');
+        if (entries !== msg.params[last]) {
+          msg.params[last] = entries;
+          dirty = true;
+        }
+      }
+    }
+
+    // RPL_WHOREPLY: `<client> <channel> <user> <host> <server> <nick> <flags> :…`.
+    if (msg.command === '352' && msg.params.length >= 7 && !caps.has('multi-prefix')) {
+      const flags = whoFlagsHighestPrefixOnly(msg.params[6], this.prefixSymbols());
+      if (flags !== msg.params[6]) {
+        msg.params[6] = flags;
+        dirty = true;
+      }
+    }
+
+    // The multiline spec's fallback: a client without the cap gets the batch's
+    // lines as plain messages, never a blank one, with the batch's tags moved
+    // onto them.
+    if (
+      batch?.type === MULTILINE_BATCH &&
+      (msg.command === 'PRIVMSG' || msg.command === 'NOTICE')
+    ) {
+      if ((msg.params[1] ?? '') === '') return [];
+      const carried = batch.first
+        ? batch.tags
+        : batch.tags.filter((tag) => tagKey(tag) !== 'msgid');
+      batch.first = false;
+      const present = new Set(msg.tags.map(tagKey));
+      const added = carried.filter((tag) => !present.has(tagKey(tag)));
+      if (added.length > 0) {
+        msg.tags = [...added, ...msg.tags];
+        dirty = true;
+      }
+    }
+    // Multiline is never offered, so its concat marker never goes out.
+    if (msg.tags.some((tag) => tagKey(tag) === MULTILINE_CONCAT)) {
+      msg.tags = msg.tags.filter((tag) => tagKey(tag) !== MULTILINE_CONCAT);
+      dirty = true;
+    }
+
+    if (!caps.has('message-tags')) {
+      const kept = msg.tags.filter((tag) => {
+        const cap = TAG_CAPS[tagKey(tag)];
+        return cap !== undefined && caps.has(cap);
+      });
+      if (kept.length !== msg.tags.length || (kept.length === 0 && line.startsWith('@'))) {
+        msg.tags = kept;
+        dirty = true;
+      }
+    }
+
+    return [dirty ? formatLine(msg) : line];
+  }
+
+  /**
+   * Forget the network's open batches. A new upstream connection starts with
+   * none, and its references can repeat the old connection's (soju keeps them
+   * per upstream connection too).
+   */
+  resetBatches(): void {
+    this.batches.clear();
+  }
+
+  private prefixSymbols(): string {
+    return this.view
+      .prefixes()
+      .map((p) => p.symbol)
+      .join('');
+  }
+
+  // ZNC's fallback for a client without chghost, which is also the chghost
+  // spec's SHOULD: what the network would have sent had Lurker not asked it for
+  // chghost. A QUIT, then a JOIN in each shared channel and a MODE restoring the
+  // prefix modes there. soju just drops the line, which leaves the client
+  // holding a stale hostmask.
+  private chghostFallback(msg: ClientLine): string[] {
+    const source = msg.source ?? '';
+    const bang = source.indexOf('!');
+    const nick = bang === -1 ? source : source.slice(0, bang);
+    const [user, host] = msg.params;
+    const self = this.view.nick();
+    // Our own change needs no fallback: the network reports it with a 396 of its
+    // own, which the relay passes on.
+    if (!nick || !user || !host || (self && nick.toLowerCase() === self.toLowerCase())) return [];
+    const shared = this.view.sharedChannels(nick);
+    if (shared.length === 0) return [];
+    // The change's time applies to every fallback line. Its msgid names the
+    // CHGHOST, not any of them, so it stays behind.
+    const time = msg.tags.filter((tag) => tagKey(tag) === 'time');
+    const tagBlock = time.length > 0 ? `@${time.join(';')} ` : '';
+    const lines = [`${tagBlock}:${source} QUIT :Changing hostname`];
+    const prefixes = this.view.prefixes();
+    for (const { channel, modes } of shared) {
+      lines.push(`${tagBlock}:${nick}!${user}@${host} JOIN ${channel}`);
+      const restored = prefixes.filter((p) => modes.includes(p.mode)).map((p) => p.mode);
+      if (restored.length > 0) {
+        const nicks = restored.map(() => nick).join(' ');
+        lines.push(
+          `${tagBlock}:${this.view.serverName} MODE ${channel} +${restored.join('')} ${nicks}`,
+        );
+      }
+    }
+    return lines.flatMap((l) => this.apply(l));
+  }
+}

--- a/server/services/bouncerClientFilter.ts
+++ b/server/services/bouncerClientFilter.ts
@@ -135,8 +135,12 @@ export interface ClientView {
   nick(): string | null;
   // The network's ISUPPORT PREFIX, highest rank first.
   prefixes(): ReadonlyArray<{ mode: string; symbol: string }>;
-  // The channels `nick` shares with us, with its prefix modes in each.
-  sharedChannels(nick: string): Array<{ channel: string; modes: readonly string[] }>;
+  // The channels `nick` shares with us, with its prefix modes in each and the
+  // services account we know it by (a string; null when logged out; undefined
+  // when never learned).
+  sharedChannels(
+    nick: string,
+  ): Array<{ channel: string; modes: readonly string[]; account?: string | null }>;
 }
 
 const MULTILINE_BATCH = 'draft/multiline';
@@ -348,8 +352,12 @@ export class ClientLineFilter {
     const tagBlock = time.length > 0 ? `@${time.join(';')} ` : '';
     const lines = [`${tagBlock}:${source} QUIT :Changing hostname`];
     const prefixes = this.view.prefixes();
-    for (const { channel, modes } of shared) {
-      lines.push(`${tagBlock}:${nick}!${user}@${host} JOIN ${channel}`);
+    for (const { channel, modes, account } of shared) {
+      // Built in extended-join form, which apply() trims for a client without
+      // it. Members carry no realname, so that stays empty. (ZNC sends a plain
+      // JOIN here, with a TODO for extended-join.)
+      const accountParam = typeof account === 'string' ? account : '*';
+      lines.push(`${tagBlock}:${nick}!${user}@${host} JOIN ${channel} ${accountParam} :`);
       const restored = prefixes.filter((p) => modes.includes(p.mode)).map((p) => p.mode);
       if (restored.length > 0) {
         const nicks = restored.map(() => nick).join(' ');

--- a/server/services/bouncerClientFilter.ts
+++ b/server/services/bouncerClientFilter.ts
@@ -171,8 +171,8 @@ const TAG_CAPS: Record<string, string> = {
 
 interface OpenBatch {
   type: string;
-  // Whether this client was sent the `BATCH +` line. Lines inside keep their
-  // batch tag only then.
+  // Whether this client was sent the `BATCH +` line, and hasn't given up batch
+  // since. Lines inside keep their batch tag only then.
   opened: boolean;
   // The `BATCH +` line's own tags. The multiline fallback puts them on the lines
   // instead: all of them on the first, all but msgid after that.
@@ -206,7 +206,7 @@ export class ClientLineFilter {
     // That also covers a client that attached part-way through a batch.
     const ref = tagValue(msg.tags, 'batch');
     const batch = ref === undefined ? undefined : this.batches.get(ref);
-    if (ref !== undefined && !batch?.opened) {
+    if (ref !== undefined && !this.sent(ref)) {
       msg.tags = msg.tags.filter((tag) => tagKey(tag) !== 'batch');
       dirty = true;
     }
@@ -287,9 +287,13 @@ export class ClientLineFilter {
       (msg.command === 'PRIVMSG' || msg.command === 'NOTICE')
     ) {
       if ((msg.params[1] ?? '') === '') return [];
-      const carried = batch.first
-        ? batch.tags
-        : batch.tags.filter((tag) => tagKey(tag) !== 'msgid');
+      const carried = batch.tags.filter((tag) => {
+        const key = tagKey(tag);
+        if (key === 'msgid') return batch.first;
+        // An enclosing batch, only while it's still this client's.
+        if (key === 'batch') return this.sent(tag.slice(key.length + 1));
+        return true;
+      });
       batch.first = false;
       const present = new Set(msg.tags.map(tagKey));
       const added = carried.filter((tag) => !present.has(tagKey(tag)));
@@ -339,6 +343,20 @@ export class ClientLineFilter {
    */
   resetBatches(): void {
     this.batches.clear();
+  }
+
+  /**
+   * The client gave up `batch` (CAP REQ :-batch). Every batch it was sent is
+   * over for it: the rest of their lines lose the batch tag, their `BATCH -`
+   * never reaches it, and asking for batch again doesn't bring one back.
+   */
+  forgetSentBatches(): void {
+    for (const open of this.batches.values()) open.opened = false;
+  }
+
+  // Whether this client was sent batch `ref`'s start and still has the batch cap.
+  private sent(ref: string): boolean {
+    return this.view.caps.has('batch') && this.batches.get(ref)?.opened === true;
   }
 
   private prefixSymbols(): string {

--- a/server/test-utils/bouncerHarness.ts
+++ b/server/test-utils/bouncerHarness.ts
@@ -34,9 +34,39 @@ import type { User } from '../db/users.js';
 export interface FakeChannel {
   name: string;
   topic: string | null;
-  members: Map<string, { nick: string; modes: string[] }>;
+  members: Map<string, FakeMember>;
   modes: Set<string>;
 }
+
+// The ChannelMember fields the bouncer reads. The optional ones are unknown
+// until a test sets them, as they often are on a real connection.
+export interface FakeMember {
+  nick: string;
+  modes: string[];
+  account?: string | null;
+  user?: string | null;
+  host?: string | null;
+}
+
+// What irc-framework and IrcConnection typically end up negotiating with an
+// IRCv3 network. The bouncer offers its pass-through caps only while the bound
+// network has them; replace `upstream.client.network.cap.enabled` in a test to
+// model a network without some.
+export const UPSTREAM_CAPS = [
+  'cap-notify',
+  'batch',
+  'multi-prefix',
+  'message-tags',
+  'away-notify',
+  'invite-notify',
+  'account-notify',
+  'account-tag',
+  'server-time',
+  'userhost-in-names',
+  'extended-join',
+  'chghost',
+  'echo-message',
+];
 
 // Minimal stand-in for IrcConnection covering exactly what bouncer.ts reads.
 export class FakeUpstream {
@@ -69,6 +99,7 @@ export class FakeUpstream {
           { mode: 'v', symbol: '+' },
         ],
       },
+      cap: { enabled: [...UPSTREAM_CAPS] },
     };
     this.client = client;
   }
@@ -87,7 +118,7 @@ export class FakeUpstream {
   }
 
   addChannel(name: string, opts: { topic?: string; members?: string[] } = {}): FakeChannel {
-    const members = new Map<string, { nick: string; modes: string[] }>();
+    const members = new Map<string, FakeMember>();
     for (const raw of opts.members ?? []) {
       const modes: string[] = [];
       let nick = raw;


### PR DESCRIPTION
Fixes #926.

A client that negotiated only `echo-message` still got `AWAY` lines. The cause is the same as #892. The bouncer relayed the network's raw lines, and the network speaks to Lurker with the caps Lurker negotiated. irc-framework requests away-notify, account-notify, extended-join, multi-prefix, userhost-in-names, invite-notify and others by default. The relay dropped only a handful of commands, so everything those caps bring reached clients that never asked for it.

The fix follows soju and ZNC in both directions: what a client can negotiate, and what it receives.

## What a client can negotiate

soju's pass-through caps are offered while the bound network has them: `away-notify`, `account-notify`, `account-tag`, `chghost`, `extended-join` and `multi-prefix`, plus ZNC's `userhost-in-names`. `cap-notify` and `invite-notify` are always offered, as in soju.

- `CAP LS 302` before registration lists the pass-through caps, because the network isn't known yet.
- On binding, `CAP DEL` takes back any the network lacks, before the welcome.
- After that, `CAP NEW` and `CAP DEL` track the upstream: a connect, a disconnect, or a cap the network grants mid-session.
- A control connection has no network, so it gets none of them.

This is soju's `updateSupportedCaps`.

## What a client receives

Every line to a client now goes through one per-client filter, `server/services/bouncerClientFilter.ts`, whichever code path wrote it: the relay, welcome and channel replay, playback, CHATHISTORY or self-echo. #892 was a write path that skipped the old filter; #926 was a rule it lacked. With a single exit point, neither can happen again.

The rules follow soju's `SendMessage` and ZNC's `PutClient`:

| Line | Sent as-is only with |
|---|---|
| `AWAY`, `ACCOUNT`, `CHGHOST`, `SETNAME`, `TAGMSG`, `BATCH` | the matching cap |
| `INVITE` for someone else | `invite-notify` |
| `JOIN #c account :realname` (otherwise `JOIN #c`) | `extended-join` |
| NAMES `@+nick!u@h` (otherwise `@nick`) | `multi-prefix`, `userhost-in-names` |
| WHO flags `H@+` (otherwise `H@`) | `multi-prefix` |
| tags other than `time`, `batch` and `account`, each of which has its own cap | `message-tags` |

`REDACT`, `MARKREAD` and `METADATA` are gated too. Lurker doesn't request their caps upstream today, but requesting one later shouldn't reopen this.

The channel replay now builds JOIN and NAMES in full, with account and realname, every prefix, and hostmasks where known, then lets the filter trim them for each client.

Two lines can't go out as they are, so they get fallbacks:
- **CHGHOST for a client without `chghost`:** a QUIT, a JOIN in each shared channel, and a MODE restoring prefix modes. This is ZNC's behaviour and what the chghost spec says servers SHOULD send. soju drops the line, which leaves the client with a stale hostmask. A client that negotiates `chghost` gets the CHGHOST itself.
- **`draft/multiline`**, which Lurker requests upstream but never offers: the spec's fallback. No BATCH, no blank lines, and the batch's tags go on the lines, with msgid on the first only.

A batch tag is kept only if the client was sent that batch's start. That also covers a client that attaches mid-batch.

Relayed lines that arrive without `@time` get one for server-time clients, as soju does.

Not offered yet:
- `extended-monitor`: a client's MONITOR is still relayed raw into Lurker's own list.
- `labeled-response`: needs per-request reply routing (#493).

The remaining soju gaps are follow-up work, most visible first: history sent twice to chathistory clients, per-client MONITOR, read markers, and routing replies back to the client that asked.

## Tests
- `bouncer.integration.test.ts`:
  - Relay: the reporter's exchange; extended-join, NAMES and WHO trimming; ACCOUNT and INVITE; the CHGHOST fallback; batches with and without `batch`; a multiline batch, including keeping the network's time for a server-time client; a client giving up `batch` part-way through a batch, then asking for it again.
  - Caps: LS at 301 and 302; delivery once negotiated; `CAP DEL` before the welcome on a network without the caps; a control connection; `CAP NEW` when a network connects and when it grants a cap; a pre-302 client asking after registration; `-cap-notify` refused; the replayed JOIN and NAMES per client; `@time` stamping.
- `bouncerClientFilter.test.ts`: the rules case by case, including the multiline spec's own example and a multiline batch nested inside a replay batch.
- Checked that the tests catch regressions:
  - With `write()` bypassing the filter, the relay tests fail, and so does #892's no-caps replay test.
  - With `updateSupportedCaps` turned into a no-op, the five tests for CAP DEL, CAP NEW and a pre-302 client's request fail.
  - `/code-review high` found two bugs: multiline lines were losing their batch's time, and losing the batch that encloses them. Each fix has a test that failed before it.
- `npm run check` passes, and so does the full suite (330 files, 4929 tests). An earlier run failed only `engineLink.test.ts:207`, a timing test that fails the same way on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqqAE2Hm786ooHebZtqdHN
