### PR TITLE
Bouncer: no attach playback for draft/chathistory clients

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -476,7 +476,8 @@ VAPID_SUBJECT=mailto:you@example.com
 #
 # Lines of history replayed per buffer when a client attaches (0 disables
 # playback, max 1000). Joined channels always replay; the 20 most recently
-# active open DMs replay too. LURKER_BOUNCER_MAX_PLAYBACK_TOTAL caps the total
+# active open DMs replay too. A client that negotiates draft/chathistory gets
+# none and fetches its own. LURKER_BOUNCER_MAX_PLAYBACK_TOTAL caps the total
 # lines replayed across ALL buffers on one attach (default 10000) so a user in
 # many buffers can't stall the event loop.
 # LURKER_BOUNCER_PLAYBACK=50

--- a/docs/IRCV3.md
+++ b/docs/IRCV3.md
@@ -179,6 +179,9 @@ Implementation notes worth knowing if you're writing against it:
   Lurker's stored history IDs and an upstream network's message IDs are different
   namespaces and mixing them would break paging across the boundary.
   <br>`server/services/bouncer.ts:146`, `:520`
+- A client that negotiates `draft/chathistory` gets no playback on attach, as with
+  soju. It fetches the history it wants itself, so it doesn't see the same lines twice.
+  <br>`server/services/bouncer.ts:1717`
 - Tags that only a server may set — `time`, `account`, `msgid`, `label`, `batch` —
   are stripped from anything an attached client sends, so a downstream client can't
   forge them.

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -531,7 +531,7 @@ Modern IRCv3 clients (Halloy, gamja, Goguma, …) get more than the server-passw
 
 - **SASL** — log in with the same credential via SASL PLAIN instead of a server password.
 - **Network discovery** (`soju.im/bouncer-networks`) — the client lists and binds your networks itself, so you don't hardcode `username/networkname`; connect as just `username` and pick from the list. This is what the idle connection above is for.
-- **On-demand scrollback** (`draft/chathistory`) — page back through history on demand instead of relying only on the fixed replay-on-attach.
+- **On-demand scrollback** (`draft/chathistory`) — the client fetches the history it wants itself, so Lurker skips the replay on attach.
 
 These are negotiated automatically; plain clients that don't support them keep working over the server-password path.
 
@@ -555,7 +555,7 @@ Plain-text IRC would send that credential across the wire in the clear, so **the
 
 Repeated failed logins from an address are throttled automatically.
 
-Playback replays the last 50 lines per joined channel (plus your 20 most recently active DMs) on attach; tune with `LURKER_BOUNCER_PLAYBACK` (0 disables, max 1000). Clients that negotiate IRCv3 `server-time` get real timestamps on replayed lines.
+Playback replays the last 50 lines per joined channel (plus your 20 most recently active DMs) on attach; tune with `LURKER_BOUNCER_PLAYBACK` (0 disables, max 1000). Clients that negotiate IRCv3 `server-time` get real timestamps on replayed lines. Clients that negotiate `draft/chathistory` get no playback, since they fetch their own.
 
 Known limitations (shared-connection bouncer semantics): replies to one attached client's WHOIS/LIST are visible to all attached clients on that network; Lurker-side ignore rules don't filter the live relay; and on end-to-end encrypted channels an attached client sees the wire ciphertext for incoming messages.
 

--- a/server/services/bouncer.chathistory.test.ts
+++ b/server/services/bouncer.chathistory.test.ts
@@ -100,6 +100,38 @@ describe('CHATHISTORY advertisement', () => {
   });
 });
 
+describe('attach playback', () => {
+  // A joined channel and a DM, both with history.
+  async function attachWithHistory(nick: string, caps: string): Promise<Client> {
+    const acct = harnessMod.seedAccount({ nick });
+    acct.upstream.addChannel('#room', { members: [nick, 'bob'] });
+    seedMessages(acct.network.id, '#room', 2);
+    seedMessages(acct.network.id, 'bob', 1);
+    const c = await harness.connect();
+    await attachBound(c, acct, caps);
+    // Playback goes out in the same pass as the 422, so the PONG comes after it.
+    c.send('PING sync');
+    await c.waitForCommand('PONG');
+    return c;
+  }
+
+  it('sends none to a client that negotiated draft/chathistory', async () => {
+    // soju skips it too (downstream.go:1841): the client fetches its own
+    // history, so a replay shows every line twice.
+    const c = await attachWithHistory('ap1', HISTORY_CAPS);
+    expect(c.lines.some((l) => l.includes('JOIN #room'))).toBe(true);
+    expect(c.lines.filter((l) => l.includes(' PRIVMSG '))).toEqual([]);
+    c.close();
+  });
+
+  it('still replays channels and DMs to a client without it', async () => {
+    const c = await attachWithHistory('ap2', 'sasl batch server-time message-tags');
+    expect(c.lines.some((l) => l.includes('PRIVMSG #room :msg2'))).toBe(true);
+    expect(c.lines.some((l) => l.includes('PRIVMSG ap2 :msg1'))).toBe(true);
+    c.close();
+  });
+});
+
 describe('CHATHISTORY LATEST', () => {
   it('returns the newest messages oldest-first, in a chathistory batch with msgid+time', async () => {
     const acct = harnessMod.seedAccount({ nick: 'ch2' });

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -1712,6 +1712,9 @@ class BouncerSession {
   }
 
   private sendPlayback(): void {
+    // A draft/chathistory client fetches its own history, so replaying it here
+    // shows every line twice. soju skips it the same way (downstream.go:1841).
+    if (this.caps.has(CAP_CHATHISTORY)) return;
     const limit = playbackLimit();
     if (limit <= 0) return;
     const conn = this.conn!;


### PR DESCRIPTION
The next soju parity gap after #927.

A client that negotiates `draft/chathistory` fetches its own history, but Lurker also replayed history when it attached. goguma, gamja and halloy showed missed lines twice, and HexDroid did the same in its channels. soju skips the attach backlog for these clients (`downstream.go:1841`), and now Lurker does too.

`sendPlayback()` returns early when the client negotiated `draft/chathistory`. Clients without the cap still get channel and DM playback. ZNC has no chathistory and always replays, so there's nothing to match there.

## HexDroid and DMs

HexDroid only asks for history in the channels it joins: it sends `CHATHISTORY LATEST` when it sees its own JOIN. Its TARGETS, BEFORE and AFTER requests are never called. So a HexDroid user no longer sees DMs that came in while they were detached.

soju behaves the same. Keeping the DM replay would show those DMs twice in goguma, gamja and halloy, so this follows soju.

## Tests
- `bouncer.chathistory.test.ts`, "attach playback":
  - A chathistory client gets the JOIN burst and no playback. This failed before the fix, with the channel and DM lines replayed.
  - A client without the cap still gets channel and DM playback.
- `npm run check` passes, and so does the full suite (330 files, 4939 tests). An earlier run failed every test in `pushDevices.test.ts` with 401s while `npm run check` was running alongside it. That file passes alone and in the clean rerun.
- `/code-review high` found the HexDroid DM gap above.
- Not tried with a real client yet.

Docs: `SELF_HOSTING.md`, `IRCV3.md` and `.env.example` say chathistory clients get no playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011W9ZzH7u9QwryMYnr1p9u3
